### PR TITLE
Add previous/next links in Getting Started documentation

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-vagrantup.com

--- a/_layouts/getting_started.html
+++ b/_layouts/getting_started.html
@@ -2,17 +2,61 @@
     <div class="grid_3 alpha sidebar">
       <div class="block">
         <ol>
-          <li><a href="/docs/getting-started/index.html">Overview</a></li>
-          <li><a href="/docs/getting-started/why.html">Why Vagrant?</a></li>
-          <li><a href="/docs/getting-started/introduction.html">Introduction</a></li>
-          <li><a href="/docs/getting-started/setup.html">Project Setup</a></li>
-          <li><a href="/docs/getting-started/boxes.html">Boxes</a></li>
-          <li><a href="/docs/getting-started/ssh.html">SSH</a></li>
-          <li><a href="/docs/getting-started/provisioning.html">Provisioning</a></li>
-          <li><a href="/docs/getting-started/ports.html">Port Forwarding</a></li>
-          <li><a href="/docs/getting-started/packaging.html">Packaging</a></li>
-          <li><a href="/docs/getting-started/teardown.html">Teardown</a></li>
-          <li><a href="/docs/getting-started/rebuild.html">Rebuild Instantly</a></li>
+          {% if page.url == '/docs/getting-started/index.html' %}
+            <li>Overview</li>
+          {% else %}
+            <li><a href="/docs/getting-started/index.html">Overview</a></li>
+          {% endif %}
+          {% if page.url == '/docs/getting-started/why.html' %}
+            <li>Why Vagrant?</li>
+          {% else %}
+            <li><a href="/docs/getting-started/why.html">Why Vagrant?</a></li>
+          {% endif %}
+          {% if page.url == '/docs/getting-started/introduction.html' %}
+            <li>Introduction</li>
+          {% else %}
+            <li><a href="/docs/getting-started/introduction.html">Introduction</a></li>
+          {% endif %}
+          {% if page.url == '/docs/getting-started/setup.html' %}
+            <li>Project Setup</li>
+          {% else %}
+            <li><a href="/docs/getting-started/setup.html">Project Setup</a></li>
+          {% endif %}
+          {% if page.url == '/docs/getting-started/boxes.html' %}
+            <li>Boxes</li>
+          {% else %}
+            <li><a href="/docs/getting-started/boxes.html">Boxes</a></li>
+          {% endif %}
+          {% if page.url == '/docs/getting-started/ssh.html' %}
+            <li>SSH</li>
+          {% else %}
+            <li><a href="/docs/getting-started/ssh.html">SSH</a></li>
+          {% endif %}
+          {% if page.url == '/docs/getting-started/provisioning.html' %}
+            <li>Provisioning</li>
+          {% else %}
+            <li><a href="/docs/getting-started/provisioning.html">Provisioning</a></li>
+          {% endif %}
+          {% if page.url == '/docs/getting-started/ports.html' %}
+            <li>Port Forwarding</li>
+          {% else %}
+            <li><a href="/docs/getting-started/ports.html">Port Forwarding</a></li>
+          {% endif %}
+          {% if page.url == '/docs/getting-started/packaging.html' %}
+            <li>Packaging</li>
+          {% else %}
+            <li><a href="/docs/getting-started/packaging.html">Packaging</a></li>
+          {% endif %}
+          {% if page.url == '/docs/getting-started/teardown.html' %}
+            <li>Teardown</li>
+          {% else %}
+            <li><a href="/docs/getting-started/teardown.html">Teardown</a></li>
+          {% endif %}
+          {% if page.url == '/docs/getting-started/rebuild.html' %}
+            <li>Rebuild Instantly</li>
+          {% else %}
+            <li><a href="/docs/getting-started/rebuild.html">Rebuild Instantly</a></li>
+          {% endif %}
         </ol>
       </div>
 

--- a/docs/getting-started/boxes.md
+++ b/docs/getting-started/boxes.md
@@ -91,3 +91,5 @@ $ vagrant up
 $ vagrant destroy
 ...
 {% endhighlight %}
+
+[&larr; Project Setup](/docs/getting-started/setup.html) &middot; Boxes &middot; [SSH &rarr;](/docs/getting-started/ssh.html)

--- a/docs/getting-started/index.md
+++ b/docs/getting-started/index.md
@@ -72,3 +72,5 @@ any Vagrant environment, the above is all any developer will need to create
 their development environment! Note that the above snippet does actually
 create a fully functional 512MB virtual machine running Ubuntu in the
 background, although the machine doesn't do much in this state.
+
+Overview &middot; [Why Vagrant? &rarr;](/docs/getting-started/why.html)

--- a/docs/getting-started/introduction.md
+++ b/docs/getting-started/introduction.md
@@ -33,3 +33,5 @@ end
 As you can see, a Vagrantfile is simply Ruby code which typically contains a Vagrant
 configuration block. For most commands, Vagrant will first load the project's
 Vagrantfile for configuration.
+
+[&larr; Why Vagrant?](/docs/getting-started/why.html) &middot; Introduction &middot; [Project Setup &rarr;](/docs/getting-started/setup.html)

--- a/docs/getting-started/packaging.md
+++ b/docs/getting-started/packaging.md
@@ -83,3 +83,5 @@ mirrors the environment set up in previous steps of the guide. Notice that
 they didn't have to do do provisioning, or set up anything on their system
 (other than Vagrant), etc. Distributing development environments has never
 been so easy.
+
+[&larr; Port Forwarding](/docs/getting-started/ports.html) &middot; Packaging &middot; [Teardown &rarr;](/docs/getting-started/teardown.html)

--- a/docs/getting-started/ports.md
+++ b/docs/getting-started/ports.md
@@ -53,3 +53,5 @@ were setup, you could be developing those technologies as well.
 
 For fun, you can also edit the `index.html` file, save it, refresh your
 browser, and immediately see your changes served directly from your VM.
+
+[&larr; Provisioning](/docs/getting-started/provisioning.html) &middot; Port Forwarding &middot; [Packaging &rarr;](/docs/getting-started/packaging.html)

--- a/docs/getting-started/provisioning.md
+++ b/docs/getting-started/provisioning.md
@@ -70,3 +70,5 @@ vagrant@vagrantup:~$
 
 In the next step of the getting started guide, we'll show you how to view
 your website using your own browser.
+
+[&larr; SSH](/docs/getting-started/ssh.html) &middot; Provisioning &middot; [Port Forwarding &rarr;](/docs/getting-started/ports.html)

--- a/docs/getting-started/rebuild.md
+++ b/docs/getting-started/rebuild.md
@@ -28,3 +28,5 @@ $ vagrant up
 completes setting up your environment, it should be exactly as
 you remembered it: same server layout, same dependency versions,
 no extraneous software, etc.
+
+[&larr; Teardown](/docs/getting-started/teardown.html) &middot; Rebuild Instantly

--- a/docs/getting-started/setup.md
+++ b/docs/getting-started/setup.md
@@ -50,3 +50,5 @@ in pre-existing project folders.
     with other types of web projects.
   </p>
 </div>
+
+[&larr; Introduction](/docs/getting-started/introduction.html) &middot; Project Setup &middot; [Boxes &rarr;](/docs/getting-started/boxes.html)

--- a/docs/getting-started/ssh.md
+++ b/docs/getting-started/ssh.md
@@ -53,3 +53,5 @@ index.html Vagrantfile
 The VM has both read and write access to the shared folder.
 
 **Remember: Any changes are mirrored across both systems.**
+
+[&larr; Boxes](/docs/getting-started/boxes.html) &middot; SSH &middot; [Provisioning &rarr;](/docs/getting-started/provisioning.html)

--- a/docs/getting-started/teardown.md
+++ b/docs/getting-started/teardown.md
@@ -53,3 +53,5 @@ your environment will be rebuilt.
 The benefit of this is that your disk space is completely restored to
 pre-VM state, saving you about 1 GB on average. The cost is that you must
 wait for a full rebuild when you `vagrant up` again.
+
+[&larr; Packaging](/docs/getting-started/packaging.html) &middot; Teardown &middot; [Rebuild Instantly &rarr;](/docs/getting-started/rebuild.html)

--- a/docs/getting-started/why.md
+++ b/docs/getting-started/why.md
@@ -44,3 +44,5 @@ If you've ever maintained a large web application, one of the hardest parts is o
 Message queues, caching, database servers and other infrastructure pieces mean a lot of installation
 and a lot more configuration (see [case-in-point: insanity](http://www.robbyonrails.com/articles/2010/02/08/installing-ruby-on-rails-passenger-postgresql-mysql-oh-my-zsh-on-snow-leopard-fourth-edition)). Vagrant gives you the tools to build a development environment once and then easily distribute it to
 new members of your development team so you can get them to work and saving time, money and frustration.
+
+[&larr; Overview](/docs/getting-started/index.html) &middot; Why Vagrant? &middot; [Introduction &rarr;](/docs/getting-started/introduction.html)

--- a/scripts/generate-links.rb
+++ b/scripts/generate-links.rb
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+require 'rubygems'
+require 'active_support/all'
+
+a = %{
+<li><a href="/docs/getting-started/index.html">Overview</a></li>
+<li><a href="/docs/getting-started/why.html">Why Vagrant?</a></li>
+<li><a href="/docs/getting-started/introduction.html">Introduction</a></li>
+<li><a href="/docs/getting-started/setup.html">Project Setup</a></li>
+<li><a href="/docs/getting-started/boxes.html">Boxes</a></li>
+<li><a href="/docs/getting-started/ssh.html">SSH</a></li>
+<li><a href="/docs/getting-started/provisioning.html">Provisioning</a></li>
+<li><a href="/docs/getting-started/ports.html">Port Forwarding</a></li>
+<li><a href="/docs/getting-started/packaging.html">Packaging</a></li>
+<li><a href="/docs/getting-started/teardown.html">Teardown</a></li>
+<li><a href="/docs/getting-started/rebuild.html">Rebuild Instantly</a></li>
+}.split("\n").grep(/href/)
+
+Page = Struct.new(:number, :url, :title)
+number = 0
+pages = a.map do |line|
+  line =~ /href="(.*?)"/
+  url = $1
+  line =~ /">(.*?)<\/a/
+  title = $1
+  page = Page.new number, url, title
+  number += 1
+  page
+end
+
+###################################################
+# generates the list of linkes
+###################################################
+# pages.each do |page|
+#   puts %{
+# {% if page.url == '#{page.url}' %}
+#   <li>#{page.title}</li>
+# {% else %}
+#   <li><a href="#{page.url}">#{page.title}</a></li>
+# {% endif %}
+#   }.strip
+# end
+
+###################################################
+# generates the prev/next linkss
+###################################################
+# pages.each do |page|
+#   para = []
+#   unless page.number == 0
+#     prev_page = pages[page.number-1]
+#     para << "[&larr; #{prev_page.title}](#{prev_page.url}) &middot; "
+#   end
+#   para << page.title
+#   unless page.number == pages.length-1
+#     next_page = pages[page.number+1]
+#     para << " &middot; [#{next_page.title} &rarr;](#{next_page.url})"
+#   end
+#   puts para.join
+# end


### PR DESCRIPTION
*\* Note: I took out the CNAME file because otherwise my forked gh-pages wouldn't build. You should keep that part! **

hi,

Here are the links for the Getting Started section.

My github pages wouldn't work, so I'm not sure if they render perfectly.

In case you want to change the links, I added a script to generate them.

Best, thanks for your work,
Seamus
