### PR TITLE
Missing translation

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -9,6 +9,7 @@ en:
     errors:
       base_vm_not_found: The base VM with the name '%{name}' was not found.
       box_not_found: Box '%{name}' could not be found.
+      chef_not_detected: '%{binary}' binary does not exist.
       cli_missing_env: This command requires that a Vagrant environment be properly passed in as the last parameter.
       config_validation: |-
         There was a problem with the configuration of Vagrant. The error message(s)


### PR DESCRIPTION
Guys, I _think_ this is how the missing translation (from https://github.com/drnic/vagrant/blob/master/lib/vagrant/provisioners/chef.rb#L82) should work. I couldn't actually get it to display; perhaps you can check it?
