### PR TITLE
Fixed a syntax error

### DIFF
--- a/templates/commands/init/Vagrantfile.erb
+++ b/templates/commands/init/Vagrantfile.erb
@@ -24,7 +24,7 @@ Vagrant::Config.run do |config|
   # Share an additional folder to the guest VM. The first argument is
   # an identifier, the second is the path on the guest to mount the
   # folder, and the third is the path on the host to the actual folder.
-  # config.vm.share_folder "v-data", "/vagrant_data", "../data")
+  # config.vm.share_folder("v-data", "/vagrant_data", "../data")
 
   # Enable provisioning with chef solo, specifying a cookbooks path (relative
   # to this Vagrantfile), and adding some recipes and/or roles.


### PR DESCRIPTION
The auto-generated Vagrantfile runs into a syntax error when you uncomment the shared folder example.  Just needed to add a paren.
