### PR TITLE
Feature/package recursive include

### DIFF
--- a/lib/vagrant/action/general/package.rb
+++ b/lib/vagrant/action/general/package.rb
@@ -68,7 +68,11 @@ module Vagrant
           files_to_copy.each do |from, to|
             @env.ui.info I18n.t("vagrant.actions.general.package.packaging", :file => from)
             FileUtils.mkdir_p(to.parent)
-            FileUtils.cp(from, to)
+            if FileTest.file?(from)
+              FileUtils.cp(from, to)
+            else
+              FileUtils.cp_r(Dir.glob(from), to.parent)
+            end
           end
         end
 

--- a/test/vagrant/action/general/package_test.rb
+++ b/test/vagrant/action/general/package_test.rb
@@ -173,7 +173,21 @@ class PackageGeneralActionTest < Test::Unit::TestCase
         seq = sequence("seq")
         @instance.files_to_copy.each do |from, to|
           FileUtils.expects(:mkdir_p).with(to.parent).in_sequence(seq)
+          FileTest.expects(:file?).with(from).returns(true).in_sequence(seq)
           FileUtils.expects(:cp).with(from, to).in_sequence(seq)
+        end
+
+        @instance.copy_include_files
+      end
+
+      should "create the include directory and recursively copy globbed files to it" do
+        @env["package.include"] = ["foo*.txt"]
+        seq = sequence("seq")
+        @instance.files_to_copy.each do |from, to|
+          FileUtils.expects(:mkdir_p).with(to.parent).in_sequence(seq)
+          FileTest.expects(:file?).with(from).returns(false).in_sequence(seq)
+          Dir.expects(:glob).with(from).returns(from).in_sequence(seq)
+          FileUtils.expects(:cp_r).with(from, to.parent).in_sequence(seq)
         end
 
         @instance.copy_include_files


### PR DESCRIPTION
Hi,

I'm proposing here a feature to include recursively files into the packaged box.
It's useful to bundle a set of puppet manifests (or chef cookbooks), or anything else with a given box.

Thanks!
