### PR TITLE
Add the possibility to set Puppet options in Vagrantfile

### DIFF
--- a/lib/vagrant/provisioners/puppet.rb
+++ b/lib/vagrant/provisioners/puppet.rb
@@ -11,11 +11,13 @@ module Vagrant
     attr_accessor :manifest_file
     attr_accessor :manifests_path
     attr_accessor :pp_path
+    attr_accessor :options
 
     def initialize
       @manifest_file = ""
       @manifests_path = "manifests"
       @pp_path = "/tmp/vagrant-puppet"
+      @options = []
     end
   end
 
@@ -66,7 +68,7 @@ module Vagrant
     end 
 
     def run_puppet_client
-      command = "cd #{env.config.puppet.pp_path} && sudo -E puppet #{@manifest}"
+      command = "cd #{env.config.puppet.pp_path} && sudo -E puppet #{env.config.puppet.options.join(" ")} #{@manifest}"
 
       env.ui.info I18n.t("vagrant.provisioners.puppet.running_puppet")
 

--- a/test/vagrant/provisioners/puppet_test.rb
+++ b/test/vagrant/provisioners/puppet_test.rb
@@ -110,7 +110,13 @@ class PuppetProvisionerTest < Test::Unit::TestCase
     end
 
     should "cd into the pp_path directory and run puppet" do
-      @ssh.expects(:exec!).with("cd #{@env.config.puppet.pp_path} && sudo -E puppet #{@manifest}").once
+      @ssh.expects(:exec!).with("cd #{@env.config.puppet.pp_path} && sudo -E puppet  #{@manifest}").once
+      @action.run_puppet_client
+    end
+
+    should "cd into the pp_path directory and run puppet with given options" do
+      @env.config.puppet.options = ["--modulepath", "modules", "--verbose"]
+      @ssh.expects(:exec!).with("cd #{@env.config.puppet.pp_path} && sudo -E puppet --modulepath modules --verbose #{@manifest}").once
       @action.run_puppet_client
     end
 


### PR DESCRIPTION
Hi,

This patch allows to add options to the puppet run when provisionning with puppet.
This is useful if you want to add puppet modulepath or verbose/debug mode.

Thanks,
Brice
