### PR TITLE
BSD/OSX hosts using GNU sed produces an error when cleaning nfs shares

### DIFF
--- a/lib/vagrant/hosts/bsd.rb
+++ b/lib/vagrant/hosts/bsd.rb
@@ -42,7 +42,7 @@ module Vagrant
           if $?.to_i == 0
             # Use sed to just strip out the block of code which was inserted
             # by Vagrant
-            system("sudo sed -e '/^# VAGRANT-BEGIN: #{env.vm.uuid}/,/^# VAGRANT-END: #{env.vm.uuid}/ d' -i bak /etc/exports")
+            system("sudo sed -e '/^# VAGRANT-BEGIN: #{env.vm.uuid}/,/^# VAGRANT-END: #{env.vm.uuid}/ d' -ibak /etc/exports")
           end
         end
       end


### PR DESCRIPTION
BSD or OSX hosts with GNU sed installed in the path choke on the current '-i bak' usage of the -i options of sed when cleaning the nfs shares from /etc/exports.
This patch removes the space, which makes the command run fine on BSD sed and GNU sed. 

Thanks,
Brice
