### PR TITLE
Add ForwardX11 support for ssh

### DIFF
--- a/config/default.rb
+++ b/config/default.rb
@@ -12,6 +12,7 @@ Vagrant::Config.run do |config|
   config.ssh.timeout = 30
   config.ssh.private_key_path = File.expand_path("keys/vagrant", Vagrant.source_root)
   config.ssh.forward_agent = false
+  config.ssh.forward_x11 = false
 
   config.vm.auto_port_range = (2200..2250)
   config.vm.box_ovf = "box.ovf"

--- a/lib/vagrant/action/vm/nfs.rb
+++ b/lib/vagrant/action/vm/nfs.rb
@@ -114,7 +114,7 @@ module Vagrant
           @env.ui.info I18n.t("vagrant.actions.vm.nfs.mounting")
 
           # Only mount the folders which have a guest path specified
-          am_folders = folders.select { |folder| folder[:guestpath] }
+          am_folders = Hash[*folders.select { |name, options| options && options[:guestpath] }.flatten]
           @env["vm"].system.mount_nfs(host_ip, am_folders)
         end
 

--- a/lib/vagrant/config/ssh.rb
+++ b/lib/vagrant/config/ssh.rb
@@ -11,6 +11,7 @@ module Vagrant
       attr_accessor :timeout
       attr_writer :private_key_path
       attr_accessor :forward_agent
+      attr_accessor :forward_x11
 
       def private_key_path
         File.expand_path(@private_key_path, env.root_path)

--- a/lib/vagrant/ssh.rb
+++ b/lib/vagrant/ssh.rb
@@ -42,6 +42,7 @@ module Vagrant
                          "-o StrictHostKeyChecking=no", "-o IdentitiesOnly=yes",
                          "-i #{options[:private_key_path]}"]
       command_options << "-o ForwardAgent=yes" if env.config.ssh.forward_agent
+      command_options << "-o ForwardX11=yes" if env.config.ssh.forward_x11
 
       # Some hackery going on here. On Mac OS X Leopard (10.5), exec fails
       # (GH-51). As a workaround, we fork and wait. On all other platforms,

--- a/test/vagrant/action/vm/nfs_test.rb
+++ b/test/vagrant/action/vm/nfs_test.rb
@@ -160,7 +160,7 @@ class NFSVMActionTest < Test::Unit::TestCase
     context "mounting folders" do
       setup do
         @instance.stubs(:host_ip).returns("foo")
-        @instance.stubs(:folders).returns([{:guestpath => "foo"}])
+        @instance.stubs(:folders).returns(:foo => {:guestpath => "foo"})
       end
 
       should "mount the folders on the system" do
@@ -169,8 +169,8 @@ class NFSVMActionTest < Test::Unit::TestCase
       end
 
       should "not mount folders which have no guest path" do
-        @instance.stubs(:folders).returns([{}])
-        @vm.system.expects(:mount_nfs).with(@instance.host_ip, [])
+        @instance.stubs(:folders).returns({})
+        @vm.system.expects(:mount_nfs).with(@instance.host_ip, {})
         @instance.mount_folders
       end
     end

--- a/test/vagrant/ssh_test.rb
+++ b/test/vagrant/ssh_test.rb
@@ -69,6 +69,17 @@ class SshTest < Test::Unit::TestCase
       @ssh.connect
     end
 
+    should "add forward X11 option if enabled" do
+      @env.config.ssh.forward_x11 = true
+      ssh_exec_expect(@ssh.port,
+                      @env.config.ssh.private_key_path,
+                      @env.config.ssh.username,
+                      @env.config.ssh.host) do |args|
+        assert args =~ /-o ForwardX11=yes/
+      end
+      @ssh.connect
+    end
+
     context "on leopard" do
       setup do
         Vagrant::Util::Platform.stubs(:leopard?).returns(true)


### PR DESCRIPTION
Hey, 

I run my cucumber/capybara features inside the vm, and with ssh X11 forwarding it is pretty convenient (browser pops in the host, at least on OS X). 

I believe that this option should be useful to others too. 

Many thanks for your efforts. 
