### PR TITLE
Fix to allow maproot as an nfs mount option

### DIFF
--- a/config/default.rb
+++ b/config/default.rb
@@ -36,6 +36,7 @@ Vagrant::Config.run do |config|
 
   config.nfs.map_uid = :auto
   config.nfs.map_gid = :auto
+  config.nfs.map_root = false
 
   config.package.name = 'package.box'
 end

--- a/lib/vagrant/action/vm/nfs.rb
+++ b/lib/vagrant/action/vm/nfs.rb
@@ -78,6 +78,7 @@ module Vagrant
             opts[:nfs] = {} if !opts.is_a?(Hash)
             opts[:map_uid] = prepare_permission(:uid, opts)
             opts[:map_gid] = prepare_permission(:gid, opts)
+            opts[:map_root] = opts.has_key?(:map_root) ? opts[:map_root] : @env["config"].nfs.map_root
 
             acc[key] = opts
             acc
@@ -150,6 +151,7 @@ module Vagrant
           raise Errors::NFSHostRequired if @env["host"].nil?
           raise Errors::NFSNotSupported if !@env["host"].nfs?
           raise Errors::NFSNoHostNetwork if @env["config"].vm.network_options.empty?
+          raise Errors::NFSImpossibleOptions if @env["config"].nfs.map_root && @env["config"].nfs.map_uid
         end
       end
     end

--- a/lib/vagrant/config/nfs.rb
+++ b/lib/vagrant/config/nfs.rb
@@ -5,6 +5,7 @@ module Vagrant
 
       attr_accessor :map_uid
       attr_accessor :map_gid
+      attr_accessor :map_root
     end
   end
 end

--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -205,6 +205,11 @@ module Vagrant
       error_key(:no_host_network, "vagrant.actions.vm.nfs")
     end
 
+    class NFSImpossibleOptions < VagrantError
+      status_code(34)
+      error_key(:impossible_options, "vagrant.actions.vm.nfs")
+    end
+
     class NoEnvironmentError < VagrantError
       status_code(3)
       error_key(:no_env)

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -334,6 +334,10 @@ en:
             The host class is reporting that NFS is not supported by this host,
             or `nfsd` may not be installed. Please verify that `nfsd` is installed
             on your machine, and retry.
+          impossible_options: |-
+            The options you've specified for this NFS conneciton are not valid. This is 
+            likely due to having specified both map_root and map_uid, which are mutually
+            exclusive
           exporting: Exporting NFS shared folders...
           mounting: Mounting NFS shared folders...
         persist:

--- a/templates/nfs/exports.erb
+++ b/templates/nfs/exports.erb
@@ -1,5 +1,5 @@
 # VAGRANT-BEGIN: <%= uuid %>
 <% folders.each do |name, opts| %>
-<%= opts[:hostpath] %> <%= ip %><% if opts[:map_uid] -%> -mapall=<%= [opts[:map_uid],opts[:map_gid]].compact.join(":") %><% end -%>
+  <%= opts[:hostpath] %> <%= ip %><% if opts[:map_root] -%> -maproot=root <% end -%><% if opts[:map_uid] -%> -mapall=<%= [opts[:map_uid],opts[:map_gid]].compact.join(":") %><% end -%>
 <% end %>
 # VAGRANT-END: <%= uuid %>


### PR DESCRIPTION
NFS as it's used in Vagrant 4.0 currently maps all filesystem access in the guest (including that of root) onto a single uid/gid on the host. This makes it impossible to perform operations as root on the shared folder inside the guest (in particular, things like chown and chgrp aren't possible). This is a major dealbreaker for many uses of vagrant VMs, as one cannot give files in a shared project away to (for example) apache. 

This can be mostly mitigated by mounting the filesystem with the maproot option, as this patch provides. However, because that mode maps non root guest access 1:1 with uids on the host, the issue of host-side permissions becomes important, so it's not a complete fix.

A possible final piece of the puzzle (which this request doesn't address) is to provide a way to change the uid of the remote vagrant user to match that of the current host user. This would provide a (somewhat inelegant) way to get around this 1:1 mapping by making the users of interest on both the host and guest machines share the same uid.
