### PR TITLE
Fixed warning on ssh login

### DIFF
--- a/lib/vagrant/ssh.rb
+++ b/lib/vagrant/ssh.rb
@@ -44,7 +44,11 @@ module Vagrant
                          "-o StrictHostKeyChecking=no", "-o IdentitiesOnly=yes",
                          "-i #{options[:private_key_path]}"]
       command_options << "-o ForwardAgent=yes" if env.config.ssh.forward_agent
-      command_options << "-o ForwardX11=yes" if env.config.ssh.forward_x11
+
+      if env.config.ssh.forward_x11
+         command_options << "-o ForwardX11=yes"
+         command_options << "-o ForwardX11Trusted=yes"
+       end
 
       # Some hackery going on here. On Mac OS X Leopard (10.5), exec fails
       # (GH-51). As a workaround, we fork and wait. On all other platforms,


### PR DESCRIPTION
The warning was 

`Warning: untrusted X11 forwarding setup failed: xauth key data not generated`
Completely harmless, I think, but mildly annoying. 

After digging around a bit I came up with this fix. 

Cheers.
