### PR TITLE
Get provisioners working again on Debian "lenny"

### DIFF
--- a/lib/vagrant/ssh/session.rb
+++ b/lib/vagrant/ssh/session.rb
@@ -32,7 +32,7 @@ module Vagrant
       # of `sudo`.
       def sudo!(commands, options=nil, &block)
         session.open_channel do |ch|
-          ch.exec("sudo -i sh") do |ch2, success|
+          ch.exec("sudo sh -l") do |ch2, success|
             # Output each command as if they were entered on the command line
             [commands].flatten.each do |command|
               ch2.send_data "#{command}\n"


### PR DESCRIPTION
As discussed on the list, the version of sudo (1.6.9) in Debian "lenny" has a bug that breaks "sudo -i sh".  This patch makes Vagrant::SSH::Session#sudo! use "sudo sh -l" instead, which I believe will have the same effect, and works in lenny.
