### PR TITLE
chef server knobs

### DIFF
--- a/lib/vagrant/provisioners/chef_server.rb
+++ b/lib/vagrant/provisioners/chef_server.rb
@@ -12,12 +12,16 @@ module Vagrant
         attr_accessor :validation_key_path
         attr_accessor :validation_client_name
         attr_accessor :client_key_path
+        attr_accessor :file_cache_path
+        attr_accessor :file_backup_path
 
         def initialize
           super
 
           @validation_client_name = "chef-validator"
           @client_key_path = "/etc/chef/client.pem"
+          @file_cache_path = "/srv/chef/file_store"
+          @file_backup_path = "/srv/chef/cache"
         end
 
         def validate(errors)
@@ -65,7 +69,9 @@ module Vagrant
           :chef_server_url => config.chef_server_url,
           :validation_client_name => config.validation_client_name,
           :validation_key => guest_validation_key_path,
-          :client_key => config.client_key_path
+          :client_key => config.client_key_path,
+          :file_cache_path => config.file_cache_path,
+          :file_backup_path => config.file_backup_path
         })
       end
 

--- a/templates/chef_server_client.erb
+++ b/templates/chef_server_client.erb
@@ -10,8 +10,8 @@ validation_client_name "<%= validation_client_name %>"
 validation_key         "<%= validation_key %>"
 client_key             "<%= client_key %>"
 
-file_store_path    "/srv/chef/file_store"
-file_cache_path    "/srv/chef/cache"
+file_cache_path    "<%= file_cache_path %>"
+file_backup_path   "<%= file_backup_path %>"
 
 pid_file           "/var/run/chef/chef-client.pid"
 

--- a/test/vagrant/provisioners/chef_server_test.rb
+++ b/test/vagrant/provisioners/chef_server_test.rb
@@ -159,7 +159,9 @@ class ChefServerProvisionerTest < Test::Unit::TestCase
         :chef_server_url => @config.chef_server_url,
         :validation_client_name => @config.validation_client_name,
         :validation_key => @action.guest_validation_key_path,
-        :client_key => @config.client_key_path
+        :client_key => @config.client_key_path,
+        :file_cache_path => @config.file_cache_path,
+        :file_backup_path => @config.file_backup_path
       })
 
       @action.setup_server_config


### PR DESCRIPTION
When using the :chef_server provisioner, I'd like to be able to configure the :file_cache_path and :file_backup_path parameters.

Also, :file_store_path is no longer used by chef (deprecated).
