### PR TITLE
Fix issue with port forwarding not respecting protocol option.

### DIFF
--- a/lib/vagrant/action/vm/forward_ports.rb
+++ b/lib/vagrant/action/vm/forward_ports.rb
@@ -125,6 +125,7 @@ module Vagrant
           port.name = name
           port.guestport = options[:guestport]
           port.hostport = options[:hostport]
+          port.protocol = options[:protocol] || :tcp
           @env["vm"].vm.network_adapters[options[:adapter]].nat_driver.forwarded_ports << port
         end
       end

--- a/lib/vagrant/config/vm.rb
+++ b/lib/vagrant/config/vm.rb
@@ -35,7 +35,7 @@ module Vagrant
         options = {
           :guestport  => guestport,
           :hostport   => hostport,
-          :protocol   => "TCP",
+          :protocol   => :tcp,
           :adapter    => 0,
           :auto       => false
         }.merge(options || {})


### PR DESCRIPTION
There are two issues that prevent changing the protocol to UDP for port forwarding.  Currently, the NATForwardedPort is not passed the protocol option.  The other issue is the default protocol being sent from config.vm.forward_port upper-case TCP, however the protocol mappings defined in the virtualbox library are lowercase.
