### PR TITLE
Ticket/320

### DIFF
--- a/templates/commands/init/Vagrantfile.erb
+++ b/templates/commands/init/Vagrantfile.erb
@@ -26,6 +26,25 @@ Vagrant::Config.run do |config|
   # folder, and the third is the path on the host to the actual folder.
   # config.vm.share_folder "v-data", "/vagrant_data", "../data"
 
+  # Enable provisioning with Puppet stand alone.  Puppet manifests
+  # are contained in a directory path relative to this Vagrantfile.
+  # You will need to create the manifests directory and a manifest in
+  # the file <%= box_name %>.pp in the manifests_path directory.
+  #
+  # An example Puppet manifest to provision the message of the day:
+  #
+  # # File { owner => 0, group => 0, mode => 0644 }
+  # #
+  # # file { '/etc/motd':
+  # #   content => "Welcome to your Vagrant-built virtual machine!
+  # #               Managed by Puppet.\n"
+  # # }
+  #
+  # config.vm.provision :puppet do |puppet|
+  #   puppet.manifests_path = "manifests"
+  #   puppet.manifest_file  = "<%= box_name %>.pp"
+  # end
+
   # Enable provisioning with chef solo, specifying a cookbooks path (relative
   # to this Vagrantfile), and adding some recipes and/or roles.
   #


### PR DESCRIPTION
This commit provides a patch to address ticket #320 in the issue tracker.

https://github.com/mitchellh/vagrant/issues/#issue/320

The commit message is:

```
Add puppet provisioner config example.

This commit should provide enough example information to get started
provisioning a box using the Puppet provisioner.

The goal of this commit is to provide just enough information to quickly
get started but not so much that the configuration file is polluted or
confuses the user.
```

Cheers,
-Jeff McCune
