### PR TITLE
stupid non-critical bug in gentoo network template

### DIFF
--- a/templates/network_entry_gentoo.erb
+++ b/templates/network_entry_gentoo.erb
@@ -3,5 +3,3 @@
 # Please do not modify any of these contents.
 config_eth<%= net_options[:adapter] %>=("<%= net_options[:ip] %> netmask <%= net_options[:netmask] %>")
 #VAGRANT-END
-~            
-


### PR DESCRIPTION
Due to an additional character the network template generates lots of warnings when restarted.
