### PR TITLE
Adding extra runtime config options for chef.

### DIFF
--- a/lib/vagrant/provisioners/chef.rb
+++ b/lib/vagrant/provisioners/chef.rb
@@ -81,6 +81,8 @@ module Vagrant
         attr_accessor :https_proxy_user
         attr_accessor :https_proxy_pass
         attr_accessor :no_proxy
+        attr_accessor :binary_path
+        attr_accessor :binary_env
 
         def initialize
           @provisioning_path = "/tmp/vagrant-chef"
@@ -93,6 +95,8 @@ module Vagrant
           @https_proxy_user = nil
           @https_proxy_pass = nil
           @no_proxy = nil
+          @binary_path = nil
+          @binary_env = nil
         end
 
         # Returns the run list for the provisioning

--- a/lib/vagrant/provisioners/chef_server.rb
+++ b/lib/vagrant/provisioners/chef_server.rb
@@ -40,7 +40,7 @@ module Vagrant
       end
 
       def provision!
-        verify_binary("chef-client")
+        verify_binary(chef_client_binary)
         chown_provisioning_folder
         create_client_key_folder
         upload_validation_key
@@ -77,7 +77,7 @@ module Vagrant
 
       def run_chef_client
         commands = ["cd #{config.provisioning_path}",
-                    "chef-client -c client.rb -j dna.json"]
+                    "#{config.binary_env} #{chef_client_binary} -c client.rb -j dna.json"]
 
         env.ui.info I18n.t("vagrant.provisioners.chef.running_client")
         vm.ssh.execute do |ssh|
@@ -88,6 +88,14 @@ module Vagrant
               env.ui.info("#{data}: #{type}")
             end
           end
+        end
+      end
+
+      def chef_client_binary
+        if config.binary_path.nil? || config.binary_path.empty?
+          "chef-client"
+        else
+          File.join(config.binary_path, "chef-client")
         end
       end
 

--- a/lib/vagrant/provisioners/chef_solo.rb
+++ b/lib/vagrant/provisioners/chef_solo.rb
@@ -30,7 +30,7 @@ module Vagrant
       end
 
       def provision!
-        verify_binary("chef-solo")
+        verify_binary(chef_solo_binary)
         chown_provisioning_folder
         setup_json
         setup_solo_config
@@ -60,7 +60,7 @@ module Vagrant
       end
 
       def run_chef_solo
-        commands = ["cd #{config.provisioning_path}", "chef-solo -c solo.rb -j dna.json"]
+        commands = ["cd #{config.provisioning_path}", "#{config.binary_env} #{chef_solo_binary} -c solo.rb -j dna.json"]
 
         env.ui.info I18n.t("vagrant.provisioners.chef.running_solo")
         vm.ssh.execute do |ssh|
@@ -71,6 +71,14 @@ module Vagrant
               env.ui.info("#{data}: #{type}")
             end
           end
+        end
+      end
+
+      def chef_solo_binary
+        if config.binary_path.nil? || config.binary_path.empty?
+          "chef-solo"
+        else
+          File.join(config.binary_path, "chef-solo")
         end
       end
 


### PR DESCRIPTION
Adding chef.binary_path and chef.binary_env to the config options for controlling where to find chef-solo/chef-client and how to run them.

Here's a config example:
chef.binary_env = "GEM_HOME=/opt/rightscale/sandbox/lib/ruby/gems/1.8 GEM_PATH=/opt/rightscale/sandbox/lib/ruby/gems/1.8"
chef.binary_path = "/opt/rightscale/sandbox/bin/"

This was motivated by developing for the RightScale Chef environment.  They've created a sandboxed ruby environment in addition to the system ruby and rvm rubies.  This was the only sane way I had to make sure that vagrant was running the sandboxed chef every time (just like production).
