### PR TITLE
Add NFS support for Arch Linux

### DIFF
--- a/lib/vagrant/hosts.rb
+++ b/lib/vagrant/hosts.rb
@@ -3,5 +3,6 @@ module Vagrant
     autoload :Base,  'vagrant/hosts/base'
     autoload :BSD,   'vagrant/hosts/bsd'
     autoload :Linux, 'vagrant/hosts/linux'
+    autoload :Arch,  'vagrant/hosts/arch'
   end
 end

--- a/lib/vagrant/hosts/arch.rb
+++ b/lib/vagrant/hosts/arch.rb
@@ -1,0 +1,27 @@
+module Vagrant
+  module Hosts
+    class Arch < Linux
+      def nfs_export(ip, folders)
+        output = TemplateRenderer.render('nfs/exports_linux',
+                                         :uuid => env.vm.uuid,
+                                         :ip => ip,
+                                         :folders => folders)
+
+        env.ui.info I18n.t("vagrant.hosts.arch.nfs_export.prepare")
+        sleep 0.5
+
+        output.split("\n").each do |line|
+          # This should only ask for administrative permission once, even
+          # though its executed in multiple subshells.
+          system(%Q[sudo su root -c "echo '#{line}' >> /etc/exports"])
+        end
+
+        # We run restart here instead of "update" just in case nfsd
+        # is not starting
+        system("sudo /etc/rc.d/rpcbind restart")
+        system("sudo /etc/rc.d/nfs-common restart")
+        system("sudo /etc/rc.d/nfs-server restart")
+      end
+    end
+  end
+end

--- a/lib/vagrant/hosts/base.rb
+++ b/lib/vagrant/hosts/base.rb
@@ -31,6 +31,7 @@ module Vagrant
           classes = {
             :darwin => BSD,
             :bsd => BSD,
+            :arch => Arch,
             :linux => Linux
           }
 

--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -28,6 +28,11 @@ module Vagrant
           false
         end
 
+        def arch?
+          linux?() and File.exist?('/etc/rc.conf') and
+            File.exist?('/etc/pacman.conf') and File.exist?('/etc/rc.d/')
+        end
+
         # Returns boolean noting whether this is a 64-bit CPU. This
         # is not 100% accurate and there could easily be false negatives.
         #

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -451,6 +451,10 @@ en:
         nfs_export:
           prepare: "Preparing to edit /etc/exports. Administrator privileges will be required..."
 
+      arch:
+        nfs_export:
+          prepare: "Preparing to edit /etc/exports. Administrator privileges will be required..."
+
     provisioners:
       chef:
         json: "Generating chef JSON and uploading..."


### PR DESCRIPTION
Added NFS support for Arch Linux under `vagrant/hosts` by adding `vagrant/hosts/arch` and a platform test for Arch Linux.
