### PR TITLE
This is a patch for ruby 1.8.x users.

### DIFF
--- a/lib/vagrant/action/vm/nfs.rb
+++ b/lib/vagrant/action/vm/nfs.rb
@@ -115,6 +115,7 @@ module Vagrant
 
           # Only mount the folders which have a guest path specified
           am_folders = folders.select { |name, folder| folder[:guestpath] }
+          am_folders = Hash[*am_folders.flatten] if am_folders.is_a?(Array)
           @env["vm"].system.mount_nfs(host_ip, Hash[am_folders])
         end
 


### PR DESCRIPTION
Hash#select in ruby 1.8.6 will return an array while 1.9.x returns a hash. As is vagrant 0.7.3 will error our when mounting nfs shares with a 

/usr/local/rvm/gems/ree-1.8.6-20090610/gems/vagrant-0.7.3/lib/vagrant/action/vm/nfs.rb:119:in `[]': odd number of arguments for Hash (ArgumentError)

This is because am_folders is in the form of 

[[:app => {}]]
