### PR TITLE
Suppress "Permanently added '[127.0.0.1]:2222' (RSA) to the list of known hosts."

### DIFF
--- a/lib/vagrant/ssh.rb
+++ b/lib/vagrant/ssh.rb
@@ -42,7 +42,7 @@ module Vagrant
       # Command line options
       command_options = ["-p #{options[:port]}", "-o UserKnownHostsFile=/dev/null",
                          "-o StrictHostKeyChecking=no", "-o IdentitiesOnly=yes",
-                         "-i #{options[:private_key_path]}"]
+                         "-i #{options[:private_key_path]}", "-o LogLevel=ERROR"]
       command_options << "-o ForwardAgent=yes" if env.config.ssh.forward_agent
 
       if env.config.ssh.forward_x11


### PR DESCRIPTION
Vagrant already disables StrictHostKeyChecking and redirects UserKnownHostsFile to /dev/null, so we may as well suppress the meaningless warning also.

Just a personal preference. If there's something wrong with suppressing warnings here let me know.
