### PR TITLE
Data Bags for Chef Solo runs

### DIFF
--- a/lib/vagrant/provisioners/chef_solo.rb
+++ b/lib/vagrant/provisioners/chef_solo.rb
@@ -7,6 +7,7 @@ module Vagrant
       class Config < Chef::Config
         attr_accessor :cookbooks_path
         attr_accessor :roles_path
+        attr_accessor :data_bags_path
         attr_accessor :recipe_url
 
         def initialize
@@ -14,6 +15,7 @@ module Vagrant
 
           @cookbooks_path = ["cookbooks", [:vm, "cookbooks"]]
           @roles_path = []
+          @data_bags_path = []
         end
 
         def validate(errors)
@@ -27,6 +29,7 @@ module Vagrant
       def prepare
         share_cookbook_folders
         share_role_folders
+        share_data_bags_folders
       end
 
       def provision!
@@ -49,6 +52,12 @@ module Vagrant
         end
       end
 
+      def share_data_bags_folders
+        host_data_bag_paths.each_with_index do |data_bag, i|
+          env.config.vm.share_folder("v-csdb-#{i}", data_bag_path(i), data_bag)
+        end
+      end
+
       def setup_solo_config
         setup_config("chef_solo_solo", "solo.rb", {
           :node_name => config.node_name,
@@ -56,6 +65,7 @@ module Vagrant
           :cookbooks_path => cookbooks_path,
           :recipe_url => config.recipe_url,
           :roles_path => roles_path,
+          :data_bags_path => data_bags_path,
         })
       end
 
@@ -122,6 +132,10 @@ module Vagrant
         host_folder_paths(config.roles_path)
       end
 
+      def host_data_bag_paths
+        host_folder_paths(config.data_bags_path)
+      end
+
       def cookbook_path(i)
         folder_path("cookbooks", i)
       end
@@ -130,12 +144,20 @@ module Vagrant
         folder_path("roles", i)
       end
 
+      def data_bag_path(i)
+        folder_path("data_bags", i)
+      end
+
       def cookbooks_path
         folders_path(config.cookbooks_path, "cookbooks").to_json
       end
 
       def roles_path
         folders_path(config.roles_path, "roles").to_json
+      end
+
+      def data_bags_path
+        folders_path(config.data_bags_path, "data_bags").to_json
       end
     end
   end

--- a/templates/chef_solo_solo.erb
+++ b/templates/chef_solo_solo.erb
@@ -6,6 +6,10 @@ cookbook_path <%= cookbooks_path %>
 role_path <%= roles_path %>
 log_level <%= log_level.inspect %>
 
+<% if data_bags_path %>
+data_bag_path <%= data_bags_path %>
+<% end %>
+
 <% if recipe_url -%>
 recipe_url "<%= recipe_url %>"
 <% end -%>

--- a/test/vagrant/provisioners/chef_solo_test.rb
+++ b/test/vagrant/provisioners/chef_solo_test.rb
@@ -42,6 +42,11 @@ class ChefSoloProvisionerTest < Test::Unit::TestCase
       @action.expects(:share_role_folders).once
       @action.prepare
     end
+
+    should "share data bag folders" do
+      @action.expects(:share_data_bags_folders).once
+      @action.prepare
+    end
   end
 
   context "provisioning" do
@@ -86,6 +91,22 @@ class ChefSoloProvisionerTest < Test::Unit::TestCase
       @action.share_role_folders
     end
   end
+  
+  context "sharing data bag folders" do
+    setup do
+      @host_data_bag_paths = ["foo", "bar"]
+      @action.stubs(:host_data_bag_paths).returns(@host_data_bag_paths)
+    end
+
+    should "share each data bag folder" do
+      share_seq = sequence("share_seq")
+      @host_data_bag_paths.each_with_index do |data_bag, i|
+        @env.config.vm.expects(:share_folder).with("v-csdb-#{i}", @action.data_bag_path(i), data_bag).in_sequence(share_seq)
+      end
+
+      @action.share_data_bags_folders
+    end
+  end
 
   context "host folder paths" do
     should "ignore VM paths" do
@@ -122,6 +143,15 @@ class ChefSoloProvisionerTest < Test::Unit::TestCase
       @config.stubs(:roles_path).returns("foo")
       @action.expects(:host_folder_paths).with(@config.roles_path).returns(result)
       assert_equal result, @action.host_role_paths
+    end
+  end
+  
+  context "host data bags paths" do
+    should "get folders path for configured data bag path" do
+      result = mock("result")
+      @config.stubs(:data_bags_path).returns("foo")
+      @action.expects(:host_folder_paths).with(@config.data_bags_path).returns(result)
+      assert_equal result, @action.host_data_bag_paths
     end
   end
 
@@ -179,6 +209,19 @@ class ChefSoloProvisionerTest < Test::Unit::TestCase
     end
   end
 
+  context "data bags path" do
+    should "return a proper path to a single data bag" do
+      expected = File.join(@config.provisioning_path, "data_bags-5")
+      assert_equal expected, @action.data_bag_path(5)
+    end
+
+    should "properly call folders path and return result" do
+      result = [:a, :b, :c]
+      @action.expects(:folders_path).with(@config.data_bags_path, "data_bags").once.returns(result)
+      assert_equal result.to_json, @action.data_bags_path
+    end
+  end
+
   context "generating and uploading chef solo configuration file" do
     setup do
       @vm.ssh.stubs(:upload!)
@@ -192,7 +235,8 @@ class ChefSoloProvisionerTest < Test::Unit::TestCase
         :provisioning_path => @config.provisioning_path,
         :cookbooks_path => @action.cookbooks_path,
         :recipe_url => @config.recipe_url,
-        :roles_path => @action.roles_path
+        :roles_path => @action.roles_path,
+        :data_bags_path => @action.data_bags_path
       })
 
       @action.setup_solo_config


### PR DESCRIPTION
Adding data bag support for chef-solo provisions:

```
  config.vm.provision :chef_solo do |chef|
    chef.provisioning_path = "/srv/chef"
    chef.cookbooks_path = ["cookbooks", "site-cookbooks"]
    chef.roles_path     = "roles"
    chef.data_bags_path = "data_bags"
    chef.add_role("development")
  end
```

This will share the specified data bag directly like it does with cookbooks/roles.  Currently (I'm going to make a pull request over to chef shortly), the best way to take advantage of this is to add a Mixin into one of your cookbooks (I'm putting mine in cookbooks/chef/libraries) that will read this new chef solo config option and do local parses of the shared json data bags.  I originally got the idea from the chef mailing list back in Feb: https://gist.github.com/967980.

Just take that code, drop it into your cookbooks in a library somewhere and it should work.
