### PR TITLE
consider adding port option to ssh config 

### DIFF
--- a/lib/vagrant/config/ssh.rb
+++ b/lib/vagrant/config/ssh.rb
@@ -12,6 +12,7 @@ module Vagrant
       attr_accessor :forward_agent
       attr_accessor :forward_x11
       attr_accessor :sudo_shell
+      attr_accessor :port
 
       def initialize
         @sudo_shell = "bash"

--- a/lib/vagrant/ssh.rb
+++ b/lib/vagrant/ssh.rb
@@ -154,6 +154,9 @@ module Vagrant
       pnum = opts[:port]
       return pnum if pnum
 
+      # Check if a port was specified in the config
+      return env.config.ssh.port if env.config.ssh.port
+      
       # Check if we have an SSH forwarded port
       pnum = nil
       env.vm.vm.network_adapters.each do |na|


### PR DESCRIPTION
Hey Mitchell, 

I have a usecase where I am bringing up pxeboot images withen vagrant. I was able to get this partially functional out of the box (or with a little tuning rather). But without being able to specify the ssh port as an option for host-only networking, I was unable to make a realistic setup of our datacenter because I can't make some nodes launch with NAT on eth0 and others with host-only on eth0. 

Specifically, I have this in my Vagrant file to specify the ip that the host-only instance will get:

  nova_config.ssh.host = '10.0.0.5'

but I can't specify the port, so it's useless without this patch.

Please let me know if there was another way to accomplish this better/simpler. 

Thanks,

Martin 
