### PR TITLE
Set the home directory to /root when using sudo

### DIFF
--- a/lib/vagrant/ssh/session.rb
+++ b/lib/vagrant/ssh/session.rb
@@ -34,7 +34,7 @@ module Vagrant
       # of `sudo`.
       def sudo!(commands, options=nil, &block)
         channel = session.open_channel do |ch|
-          ch.exec("sudo #{env.config.ssh.sudo_shell} -l") do |ch2, success|
+          ch.exec("sudo -H #{env.config.ssh.sudo_shell} -l") do |ch2, success|
             # Set the terminal
             ch2.send_data "export TERM=vt100\n"
 


### PR DESCRIPTION
Encountered this issue while using puppet. Created configuration file /root/.my.cnf
but mysql was looking for /home/vagrant/.my.cnf

Passing -H to sudo causes sudo to set env HOME=/root/
