### PR TITLE
provide absolute paths for solo.rb and dna.js in order to make it work co

### DIFF
--- a/lib/vagrant/provisioners/chef_solo.rb
+++ b/lib/vagrant/provisioners/chef_solo.rb
@@ -71,7 +71,8 @@ module Vagrant
 
       def run_chef_solo
         command_env = config.binary_env ? "#{config.binary_env} " : ""
-        commands = ["cd #{config.provisioning_path}", "#{command_env}#{chef_binary_path("chef-solo")} -c solo.rb -j dna.json"]
+        commands = ["cd #{config.provisioning_path}",
+                    "#{command_env}#{chef_binary_path("chef-solo")} -c #{config.provisioning_path}/solo.rb -j #{config.provisioning_path}/dna.json"]
 
         env.ui.info I18n.t("vagrant.provisioners.chef.running_solo")
         vm.ssh.execute do |ssh|

--- a/test/vagrant/provisioners/chef_solo_test.rb
+++ b/test/vagrant/provisioners/chef_solo_test.rb
@@ -91,7 +91,7 @@ class ChefSoloProvisionerTest < Test::Unit::TestCase
       @action.share_role_folders
     end
   end
-  
+
   context "sharing data bag folders" do
     setup do
       @host_data_bag_paths = ["foo", "bar"]
@@ -145,7 +145,7 @@ class ChefSoloProvisionerTest < Test::Unit::TestCase
       assert_equal result, @action.host_role_paths
     end
   end
-  
+
   context "host data bags paths" do
     should "get folders path for configured data bag path" do
       result = mock("result")
@@ -250,7 +250,7 @@ class ChefSoloProvisionerTest < Test::Unit::TestCase
     end
 
     should "cd into the provisioning directory and run chef solo" do
-      @ssh.expects(:sudo!).with(["cd #{@config.provisioning_path}", "chef-solo -c solo.rb -j dna.json"]).once
+      @ssh.expects(:sudo!).with(["cd #{@config.provisioning_path}", "chef-solo -c #{@config.provisioning_path}/solo.rb -j #{@config.provisioning_path}/dna.json"]).once
       @action.run_chef_solo
     end
 


### PR DESCRIPTION
provide absolute paths for solo.rb and dna.js in order to make it work correctly with the restart cookbook https://github.com/dreamcat4/site-cookbooks/tree/COOK-245/restart/
