### PR TITLE
config: share_folder add :optional parameter

### DIFF
--- a/lib/vagrant/config/vm.rb
+++ b/lib/vagrant/config/vm.rb
@@ -120,7 +120,8 @@ module Vagrant
         errors.add(I18n.t("vagrant.config.vm.base_mac_invalid")) if env.box && !base_mac
 
         shared_folders.each do |name, options|
-          if !File.directory?(File.expand_path(options[:hostpath].to_s, env.root_path))
+          if !File.directory?(File.expand_path(options[:hostpath].to_s, env.root_path)) &&
+            !options[:optional]
             errors.add(I18n.t("vagrant.config.vm.shared_folder_hostpath_missing",
                        :name => name,
                        :path => options[:hostpath]))

--- a/test/vagrant/action/vm/share_folders_test.rb
+++ b/test/vagrant/action/vm/share_folders_test.rb
@@ -126,7 +126,7 @@ class ShareFoldersVMActionTest < Test::Unit::TestCase
     should "mount all shared folders to the VM" do
       mount_seq = sequence("mount_seq")
       @folders.each do |name, data|
-        if data[:guestpath]
+        if data[:guestpath] and !data[:optional]
           @vm.system.expects(:mount_shared_folder).with(@ssh, name, data[:guestpath]).in_sequence(mount_seq)
         else
           @vm.system.expects(:mount_shared_folder).with(@ssh, name, anything).never


### PR DESCRIPTION
Add config option for optional share_folder mounts.  This is useful in
our case when we have binaries installed for a tool but need a git
checkout available to debug it when it breaks.
