### PR TITLE
Changing the Chef Server provisioning commands to a single command

### DIFF
--- a/lib/vagrant/provisioners/chef_server.rb
+++ b/lib/vagrant/provisioners/chef_server.rb
@@ -79,8 +79,11 @@ module Vagrant
 
       def run_chef_client
         command_env = config.binary_env ? "#{config.binary_env} " : ""
-        commands = ["cd #{config.provisioning_path}",
-                    "#{command_env}#{chef_binary_path("chef-client")} -c client.rb -j dna.json"]
+
+        client_file = File.join(config.provisioning_path, "client.rb")
+        json_file = File.join(config.provisioning_path, "dna.json")
+
+        commands = ["#{command_env}#{chef_binary_path("chef-client")} -c #{client_file} -j #{json_file}"]
 
         env.ui.info I18n.t("vagrant.provisioners.chef.running_client")
         vm.ssh.execute do |ssh|

--- a/test/vagrant/provisioners/chef_server_test.rb
+++ b/test/vagrant/provisioners/chef_server_test.rb
@@ -175,8 +175,8 @@ class ChefServerProvisionerTest < Test::Unit::TestCase
       @vm.ssh.stubs(:execute).yields(@ssh)
     end
 
-    should "cd into the provisioning directory and run chef client" do
-      @ssh.expects(:sudo!).with(["cd #{@config.provisioning_path}", "chef-client -c client.rb -j dna.json"]).once
+    should "run chef client with the client and dna from the provisioning directory" do
+      @ssh.expects(:sudo!).with(["chef-client -c #{@config.provisioning_path}/client.rb -j #{@config.provisioning_path}/dna.json"]).once
       @action.run_chef_client
     end
 


### PR DESCRIPTION
Hey,

This is a pretty silly fix, but I've been wanting it since day one.  Since I use vagrant to debug my Chef cookbooks, I'm often SSHing to the VM to run the chef-client command and look at the failure output, and often copy-paste the chef-client command, so it is nice if it is a one-liner to it can sit in my bash history.  Take it if you like it.

Tests updated.

I've got a slightly more interesting patch in the works as well.  Thanks,

-nick
