### PR TITLE
Ability to specify shell provisioning commands within the Vagrantfile.

### DIFF
--- a/lib/vagrant/provisioners/shell.rb
+++ b/lib/vagrant/provisioners/shell.rb
@@ -4,6 +4,7 @@ module Vagrant
       register :shell
 
       class Config < Vagrant::Config::Base
+        attr_accessor :script
         attr_accessor :path
         attr_accessor :upload_path
 
@@ -18,33 +19,53 @@ module Vagrant
         def validate(errors)
           super
 
-          if !path
-            errors.add(I18n.t("vagrant.provisioners.shell.path_not_set"))
-          elsif !expanded_path.file?
-            errors.add(I18n.t("vagrant.provisioners.shell.path_invalid", :path => expanded_path))
-          end
+          if script
+            if path
+              errors.add(I18n.t("vagrant.provisioners.shell.path_set_with_script"))
+            end
+          else
+            if !path
+              errors.add(I18n.t("vagrant.provisioners.shell.path_not_set"))
+            elsif !expanded_path.file?
+              errors.add(I18n.t("vagrant.provisioners.shell.path_invalid", :path => expanded_path))
+            end
 
-          if !upload_path
-            errors.add(I18n.t("vagrant.provisioners.shell.upload_path_not_set"))
+            if !upload_path
+              errors.add(I18n.t("vagrant.provisioners.shell.upload_path_not_set"))
+            end
           end
         end
       end
 
       def provision!
-        commands = ["chmod +x #{config.upload_path}", config.upload_path]
-
-        # Upload the script to the VM
-        vm.ssh.upload!(config.expanded_path.to_s, config.upload_path)
-
-        # Execute it with sudo
-        vm.ssh.execute do |ssh|
-          ssh.sudo!(commands) do |ch, type, data|
-            if type == :exit_status
-              ssh.check_exit_status(data, commands)
-            else
-              env.ui.info(data)
+        if config.script
+          # Execute it with sudo
+          vm.ssh.execute do |ssh|
+            ssh.sudo!(config.script) do |ch, type, data|
+              if type == :exit_status
+                ssh.check_exit_status(data, config.script)
+              else
+                env.ui.info(data)
+              end
             end
           end
+        else
+          commands = ["chmod +x #{config.upload_path}", config.upload_path]
+
+          # Upload the script to the VM
+          vm.ssh.upload!(config.expanded_path.to_s, config.upload_path)
+
+          # Execute it with sudo
+          vm.ssh.execute do |ssh|
+            ssh.sudo!(commands) do |ch, type, data|
+              if type == :exit_status
+                ssh.check_exit_status(data, commands)
+              else
+                env.ui.info(data)
+              end
+            end
+          end
+
         end
       end
     end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -508,6 +508,7 @@ en:
         path_not_set: "`path` parameter pointing to script file to execute for shell provisioner is required"
         path_invalid: "`path` for shell provisioner does not exist on the host system: %{path}"
         upload_path_not_set: "`upload_path` must be set for the shell provisioner."
+        path_set_with_script: "Cannot specify `path` when using the `script` paramter."
 
     systems:
       base:

--- a/test/vagrant/provisioners/shell_test.rb
+++ b/test/vagrant/provisioners/shell_test.rb
@@ -47,6 +47,21 @@ class ShellProvisionerTest < Test::Unit::TestCase
       @config.validate(@errors)
       assert !@errors.errors.empty?
     end
+
+    should "be invalid if a path and a script are set" do
+      @config.script = "whoami"
+
+      @config.validate(@errors)
+      assert !@errors.errors.empty?
+    end
+
+    should "be invalid if script is set and path is not" do
+      @config.script = "whoami"
+      @config.path = nil
+
+      @config.validate(@errors)
+      assert @errors.errors.empty?
+    end
   end
 
   context "provisioning" do
@@ -61,6 +76,15 @@ class ShellProvisionerTest < Test::Unit::TestCase
       p_seq = sequence("provisioning")
       @action.vm.ssh.expects(:upload!).with(@config.expanded_path.to_s, @config.upload_path).in_sequence(p_seq)
       @ssh.expects(:sudo!).with(commands).in_sequence(p_seq)
+
+      @action.provision!
+    end
+
+    should "run script if script is set" do
+      @config.script = "whoami"
+
+      p_seq = sequence("provisioning")
+      @ssh.expects(:sudo!).with(@config.script).in_sequence(p_seq)
 
       @action.provision!
     end


### PR DESCRIPTION
This allows a provisioning via shell commands that can be completely contained within the Vagrantfile, rather than included in an outside shell script.  Complex shell provisioning might still be better from and outside file, but this allows for a quick-n-easy way to tweak the vagrant box image, if necesary, before running other provisioners.

Two thoughts/questions:

1)  This could be in a different provisioner entirely (maybe 'script' vs. 'shell'?).  It fits OK in shell.rb, but adds a little more logic.  The problem is that I'd think this method could be called 'shell' and the upload-and-run-a-file method be called 'script', although that wouldn't be backwards compatible.

2) The commands could be specified as an array instead of a string.  I think I like the string way more, works with heredoc or a few ';' delineated commands, although passing as an array would work well too, since the ssh connection accepts and array of commands anyway.

Let me know if you want me to make some changes, or touch it up yourselves.  

Thanks!

-nick
