### PR TITLE
Add support for Chef encrypted data bags in Chef Server provisioner

### DIFF
--- a/templates/chef_server_client.erb
+++ b/templates/chef_server_client.erb
@@ -10,6 +10,8 @@ validation_client_name "<%= validation_client_name %>"
 validation_key         "<%= validation_key %>"
 client_key             "<%= client_key %>"
 
+encrypted_data_bag_secret "<%= encrypted_data_bag_secret %>"
+
 <% unless environment.nil? %>
 environment        "<%= environment %>"
 <% end %>

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -465,6 +465,7 @@ en:
         json: "Generating chef JSON and uploading..."
         client_key_folder: "Creating folder to hold client key..."
         upload_validation_key: "Uploading chef client validation key..."
+        upload_encrypted_data_bag_secret_key: "Uploading chef encrypted data bag secret key..."
         running_client: "Running chef-client..."
         running_solo: "Running chef-solo..."
         invalid_provisioner: "Vagrant::Provisioners::Chef is not a valid provisioner! Use ChefSolo or ChefServer instead."

--- a/test/vagrant/provisioners/chef_server_test.rb
+++ b/test/vagrant/provisioners/chef_server_test.rb
@@ -162,7 +162,8 @@ class ChefServerProvisionerTest < Test::Unit::TestCase
         :client_key => @config.client_key_path,
         :file_cache_path => @config.file_cache_path,
         :file_backup_path => @config.file_backup_path,
-        :environment => @config.environment
+        :environment => @config.environment,
+        :encrypted_data_bag_secret => @config.encrypted_data_bag_secret
       })
 
       @action.setup_server_config


### PR DESCRIPTION
Add support for Chef encrypted data bags: http://wiki.opscode.com/display/chef/Encrypted+Data+Bags

Add two configuration options to chef_server provision:
  encrypted_data_bag_secret_key_path - the location of your encrypted secret key on your local machine
  encrypted_data_bag_secret - the location you wish to place the key on the target machine and the value of Chef::Config[:encrypted_data_bag_secret]. Default value of "/etc/chef/encrypted_data_bag".
