### PR TITLE
Don't delete package file if error results from pre-existing package file

### DIFF
--- a/lib/vagrant/action/general/package.rb
+++ b/lib/vagrant/action/general/package.rb
@@ -38,8 +38,10 @@ module Vagrant
         end
 
         def recover(env)
-          # Cleanup any packaged files if the packaging failed at some point.
-          File.delete(tar_path) if File.exist?(tar_path)
+          unless env["vagrant.error"].is_a?(Errors::PackageOutputExists)
+						# Cleanup any packaged files if the packaging failed at some point.
+						File.delete(tar_path) if File.exist?(tar_path)
+					end
         end
 
         def files_to_copy


### PR DESCRIPTION
The recovery function for the packaging middleware deletes the package tar file, even if the error that prompted the recovery is that the tar file already exists. I just added a guard that skips tar file deletion for that error (Errors::PackageOutputExists).
