### PR TITLE
this translation has to be quoted. would otherwise fail on Psych: ~/.rvm/

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -164,7 +164,7 @@ en:
 #-------------------------------------------------------------------------------
     config:
       common:
-        error_empty: `%{field}` must be filled in.
+        error_empty: "`%{field}` must be filled in."
       chef:
         run_list_empty: "Run list must not be empty."
         cookbooks_path_empty: "Must specify a cookbooks path for chef solo."


### PR DESCRIPTION
this translation has to be quoted. would otherwise fail on Psych: ~/.rvm/rubies/ruby-1.9.2-p180/lib/ruby/1.9.1/psych.rb:148:in `parse': couldn't parse YAML at line 162 column 21 (Psych::SyntaxError)
