### PR TITLE
The puppet example in the default Vagrantfile fails

### DIFF
--- a/templates/commands/init/Vagrantfile.erb
+++ b/templates/commands/init/Vagrantfile.erb
@@ -33,6 +33,10 @@ Vagrant::Config.run do |config|
   #
   # An example Puppet manifest to provision the message of the day:
   #
+  # # group { "puppet":
+  # #   ensure => "present",
+  # # }
+  # #
   # # File { owner => 0, group => 0, mode => 0644 }
   # #
   # # file { '/etc/motd':


### PR DESCRIPTION
This is causing a lot of people to stumble.
http://groups.google.com/group/vagrant-up/browse_thread/thread/fbd824efcce973f
It's pretty simple to make it work and encourage people to actually use Vagrant and Puppet. This commit could change the world. I'm just say'n.
