### PR TITLE
Fix problems provisioning via chef solo

### DIFF
--- a/lib/vagrant/provisioners/chef_solo.rb
+++ b/lib/vagrant/provisioners/chef_solo.rb
@@ -65,7 +65,7 @@ module Vagrant
           # or VM path.
           local_path = nil
           local_path = File.expand_path(path, env.root_path) if type == :host
-          remote_path = type == :host ? "#{config.provisioning_path}/chef-solo-#{index}" : path
+          remote_path = type == :host ? "#{config.provisioning_path}/chef-solo-#{index}-#{File.basename(local_path)}" : path
           index += 1
 
           # Return the result

--- a/test/vagrant/provisioners/chef_solo_test.rb
+++ b/test/vagrant/provisioners/chef_solo_test.rb
@@ -52,8 +52,16 @@ class ChefSoloProvisionerTest < Test::Unit::TestCase
     should "expand host folders properly" do
       path = "foo"
       local_path = File.expand_path(path, @env.root_path)
-      remote_path = "#{@action.config.provisioning_path}/chef-solo-0"
+      remote_path = "#{@action.config.provisioning_path}/chef-solo-0-#{path}"
       assert_equal [[:host, local_path, remote_path]], @action.expanded_folders([:host, path])
+    end
+
+    should "share roles and cookbooks in different folders" do
+      local_roles_path = File.expand_path('roles',@env.root_path)
+      local_cookbooks_path = File.expand_path('cookbooks',@env.root_path)
+      remote_roles_path = @action.expanded_folders([:host,local_roles_path])[0][2]
+      remote_cookbooks_path = @action.expanded_folders([:host,local_cookbooks_path])[0][2]
+      assert_not_equal remote_roles_path, remote_cookbooks_path
     end
   end
 


### PR DESCRIPTION
I found an issue provisioning with chef solo when I upgraded from 0.7.x to 0.8.0. I've committed a fix and added a corresponding unit test.

When creating an VM and provisioning with chef-solo, vagrant would share both the cookbooks and roles folders to the same location. Modified ChefSolo.expanded_folders to create unique folder names for different entities and added a unit test to verify that roles and cookbooks local folders are shared to different vm folders.
