### PR TITLE
With puppet 2.7.x, the following warning is outputted when using the puppet provisioner

### DIFF
--- a/lib/vagrant/provisioners/puppet.rb
+++ b/lib/vagrant/provisioners/puppet.rb
@@ -118,7 +118,7 @@ module Vagrant
         options = options.join(" ")
 
         commands = ["cd #{manifests_guest_path}",
-                    "puppet #{options}"]
+                    "puppet apply #{options}"]
 
         env.ui.info I18n.t("vagrant.provisioners.puppet.running_puppet", :manifest => config.computed_manifest_file)
 


### PR DESCRIPTION
warning: Implicit invocation of 'puppet apply' by passing files (or flags) directly
to 'puppet' is deprecated, and will be removed in the 2.8 series.  Please
invoke 'puppet apply' directly in the future.

Since puppet 2.6, 'puppet apply manifestfile.pp' is the preferred way to apply a puppet manifest file, instead of 'puppet manifestfile.pp'.  The use of puppet without the apply option will be deprecated in 2.8.

Changed the 'commands' array to reflect the new syntax.
