### PR TITLE
Restore indexes on roles_path and data_bags_path

### DIFF
--- a/lib/vagrant/provisioners/chef_solo.rb
+++ b/lib/vagrant/provisioners/chef_solo.rb
@@ -4,6 +4,8 @@ module Vagrant
     class ChefSolo < Chef
       register :chef_solo
 
+      extend Util::Counter
+
       class Config < Chef::Config
         attr_accessor :cookbooks_path
         attr_accessor :roles_path
@@ -56,7 +58,6 @@ module Vagrant
         # path element which contains the folder location (:host or :vm)
         paths = [paths] if paths.is_a?(String) || paths.first.is_a?(Symbol)
 
-        index = 0
         paths.map do |path|
           path = [:host, path] if !path.is_a?(Array)
           type, path = path
@@ -65,8 +66,7 @@ module Vagrant
           # or VM path.
           local_path = nil
           local_path = File.expand_path(path, env.root_path) if type == :host
-          remote_path = type == :host ? "#{config.provisioning_path}/chef-solo-#{index}" : path
-          index += 1
+          remote_path = type == :host ? "#{config.provisioning_path}/chef-solo-#{self.class.get_and_update_counter}" : path
 
           # Return the result
           [type, local_path, remote_path]
@@ -79,7 +79,7 @@ module Vagrant
         index = 0
         folders.each do |type, local_path, remote_path|
           if type == :host
-            env.config.vm.share_folder("v-#{prefix}-#{index}",
+            env.config.vm.share_folder("v-#{prefix}-#{type}-#{index}",
                                        remote_path, local_path, :nfs => config.nfs)
             index += 1
           end

--- a/test/vagrant/provisioners/chef_solo_test.rb
+++ b/test/vagrant/provisioners/chef_solo_test.rb
@@ -52,9 +52,23 @@ class ChefSoloProvisionerTest < Test::Unit::TestCase
     should "expand host folders properly" do
       path = "foo"
       local_path = File.expand_path(path, @env.root_path)
-      remote_path = "#{@action.config.provisioning_path}/chef-solo-0"
+      remote_path = "#{@action.config.provisioning_path}/chef-solo-1"
       assert_equal [[:host, local_path, remote_path]], @action.expanded_folders([:host, path])
     end
+
+    should "expand multiple host folders properly" do
+      cookbooks_path = "cookbooks"
+      cookbooks_local_path = File.expand_path(cookbooks_path, @env.root_path)
+      cookbooks_remote_path = "#{@action.config.provisioning_path}/chef-solo-4"
+      roles_path = "roles"
+      roles_local_path = File.expand_path(roles_path, @env.root_path)
+      roles_remote_path = "#{@action.config.provisioning_path}/chef-solo-5"
+
+      assert_not_equal @action.expanded_folders([:host, cookbooks_path])[0].last, @action.expanded_folders([:host, roles_path])[0].last
+      assert_equal [[:host, cookbooks_local_path, cookbooks_remote_path]], @action.expanded_folders([:host, cookbooks_path])
+      assert_equal [[:host, roles_local_path, roles_remote_path]], @action.expanded_folders([:host, roles_path])
+    end
+
   end
 
   context "guest paths" do


### PR DESCRIPTION
This fix restores indexes (and I think implements the multiple provisioners fix) for GH #407. Without this the chef solo provisioner is broken for roles_path and data_bags_path. Thanks!
