### PR TITLE
Changed data_bags_path and roles_path in chef-solo provisioner to strings

### DIFF
--- a/lib/vagrant/provisioners/chef_solo.rb
+++ b/lib/vagrant/provisioners/chef_solo.rb
@@ -17,8 +17,8 @@ module Vagrant
           super
 
           @cookbooks_path = ["cookbooks", [:vm, "cookbooks"]]
-          @roles_path = []
-          @data_bags_path = []
+          @roles_path = ""
+          @data_bags_path = ""
           @nfs = false
         end
 
@@ -86,8 +86,8 @@ module Vagrant
 
       def setup_solo_config
         cookbooks_path = guest_paths(@cookbook_folders)
-        roles_path = guest_paths(@role_folders)
-        data_bags_path = guest_paths(@data_bags_folders)
+        roles_path = guest_paths(@role_folders).first
+        data_bags_path = guest_paths(@data_bags_folders).first
 
         setup_config("chef_solo_solo", "solo.rb", {
           :node_name => config.node_name,


### PR DESCRIPTION
Chef's solo.rb config file parsing will throw an exception if `data_bag_path` is an array. This _should_ be the behaviour for `role_path` config directive as well, but Chef uses `File.join()` on `role_path` internally, which will have no negative effects if it's a single-element array. Since Chef 0.10.4 is about to come out and includes data bag support for chef-solo, it'd be nice to see this fixed in Vagrant soon so we can take advantage of the new feature.
