### PR TITLE
Add "short" hostname to "/etc/hosts" mimicking Debian behaviour.

### DIFF
--- a/lib/vagrant/systems/redhat.rb
+++ b/lib/vagrant/systems/redhat.rb
@@ -39,7 +39,7 @@ module Vagrant
           if !ssh.test?("sudo hostname | grep '#{name}'")
             ssh.exec!("sudo sed -i 's/\\(HOSTNAME=\\).*/\\1#{name}/' /etc/sysconfig/network")
             ssh.exec!("sudo hostname #{name}")
-            ssh.exec!("sudo sed -i 's@^\\(127[.]0[.]0[.]1[[:space:]]\\+\\)@\\1#{name} @' /etc/hosts")
+            ssh.exec!("sudo sed -i 's@^\\(127[.]0[.]0[.]1[[:space:]]\\+\\)@\\1#{name} #{name.split('.')[0]} @' /etc/hosts")
           end
         end
       end


### PR DESCRIPTION
Allows `hostname -s` to work and resolve on RHEL and CentOS boxes. Required by some services that don't use the machine's FQDN, like RabbitMQ.
