### PR TITLE
Change message for virualbox_not_detected to accurately indicate which version of VirtualBox is required.

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -127,7 +127,7 @@ en:
       virtualbox_not_detected: |-
         Vagrant could not detect VirtualBox! Make sure VirtualBox is properly installed.
         If VirtualBox is installed, it may be an incorrect version. Vagrant currently
-        requires VirtualBox 4.0.x. Please install the proper version to continue.
+        requires VirtualBox 4.1.x. Please install the proper version to continue.
 
         If you have an older or newer version of VirtualBox, please make sure you're
         using the proper version of Vagrant. Ask the mailing list if you have questions.


### PR DESCRIPTION
When vagrant can't find VirtualBox, it says it requires version 4.0.x. It now requires 4.1.x.
