### PR TITLE
use VERIFY_PEER instead of VERIFY_NONE when downloading over SSL

### DIFF
--- a/lib/vagrant/downloaders/http.rb
+++ b/lib/vagrant/downloaders/http.rb
@@ -21,7 +21,7 @@ module Vagrant
 
         if uri.scheme == "https"
           http.use_ssl = true
-          http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+          http.verify_mode = OpenSSL::SSL::VERIFY_PEER
         end
 
         http.start do |h|


### PR DESCRIPTION
Use OpenSSL::SSL::VERIFY_PEER instead of OpenSSL::SSL::VERIFY_NONE for downloads to verify certificates, decreasing the viability of a man in the middle attack vector.

re: e.g., http://www.rubyinside.com/how-to-cure-nethttps-risky-default-https-behavior-4010.html, http://notetoself.vrensk.com/2008/09/verified-https-in-ruby/ 

-t
