### PR TITLE
undefined method `clear_line' for #<Vagrant::UI:0x1071767d8>

### DIFF
--- a/lib/vagrant/ui.rb
+++ b/lib/vagrant/ui.rb
@@ -16,7 +16,7 @@ module Vagrant
       end
     end
 
-    [:report_progress, :ask, :no?, :yes?].each do |method|
+    [:clear_line, :report_progress, :ask, :no?, :yes?].each do |method|
       # By default do nothing, these aren't logged
       define_method(method) { |*args| }
     end


### PR DESCRIPTION
`Vagrant::Action::VM::Import#call` calls `env.ui.clear_line` [here](https://github.com/mitchellh/vagrant/blob/master/lib/vagrant/action/vm/import.rb#L14) which will raise an error if ui is not a shell

I've added `:clear_line` to the 'do nothing' methods in `Vagrant::UI`
