### PR TITLE
Don't do the port threshold check if running under root

### DIFF
--- a/lib/vagrant/action/vm/forward_ports.rb
+++ b/lib/vagrant/action/vm/forward_ports.rb
@@ -10,7 +10,7 @@ module Vagrant
           @app = app
           @env = env
 
-          threshold_check
+          threshold_check unless ENV["USER"] == "root"
           external_collision_check
         end
 


### PR DESCRIPTION
For the rare case where a risk-taker wants to run the machine under root (and thus have access to ports under 1024), allow them.

It's fairly important in our setup that we forward ports 80 and 443 to vagrant, running the machine under root is an acceptable compromise.
