### PR TITLE
Support for no_proxy environment variable

### DIFF
--- a/lib/vagrant/downloaders/http.rb
+++ b/lib/vagrant/downloaders/http.rb
@@ -15,8 +15,10 @@ module Vagrant
       end
 
       def download!(source_url, destination_file)
-        proxy_uri = URI.parse(ENV["http_proxy"] || "")
+        
         uri = URI.parse(source_url)
+        proxy_uri = resolve_proxy(uri)
+        
         http = Net::HTTP.new(uri.host, uri.port, proxy_uri.host, proxy_uri.port, proxy_uri.user, proxy_uri.password)
 
         if uri.scheme == "https"
@@ -65,6 +67,19 @@ module Vagrant
       rescue SocketError
         raise Errors::DownloaderHTTPSocketError
       end
+
+      private
+
+      def resolve_proxy(source_uri)
+        proxy_string = nil
+        if ENV['no_proxy'] && ENV['no_proxy'].split(',').any? { |h| source_uri.host =~ /#{Regexp.quote(h.strip)}$/  }
+          proxy_string = ''
+        else
+          proxy_string = ENV["http_proxy"] || ''
+        end 
+        URI.parse(proxy_string) 
+      end
+
     end
   end
 end

--- a/test/unit/vagrant/downloaders/http_test.rb
+++ b/test/unit/vagrant/downloaders/http_test.rb
@@ -32,6 +32,16 @@ class HttpDownloaderTest < Test::Unit::TestCase
       @downloader.download!(@uri, @tempfile)
     end
 
+    should "create a proper net/http object without a proxy if no_proxy defined" do
+      @uri = "http://somewhere.direct.com/some_file"
+      @parsed_uri = URI.parse(@uri)
+      ENV["http_proxy"] = "http://user:foo@google.com"
+      ENV["no_proxy"] = "direct.com"
+      Net::HTTP.expects(:new).with(@parsed_uri.host, @parsed_uri.port, nil, nil, nil, nil).once.returns(@http)
+      @http.expects(:start)
+      @downloader.download!(@uri, @tempfile)
+    end
+
     should "enable SSL if scheme is https" do
       @uri = "https://google.com/"
       @http.expects(:use_ssl=).with(true).once


### PR DESCRIPTION
Adding support for 'no_proxy' environment variable to suppress proxy in http downloader
