### PR TITLE
File-local filetype settings for Vagrantfile - emacs and vi

### DIFF
--- a/templates/commands/init/Vagrantfile.erb
+++ b/templates/commands/init/Vagrantfile.erb
@@ -1,3 +1,8 @@
+<%= <<-END
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+END
+%>
 Vagrant::Config.run do |config|
   # All Vagrant configuration is done here. The most common configuration
   # options are documented and commented below. For a complete reference,


### PR DESCRIPTION
Adds filetype setting to the Vagrantfile template so that when people `vagrant init` a project they get a Vagrantfile that will be recognised as Ruby syntax by both vi and emacs even if they haven't set up a rule in their rc files to set the filetype of this filename. 
