### PR TITLE
Use cookbooks_path and roles_path; chef-solo requires plural form on conf

### DIFF
--- a/templates/chef_solo_solo.erb
+++ b/templates/chef_solo_solo.erb
@@ -2,8 +2,8 @@
 node_name "<%= node_name %>"
 <% end %>
 file_cache_path "<%= provisioning_path %>"
-cookbook_path <%= cookbooks_path.inspect %>
-role_path <%= roles_path.inspect %>
+cookbooks_path <%= cookbooks_path.inspect %>
+roles_path <%= roles_path.inspect %>
 log_level <%= log_level.inspect %>
 
 <% if data_bags_path -%>


### PR DESCRIPTION
Use cookbooks_path and roles_path; chef-solo requires plural form of these configuration settings.

I am a chef n00b, so maybe I'm missing something with this PR. :) However, I did a fair bit of trekking through both vagrant and chef to narrow down this fix -- hopefully it's right.
