### PR TITLE
Basic Auth support for HTTP downloader

### DIFF
--- a/lib/vagrant/downloaders/http.rb
+++ b/lib/vagrant/downloaders/http.rb
@@ -2,6 +2,7 @@ require 'net/http'
 require 'net/https'
 require 'open-uri'
 require 'uri'
+require 'base64'
 
 module Vagrant
   module Downloaders
@@ -27,7 +28,12 @@ module Vagrant
         http.start do |h|
           env.ui.info I18n.t("vagrant.downloaders.http.download", :url => source_url)
 
-          h.request_get(uri.request_uri) do |response|
+          headers = nil
+          if uri.user && uri.password
+            headers = {'Authorization' => 'Basic ' + Base64.encode64(uri.user + ':' + uri.password)}
+          end
+
+          h.request_get(uri.request_uri, headers) do |response|
             if response.is_a?(Net::HTTPRedirection)
               # Follow the HTTP redirect.
               # TODO: Error on some redirect limit

--- a/test/unit/vagrant/downloaders/http_test.rb
+++ b/test/unit/vagrant/downloaders/http_test.rb
@@ -6,6 +6,7 @@ class HttpDownloaderTest < Test::Unit::TestCase
     @downloader.stubs(:report_progress)
     @downloader.stubs(:complete_progress)
     @uri = "http://google.com/"
+    @headers = nil
   end
 
   context "downloading" do
@@ -48,7 +49,7 @@ class HttpDownloaderTest < Test::Unit::TestCase
       segment.stubs(:length).returns(7)
 
       @http.stubs(:start).yields(h)
-      h.expects(:request_get).with(@parsed_uri.request_uri).once.yields(response)
+      h.expects(:request_get).with(@parsed_uri.request_uri, @headers).once.yields(response)
       response.expects(:read_body).once.yields(segment)
       @tempfile.expects(:write).with(segment).once
 


### PR DESCRIPTION
This adds basic authentication support for the Vagrantfile's box_url configuration.  

Url's can be entered in typical basic-auth fashion:
    config.vm.box_url = "http://user:pass@domain.com/path/to/above.box"
