### PR TITLE
Mount Order on Unix hosts should be from shortest to longest

### DIFF
--- a/lib/vagrant/action/vm/share_folders.rb
+++ b/lib/vagrant/action/vm/share_folders.rb
@@ -51,7 +51,8 @@ module Vagrant
           @env.ui.info I18n.t("vagrant.actions.vm.share_folders.mounting")
 
           @env["vm"].ssh.execute do |ssh|
-            shared_folders.each do |name, data|
+            # short guestpaths first, so we don't step on ourselves
+            shared_folders.sort_by {|name, data| data[:guestpath].length}.each do |name, data|
               if data[:guestpath]
                 # Guest path specified, so mount the folder to specified point
                 @env.ui.info(I18n.t("vagrant.actions.vm.share_folders.mounting_entry",


### PR DESCRIPTION
Detailed in michellh/vagrant#524

Basically we can't mount in random order... we need to mount directories closer to '/' first, then work our way outward.

So /vagrant/cache doesn't mount before /vagrant (which would make /vagrant/cache disappear.
