### PR TITLE
Make init respect the env's cwd.

### DIFF
--- a/lib/vagrant/command/init.rb
+++ b/lib/vagrant/command/init.rb
@@ -7,7 +7,7 @@ module Vagrant
       register "init [box_name] [box_url]", "Initializes the current folder for Vagrant usage"
 
       def execute
-        template "Vagrantfile.erb", "Vagrantfile"
+        template "Vagrantfile.erb", env.cwd.join("Vagrantfile")
       end
     end
   end

--- a/lib/vagrant/test_helpers.rb
+++ b/lib/vagrant/test_helpers.rb
@@ -84,6 +84,29 @@ module Vagrant
       [app, env]
     end
 
+    # Utility method for capturing output streams.
+    # @example Evaluate the output
+    #   output = capture(:stdout){ env.cli("foo") }
+    #   assert_equal "bar", output
+    # @example Silence the output
+    #   silence(:stdout){ env.cli("init") }
+    # @param [:stdout, :stderr] stream The stream to capture
+    # @yieldreturn String
+    # @see https://github.com/wycats/thor/blob/master/spec/spec_helper.rb
+    def capture(stream)
+      begin
+        stream = stream.to_s
+        eval "$#{stream} = StringIO.new"
+        yield
+        result = eval("$#{stream}").string
+      ensure
+        eval("$#{stream} = #{stream.upcase}")
+      end
+
+      result
+    end
+    alias :silence :capture
+
     #------------------------------------------------------------
     # Path helpers
     #------------------------------------------------------------

--- a/test/unit/vagrant/command/init_test.rb
+++ b/test/unit/vagrant/command/init_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class CommandInitCommandTest < Test::Unit::TestCase
+  should "create a Vagrantfile in the environment's cwd" do
+    path = vagrant_app
+    env = Vagrant::Environment.new(:cwd => path)
+    silence(:stdout) { env.cli("init") }
+    assert File.exist?(path.join("Vagrantfile"))
+  end
+end


### PR DESCRIPTION
Here's the problem I was having...

``` ruby
FileUtils.mkdir_p 'tmp'
env = Vagrant::Environment.new(:cwd => File.expand_path('tmp'))
Dir.chdir 'tmp' do
  env.cli 'init'
end
```

I would expect that `init` would create the Vagrantfile in the cwd as specified in the vagrant environment. Instead, it's created in `Dir.pwd`. This pull request fixes that.
