### PR TITLE
Adding a "down" alias for the "halt" command.

### DIFF
--- a/lib/vagrant/command/halt.rb
+++ b/lib/vagrant/command/halt.rb
@@ -3,6 +3,7 @@ module Vagrant
     class HaltCommand < NamedBase
       class_option :force, :type => :boolean, :default => false, :aliases => "-f"
       register "halt", "Halt the running VMs in the environment"
+      register "down", "Alias for the \"halt\" command"
 
       def execute
         target_vms.each do |vm|


### PR DESCRIPTION
I often find myself typing "vagrant down" instead of "vagrant halt".  It just seems like a logical equivalent to "vagrant up" to me.  This commit simply adds a "down" alias for "halt".
