### PR TITLE
Issues 532 and 501 - Chef solo remote with linux guest does not work on windows

### DIFF
--- a/lib/vagrant/provisioners/chef_solo.rb
+++ b/lib/vagrant/provisioners/chef_solo.rb
@@ -77,6 +77,9 @@ module Vagrant
             # Path already exists on the virtual machine. Expand it
             # relative to where we're provisioning.
             remote_path = File.expand_path(path, config.provisioning_path)
+            
+            # Remove drive letter if running on a windows host
+            remote_path = remote_path.gsub(/^[a-zA-Z]:/, "")
           end
 
           # Return the result


### PR DESCRIPTION
Fix for #532 (and #501). Remove windows drive letter from path if running a chef solo provisioner on a Windows guest

The commit fixes this test case on Windows:

https://github.com/mitchellh/vagrant/blob/master/test/unit/vagrant/provisioners/chef_solo_test.rb#L48

... I'm wondering if this fix might affect https://github.com/mitchellh/vagrant/pull/430 negatively, though
