### PR TITLE
Add RemoteForward option to ssh config

### DIFF
--- a/lib/vagrant/command/ssh_config.rb
+++ b/lib/vagrant/command/ssh_config.rb
@@ -21,7 +21,8 @@ module Vagrant
           :ssh_port => vm.ssh.port,
           :private_key_path => vm.env.config.ssh.private_key_path,
           :forward_agent => vm.env.config.ssh.forward_agent,
-          :forward_x11   => vm.env.config.ssh.forward_x11
+          :forward_x11   => vm.env.config.ssh.forward_x11,
+          :remote_forward => vm.env.config.ssh.remote_forward
         }))
       end
     end

--- a/lib/vagrant/config/ssh.rb
+++ b/lib/vagrant/config/ssh.rb
@@ -14,6 +14,7 @@ module Vagrant
       attr_accessor :forward_x11
       attr_accessor :shell
       attr_accessor :port
+      attr_accessor :remote_forward
 
       def initialize
         @shell = "bash"

--- a/lib/vagrant/ssh.rb
+++ b/lib/vagrant/ssh.rb
@@ -47,6 +47,8 @@ module Vagrant
                          "-i #{options[:private_key_path]}", "-o LogLevel=ERROR"]
       command_options << "-o ForwardAgent=yes" if env.config.ssh.forward_agent
 
+      command_options << "-o RemoteForward='#{env.config.ssh.remote_forward}'" if env.config.ssh.remote_forward
+
       if env.config.ssh.forward_x11
         # Both are required so that no warnings are shown regarding X11
         command_options << "-o ForwardX11=yes"

--- a/templates/ssh_config.erb
+++ b/templates/ssh_config.erb
@@ -13,3 +13,6 @@ Host <%= host_key %>
 <% if forward_x11 -%>
   ForwardX11 yes
 <% end -%>
+<% if remote_forward -%>
+  RemoteForward <%= remote_forward %>
+<% end -%>


### PR DESCRIPTION
I've added this so I can run commands on my local box from inside the vagrant box.

In my Vagrantfile:
`config.ssh.remote_forward = '2048 localhost:22'`

In my vagrant box:
`ssh -p 2048 lewis@localhost 'open http://www.google.com'`
