### PR TITLE
Remove the chef dependency on the default 'v-root' shared folder.

### DIFF
--- a/lib/vagrant/provisioners/chef.rb
+++ b/lib/vagrant/provisioners/chef.rb
@@ -57,10 +57,10 @@ module Vagrant
         env.ui.info I18n.t("vagrant.provisioners.chef.json")
 
         # Set up initial configuration
-        data = {
-          :config => env.config.to_hash,
-          :directory => env.config.vm.shared_folders["v-root"][:guestpath],
-        }
+        data, default_share = { :config => env.config.to_hash }, env.config.vm.shared_folders["v-root"]
+
+        # Add the directory on the guest if the default shared folder exists
+        data[:directory] = default_share[:guestpath] if default_share
 
         # And wrap it under the "vagrant" namespace
         data = { :vagrant => data }

--- a/test/unit/vagrant/provisioners/chef_test.rb
+++ b/test/unit/vagrant/provisioners/chef_test.rb
@@ -186,6 +186,13 @@ class ChefProvisionerTest < Test::Unit::TestCase
       end
     end
 
+    should "not add the directory if the 'v-root' shared folder doesn't exist" do
+      @env.config.vm.shared_folders.delete("v-root")
+      assert_json do |data|
+        assert !data["vagrant"].has_key?("directory")
+      end
+    end
+
     should "add the config to the JSON" do
       assert_json do |data|
         assert_equal @env.config.ssh.username, data["vagrant"]["config"]["ssh"]["username"]


### PR DESCRIPTION
My vagrant box does not have the guest additions installed (on purpose), I plan to solely use NFS. So right away I have to override the defaults by doing something like this:

``` ruby
config.vm.share_folder "v-root", "/vagrant", ".", nfs: true
```

This is fine for a simple `Vagrantfile`. However, my `Vagrantfile` has become increasingly complex. I won't bore you with all the details but I am dynamically creating shared folders like so:

``` ruby
Vagrant::Config.run do |config|
  # ...

  # Use NFS to mount your local checkouts on the machine.
  projects.each do |project|
    project_config = config.send(project)
    config.vm.share_folder project.to_s, project_config.dir, project_config.local_dir, nfs: true
  end

  # ...
end
```

Each project is in a subdirectory of the directory containing the `Vagrantfile`.

``` bash
$ ls
project_1
project_2
project_3
Vagrantfile
```

The projects are all shared to different directories on the guest so I don't want the `v-root` shared folder anymore. Plus NFS won't let you share a subdirectory of a directory that is already shared. To accomplish that I just add the following to my `Vagrantfile`.

``` ruby
# Undo default vagrant config
config.vm.shared_folders.delete "v-root"
```

After you do this it blows up because `Vagrant::Provisioners::Chef#setup_json` expects the `v-root` shared folder to exist.

This pull request modifies `Vagrant::Provisioners::Chef#setup_json` so it will pass the directory to chef **only if** the `v-root` shared folder exists. There was also a stray comma in the initial code.  ;-)
