### PR TITLE
Make NFS protocol version selectable, use v3 by default

### DIFF
--- a/lib/vagrant/action/vm/nfs.rb
+++ b/lib/vagrant/action/vm/nfs.rb
@@ -78,6 +78,7 @@ module Vagrant
             opts[:nfs] = {} if !opts.is_a?(Hash)
             opts[:map_uid] = prepare_permission(:uid, opts)
             opts[:map_gid] = prepare_permission(:gid, opts)
+            opts[:version] = opts.has_key?(:version) ? opts[:version] : 3
 
             acc[key] = opts
             acc

--- a/lib/vagrant/config/nfs.rb
+++ b/lib/vagrant/config/nfs.rb
@@ -5,6 +5,7 @@ module Vagrant
 
       attr_accessor :map_uid
       attr_accessor :map_gid
+      attr_accessor :version
     end
   end
 end

--- a/lib/vagrant/systems/linux.rb
+++ b/lib/vagrant/systems/linux.rb
@@ -51,7 +51,7 @@ module Vagrant
         folders.each do |name, opts|
           vm.ssh.execute do |ssh|
             ssh.exec!("sudo mkdir -p #{opts[:guestpath]}")
-            ssh.exec!("sudo mount #{ip}:'#{opts[:hostpath]}' #{opts[:guestpath]}", :_error_class => LinuxError, :_key => :mount_nfs_fail)
+            ssh.exec!("sudo mount -o vers=#{opts[:version]} #{ip}:'#{opts[:hostpath]}' #{opts[:guestpath]}", :_error_class => LinuxError, :_key => :mount_nfs_fail)
           end
         end
       end


### PR DESCRIPTION
NFSv4 has siginificant added complexity in the form of ID-mapping which
can cause problems with applications without extra setup. Best to
force version 3 unless the user requests it.
