### PR TITLE
Hack to fix puppet hanging on JRuby

### DIFF
--- a/lib/vagrant/provisioners/puppet.rb
+++ b/lib/vagrant/provisioners/puppet.rb
@@ -123,11 +123,16 @@ module Vagrant
         env.ui.info I18n.t("vagrant.provisioners.puppet.running_puppet", :manifest => config.computed_manifest_file)
 
         vm.ssh.execute do |ssh|
+          last_data="" # hack for JRuby
           ssh.sudo! commands do |ch, type, data|
             if type == :exit_status
               ssh.check_exit_status(data, commands)
+            elsif last_data.include?("notice: Finished catalog run in")
+              # hack for JRuby
+              return
             else
               env.ui.info(data)
+              last_data=data unless data.strip.empty? # hack for JRuby
             end
           end
         end


### PR DESCRIPTION
I know this is really hacky.  But i tried to make so that the change would not affect non-JRuby environments.  

See this issue:
https://github.com/mitchellh/vagrant/issues/566

I tried to figure out how to get the channel.on_request("exit-status") callback to be invoked in lib/vagrant/ssh/session.rb but i could not figure it out.

I'll be happy to help make this right with a little guidence.  

Thanks!
