### PR TITLE
Improve hostname-changing support on Debian

### DIFF
--- a/lib/vagrant/systems/debian.rb
+++ b/lib/vagrant/systems/debian.rb
@@ -24,9 +24,9 @@ module Vagrant
 
       def change_host_name(name)
         vm.ssh.execute do |ssh|
-          if !ssh.test?("sudo hostname | grep '#{name}'")
-            ssh.exec!("sudo sed -i 's@^\\(127[.]0[.]1[.]1[[:space:]]\\+\\)@\\1#{name} #{name.split('.')[0]} @' /etc/hosts")
-            ssh.exec!("sudo sed -i 's/.*$/#{name}/' /etc/hostname")
+          if !ssh.test?("hostname --fqdn | grep '^#{name}$' || hostname --short | grep '^#{name}$'")
+            ssh.exec!("sudo sed -r -i 's/^(127[.]0[.]1[.]1[[:space:]]+).*$/\\1#{name} #{name.split('.')[0]}/' /etc/hosts")
+            ssh.exec!("sudo sed -i 's/.*$/#{name.split('.')[0]}/' /etc/hostname")
             ssh.exec!("sudo hostname -F /etc/hostname")
           end
         end

--- a/test/unit/vagrant/action/vm/host_name_test.rb
+++ b/test/unit/vagrant/action/vm/host_name_test.rb
@@ -33,4 +33,17 @@ class HostNameVMActionTest < Test::Unit::TestCase
 
     @instance.call(@env)
   end
+
+  should "change host name if set to a fqdn" do
+    @env["config"].vm.host_name = "foo.example.com"
+
+    system = mock("system")
+    @vm.stubs(:system).returns(system)
+
+    seq = sequence("host_seq")
+    @app.expects(:call).with(@env).in_sequence(seq)
+    system.expects(:change_host_name).with(@env["config"].vm.host_name).in_sequence(seq)
+
+    @instance.call(@env)
+  end
 end


### PR DESCRIPTION
- Store short hostname in /etc/hostname on Debian
  (see http://oreilly.com/openbook/debian/book/ch10_02.html#CH10-PGFID-460680)
- Support switching between short hostnames and fully-qualified domain
  names in config.vm.host_name
- Overwrite entire 127.0.1.1 line in /etc/hosts so it doesn't contain
  old hostnames when the hostname changes
- Fix testing of current hostname so changes to domain work as do
  changes in which the new hostname is a substring of the old hostname

_The change to the unit test doesn't actually test these changes.  Being new to both vagrant and ruby, I couldn't figure out how to create a distribution-specific test.  Help would be appreciated._
