### PR TITLE
Emit event for Upstart configs when shared folders are mounted

### DIFF
--- a/lib/vagrant/action/vm/share_folders.rb
+++ b/lib/vagrant/action/vm/share_folders.rb
@@ -81,6 +81,8 @@ module Vagrant
                                     :name => name))
               end
             end
+            # Emit an event for Upstart configs
+            ssh.exec!("[ -x /sbin/initctl ] && sudo /sbin/initctl emit vagrant-mounted")
           end
         end
       end


### PR DESCRIPTION
A common use of Vagrant's shared folders is to mount the working directory of the repo in the guest VM, where an application-specific web server can be launched. That allows developers to edit files locally on their host OS with their preferred tools, while the guest VM picks up code changes and auto-reloads the web server (eg., WEBrick and Mongrel for Ruby/Rails, Django's runserver).

Currently, this web server needs to be manually started by the user by SSH'ing in to the guest VM. It's possible to use a Upstart config to automatically start it when the VM boots or restarts (`vagrant reload`). However, the problem is that the shared folders are mounted very late in the boot process, after Upstart has run -- when the app web server attempts to run, it (typically) crashes because the path to the application's source code does not (yet) exist. Additionally, there is no way to notify the Upstart config for the web server that the path is now available.

This pull request simply emits an event on the guest VM using Upstart's `initctl` command after the shared folders have been mounted. A user can then write an Upstart config that registers an interest in this event, for example, by starting when the event is emitted (eg., `start on <my-event>`).

The particular event name is just a symbol, it can be named anything so long as it is reasonably unique.
