### PR TITLE
Swap order of logging message and stream type for less empty lines in logging

### DIFF
--- a/lib/vagrant/provisioners/chef_solo.rb
+++ b/lib/vagrant/provisioners/chef_solo.rb
@@ -129,7 +129,7 @@ module Vagrant
             if type == :exit_status
               ssh.check_exit_status(data, command)
             else
-              env.ui.info("#{data}: #{type}")
+              env.ui.info("#{type}: #{data}")
             end
           end
         end


### PR DESCRIPTION
type is stderr, stdout but data commonly has a trailing newline resulting in messages like:

[solo] stdin: is not a tty
: stderr
[solo] [Wed, 14 Dec 2011 22:49:38 +0000] INFO: **\* Chef 0.10.4 ***
: stdout
[solo] [Wed, 14 Dec 2011 22:49:39 +0000] INFO: Setting the run_list to ["role[solo]"] from JSON
: stdout
[solo] [Wed, 14 Dec 2011 22:49:39 +0000] INFO: Run List is [role[solo]]
: stdout
[solo] [Wed, 14 Dec 2011 22:49:39 +0000] INFO: Run List expands to [skeleton]
: stdout
[solo] [Wed, 14 Dec 2011 22:49:39 +0000] INFO: Starting Chef Run for debian-64.vagrantup.com
: stdout

By prepending the data with which stream it's more readable and no longer unnecessarily breaks lines.
