### PR TITLE
Do shell expansion before doing the file test in Vagrant::Downloaders::File#prepare

### DIFF
--- a/lib/vagrant/downloaders/file.rb
+++ b/lib/vagrant/downloaders/file.rb
@@ -15,7 +15,7 @@ module Vagrant
 
       def download!(source_url, destination_file)
         @ui.info I18n.t("vagrant.downloaders.file.download")
-        FileUtils.cp(source_url, destination_file.path)
+        FileUtils.cp(::File.expand_path(source_url), destination_file.path)
       end
     end
   end


### PR DESCRIPTION
Do shell expansion before doing the file test in Vagrant::Downloaders::File#prepare so that "~/file/paths" work.

I couldn't come up with a good way to write a test for this. Any ideas?
