### PR TITLE
Ignore distro-specific suffix when comparing guest addition version

### DIFF
--- a/lib/vagrant/action/vm/check_guest_additions.rb
+++ b/lib/vagrant/action/vm/check_guest_additions.rb
@@ -22,7 +22,7 @@ module Vagrant
               v.gsub(/[-_]ose/i, '')
             end
 
-            if guest_version != vb_version
+            if guest_version.split("_").first != vb_version
               env[:ui].warn(I18n.t("vagrant.actions.vm.check_guest_additions.version_mismatch",
                                    :guest_version => version,
                                    :virtualbox_version => vb_version))


### PR DESCRIPTION
Hello,

this is my first contribution, so please bear with me for not supplying tests or adhering to common guidelines. But do correct me I'm thankful for advise :)

When having installed virtualbox from the Ubuntu 11.10 repositories, VirtualBox reports it's version number suffixed by "_ubuntu". When vagrant checks for guest additions at vm-boot, a version mismatch is reported, because "1.2.3" does not equal "1.2.3_ubuntu".

I sanitized the version number before comparison, assuming all distro-specific versions use "_" as delimiter.
