### PR TITLE
Fix 'box help' subcommand for Ruby 1.8.7

### DIFF
--- a/lib/vagrant/command/box.rb
+++ b/lib/vagrant/command/box.rb
@@ -41,7 +41,7 @@ module Vagrant
           # Add the available subcommands as separators in order to print them
           # out as well.
           keys = []
-          @subcommands.each { |key, value| keys << key }
+          @subcommands.each { |key, value| keys << key.to_s }
 
           keys.sort.each do |key|
             opts.separator "     #{key}"


### PR DESCRIPTION
This is related to Github issue #599, with a similar fix.
