### PR TITLE
enable colors on Windows when using ANSICON

### DIFF
--- a/bin/vagrant
+++ b/bin/vagrant
@@ -19,7 +19,7 @@ opts = {}
 # Disable color if the proper argument was passed or if we're
 # on Windows since the default Windows terminal doesn't support
 # colors.
-if !$stdout.tty? || ARGV.include?("--no-color") || Vagrant::Util::Platform.windows?
+if !Vagrant::Util::Platform.terminal_supports_colors?
   # Delete the argument from the list so that it doesn't cause any
   # invalid arguments down the road.
   ARGV.delete("--no-color")

--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -44,6 +44,11 @@ module Vagrant
           !bit64?
         end
 
+        def terminal_supports_colors?
+           !$stdout.tty? || ARGV.include?("--no-color") || 
+             (Vagrant::Util::Platform.windows? ? ENV['ansicon'] : false)
+        end
+
         def tar_file_options
           # create, write only, fail if the file exists, binary if windows
           File::WRONLY | File::EXCL | File::CREAT | (windows? ? File::BINARY : 0)


### PR DESCRIPTION
Show colors when ANSICON is installed on Windows. ANSICON is also used by RSpec on Windows for example.
