### PR TITLE
add domain name to Vagrantfile for automaticly set in /etc/hosts, logic same as nfs configuration in /etc/exports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "http://rubygems.org"
+gem 'sys-proctable'
 
 gemspec

--- a/lib/vagrant/action.rb
+++ b/lib/vagrant/action.rb
@@ -45,6 +45,8 @@ module Vagrant
       autoload :Import,              'vagrant/action/vm/import'
       autoload :MatchMACAddress,     'vagrant/action/vm/match_mac_address'
       autoload :Network,             'vagrant/action/vm/network'
+      autoload :DOMAIN,              'vagrant/action/vm/domain'
+      autoload :PruneDOMAIN,         'vagrant/action/vm/prune_domain'
       autoload :NFS,                 'vagrant/action/vm/nfs'
       autoload :Package,             'vagrant/action/vm/package'
       autoload :PackageVagrantfile,  'vagrant/action/vm/package_vagrantfile'

--- a/lib/vagrant/action/builtin.rb
+++ b/lib/vagrant/action/builtin.rb
@@ -26,6 +26,7 @@ module Vagrant
           use VM::ForwardPorts
           use VM::Provision
           use VM::PruneNFSExports
+          use VM::DOMAIN
           use VM::NFS
           use VM::ClearSharedFolders
           use VM::ShareFolders
@@ -98,6 +99,7 @@ module Vagrant
           use registry.get(:halt), :force => true
           use VM::ProvisionerCleanup
           use VM::PruneNFSExports
+          use VM::PruneDOMAIN
           use VM::Destroy
           use VM::CleanMachineFolder
           use VM::DestroyUnusedNetworkInterfaces

--- a/lib/vagrant/action/vm/domain.rb
+++ b/lib/vagrant/action/vm/domain.rb
@@ -1,0 +1,61 @@
+module Vagrant
+  module Action
+    module VM
+      # edit /etc/hosts on host machine.
+      # for redirect domain names to guest machine
+      class DOMAIN
+        include Vagrant::Util
+        def initialize(app,env)
+          @app = app
+          @env = env
+
+          verify_settings if domain_enabled?
+        end
+
+        def call(env)
+          @env = env
+          configure_hosts_file
+        end
+
+        def configure_hosts_file
+          domains = @env[:vm].config.vm.domains
+          # replace domain if exist in /etc/hosts
+          domains.split(' ').each do |domain|
+            system(%Q[sudo su root -c "sed -i 's/#{domain}/changedbyvagrant.#{domain}/g' /etc/hosts"])
+          end
+          ip = guest_ip
+          # remove string with guest ip
+          system(%Q[sudo su root -c "sed -i '/#{ip}/d' /etc/hosts"])
+          # string like 10.20.30.1 domain1.com domain2.com domain3.ru
+          str = ip.to_s + ' ' + domains
+          system(%Q[sudo su root -c "echo -e '# VAGRANT-BEGIN' >> /etc/hosts"])
+          system(%Q[sudo su root -c "echo -e '#{str}' >> /etc/hosts"])
+          system(%Q[sudo su root -c "echo -e '# VAGRANT-END' >> /etc/hosts"])
+        end
+
+        # Returns the IP address of the guest by looking at the first
+        # enabled host only network.
+        #
+        # @return [String]
+        def guest_ip
+          @env[:vm].config.vm.networks.each do |type, args|
+            if type == :hostonly && args[0].is_a?(String)
+              return args[0]
+            end
+          end
+
+          nil
+        end
+
+        def domain_enabled?
+          !@env[:vm].config.vm.domains.nil?
+        end
+
+        def verify_settings
+          raise Errors::NFSHostRequired if @env[:host].nil?
+          raise Errors::NFSNoHostNetwork if !guest_ip
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant/action/vm/prune_domain.rb
+++ b/lib/vagrant/action/vm/prune_domain.rb
@@ -1,0 +1,21 @@
+module Vagrant
+  module Action
+    module VM
+      class PruneDOMAIN
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          if env[:host]
+            valid_ids = env[:vm].driver.read_vms
+            # remove domain from /etc/hosts
+            system("sudo sed -e '/^# VAGRANT-BEGIN/,/^# VAGRANT-END/ d' -ibak /etc/hosts")
+          end
+
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant/config/vm.rb
+++ b/lib/vagrant/config/vm.rb
@@ -13,6 +13,7 @@ module Vagrant
       attr_accessor :base_mac
       attr_accessor :boot_mode
       attr_accessor :host_name
+      attr_accessor :domains
       attr_reader :forwarded_ports
       attr_reader :shared_folders
       attr_reader :networks

--- a/templates/commands/init/Vagrantfile.erb
+++ b/templates/commands/init/Vagrantfile.erb
@@ -21,6 +21,10 @@ Vagrant::Config.run do |config|
   # any other machines on the same network, but cannot be accessed (through this
   # network interface) by any external networks.
   # config.vm.network :hostonly, "33.33.33.10"
+  #
+  # set domain to /etc/hosts
+  # config.vm.domains = 'testdomain.com test2domain.ru'
+  #
 
   # Assign this VM to a bridged network, allowing you to connect directly to a
   # network using the host's network device. This makes the VM appear as another

--- a/test/acceptance/domain_test.rb
+++ b/test/acceptance/domain_test.rb
@@ -1,0 +1,35 @@
+require File.expand_path("../base", __FILE__)
+require "acceptance/support/shared/command_examples"
+
+describe "edit hosts file" do
+  include_context "acceptance"
+
+  # This creates an initial environment that is ready for a "vagrant up"
+  def initialize_valid_environment
+    require_box("default")
+
+    assert_execute("vagrant", "box", "add", "base", box_path("default"))
+    assert_execute("vagrant", "init")
+  end
+
+  it "should add defined domain to /etc/hosts" do
+    initialize_valid_environment
+    # Setup the custom Vagrantfile
+    environment.workdir.join("Vagrantfile").open("w+") do |f|
+      f.write(<<-VF)
+Vagrant::Config.run do |config|
+  config.vm.box = "base"
+  config.vm.network :hostonly, "10.20.30.40"
+  config.vm.domains = 'domain1.com domain2.com domain3.com'
+end
+VF
+    end
+    # Bring up the VM
+    assert_execute("vagrant", "up")
+
+    # /etc/hosts should have string
+    # 10.20.30.40 domain1.com domain2.com domain3.com
+
+    `grep '10.20.30.40 domain1.com domain2.com domain3.com' /etc/hosts`.should match('10.20.30.40 domain1.com domain2.com domain3.com')
+  end
+end


### PR DESCRIPTION
add domain name to Vagrantfile for automaticly set in /etc/hosts, logic same as nfs configuration in /etc/exports
