### PR TITLE
Vagrant doesn't detect correct host

### DIFF
--- a/lib/vagrant/hosts.rb
+++ b/lib/vagrant/hosts.rb
@@ -13,7 +13,7 @@ module Vagrant
     def self.detect(registry)
       # Sort the hosts by their precedence
       host_klasses = registry.to_hash.values
-      host_klasses = host_klasses.sort_by { |a| a.precedence }.reverse
+      host_klasses = host_klasses.sort_by { |a| a.precedence }
 
       # Test for matches and return the host class that matches
       host_klasses.each do |klass|


### PR DESCRIPTION
I have tested this on Arch linux. Vagrant always detected generic linux host insted of arch. I have removed sorting host in reverse and it worked (I don't really know why it helped)
