### PR TITLE
add vbox driver support for creating transient shared folders

### DIFF
--- a/lib/vagrant/action/vm/share_folders.rb
+++ b/lib/vagrant/action/vm/share_folders.rb
@@ -63,7 +63,8 @@ module Vagrant
           shared_folders.each do |name, data|
             folders << {
               :name => name,
-              :hostpath => File.expand_path(data[:hostpath], @env[:root_path])
+              :hostpath => File.expand_path(data[:hostpath], @env[:root_path]),
+              :transient => data[:transient]
             }
           end
 

--- a/lib/vagrant/config/vm.rb
+++ b/lib/vagrant/config/vm.rb
@@ -79,6 +79,7 @@ Please change your configurations to match this new syntax.
           :owner => nil,
           :group => nil,
           :nfs   => false,
+          :transient => false,
           :extra => nil
         }.merge(opts || {})
       end

--- a/lib/vagrant/driver/virtualbox_4_0.rb
+++ b/lib/vagrant/driver/virtualbox_4_0.rb
@@ -392,8 +392,12 @@ module Vagrant
 
       def share_folders(folders)
         folders.each do |folder|
-          execute("sharedfolder", "add", @uuid, "--name",
-                  folder[:name], "--hostpath", folder[:hostpath])
+          args = ["--name",
+                  folder[:name],
+                  "--hostpath",
+                  folder[:hostpath]]
+          args << "--transient" if folder.has_key?(:transient) && folder[:transient]
+          execute("sharedfolder", "add", @uuid, *args)
         end
       end
 

--- a/lib/vagrant/driver/virtualbox_4_1.rb
+++ b/lib/vagrant/driver/virtualbox_4_1.rb
@@ -392,8 +392,12 @@ module Vagrant
 
       def share_folders(folders)
         folders.each do |folder|
-          execute("sharedfolder", "add", @uuid, "--name",
-                  folder[:name], "--hostpath", folder[:hostpath])
+          args = ["--name",
+                  folder[:name],
+                  "--hostpath",
+                  folder[:hostpath]]
+          args << "--transient" if folder.has_key?(:transient) && folder[:transient]
+          execute("sharedfolder", "add", @uuid, *args)
         end
       end
 


### PR DESCRIPTION
I'm currently creating a vagrant plugin that needs the ability to create and mount shared folders while a VM is running.  This commit exposes that existing `VBoxManage` functionality in the underlying vagrant driver.
