### PR TITLE
GH685: make escape code removal configurable

### DIFF
--- a/config/default.rb
+++ b/config/default.rb
@@ -12,6 +12,7 @@ Vagrant::Config.run do |config|
   config.ssh.forward_agent = false
   config.ssh.forward_x11 = false
   config.ssh.shell = "bash"
+  config.ssh.enable_ansi_colors = true
 
   config.vm.auto_port_range = (2200..2250)
   config.vm.box_url = nil

--- a/lib/vagrant/communication/ssh.rb
+++ b/lib/vagrant/communication/ssh.rb
@@ -171,7 +171,7 @@ module Vagrant
             ch2.on_data do |ch3, data|
               if block_given?
                 # Filter out the clear screen command
-                data = remove_ansi_escape_codes(data)
+                data = remove_ansi_escape_codes(data) unless @vm.config.ssh.enable_ansi_colors
                 @logger.debug("stdout: #{data}")
                 yield :stdout, data
               end
@@ -180,7 +180,7 @@ module Vagrant
             ch2.on_extended_data do |ch3, type, data|
               if block_given?
                 # Filter out the clear screen command
-                data = remove_ansi_escape_codes(data)
+                data = remove_ansi_escape_codes(data) unless @vm.config.ssh.enable_ansi_colors
                 @logger.debug("stderr: #{data}")
                 yield :stderr, data
               end

--- a/lib/vagrant/config/ssh.rb
+++ b/lib/vagrant/config/ssh.rb
@@ -12,6 +12,7 @@ module Vagrant
       attr_accessor :forward_agent
       attr_accessor :forward_x11
       attr_accessor :shell
+      attr_accessor :enable_ansi_colors
 
       def forwarded_port_key=(value)
         raise Errors::DeprecationError, :message => <<-MESSAGE


### PR DESCRIPTION
new option is ssh.enable_ansi_colors, currently defaults to true

 this is just a proposal for you to look at .. feel free to ignore/change
I successfully tested in my environment (Red Hat and puppet 2.7.x)
