### PR TITLE
Fix crash when using an additional interface

### DIFF
--- a/lib/vagrant/guest/redhat.rb
+++ b/lib/vagrant/guest/redhat.rb
@@ -41,7 +41,7 @@ module Vagrant
         interfaces.each do |interface|
           vm.channel.sudo("/sbin/ifconfig eth#{interface} down 2> /dev/null")
           vm.channel.sudo("cat /tmp/vagrant-network-entry_#{interface} >> #{network_scripts_dir}/ifcfg-eth#{interface}")
-          vm.channel.sudo("/sbin/ifup eth#{interface}")
+          vm.channel.sudo("/sbin/ifconfig eth#{interface} up 2> /dev/null")
         end
       end
 


### PR DESCRIPTION
When I use a bridged network interface, the interface restart (with ifup) was failing since the change to ifconfig down from ifdown.  This change works well with the tests I have run. 

I did not test this with NAT configured devices.
