### PR TITLE
Bridged Interfaces filtering

### DIFF
--- a/lib/vagrant/action/vm/network.rb
+++ b/lib/vagrant/action/vm/network.rb
@@ -319,7 +319,6 @@ module Vagrant
 
         def bridged_adapter(config)
           bridgedifs = @env[:vm].driver.read_bridged_interfaces
-
           bridgedifs.delete_if { |interface| interface[:status] == "Down" }
               
           chosen_bridge = nil


### PR DESCRIPTION
When multiple bridged interfaces are available the user is prompted for
    which interface to use. This patch removes the 'Down' interfaces for
    this list.
