### PR TITLE
Workaround for #658

### DIFF
--- a/lib/vagrant/util/subprocess.rb
+++ b/lib/vagrant/util/subprocess.rb
@@ -36,7 +36,6 @@ module Vagrant
             puts "caught SIGINT, shutting down"
             `taskkill /F /T /PID #{pid}` if windows?
           end
-          stdin.close
           [
            Thread.new(stdout) {|stdout_io|
              @logger.debug("Selecting on IO")
@@ -45,7 +44,6 @@ module Vagrant
                io_data[:stdout] += data
                yield :stdout, data if block_given?
              end
-             stdout_io.close
            },
 
            Thread.new(stderr) {|stderr_io|


### PR DESCRIPTION
This is a workaround for issue #658
https://github.com/mitchellh/vagrant/issues/658

This is the best way to handle subprocesses with IO in JRuby.  I'm also working on a patch for childprocess (so that this can be removed.  But this is a complete showstopper on JRuby for Vagrant right now.
