### PR TITLE
Restore stand-alone puppet colors

### DIFF
--- a/lib/vagrant/provisioners/puppet.rb
+++ b/lib/vagrant/provisioners/puppet.rb
@@ -146,12 +146,7 @@ module Vagrant
                              :manifest => @manifest_file)
 
         env[:vm].channel.sudo(command) do |type, data|
-          # Output the data with the proper color based on the stream.
-          color = type == :stdout ? :green : :red
-
-          # Note: Be sure to chomp the data to avoid the newlines that the
-          # Chef outputs.
-          env[:ui].info(data.chomp, :color => color, :prefix => false)
+          env[:ui].info(data.chomp, :prefix => false)
         end
       end
 


### PR DESCRIPTION
Fixes #685 for stand-alone puppet runs the same way 20fa35550238bd9fc18864ef3cacf6fab38d1ce4 did for puppet_server.
