### PR TITLE
Convert host only IPs to be RFC1918

### DIFF
--- a/lib/vagrant/guest/base.rb
+++ b/lib/vagrant/guest/base.rb
@@ -81,7 +81,7 @@ module Vagrant
       #
       # {
       #   :type      => :static,
-      #   :ip        => "33.33.33.10",
+      #   :ip        => "192.168.33.10",
       #   :netmask   => "255.255.255.0",
       #   :interface => 1
       # }

--- a/templates/commands/init/Vagrantfile.erb
+++ b/templates/commands/init/Vagrantfile.erb
@@ -20,7 +20,7 @@ Vagrant::Config.run do |config|
   # via the IP. Host-only networks can talk to the host machine as well as
   # any other machines on the same network, but cannot be accessed (through this
   # network interface) by any external networks.
-  # config.vm.network :hostonly, "33.33.33.10"
+  # config.vm.network :hostonly, "192.168.33.10"
 
   # Assign this VM to a bridged network, allowing you to connect directly to a
   # network using the host's network device. This makes the VM appear as another

--- a/test/acceptance/networking/host_only_test.rb
+++ b/test/acceptance/networking/host_only_test.rb
@@ -26,12 +26,12 @@ describe "vagrant host only networking" do
       f.puts(<<VFILE)
 Vagrant::Config.run do |config|
   config.vm.box = "base"
-  config.vm.network :hostonly, "33.33.33.10"
+  config.vm.network :hostonly, "192.168.33.10"
 end
 VFILE
     end
 
     assert_execute("vagrant", "up")
-    assert_host_to_vm_network("http://33.33.33.10:8000/", 8000)
+    assert_host_to_vm_network("http://192.168.33.10:8000/", 8000)
   end
 end

--- a/test/unit/vagrant/config/vm_test.rb
+++ b/test/unit/vagrant/config/vm_test.rb
@@ -34,15 +34,15 @@ describe Vagrant::Config::VMConfig do
 
   it "merges by appending networks" do
     a = described_class.new
-    a.network :hostonly, "33.33.33.10"
+    a.network :hostonly, "192.168.33.10"
 
     b = described_class.new
-    b.network :hostonly, "33.33.33.11"
+    b.network :hostonly, "192.168.33.11"
 
     c = a.merge(b)
     c.networks.length.should == 2
-    c.networks[0].should == [:hostonly, ["33.33.33.10"]]
-    c.networks[1].should == [:hostonly, ["33.33.33.11"]]
+    c.networks[0].should == [:hostonly, ["192.168.33.10"]]
+    c.networks[1].should == [:hostonly, ["192.168.33.11"]]
   end
 
   it "merges by appending provisioners" do


### PR DESCRIPTION
33.0.0.0/8 is owned by the DoD. At the very least this configuration breaks access to the subnet 33.33.33.0/24 that the DoD owns. If a Vagrant user wants to communicate with an IP in that range he can't because Vagrant has configured the host OS to route those packets to the guest OS (rather than the Internet).

This pull request converts the example IPs to be in 192.168.0.0/16 which is safe. I ran a basic set of tests with rake and they all passed.
