### PR TITLE
shield the guest from nameserver changes when using :hostonly networking

### DIFF
--- a/lib/vagrant/driver/virtualbox_4_0.rb
+++ b/lib/vagrant/driver/virtualbox_4_0.rb
@@ -108,6 +108,9 @@ module Vagrant
           if adapter[:hostonly]
             args.concat(["--hostonlyadapter#{adapter[:adapter]}",
                          adapter[:hostonly]])
+            # enable DNS proxy
+            # http://www.virtualbox.org/manual/ch09.html#nat-adv-dns
+            args.concat(["--natdnsproxy1", "on"])
           end
 
           if adapter[:mac_address]

--- a/lib/vagrant/driver/virtualbox_4_1.rb
+++ b/lib/vagrant/driver/virtualbox_4_1.rb
@@ -108,6 +108,9 @@ module Vagrant
           if adapter[:hostonly]
             args.concat(["--hostonlyadapter#{adapter[:adapter]}",
                          adapter[:hostonly]])
+            # enable DNS proxy
+            # http://www.virtualbox.org/manual/ch09.html#nat-adv-dns
+            args.concat(["--natdnsproxy1", "on"])
           end
 
           if adapter[:mac_address]


### PR DESCRIPTION
I provisioned a VM at coworking today and the guest VM inherited the nameserver info from that network:

```
vagrant@piab-private-chef:~$ cat /etc/resolv.conf 
nameserver 192.168.34.251
domain thebox
search thebox
```

I went home where I expected this configuration:

```
nameserver 208.67.222.222 # opendns
nameserver 10.66.44.1 # internal router
```

VirtualBox ships with the [ability to enable a DNS proxy in NAT mode](http://www.virtualbox.org/manual/ch09.html#nat-adv-dns) to shield the guest VM from this issue.  When this mode is enabled the guest VM receives this configuration:

```
vagrant@piab-private-chef:~$ cat /etc/resolv.conf 
nameserver 10.0.2.3
```

`10.0.2.3` is a DNS proxy that 'does the right thing'. We should probably enable by default when Vagrant has a network type `:hostonly`.  This commit does just that!
