### PR TITLE
Fix for permissions when re-provisioning chef.

### DIFF
--- a/lib/vagrant/provisioners/chef.rb
+++ b/lib/vagrant/provisioners/chef.rb
@@ -57,7 +57,9 @@ module Vagrant
         temp.write(config_file)
         temp.close
 
-        env[:vm].channel.upload(temp.path, File.join(config.provisioning_path, filename))
+        remote_file = File.join(config.provisioning_path, filename)
+        env[:vm].channel.sudo("rm #{remote_file}", :error_check => false)
+        env[:vm].channel.upload(temp.path, remote_file)
       end
 
       def setup_json


### PR DESCRIPTION
This should fix https://github.com/mitchellh/vagrant/issues/748

I think the chef-client recipe ends up changing ownership of client.rb leading to this issue.  This fix just sudo rm's the file before uploading it.
