### PR TITLE
Add pre-apply option so we can set Puppet facts

### DIFF
--- a/lib/vagrant/provisioners/puppet.rb
+++ b/lib/vagrant/provisioners/puppet.rb
@@ -13,11 +13,13 @@ module Vagrant
         attr_accessor :module_path
         attr_accessor :pp_path
         attr_accessor :options
+        attr_accessor :pre_apply
 
         def manifest_file; @manifest_file || "default.pp"; end
         def manifests_path; @manifests_path || "manifests"; end
         def pp_path; @pp_path || "/tmp/vagrant-puppet"; end
         def options; @options ||= []; end
+        def pre_apply; @options ||= []; end
 
         # Returns the manifests path expanded relative to the root path of the
         # environment.
@@ -138,7 +140,9 @@ module Vagrant
         options << @manifest_file
         options = options.join(" ")
 
-        command = "cd #{manifests_guest_path} && puppet apply #{options}"
+        pre_apply = [config.pre_apply].flatten
+
+        command = "cd #{manifests_guest_path} && #{pre_apply} puppet apply #{options}"
 
         env[:ui].info I18n.t("vagrant.provisioners.puppet.running_puppet",
                              :manifest => @manifest_file)


### PR DESCRIPTION
Hi,

There's this great, little known ability in Puppet (well, Facter actually) whereby you can set facts prior to running 'puppet apply' in a fashion similar to altering environment variables using ENV:

``` shell
# override $operatingsystem for testing purposes
$ FACTER_operatingsystem=Debian puppet -e 'notify { "We are running on $operatingsystem": }'
notice: We are running on Debian
```

(ref.: [Puppet Cookbook](http://www.puppetcookbook.com/posts/override-a-facter-fact.html))

I modeled 'pre_apply' directly on the 'option' setting for puppet, so that single facts, such as:

``` ruby
config.vm.provision :puppet, :pre_apply   = "FACTER_fqdn='www.ergonlogic.com'"
```

or an array of facts work equally well:

``` ruby
config.vm.provision :puppet, :pre_apply   = [ "FACTER_domain='ergonlogic.com'", "FACTER_hostname='www'" ]
```

Let me know if you like the idea and I'll write up some tests to go along with it.

By the way, my hope is to use this for a Vagrant-based project I started called [Aegir-up](http://drupal.org/project/aegir-up). The itch that led to this little patch is that there's a [bug in Puppet](http://bugs.debian.org/cgi-bin/bugreport.cgi?bug=637894) that results in incorrect FQDNs on Debian systems when using an internal DNS server. 
