### PR TITLE
FooProvisioner::Config does not seem to be used by default

### DIFF
--- a/lib/vagrant/config/vm/provisioner.rb
+++ b/lib/vagrant/config/vm/provisioner.rb
@@ -24,6 +24,9 @@ module Vagrant
         # Configures the provisioner if it can (if it is valid).
         def configure(options=nil, &block)
           config_class = @provisioner.config_class
+          if !config_class && defined? @provisioner::Config
+            config_class = @provisioner::Config
+          end
           return if !config_class
 
           @logger.debug("Configuring provisioner with: #{config_class}")


### PR DESCRIPTION
Hello,

The doc here http://vagrantup.com/docs/provisioners/others.html states that 

```
class FooProvisioner < Vagrant::Provisioners::Base
  # Vagrant automatically finds a class named "Config" namespaced
  # beneath the provisioner, and uses it!
  class Config < Vagrant::Config::Base
```

However, it did not seem to be the case. I had to add this method to my provisioner (copied from the standard provisioner's code):

```
def self.config_class
  Config
end
```

This patch should solve the issue. Be careful though, as I'm not familiar at all with vagrant's code ;-)

Best regards,
Dom
