### PR TITLE
Fix for #788. Prevents FloatDomainError when downloading a box and no content-length header is present

### DIFF
--- a/lib/vagrant/ui.rb
+++ b/lib/vagrant/ui.rb
@@ -78,9 +78,13 @@ module Vagrant
       # to the UI. Send `clear_line` to clear the line to show
       # a continuous progress meter.
       def report_progress(progress, total, show_parts=true)
-        percent = (progress.to_f / total.to_f) * 100
-        line    = "Progress: #{percent.to_i}%"
-        line   << " (#{progress} / #{total})" if show_parts
+        if total and not total == 0
+          percent = (progress.to_f / total.to_f) * 100
+          line    = "Progress: #{percent.to_i}%"
+          line   << " (#{progress} / #{total})" if show_parts
+        else
+          line    = "Progress: #{progress}"
+        end
 
         info(line, :new_line => false)
       end


### PR DESCRIPTION
If the total is not provided or is unknown then don't attempt to calculate or display a percentage, just show the current progress instead.

For example:

Output when downloading a box and content-length header is present:

```
[vagrant] Progress: 21% (110968832 / 524483584)
```

And if a content-length header is not present (total bytes are unknown):

```
[vagrant] Progress: 110968832
```
