### PR TITLE
Fix exporting base boxes by name in Vagrant 1.0.0

### DIFF
--- a/lib/vagrant/vm.rb
+++ b/lib/vagrant/vm.rb
@@ -22,14 +22,9 @@ module Vagrant
       @box    = env.boxes.find(config.vm.box)
 
       opts ||= {}
-      if opts[:base]
-        # The name is the ID we use.
-        @uuid = name
-      else
-        # Load the UUID if its saved.
-        active = env.local_data[:active] || {}
-        @uuid = active[@name.to_s]
-      end
+      # Load the UUID if its saved.
+      active = env.local_data[:active] || {}
+      @uuid = active[@name.to_s]
 
       # Reload ourselves to get the state
       reload!


### PR DESCRIPTION
Currently if :base is in options @uuid is set to the name of the box defined in Vagrantfile. It the fails out complaining it cannot find this name in the list of uuids of virtual box vms. I have modified lib/vagrant/vm.rb to always pass the uuid, which correctly allows me to export a base box by name. 

This fixes issue 799 (https://github.com/mitchellh/vagrant/issues/799). 

If there is a reason you want to pass the name to @uuid in vm.rb, I'd love to know so that I can help fix it, I'd love to start contributing to the project that has really helped me in my dev environments. 
