### PR TITLE
Allow provisioners to prepare, even if they're not enabled

### DIFF
--- a/lib/vagrant/action/vm/provision.rb
+++ b/lib/vagrant/action/vm/provision.rb
@@ -19,12 +19,10 @@ module Vagrant
           # We set this here so that even if this value is changed in the future,
           # it stays constant to what we expect here in this moment.
           enabled = env["provision.enabled"]
-          if enabled
-            # Instantiate and prepare the provisioners. Preparation must happen here
-            # so that shared folders and such can properly take effect.
-            provisioners = enabled_provisioners
-            provisioners.map { |p| p.prepare }
-          end
+          # Instantiate and prepare the provisioners. Preparation must happen here
+          # so that shared folders and such can properly take effect.
+          provisioners = enabled_provisioners
+          provisioners.map { |p| p.prepare }
 
           @app.call(env)
 


### PR DESCRIPTION
Without this, my silly Vagrant plugin for Jenkins gets all kinds of sad :(

Fixes #801
