### PR TITLE
only move to the work directory once

### DIFF
--- a/lib/vagrant/util/subprocess.rb
+++ b/lib/vagrant/util/subprocess.rb
@@ -52,9 +52,8 @@ module Vagrant
 
         # Start the process
         begin
-          Dir.chdir(workdir) do
-            process.start
-          end
+          Dir.chdir(workdir) if File.expand_path(workdir) != Dir.pwd
+          process.start
         rescue ChildProcess::LaunchError
           # Raise our own version of the error so that users of the class
           # don't need to be aware of ChildProcess


### PR DESCRIPTION
Right now, every time that Vagrant wants to run a command it moves to the work directory. If two processes try to move to the directory at the same time it fails. It only needs to move to the work directory once though.

This patch fix this issue.
