### PR TITLE
Use RFC1918 addresses in doc examples

### DIFF
--- a/docs/config/vm/network.md
+++ b/docs/config/vm/network.md
@@ -21,12 +21,12 @@ Host only neworks can be defined by providing only a simple IP:
 {% highlight ruby %}
 Vagrant::Config.run do |config|
   # ...
-  config.vm.network :hostonly, "33.33.33.10"
+  config.vm.network :hostonly, "10.11.12.13"
 end
 {% endhighlight %}
 
 This will configure a host only network on the virtual machine
-that is assigned a static IP of "33.33.33.10."
+that is assigned a static IP of "10.11.12.13."
 
 Other options are available for host only networks and may be
 passed in as an options hash for the 3rd parameter. The available

--- a/docs/host_only_networking.md
+++ b/docs/host_only_networking.md
@@ -59,9 +59,9 @@ to make sure that no static IPs will collide with other virtual machines.
 
 By default, Vagrant uses a netmask of `255.255.255.0`. This means that
 as long as the first three parts of the IP are equivalent, VMs will join
-the same network. So if two VMs are created with IPs `33.33.33.10` and
-`33.33.33.11`, they will be networked together. However, if a VM is
-created with an IP of `33.33.34.10`, it will be on a separate network
+the same network. So if two VMs are created with IPs `10.11.12.13` and
+`10.11.12.14`, they will be networked together. However, if a VM is
+created with an IP of `10.11.20.21`, it will be on a separate network
 and will not be able to communicate with the other VMs.
 
 A custom netmask can also be used, although a netmask of `255.255.255.0`
@@ -70,7 +70,7 @@ is shown below:
 
 {% highlight ruby %}
 Vagrant::Config.run do |config|
-  config.vm.network :hostonly, "33.33.34.10", :netmask => "255.255.0.0"
+  config.vm.network :hostonly, "10.11.12.13", :netmask => "255.255.0.0"
 end
 {% endhighlight %}
 


### PR DESCRIPTION
33.33.x.x is part of an officially allocated IP address block. It's bad
practice to use non-private IP addresses, event behind NAT.

This isn't a big issue, but it _suggests_ bad practice and we know
people often copy-paste examples without thinking too much.

What's the point to try to fix the devops problem, if you upset your
network admin on the way ? ;-)
