### PR TITLE
Add encrypted data bag options to chef-solo

### DIFF
--- a/templates/provisioners/chef_solo/solo.erb
+++ b/templates/provisioners/chef_solo/solo.erb
@@ -6,6 +6,8 @@ cookbook_path <%= cookbooks_path.inspect %>
 role_path <%= roles_path.inspect %>
 log_level <%= log_level.inspect %>
 
+encrypted_data_bag_secret "<%= encrypted_data_bag_secret %>"
+
 <% if data_bags_path -%>
 data_bag_path <%= data_bags_path.inspect %>
 <% end %>

--- a/test/unit_legacy/vagrant/provisioners/chef_solo_test.rb
+++ b/test/unit_legacy/vagrant/provisioners/chef_solo_test.rb
@@ -87,7 +87,8 @@ class ChefSoloProvisionerTest < Test::Unit::TestCase
         :cookbooks_path => @action.guest_paths(@action.cookbook_folders),
         :recipe_url => @config.recipe_url,
         :roles_path => @action.guest_paths(@action.role_folders).first,
-        :data_bags_path => @action.guest_paths(@action.data_bags_folders).first
+        :data_bags_path => @action.guest_paths(@action.data_bags_folders).first,
+        :encrypted_data_bag_secret => @config.encrypted_data_bag_secret
       })
 
       @action.setup_solo_config


### PR DESCRIPTION
Basically what the title says. It adds encrypted data bag support to the chef-solo provisioner. I took what was in chef-client and basically duplicated it in chef-solo. 
