### PR TITLE
Suppot SunSSH

### DIFF
--- a/lib/vagrant/ssh.rb
+++ b/lib/vagrant/ssh.rb
@@ -76,8 +76,11 @@ module Vagrant
 
       # Command line options
       command_options = ["-p", options[:port].to_s, "-o", "UserKnownHostsFile=/dev/null",
-                         "-o", "StrictHostKeyChecking=no", "-o", "IdentitiesOnly=yes",
-                         "-o", "LogLevel=ERROR"]
+                         "-o", "StrictHostKeyChecking=no", "-o", "LogLevel=ERROR"]
+
+      # Solaris/OpenSolaris/Illumos uses SunSSH which doesn't support the IdentitiesOnly option
+      command_options += ["-o", "IdentitiesOnly=yes"] unless Util::Platform.solaris?
+
       command_options += ["-i", options[:private_key_path]] if !plain_mode
       command_options += ["-o", "ForwardAgent=yes"] if ssh_info[:forward_agent]
 

--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -14,7 +14,7 @@ module Vagrant
           platform.include?("darwin9")
         end
 
-        [:darwin, :bsd, :freebsd, :linux].each do |type|
+        [:darwin, :bsd, :freebsd, :linux, :solaris].each do |type|
           define_method("#{type}?") do
             platform.include?(type.to_s)
           end


### PR DESCRIPTION
Hi there,

SunSSH is default on Solaris/OpenSolaris/Illumos/OpenIndiana (instead of OpenSSH). SunSSH currently does not support the IdentitiesOnly option. 'vagrant ssh' works when the options is not supplied.

I don't know if this solution is the right way to go, but it works on my Illumos machine. 

Cheers,
Hendrik
