### PR TITLE
Enable DNS proxy (in NAT mode) by default

### DIFF
--- a/lib/vagrant/action/vm/sane_defaults.rb
+++ b/lib/vagrant/action/vm/sane_defaults.rb
@@ -21,6 +21,14 @@ module Vagrant
           ]
           env[:vm].driver.execute_command(command)
 
+          # Enable the DNS proxy while in NAT mode.  This shields the guest
+          # VM from external DNS changs on the host machine.
+          command = [
+            "modifyvm", env[:vm].uuid,
+            "--natdnsproxy1", "on"
+          ]
+          env[:vm].driver.execute_command(command)
+
           @app.call(env)
         end
       end


### PR DESCRIPTION
This is just the new incarnation of: https://github.com/mitchellh/vagrant/pull/749

**Original description:**

I provisioned a VM at coworking today and the guest VM inherited the nameserver info from that network:

```
vagrant@piab-private-chef:~$ cat /etc/resolv.conf 
nameserver 192.168.34.251
domain thebox
search thebox
```

I went home where I expected this configuration:

```
nameserver 208.67.222.222 # opendns
nameserver 10.66.44.1 # internal router
```

VirtualBox ships with the [ability to enable a DNS proxy in NAT mode](http://www.virtualbox.org/manual/ch09.html#nat-adv-dns) to shield the guest VM from this issue.  When this mode is enabled the guest VM receives this configuration:

```
vagrant@piab-private-chef:~$ cat /etc/resolv.conf 
nameserver 10.0.2.3
```

`10.0.2.3` is a DNS proxy that 'does the right thing'. We should probably enable by default when Vagrant has a network type `:hostonly`.  This commit does just that!
