### PR TITLE
Detect when the VirtualBox installation is incomplete and error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.1.0 (unreleased)
 
   - Improve the SSH "ready?" check. [GH-841]
+  - Detect when the VirtualBox installation is incomplete and error.
 
 ## 1.0.2 (March 25, 2012)
 

--- a/lib/vagrant/driver/virtualbox.rb
+++ b/lib/vagrant/driver/virtualbox.rb
@@ -122,6 +122,12 @@ module Vagrant
         output = execute("--version")
         if output =~ /vboxdrv kernel module is not loaded/
           raise Errors::VirtualBoxKernelModuleNotLoaded
+        # Check for installation incomplete warnings, for example:
+        # "WARNING: The character device /dev/vboxdrv does not
+        # exist. Please install the virtualbox-ose-dkms package and
+        # the appropriate headers, most likely linux-headers-generic."
+        elsif output =~ /Please install/
+          raise Errors::VirtualBoxInstallIncomplete
         end
 
         parts = output.split("_")

--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -383,6 +383,11 @@ module Vagrant
       error_key(:virtualbox_kernel_module_not_loaded)
     end
 
+    class VirtualBoxInstallIncomplete < VagrantError
+      status_code(79)
+      error_key(:virtualbox_install_incomplete)
+    end
+
     class VMBaseMacNotSpecified < VagrantError
       status_code(47)
       error_key(:no_base_mac, "vagrant.actions.vm.match_mac")

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -184,6 +184,10 @@ en:
         VirtualBox is complaining that the kernel module is not loaded. Please
         run `VBoxManage --version` to see the error message which should contain
         instructions on how to fix this error.
+      virtualbox_install_incomplete: |-
+        VirtualBox is complaining that the installation is incomplete. Please
+        run `VBoxManage --version` to see the error message which should contain
+        instructions on how to fix this error.
       virtualbox_not_detected: |-
         Vagrant could not detect VirtualBox! Make sure VirtualBox is properly installed.
         Vagrant uses the `VBoxManage` binary that ships with VirtualBox, and requires


### PR DESCRIPTION
After a kernel upgrade without rebuilding the VirtualBox kernel modules, Vagrant gave the following error:

```
Vagrant has detected that you have a version of VirtualBox installed
that is not supported. Please install one of the supported versions
listed below to use Vagrant:

4.0, 4.1
```

I saw [GH-677] and noticed that VBoxManage was complaining with the following error:

```
$ VBoxManage --version
WARNING: The character device /dev/vboxdrv does not exist.
         Please install the virtualbox-ose-dkms package and the appropriate
         headers, most likely linux-headers-generic.

         You will not be able to start VMs until this problem is fixed.
4.1.2_Ubuntur38459
```

Because it didn't fit the error output matched in ce2ea4ea9339e0292b9f85574e59fd8868e1669e, I've added an additional error condition check which warns of an incomplete VirtualBox installation.
