### PR TITLE
Eliminate SSH warning messages

### DIFF
--- a/templates/commands/ssh_config/config.erb
+++ b/templates/commands/ssh_config/config.erb
@@ -2,7 +2,7 @@ Host <%= host_key %>
   HostName <%= ssh_host %>
   User <%= ssh_user %>
   Port <%= ssh_port %>
-  UserKnownHostsFile /dev/null
+  UserKnownHostsFile <%= File.dirname(private_key_path) + "/known_hosts">
   StrictHostKeyChecking no
   PasswordAuthentication no
   IdentityFile <%= private_key_path %>


### PR DESCRIPTION
I set up a Vagrant VM to use host-only networking, then run 'vagrant ssh-config >> ~/.ssh/config'.

When I ssh or scp to my Vagrant VM, I get a blizzard of warning messages:

```
Warning: Permanently added '[127.0.0.1]:2222' (RSA) to the list of known hosts.
```

The problem is that Vagrant sets UserKnownHostsFile to '/dev/null'.  Nothing can get added to the list of known hosts, so you get the warning message over and over again.

The solution is to set the UnserKnownHostsFile to '~/.vagrant.d/known_hosts'.  Once this is done, you see the warning message only once.
