### PR TITLE
fix #809: Show a more descriptive error mouting shared folders

### DIFF
--- a/lib/vagrant/guest/linux.rb
+++ b/lib/vagrant/guest/linux.rb
@@ -102,7 +102,11 @@ module Vagrant
         attempts = 0
         while true
           success = true
-          @vm.channel.sudo("mount -t vboxsf #{mount_options} #{name} #{guestpath}") do |type, data|
+          @vm.channel.sudo("mount -t vboxsf #{mount_options} #{name} #{guestpath}",
+                          :error_class => LinuxError,
+                          :error_key => :mount_folder_fail,
+                          :name => name,
+                          :host_path => options[:hostpath]) do |type, data|
             success = false if type == :stderr && data =~ /No such device/i
           end
 

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -746,7 +746,10 @@ en:
           for one of your shared folders. This is an extremely rare error case
           and most likely indicates an unusual configuration of the guest system.
           Please report a bug with your Vagrantfile.
-        mount_fail: "Failed to mount shared folders. `vboxsf` was not available."
+        mount_fail: "Failed to mount shared folders. `vboxfs` was not available."
+        mount_folder_fail: |-
+          Failed to mount shared folder `%{name}`. `%{host_path}` does not exist.
+
         mount_nfs_fail: |-
           Mounting NFS shared folders failed. This is most often caused by the NFS
           client software not being installed on the guest machine. Please verify


### PR DESCRIPTION
I'm not sure if the legacy test suite is being maintained, so I don't know if I should add a test case there.
