### PR TITLE
Cleanup any tmp files set by vagrant to fix a permissions issue when switching users.

### DIFF
--- a/lib/vagrant/action/vm/network.rb
+++ b/lib/vagrant/action/vm/network.rb
@@ -70,7 +70,6 @@ module Vagrant
             networks_to_configure = networks.select { |n| n[:_auto_config] }
             env[:ui].info I18n.t("vagrant.actions.vm.network.configuring")
             env[:vm].guest.configure_networks(networks_to_configure)
-            env[:vm].channel.sudo("su -c 'rm /tmp/vagrant-*'")
           end
         end
 

--- a/lib/vagrant/guest/arch.rb
+++ b/lib/vagrant/guest/arch.rb
@@ -22,6 +22,7 @@ module Vagrant
         # Remove previous Vagrant-managed network interfaces
         vm.channel.sudo("sed -e '/^#VAGRANT-BEGIN/,/^#VAGRANT-END/ d' /etc/rc.conf > /tmp/vagrant-network-interfaces")
         vm.channel.sudo("cat /tmp/vagrant-network-interfaces > /etc/rc.conf")
+        vm.channel.sudo("rm /tmp/vagrant-network-interfaces")
 
         # Configure the network interfaces
         interfaces = Set.new
@@ -45,6 +46,7 @@ module Vagrant
 
         # Reconfigure the network interfaces
         vm.channel.sudo("cat /tmp/vagrant-network-entry >> /etc/rc.conf")
+        vm.channel.sudo("rm /tmp/vagrant-network-entry")
         vm.channel.sudo("/etc/rc.d/network restart")
 
         interfaces.each do |interface|

--- a/lib/vagrant/guest/debian.rb
+++ b/lib/vagrant/guest/debian.rb
@@ -14,6 +14,7 @@ module Vagrant
         # from the interface file.
         vm.channel.sudo("sed -e '/^#VAGRANT-BEGIN/,/^#VAGRANT-END/ d' /etc/network/interfaces > /tmp/vagrant-network-interfaces")
         vm.channel.sudo("su -c 'cat /tmp/vagrant-network-interfaces > /etc/network/interfaces'")
+        vm.channel.sudo("rm /tmp/vagrant-network-interfaces")
 
         # Accumulate the configurations to add to the interfaces file as
         # well as what interfaces we're actually configuring since we use that
@@ -45,6 +46,7 @@ module Vagrant
         end
 
         vm.channel.sudo("cat /tmp/vagrant-network-entry >> /etc/network/interfaces")
+        vm.channel.sudo("rm /tmp/vagrant-network-entry")
 
         # Bring back up each network interface, reconfigured
         interfaces.each do |interface|

--- a/lib/vagrant/guest/fedora.rb
+++ b/lib/vagrant/guest/fedora.rb
@@ -21,6 +21,7 @@ module Vagrant
           vm.channel.sudo("touch #{network_scripts_dir}/ifcfg-p7p#{network[:interface]}")
           vm.channel.sudo("sed -e '/^#VAGRANT-BEGIN/,/^#VAGRANT-END/ d' #{network_scripts_dir}/ifcfg-p7p#{network[:interface]} > /tmp/vagrant-ifcfg-p7p#{network[:interface]}")
           vm.channel.sudo("cat /tmp/vagrant-ifcfg-p7p#{network[:interface]} > #{network_scripts_dir}/ifcfg-p7p#{network[:interface]}")
+          vm.channel.sudo("rm /tmp/vagrant-ifcfg-p7p#{network[:interface]}")
 
           # Render and upload the network entry file to a deterministic
           # temporary location.
@@ -41,6 +42,7 @@ module Vagrant
         interfaces.each do |interface|
           vm.channel.sudo("/sbin/ifdown p7p#{interface} 2> /dev/null", :error_check => false)
           vm.channel.sudo("cat /tmp/vagrant-network-entry_#{interface} >> #{network_scripts_dir}/ifcfg-p7p#{interface}")
+          vm.channel.sudo("rm /tmp/vagrant-network-entry_#{interface}")
           vm.channel.sudo("/sbin/ifup p7p#{interface} 2> /dev/null")
         end
       end

--- a/lib/vagrant/guest/freebsd.rb
+++ b/lib/vagrant/guest/freebsd.rb
@@ -67,6 +67,8 @@ module Vagrant
                                           :options => network)
           vm.channel.upload(StringIO.new(entry), "/tmp/vagrant-network-entry")
           vm.channel.sudo("su -m root -c 'cat /tmp/vagrant-network-entry >> /etc/rc.conf'")
+          vm.channel.sudo("rm /tmp/vagrant-network-entry")
+
           if network[:type].to_sym == :static
             vm.channel.sudo("ifconfig em#{network[:interface]} inet #{network[:ip]} netmask #{network[:netmask]}")
           elsif network[:type].to_sym == :dhcp

--- a/lib/vagrant/guest/gentoo.rb
+++ b/lib/vagrant/guest/gentoo.rb
@@ -12,6 +12,7 @@ module Vagrant
         # Remove any previous host only network additions to the interface file
         vm.channel.sudo("sed -e '/^#VAGRANT-BEGIN/,/^#VAGRANT-END/ d' /etc/conf.d/net > /tmp/vagrant-network-interfaces")
         vm.channel.sudo("cat /tmp/vagrant-network-interfaces > /etc/conf.d/net")
+        vm.channel.sudo("rm /tmp/vagrant-network-interfaces")
 
         # Configure each network interface
         networks.each do |network|
@@ -30,6 +31,7 @@ module Vagrant
           vm.channel.sudo("ln -fs /etc/init.d/net.lo /etc/init.d/net.eth#{network[:interface]}")
           vm.channel.sudo("/etc/init.d/net.eth#{network[:interface]} stop 2> /dev/null")
           vm.channel.sudo("cat /tmp/vagrant-network-entry >> /etc/conf.d/net")
+          vm.channel.sudo("rm /tmp/vagrant-network-entry")
           vm.channel.sudo("/etc/init.d/net.eth#{network[:interface]} start")
         end
       end

--- a/lib/vagrant/guest/redhat.rb
+++ b/lib/vagrant/guest/redhat.rb
@@ -22,6 +22,7 @@ module Vagrant
           vm.channel.sudo("touch #{network_scripts_dir}/ifcfg-eth#{network[:interface]}")
           vm.channel.sudo("sed -e '/^#VAGRANT-BEGIN/,/^#VAGRANT-END/ d' #{network_scripts_dir}/ifcfg-eth#{network[:interface]} > /tmp/vagrant-ifcfg-eth#{network[:interface]}")
           vm.channel.sudo("cat /tmp/vagrant-ifcfg-eth#{network[:interface]} > #{network_scripts_dir}/ifcfg-eth#{network[:interface]}")
+          vm.channel.sudo("rm /tmp/vagrant-ifcfg-eth#{network[:interface]}")
 
           # Render and upload the network entry file to a deterministic
           # temporary location.
@@ -42,6 +43,7 @@ module Vagrant
         interfaces.each do |interface|
           vm.channel.sudo("/sbin/ifdown eth#{interface} 2> /dev/null", :error_check => false)
           vm.channel.sudo("cat /tmp/vagrant-network-entry_#{interface} >> #{network_scripts_dir}/ifcfg-eth#{interface}")
+          vm.channel.sudo("rm /tmp/vagrant-network-entry_#{interface}")
           vm.channel.sudo("/sbin/ifup eth#{interface} 2> /dev/null")
         end
       end


### PR DESCRIPTION
I ran into a permissions issue where if I changed the user in the Vagrantfile and ran `vagrant reload` an error would be raised when trying to upload a tmp file [1], because it was owned by the previous user.

This pull request avoids that by cleaning up any /tmp/vagrant-\* after the network has been configured. I'm not sure how to write a test for this, and I've only tested on ubuntu64.

[1] https://github.com/mitchellh/vagrant/blob/master/lib/vagrant/guest/debian.rb#L38
