### PR TITLE
Allow to customize the chef solo/client configuration

### DIFF
--- a/templates/provisioners/chef_client/client.erb
+++ b/templates/provisioners/chef_client/client.erb
@@ -30,3 +30,7 @@ no_proxy <%= no_proxy.inspect %>
 pid_file           "/var/run/chef/chef-client.pid"
 
 Mixlib::Log::Formatter.show_time = true
+
+<% if custom_configuration %>
+require 'chef-custom-configuration'
+<% end %>

--- a/templates/provisioners/chef_solo/solo.erb
+++ b/templates/provisioners/chef_solo/solo.erb
@@ -23,3 +23,7 @@ https_proxy <%= https_proxy.inspect %>
 https_proxy_user <%= https_proxy_user.inspect %>
 https_proxy_pass <%= https_proxy_pass.inspect %>
 no_proxy <%= no_proxy.inspect %>
+
+<% if custom_configuration %>
+require 'chef-custom-configuration'
+<% end %>


### PR DESCRIPTION
Right now Vagrant generates Chef solo/client configuration from a template, but the fields are fixed and it's imposible to add things that are not in the basic configuration, like report handlers for instance.

I was considering to add a new attribute to allow to use a configuration file provided by the user but I'm not sure if that's the best approach since I still need to add the paths that vagrant generates into the vm for the recipes.

Ideas and comments are really appreciated.
