### PR TITLE
Don't use IdentitiesOnly under 'ssh -p'

### DIFF
--- a/lib/vagrant/ssh.rb
+++ b/lib/vagrant/ssh.rb
@@ -80,7 +80,7 @@ module Vagrant
 
       # Solaris/OpenSolaris/Illumos uses SunSSH which doesn't support the IdentitiesOnly option
       # (Also don't use it in plain mode, it'll skip user agents.)
-      command_options += ["-o", "IdentitiesOnly=yes"] if !Util::Platform.solaris? || plain_mode
+      command_options += ["-o", "IdentitiesOnly=yes"] if !(Util::Platform.solaris? || plain_mode)
 
       command_options += ["-i", options[:private_key_path]] if !plain_mode
       command_options += ["-o", "ForwardAgent=yes"] if ssh_info[:forward_agent]


### PR DESCRIPTION
Plain mode SSH shouldn't specify IdentitiesOnly, as that forgoes use of the local user's own SSH agent. Plain mode implies "use my local SSH setup, I just want Vagrant filling in the blanks re: VM port" so having one's agent work is pretty important :)
