### PR TITLE
Fix for issue #898 - interfaces assigned in wrong order under ruby1.8

### DIFF
--- a/lib/vagrant/action/vm/network.rb
+++ b/lib/vagrant/action/vm/network.rb
@@ -135,7 +135,7 @@ module Vagrant
 
           # Make a first pass to assign interface numbers by adapter location
           vm_adapters = @env[:vm].driver.read_network_interfaces
-          vm_adapters.each do |number, adapter|
+          vm_adapters.sort.each do |number, adapter|
             if adapter[:type] != :none
               # Not used, so assign the interface number and increment
               adapter_to_interface[number] = current


### PR DESCRIPTION
Fixes a bug where interfaces are assigned in a wrong order when using ruby1.8, causing vm boot to stop as documented in issue #898
