### PR TITLE
Detect and disable DNS settings that break on Ubuntu 12.04.

### DIFF
--- a/lib/vagrant/action/vm/sane_defaults.rb
+++ b/lib/vagrant/action/vm/sane_defaults.rb
@@ -28,7 +28,7 @@ module Vagrant
           ]
           attempt_and_log(command, "Enabling the Host I/O cache on the SATA controller...")
 
-          case IO.read("/etc/resolv.conf")
+          case begin IO.read("/etc/resolv.conf") rescue nil end
           when /^nameserver 127\.0\.0\.1$/ then
             # The use of both natdnsproxy and natdnshostresolver break on newest ubunt 12.04
             # that uses resolvconf with localhost. When used VirtualBox will give the client


### PR DESCRIPTION
The change in c137dec14f6a7dcfc032a0967ed520addba16b87 breaks for newer ubuntu installations,
as found in https://github.com/mitchellh/vagrant/pull/834#issuecomment-5049407

This small fix detects that 127.0.0.1 is localhost, and then disables any natdns changes for VirtualBox,
with the end result that DNS 10.0.2.2 is given to the VM, and that is forwarded correctly to
127.0.0.1 that is configured by default in newer Ubuntu, due to resolvconf.
