### PR TITLE
add :protocol to available port forwarding options

### DIFF
--- a/docs/config/vm/forward_port.md
+++ b/docs/config/vm/forward_port.md
@@ -34,4 +34,6 @@ accepted options are:
   try to change the host port if it finds it would collide with any
   other forwarded port. If this is `false` (default) then an error
   will be shown instead.
+* `:protocol` - This allows specifying the protocol that the forwarded port
+  will use. The default protocol, if none is specified, is `:tcp`.
 


### PR DESCRIPTION
I ended up having to dig around in the code to figure this out, so I figured it should probably be in the documentation. Cheers.
