### PR TITLE
Fix support for multiple unique easy commands

### DIFF
--- a/lib/vagrant/easy/command_base.rb
+++ b/lib/vagrant/easy/command_base.rb
@@ -5,26 +5,26 @@ module Vagrant
     # Base class for all easy commands. This contains the basic code
     # that knows how to run the easy commands.
     class CommandBase < Vagrant::Command::Base
-      @@command = nil
-      @@runner  = nil
+      @command = nil
+      @runner  = nil
 
       # This is called by the {EasyCommand.create} method when creating
       # an easy command to set the invocation command.
       def self.configure(name, &block)
-        @@command = name
-        @@runner  = block
+        @command = name
+        @runner  = block
       end
 
       def initialize(*args, &block)
         super
 
-        @logger = Log4r::Logger.new("vagrant::easy_command::#{@@command}")
+        @logger = Log4r::Logger.new("vagrant::easy_command::#{@command}")
       end
 
       def execute
         # Build up a basic little option parser
         opts = OptionParser.new do |opts|
-          opts.banner = "Usage: vagrant #{@@command}"
+          opts.banner = "Usage: vagrant #{@command}"
         end
 
         # Parse the options
@@ -32,10 +32,10 @@ module Vagrant
         return if !argv
 
         # Run the action for each VM.
-        @logger.info("Running easy command: #{@@command}")
+        @logger.info("Running easy command: #{@command}")
         with_target_vms(argv) do |vm|
           @logger.debug("Running easy command for VM: #{vm.name}")
-          @@runner.call(Operations.new(vm))
+          @runner.call(Operations.new(vm))
         end
 
         # Exit status 0 every time for now

--- a/test/unit/vagrant/plugin/v1_test.rb
+++ b/test/unit/vagrant/plugin/v1_test.rb
@@ -109,6 +109,16 @@ describe Vagrant::Plugin::V1 do
       # Check that the command class subclasses the easy command base
       plugin.command[:foo].should < Vagrant::Easy::CommandBase
     end
+
+    it "should support registering multiple unique commands" do
+      plugins = %w(foo bar baz).map do |cmd|
+        [cmd, Vagrant::Easy.create_command(cmd)]
+      end
+
+      plugins.each do |cmd, plugin|
+        plugin.instance_variable_get(:@command).should == cmd
+      end
+    end
   end
 
   describe "guests" do


### PR DESCRIPTION
So, it turns out that my original issue with the class variable usage for Vagrant::Easy::CommandBase actually causes issues. I wrote a small test that fails with the current codebase:

``` ruby
    it "should support registering multiple unique commands" do
      plugins = %w(foo bar baz).map do |cmd|
        [cmd, Vagrant::Easy.create_command(cmd)]
      end

      plugins.each do |cmd, plugin|
        plugin.class_variable_get(:@@command).should == cmd
      end
    end
```

The above test will fail since @@command will end up having the value 'baz' for all three easy commands. This is because class variables will be shared across new subclasses of Vagrant::Easy::CommandBase:

``` ruby
    def self.create_command(name, &block)
      # Create a new command class for this command, and return it
      command = Class.new(CommandBase)
      command.configure(name, &block)
      command
    end
```

The fix is to not use class variables and instead use class instance variables for @@command and @@runner.
