### PR TITLE
typo in change_host_name

### DIFF
--- a/plugins/guests/gentoo/guest.rb
+++ b/plugins/guests/gentoo/guest.rb
@@ -39,7 +39,7 @@ module VagrantPlugins
       def change_host_name(name)
         if !vm.channel.test("sudo hostname --fqdn | grep '#{name}'")
           vm.channel.sudo("echo 'hostname=#{name.split('.')[0]}' > /etc/conf.d/hostname")
-          vm.channel.sudo("sed -i 's@^\\(127[.]0[.]1[.]1[[:space:]]\\+\\)@\\1#{name} #{name.split('.')[0]} @' /etc/hosts")
+          vm.channel.sudo("sed -i 's@^\\(127[.]0[.]0[.]1[[:space:]]\\+\\)@\\1#{name} #{name.split('.')[0]} @' /etc/hosts")
           vm.channel.sudo("hostname #{name.split('.')[0]}")
         end
       end


### PR DESCRIPTION
i've copied this typo from the debian provider, and it is also present in the arch and ubuntu provider ... maybe a typo there too?
