### PR TITLE
add workaround for ubuntu precise not properly loading routes from dhcp

### DIFF
--- a/templates/guests/debian/network_dhcp.erb
+++ b/templates/guests/debian/network_dhcp.erb
@@ -4,5 +4,8 @@ auto eth<%= options[:interface] %>
 iface eth<%= options[:interface] %> inet dhcp
 <% unless options[:use_dhcp_assigned_default_route] %>
     post-up route del default dev $IFACE
+<% else %>
+    # needed as some newer distribution do not properly load routes, ubuntu 12.04
+    post-up dhclient $IFACE
 <% end %>
 #VAGRANT-END


### PR DESCRIPTION
This is a follow up to the pull requests in ticket #862. On upgrading to the Ubuntu 12.04 Precise boxes, I found that even when not deleting the route, the route is not added for dhcp interfaces. This workaround fixes the problem until I can find a root cause.
