### PR TITLE
is_port_open.rb needs to catch ENETUNREACH

### DIFF
--- a/lib/vagrant/util/is_port_open.rb
+++ b/lib/vagrant/util/is_port_open.rb
@@ -29,7 +29,7 @@ module Vagrant
           # to connect.
           return true
         end
-      rescue Timeout::Error, Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+      rescue Timeout::Error, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, Errno::ENETUNREACH
         # Any of the above exceptions signal that the port is closed.
         return false
       end


### PR DESCRIPTION
... socket connect to localhost 2222 results in ENETUNREACH which needs to be caught as per this patch.
