### PR TITLE
Preserve attritubes on included files

### DIFF
--- a/lib/vagrant/action/general/package.rb
+++ b/lib/vagrant/action/general/package.rb
@@ -63,9 +63,9 @@ module Vagrant
 
             # Copy direcotry contents recursively.
             if File.directory?(from)
-              FileUtils.cp_r(Dir.glob(from), to.parent)
+              FileUtils.cp_r(Dir.glob(from), to.parent, :preserve => true)
             else
-              FileUtils.cp(from, to)
+              FileUtils.cp(from, to, :preserve => true)
             end
           end
         end


### PR DESCRIPTION
When using ruby 1.9.2, the attributes of the included files are not preserved. Since veewee uses this ruby version, this is a problem when someone is not using the default private key, and tries to build a basebox.

See http://bugs.ruby-lang.org/issues/4507
