### PR TITLE
prevent static (hostonly) interface from messing with dns

### DIFF
--- a/templates/guests/redhat/network_static.erb
+++ b/templates/guests/redhat/network_static.erb
@@ -4,4 +4,5 @@ BOOTPROTO=static
 IPADDR=<%= options[:ip] %>
 NETMASK=<%= options[:netmask] %>
 DEVICE=eth<%= options[:interface] %>
+PEERDNS=no
 #VAGRANT-END


### PR DESCRIPTION
it seems that when centos does the ifdown and then ifup of a static interface (in my case a hostonly interface) that dhclient messes with the dns server in /etc/resolv.conf

adding PEERDNS=no to the template should prevent this

any thoughts on this change?
