### PR TITLE
Fix problem that Puppet module-paths were re-ordered by Vagrant.

### DIFF
--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -118,9 +118,9 @@ module VagrantPlugins
         end
 
         def set_module_paths
-          @module_paths = {}
+          @module_paths = []
           @expanded_module_paths.each_with_index do |path, i|
-            @module_paths[path] = File.join(config.pp_path, "modules-#{i}")
+            @module_paths << [path, File.join(config.pp_path, "modules-#{i}"]
           end
         end
 
@@ -137,7 +137,8 @@ module VagrantPlugins
 
         def run_puppet_client
           options = [config.options].flatten
-          options << "--modulepath '#{@module_paths.values.join(':')}'" if !@module_paths.empty?
+          module_paths = @module_paths.map { |_, to| to }
+          options << "--modulepath '#{module_paths.join(':')}'" if !@module_paths.empty?
           options << @manifest_file
           options = options.join(" ")
 


### PR DESCRIPTION
Puppet module-path were re-ordered by Vagrant due to the use of a
hash. This could lead to unpredictable results.

I have my Puppet modules split into several directories (/common, /ci, /production, etc). When a module is present in multiple directories, the first match decides what module is taken. So order on the module path matters in my case.

However Vagrant uses a Hash when handling module-paths, so the order is not determinist and would change from run to run. See the following output:

```
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

cd /tmp/vagrant-puppet/manifests && puppet apply --verbose --modulepath '/tmp/vagrant-puppet/modules-1:/tmp/vagrant-puppet/modules-0:/tmp/vagrant-puppet/modules-2' /tmp/vagrant-puppet/manifests/default.pp
jbraeuer@Jenss-CT-MacBook:~/dev/vms/oneiric$ vagrant provision
[default] Running provisioner: Vagrant::Provisioners::Puppet...
[default] Running Puppet with /tmp/vagrant-puppet/manifests/default.pp...
stdin: is not a tty
info: Loading facts in /tmp/vagrant-puppet/modules-1/puppetlabs-firewall/lib/facter/iptables.rb
info: Loading facts in /tmp/vagrant-puppet/modules-1/puppetlabs-stdlib/lib/facter/facter_dot_d.rb
info: Loading facts in /tmp/vagrant-puppet/modules-1/puppetlabs-stdlib/lib/facter/root_home.rb

Invalid parameter after at /tmp/vagrant-puppet/manifests/default.pp:2 on node oneiric-amd64.muppet-show
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

cd /tmp/vagrant-puppet/manifests && puppet apply --verbose --modulepath '/tmp/vagrant-puppet/modules-2:/tmp/vagrant-puppet/modules-0:/tmp/vagrant-puppet/modules-1' /tmp/vagrant-puppet/manifests/default.pp
```

So the second run, the modules are ordered 2-0-1, but on the first run it was 1-0-2.

Please double check my changes, as I was unable to add a test. (Why did Vagrant drop support for Ruby 1.8.7? - I don't have 1.9. on this machine currently).
