### PR TITLE
Add the ability to map mac addresses to interfaces

### DIFF
--- a/lib/vagrant/driver/virtualbox.rb
+++ b/lib/vagrant/driver/virtualbox.rb
@@ -88,6 +88,7 @@ module Vagrant
                                :read_guest_additions_version,
                                :read_host_only_interfaces,
                                :read_mac_address,
+                               :read_mac_addresses,
                                :read_machine_folder,
                                :read_network_interfaces,
                                :read_state,

--- a/lib/vagrant/driver/virtualbox_4_0.rb
+++ b/lib/vagrant/driver/virtualbox_4_0.rb
@@ -313,6 +313,19 @@ module Vagrant
 
         nil
       end
+      
+      def read_mac_addresses
+        macs = {}
+        info = execute("showvminfo", @uuid, "--machinereadable", :retryable => true)
+        info.split("\n").each do |line|
+          if matcher = /^macaddress(\d+)="(.+?)"$/.match(line)
+            adapter = matcher[1].to_i
+            mac = matcher[2].to_s
+            macs[adapter] = mac
+          end
+        end
+        macs 
+      end
 
       def read_machine_folder
         execute("list", "systemproperties", :retryable => true).split("\n").each do |line|

--- a/lib/vagrant/driver/virtualbox_4_1.rb
+++ b/lib/vagrant/driver/virtualbox_4_1.rb
@@ -314,6 +314,19 @@ module Vagrant
         nil
       end
 
+      def read_mac_addresses
+        macs = {}
+        info = execute("showvminfo", @uuid, "--machinereadable", :retryable => true)
+        info.split("\n").each do |line|
+          if matcher = /^macaddress(\d+)="(.+?)"$/.match(line)
+            adapter = matcher[1].to_i
+            mac = matcher[2].to_s
+            macs[adapter] = mac
+          end
+        end
+        macs 
+      end
+
       def read_machine_folder
         execute("list", "systemproperties", :retryable => true).split("\n").each do |line|
           if line =~ /^Default machine folder:\s+(.+?)$/i


### PR DESCRIPTION
As part of the windows plugin, I need the ability to match network interfaces based on the MAC address that they are assigned. Because of the way that windows manages networking interfaces, the only way to match them up to "Interface Ids" is to use the mac address. 

https://github.com/BIAINC/vagrant-windows/blob/master/lib/vagrant-windows/guest/windows.rb#L61

Thoughts?

Paul
