### PR TITLE
Allow the .vagrant dotfile to be moved into a completely different directory tree

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -115,7 +115,7 @@ module Vagrant
     # @return [Pathname]
     def dotfile_path
       return nil if !root_path
-      root_path.join(config.global.vagrant.dotfile_name)
+      root_path.join(File.expand_path(config.global.vagrant.dotfile_name))
     end
 
     # Returns the collection of boxes for the environment.


### PR DESCRIPTION
I wanted to define my dotfile as:

``` ruby
config.vagrant.dotfile_name = "~/.vagrant-projectname"
```

and noticed that the full path wasn't expanded as expected.

This patch allows the vagrant file to be placed anywhere on the filesystem.

**Note:** I know 0 Ruby, so if this is a bad idea or I did something wrong, my feelings won't be hurt.

The basis for this bug came from running out project inside my Dropbox folder. Running the project from Dropbox is really nice and convenient to keep everything synced between my work computer and laptop. Except the .vagrant file. When synced, it is killed between computers since the VM has a different UUID.

My solution was to put the .vagrant file outside of Dropbox to prevent that file from being synced.
