### PR TITLE
changing 'can no longer need' to just 'no longer need' on homepage

### DIFF
--- a/_layouts/homepage.html
+++ b/_layouts/homepage.html
@@ -19,7 +19,7 @@
 
 			<p class="home paragraph">Developers no longer need to worry about setting up complicated infrastructure components. Projects with conflicting dependencies can each get their own sandbox -- keeping a developer's workstation free of the hacks needed for multiple versions of software to coexist.</p>
 
-			<p class="home paragraph">Operations engineers can no longer need to worry about developers having a different local setup from production.  They can experiment and test their configuration management changes before going live.</p>
+			<p class="home paragraph">Operations engineers no longer need to worry about developers having a different local setup from production.  They can experiment and test their configuration management changes before going live.</p>
 
 			<p class="home paragraph">Not convinced? Read more about <a href="/v1/docs/getting-started/why.html">why Vagrant is right for you</a>.</p>
 		</div>


### PR DESCRIPTION
Small typo on the homepage.

```
Operations engineers can no longer need to worry about developers 
```

changed to

```
Operations engineers no longer need to worry about developers 
```
