### PR TITLE
Support for internal network adapter

### DIFF
--- a/lib/vagrant/action/vm/network.rb
+++ b/lib/vagrant/action/vm/network.rb
@@ -397,6 +397,40 @@ module Vagrant
             :type => :dhcp
           }
         end
+        
+        def intnet_config(args)
+          ip      = args[0]
+          options = args[1] || {}
+            
+          return {
+            :type    => "static",
+            :ip      => ip,
+            :netmask => "255.255.255.0",
+            :adapter => nil,
+            :mac     => nil,
+            :name    => nil,
+            :auto_config => true
+          }.merge(options)
+        end
+
+        def intnet_adapter(config)
+          @logger.info("Setup internal network: #{config[:ip]}")
+
+          return {
+            :adapter     => config[:adapter],
+            :type        => :intnet,
+            :mac_address => config[:mac],
+            :nic_type    => config[:nic_type]
+          }
+        end
+
+        def intnet_network_config(config)
+          return {
+            :type    => config[:type],
+            :ip      => config[:ip],
+            :netmask => config[:netmask]
+          }
+        end
       end
     end
   end

--- a/lib/vagrant/config/vm.rb
+++ b/lib/vagrant/config/vm.rb
@@ -132,8 +132,8 @@ module Vagrant
         networks.each do |type, args|
           if type == :hostonly && args[0] == :dhcp
             # Valid. There is no real way this can be invalid at the moment.
-          elsif type == :hostonly
-            # Validate the host-only network
+          elsif type == :hostonly || type == :intnet
+            # Validate the host-only|intnet network
             ip      = args[0]
             options = args[1] || {}
 

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -221,13 +221,13 @@ en:
         box_not_found: "The box '%{name}' could not be found."
         network_invalid: |-
           The network type '%{type}' is not valid. Please use
-          'hostonly' or 'bridged'.
+          'hostonly', 'bridged' or 'intnet'.
         network_ip_required: |-
-          Host only networks require an IP as an argument.
+          Host only or internal networks require an IP as an argument.
         network_ip_invalid: |-
-          The host only network IP '%{ip}' is invalid.
+          The host only or internal network IP '%{ip}' is invalid.
         network_ip_ends_one: |-
-          The host only network IP '%{ip}' must not end in a 1, as this
+          The host only or internal network IP '%{ip}' must not end in a 1, as this
           is reserved for the host machine.
         shared_folder_hostpath_missing: "Shared folder host path for '%{name}' doesn't exist: %{path}"
         shared_folder_nfs_owner_group: |-


### PR DESCRIPTION
Because of restrictions i can not use bridged oder host-only networks.
Generally we are using NAT. As second adapter we use internal network to ensure the communication between virtual machines.

I added support for this adapter.

<pre>
config.vm.network :intnet, "192.168.1.2", :adapter => 2
</pre>
