### PR TITLE
Fixes minor typo

### DIFF
--- a/templates/commands/init/Vagrantfile.erb
+++ b/templates/commands/init/Vagrantfile.erb
@@ -92,7 +92,7 @@ Vagrant.configure("1") do |config|
   # If you're using the Opscode platform, your validator client is
   # ORGNAME-validator, replacing ORGNAME with your organization name.
   #
-  # IF you have your own Chef Server, the default validation client name is
+  # If you have your own Chef Server, the default validation client name is
   # chef-validator, unless you changed the configuration.
   #
   #   chef.validation_client_name = "ORGNAME-validator"


### PR DESCRIPTION
This fixes a minor capitalization typo for the vagrant init file
