### PR TITLE
Callback on successful mount for Arch Linux guests

### DIFF
--- a/plugins/guests/arch/guest.rb
+++ b/plugins/guests/arch/guest.rb
@@ -12,6 +12,14 @@ module VagrantPlugins
       # Make the TemplateRenderer top-level
       include Vagrant::Util
 
+      def mount_shared_folder(name, guestpath, options)
+        # Mount it like normal
+        super
+
+        # Start an rc job with the name of the mounted folder so it can trigger any other jobs needed internally after the mount is complete.
+        vm.channel.sudo("[ -x /etc/rc.d/vagrant-mounted ] && MOUNTPOINT=#{guestpath} /etc/rc.d/vagrant-mounted start || echo 'No /etc/rc.d/vagrant-mounted hook available to run, skipping.'")
+      end
+
       def change_host_name(name)
         # Only do this if the hostname is not already set
         if !vm.channel.test("sudo hostname | grep '#{name}'")


### PR DESCRIPTION
Arch Linux will attempt to run `/etc/rc.d/vagrant-mounted` when a mount has been completed.

An environment variable, `MOUNTPOINT`, is passed to the job, the value of which is the path inside the guest that was mounted to.

The intention is that this script will trigger any other scripts that need to be run and exit immediately, rather than start a long-running daemon. This is to work around the fact that Arch Linux's `rc.d` system does not have support for events like Ubuntu's `upstart` does.
