### PR TITLE
[#785] Allow exporting subdirs on BSD hosts

### DIFF
--- a/templates/nfs/exports.erb
+++ b/templates/nfs/exports.erb
@@ -1,5 +1,5 @@
 # VAGRANT-BEGIN: <%= uuid %>
 <% folders.each do |name, opts| %>
-"<%= opts[:hostpath] %>" <%= ip %><% if opts[:map_uid] -%> -mapall=<%= [opts[:map_uid],opts[:map_gid]].compact.join(":") %><% end -%>
+"<%= opts[:hostpath] %>" <%= ip %><% if opts[:map_uid] -%> -alldirs -mapall=<%= [opts[:map_uid],opts[:map_gid]].compact.join(":") %><% end -%>
 <% end %>
 # VAGRANT-END: <%= uuid %>


### PR DESCRIPTION
This should be safe on all hosts calling this template, but further
testing is suggested. It does fix the referenced issue #785 for OSX
hosts.
