### PR TITLE
This commit has three minor changes to the Puppet provisioners

### DIFF
--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -100,7 +100,7 @@ module VagrantPlugins
 
           # Verify Puppet is installed and run it
           verify_binary("puppet")
-          run_puppet_client
+          run_puppet_apply
         end
 
         def share_manifests
@@ -135,7 +135,7 @@ module VagrantPlugins
                                 :binary => binary)
         end
 
-        def run_puppet_client
+        def run_puppet_apply
           options = [config.options].flatten
           module_paths = @module_paths.map { |_, to| to }
           options << "--modulepath '#{module_paths.join(':')}'" if !@module_paths.empty?

--- a/plugins/provisioners/puppet/provisioner/puppet_server.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet_server.rb
@@ -22,8 +22,8 @@ module VagrantPlugins
         end
 
         def provision!
-          verify_binary("puppetd")
-          run_puppetd_client
+          verify_binary("puppet")
+          run_puppet_agent
         end
 
         def verify_binary(binary)
@@ -33,7 +33,7 @@ module VagrantPlugins
                                 :binary => binary)
         end
 
-        def run_puppetd_client
+        def run_puppet_agent
           options = config.options
           options = [options] if !options.is_a?(Array)
 
@@ -67,7 +67,7 @@ module VagrantPlugins
             facter = "#{facts.join(" ")} "
           end
 
-          command = "#{facter}puppetd #{options} --server #{config.puppet_server}"
+          command = "#{facter}puppet agent #{options} --server #{config.puppet_server}"
 
           env[:ui].info I18n.t("vagrant.provisioners.puppet_server.running_puppetd")
           env[:vm].channel.sudo(command) do |type, data|


### PR DESCRIPTION
- Renamed the run_puppet_client method in the puppet provisioner
  to clarify it's function running Puppet in apply mode from the
  command line.
- Renamed the run_puppet_client method in the puppet server provisioner
  to clarify the agent is being run.
- Changed the Puppet server provisioner to use the more standard Git-style
  command line structure. The puppetd binary has been deprecated in favour of
  puppet with the agent flag.
