### PR TITLE
Update environment::load_plugins to fix broken modification of Gem.path on Windows

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -533,7 +533,7 @@ module Vagrant
     def load_plugins
       # Add our private gem path to the gem path and reset the paths
       # that Rubygems knows about.
-      ENV["GEM_PATH"] = "#{@gems_path}:#{ENV["GEM_PATH"]}"
+      ENV["GEM_PATH"] = "#{@gems_path}#{::File::PATH_SEPARATOR}#{ENV["GEM_PATH"]}"
       ::Gem.clear_paths
 
       # Load the plugins


### PR DESCRIPTION
Windows uses the semi-colon (';') for a path separator. The current script assumes a path seperator of colon (':'). Replace the hard-coded ':' with ::File::PATH_SEPARATOR.
