### PR TITLE
change_host_name should change mailname too

### DIFF
--- a/plugins/guests/debian/guest.rb
+++ b/plugins/guests/debian/guest.rb
@@ -62,6 +62,7 @@ module VagrantPlugins
           vm.channel.sudo("sed -r -i 's/^(127[.]0[.]1[.]1[[:space:]]+).*$/\\1#{name} #{name.split('.')[0]}/' /etc/hosts")
           vm.channel.sudo("sed -i 's/.*$/#{name.split('.')[0]}/' /etc/hostname")
           vm.channel.sudo("hostname -F /etc/hostname")
+          vm.channel.sudo("hostname --fqdn > /etc/mailname")
         end
       end
     end

--- a/plugins/guests/ubuntu/guest.rb
+++ b/plugins/guests/ubuntu/guest.rb
@@ -18,6 +18,7 @@ module VagrantPlugins
           vm.channel.sudo("sed -i 's/.*$/#{name}/' /etc/hostname")
           vm.channel.sudo("sed -i 's@^\\(127[.]0[.]1[.]1[[:space:]]\\+\\)@\\1#{name} #{name.split('.')[0]} @' /etc/hosts")
           vm.channel.sudo("service hostname start")
+          vm.channel.sudo("hostname --fqdn > /etc/mailname")
         end
       end
     end


### PR DESCRIPTION
On Debian systems config.hostname directive should change /etc/mailname
in order to prevent problems with default mailer trying to contact
default vm's name.
