### PR TITLE
Only mark environment loaded after load_config

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -322,9 +322,9 @@ module Vagrant
     # method calls its other methods is very particular.
     def load!
       if !loaded?
-        @loaded = true
         @logger.info("Loading configuration...")
         load_config!
+        @loaded = true
       end
 
       self


### PR DESCRIPTION
If `load_config` fails, `@loaded` should still be false.

Otherwise, stuff like this fails oddly:

```
env = Vagrant::Environment.new(:cwd => '/some/directory')
begin
  env.cli("up")
rescue Vagrant::Errors::VagrantError => err
  puts err.message
ensure
  if env.loaded?
    env.cli("destroy", "-f")
  end
end
```
