### PR TITLE
FEAT: add proper shutdown support for windows guests.

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -183,6 +183,7 @@ Vagrant.guests.register(:redhat)  { Vagrant::Guest::Redhat }
 Vagrant.guests.register(:solaris) { Vagrant::Guest::Solaris }
 Vagrant.guests.register(:suse)    { Vagrant::Guest::Suse }
 Vagrant.guests.register(:ubuntu)  { Vagrant::Guest::Ubuntu }
+Vagrant.guests.register(:windows)  { Vagrant::Guest::Windows }
 
 # Register the built-in provisioners
 Vagrant.provisioners.register(:chef_solo)     { Vagrant::Provisioners::ChefSolo }
@@ -195,3 +196,4 @@ Vagrant.provisioners.register(:shell)         { Vagrant::Provisioners::Shell }
 Vagrant.config_keys.register(:freebsd) { Vagrant::Guest::FreeBSD::FreeBSDConfig }
 Vagrant.config_keys.register(:linux)   { Vagrant::Guest::Linux::LinuxConfig }
 Vagrant.config_keys.register(:solaris) { Vagrant::Guest::Solaris::SolarisConfig }
+Vagrant.config_keys.register(:windows) { Vagrant::Guest::Windows::WindowsConfig }

--- a/lib/vagrant/guest.rb
+++ b/lib/vagrant/guest.rb
@@ -14,5 +14,6 @@ module Vagrant
     autoload :Solaris, 'vagrant/guest/solaris'
     autoload :Suse,    'vagrant/guest/suse'
     autoload :Ubuntu,  'vagrant/guest/ubuntu'
+    autoload :Windows, 'vagrant/guest/windows'
   end
 end

--- a/lib/vagrant/guest/windows.rb
+++ b/lib/vagrant/guest/windows.rb
@@ -1,0 +1,34 @@
+module Vagrant
+  module Guest
+    # Code adapted from vagrant-windows (by Chris McClimans <chris@hippiehacker.org>)
+    class Windows < Base
+      # A custom config class which will be made accessible via `config.windows`
+      # Here for whenever it may be used.
+      class WindowsConfig < Vagrant::Config::Base
+        attr_accessor :halt_timeout
+        attr_accessor :halt_check_interval
+
+        def initialize
+          @halt_timeout = 15
+          @halt_check_interval = 1
+        end
+      end
+
+      def halt
+        @vm.channel.execute("shutdown /s /t 1 /c \"Vagrant Halt\" /f /d p:4:1")
+
+        # Wait until the VM's state is actually powered off. If this doesn't
+        # occur within a reasonable amount of time (15 seconds by default),
+        # then simply return and allow Vagrant to kill the machine.
+        count = 0
+        while @vm.state != :poweroff
+          count += 1
+
+          return if count >= @vm.config.windows.halt_timeout
+          sleep @vm.config.windows.halt_check_interval
+        end
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
This is a first step toward better support for windows guest. This uses windows cmd to halt the VM.

There is one caveat: this requires config.vm.guest to be set to :windows. This is obviously clunky, but I don't know how guest OS detection work in vagrant.
