### PR TITLE
1 0 stable: Fix for issue 1036: Shell provisioner hangs on Windows 7

### DIFF
--- a/lib/vagrant/provisioners/shell.rb
+++ b/lib/vagrant/provisioners/shell.rb
@@ -62,8 +62,9 @@ module Vagrant
         begin
           file.write(config.inline)
           file.fsync
+          file.close
           yield file.path
-        ensure
+	rescue
           file.close
           file.unlink
         end


### PR DESCRIPTION
When doing vagrant up on Windows 7 shell provisioner hangs when uploading a temporary file from local machine to the guest VM. File created in the temporary location on the host is not closed before yielding for upload to guest VM path. This appeared to be the reason for upload process hang as the data was transferred but SCP would still not complete which could be because the end of file character was not sent. I made a change in the shell.rb file under embedded\lib\ruby\gems\1.9.1\gems\vagrant-1.0.3\lib\vagrant\provisioners folder. With this change problem went away and I could deploy the guest VM successfully. 
