### PR TITLE
Added support for downloading boxes via SCP

### DIFF
--- a/lib/vagrant/action/box/download.rb
+++ b/lib/vagrant/action/box/download.rb
@@ -12,7 +12,7 @@ module Vagrant
           @app = app
           @env = env
           @env["download.classes"] ||= []
-          @env["download.classes"] += [Downloaders::HTTP, Downloaders::File]
+          @env["download.classes"] += [Downloaders::HTTP, Downloaders::SCP, Downloaders::File]
           @downloader = nil
         end
 

--- a/lib/vagrant/downloaders.rb
+++ b/lib/vagrant/downloaders.rb
@@ -3,5 +3,6 @@ module Vagrant
     autoload :Base, 'vagrant/downloaders/base'
     autoload :File, 'vagrant/downloaders/file'
     autoload :HTTP, 'vagrant/downloaders/http'
+    autoload :SCP, 'vagrant/downloaders/scp'
   end
 end

--- a/lib/vagrant/downloaders/http.rb
+++ b/lib/vagrant/downloaders/http.rb
@@ -10,7 +10,7 @@ module Vagrant
     class HTTP < Base
       def self.match?(uri)
         # URI.parse barfs on '<drive letter>:\\files \on\ windows'
-        extracted = URI.extract(uri).first
+        extracted = URI.extract(uri, ["http", "https"]).first
         extracted && extracted.include?(uri)
       end
 

--- a/lib/vagrant/downloaders/scp.rb
+++ b/lib/vagrant/downloaders/scp.rb
@@ -1,0 +1,40 @@
+require 'net/scp'
+require 'uri'
+
+module Vagrant
+  module Downloaders
+    # Downloads a file from an SCP(SSH) URL to a temporary file. This
+    # downloader reports its progress to stdout while downloading.
+    class SCP < Base
+      def self.match?(uri)
+        # URI.parse barfs on '<drive letter>:\\files \on\ windows'
+        extracted = URI.extract(uri, "scp").first
+        extracted && extracted.include?(uri)
+      end
+
+      def download!(source_url, destination_file)
+        uri = URI.parse(source_url)
+
+        # strip the first slash to make URIs point into the users home directory by default
+        # to reference files relative to the root of the server, use 2 slashes in the URI
+        remote_file = uri.path.sub(/^\//,"")
+
+        ssh = Net::SSH.start(uri.host, uri.user)
+
+        scp = ssh.scp
+
+        @ui.info I18n.t("vagrant.downloaders.http.download", :url => source_url)
+
+        scp.download!(remote_file, destination_file) do |ch, name, received, total|
+
+          @ui.clear_line
+          @ui.report_progress(received, total)
+
+        end
+
+        # Clear the line one last time so that the progress meter disappears
+        @ui.clear_line
+      end
+    end
+  end
+end

--- a/test/unit/vagrant/downloaders/scp_test.rb
+++ b/test/unit/vagrant/downloaders/scp_test.rb
@@ -1,0 +1,25 @@
+require File.expand_path("../../../base", __FILE__)
+
+describe Vagrant::Downloaders::SCP do
+  let(:ui) { double("ui") }
+  let(:instance) { described_class.new(ui) }
+
+  describe "matching" do
+    it "should match SCP URLs" do
+      described_class.match?("scp://user@example.com/foo.box").should be
+      described_class.match?("scp://example.com/fox.box").should be
+      described_class.match?("scp://user:password@example.com//tmp/foo.box").should be
+      described_class.match?("scp://user@example.com:2222/foo.box").should be
+    end
+
+    it "should not match URLs with any other scheme" do
+      described_class.match?("ssh://example.com/foo.box").should_not be
+      described_class.match?("http://example.com:8500/foo.box").should_not be
+      described_class.match?("https://example.com:8500/foo.box").should_not be
+    end
+  end
+
+  describe "downloading" do
+    # Integration tests only.
+  end
+end


### PR DESCRIPTION
Since we have certain sensitive box files that we do not want on the open internet, we needed a way to add user authentication/authorization to box downloads.

We already have a good SSH key authentication framework in our infrastructure, so by using SCP we avoid having to set up a parallel authentication system via HTTP(S). With SCP we effectively get authentication/authorization for free.

I am contributing this, as this could be nice to have as a standard feature in Vagrant, for others to use too.

---

There is one thing currently not as I would like it to be, due to a bug/misfeature in Net::SSH. Unlike the command line SSH client, Net::SSH does not fall back to the currently logged in user, if no user is specified (either to the Net::SSH.start function or in the ssh config files).

This means that SCP URIs must be given a user (e.g. scp://user@host/path/to/file), if no user is specified in the ssh config file for the specific host.

I will submit a fix for this bug/misfeature to the Net::SSH project.
