### PR TITLE
Add config.arguments for Chef

### DIFF
--- a/plugins/provisioners/chef/provisioner/base.rb
+++ b/plugins/provisioners/chef/provisioner/base.rb
@@ -97,6 +97,7 @@ module VagrantPlugins
           attr_accessor :binary_path
           attr_accessor :binary_env
           attr_accessor :attempts
+          attr_accessor :arguments
           attr_writer :run_list
 
           # Provide defaults in such a way that they won't override the instance

--- a/plugins/provisioners/chef/provisioner/chef_client.rb
+++ b/plugins/provisioners/chef/provisioner/chef_client.rb
@@ -91,7 +91,8 @@ module VagrantPlugins
 
         def run_chef_client
           command_env = config.binary_env ? "#{config.binary_env} " : ""
-          command = "#{command_env}#{chef_binary_path("chef-client")} -c #{config.provisioning_path}/client.rb -j #{config.provisioning_path}/dna.json"
+          command_args = config.arguments ? " #{config.arguments}" : ""
+          command = "#{command_env}#{chef_binary_path("chef-client")} -c #{config.provisioning_path}/client.rb -j #{config.provisioning_path}/dna.json #{command_args}"
 
           config.attempts.times do |attempt|
             if attempt == 0

--- a/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -185,7 +185,8 @@ module VagrantPlugins
 
         def run_chef_solo
           command_env = config.binary_env ? "#{config.binary_env} " : ""
-          command = "#{command_env}#{chef_binary_path("chef-solo")} -c #{config.provisioning_path}/solo.rb -j #{config.provisioning_path}/dna.json"
+          command_args = config.arguments ? " #{config.arguments}" : ""
+          command = "#{command_env}#{chef_binary_path("chef-solo")} -c #{config.provisioning_path}/solo.rb -j #{config.provisioning_path}/dna.json #{command_args}"
 
           config.attempts.times do |attempt|
             if attempt == 0


### PR DESCRIPTION
- Adds chef.arguments to Chef::Provisioner::Config
- Usable in both chef-client and chef-solo
- Specify as a string, "-L /tmp/foo.log", e.g.

This allows users who wish to use "why-run" mode to do so, with the addition of output formatters and log level modification from the command line.
