### PR TITLE
Convey default destroy confirmation choice as 'N'

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -279,7 +279,7 @@ en:
       box:
         no_installed_boxes: "There are no installed boxes! Use `vagrant box add` to add some."
       destroy:
-        confirmation: "Are you sure you want to destroy the '%{name}' VM? [Y/N] "
+        confirmation: "Are you sure you want to destroy the '%{name}' VM? [y/N] "
         will_not_destroy: |-
           The VM '%{name}' will not be destroyed, since the confirmation
           was declined.


### PR DESCRIPTION
The convention is to capitalize the default choice when presenting
the user with a confirmation dialog. This alters the choices for
'vagrant destroy' confirmation from [Y/N] to [y/N].
