### PR TITLE
Update arch host class for systemd transition

### DIFF
--- a/lib/vagrant/hosts/arch.rb
+++ b/lib/vagrant/hosts/arch.rb
@@ -19,6 +19,8 @@ module Vagrant
         @ui.info I18n.t("vagrant.hosts.arch.nfs_export.prepare")
         sleep 0.5
 
+        nfs_cleanup(id)
+
         output.split("\n").each do |line|
           # This should only ask for administrative permission once, even
           # though its executed in multiple subshells.


### PR DESCRIPTION
This pull request comes with some caveats (and I apologize for that). Here goes...

I've changed the match function to use /etc/os-release. Any Arch users who have moved to systemd (and all users will be forced too soon) are likely able to run their systems without /etc/rc.conf entirely. Also, /etc/pacman.conf may be present on systems that aren't Arch since he's been ported around a bit.

I've also updated the restart commands to use `systemctl` when it's available. The `rc.d` versions would still work if the user has the old init package still installed (and hasn't yet removed their rc.conf), but it's my assumption that if they've got systemd installed their intention is to use the newer service files.

My two concerns/caveats are the following:
- I get a kernel panic if I issue the restart command while the nfs services are in some failed state.

I've reproduced this outside of Vagrant so I'm fairly sure it's unrelated to this patch. However, I've also noticed that Vagrant is duplicating the entries in /etc/exports rather than reusing or replacing what's already there on subsequent `reloads`. I can see in the systemd logs that the nfs service is complaining about this, but I'm not sure if it's the root cause of the failed state and eventual kernal panic.
- It doesn't always work :(

If I issue `vagrant up` while no nfs services are running, Vagrant bombs trying to mount the NFS shares -- However, the service command did do something, because if I immediately issue `vagrant reload` it works fine that time. It also works if I ensure the services are already running when I do that first `vagrant up`. I'm a bit baffled by this behavior.

Anyway, this pull request is more a solicitation for feedback, preferably from other Arch users. I'm pretty confident this is the right patch for the systemd changes, but with my kernel panic's and strange restart behavior, I can't recommend merging it. Hopefully it's still useful :).

Thanks for your great work!
Pat
