### PR TITLE
backport Windows fix onto 1-0-stable 

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -507,7 +507,7 @@ module Vagrant
     def load_plugins
       # Add our private gem path to the gem path and reset the paths
       # that Rubygems knows about.
-      ENV["GEM_PATH"] = "#{@gems_path}:#{ENV["GEM_PATH"]}"
+      ENV["GEM_PATH"] = "#{@gems_path}#{::File::PATH_SEPARATOR}#{ENV["GEM_PATH"]}"
       ::Gem.clear_paths
 
       # Load the plugins


### PR DESCRIPTION
I wish this had made it into 1.0.4, but here's a pull request to hopefully make sure it gets into any future 1.0.x ... plugins are really broken on Windows without it.

```
Update load_plugins to be more Windows friendly. Uses File::PATH_SEPARATOR instead of hard-coded colon (':').
```
