### PR TITLE
Change Fedora 16+ NFS support.

### DIFF
--- a/lib/vagrant/hosts/fedora.rb
+++ b/lib/vagrant/hosts/fedora.rb
@@ -30,7 +30,7 @@ module Vagrant
         if release_file.exist?
           release_file.open("r") do |f|
             version_number = /Fedora release ([0-9]+)/.match(f.gets)[1].to_i
-            if version_number >= 17
+            if version_number >= 16
               # For now, "service nfs-server" will redirect properly to systemctl
               # when "service nfs-server restart" is called.
               @nfs_server_binary = "/usr/sbin/service nfs-server"


### PR DESCRIPTION
Here's a quick-and-dirty pull request to add NFS support to Fedora 17 and up, as reported in #1125.

This simply parses the redhat-release file, and if the version of Fedora is 17 or greater, it changes @nfs_server_binary to `/usr/sbin/service nfs-server` instead of `/etc/init.d/nfs`, which does not exist any more in Fedora 17+ due to the switch to systemd.

This works because the `service` command in Fedora 17 will rewrite `service nfs-server restart` to `systemctl restart nfs-server.service` behind the scenes. This is the simplest way to solve this issue for now without changing too much code since `lib/vagrant/hosts/linux.rb` calls

``` ruby
system("sudo #{@nfs_server_binary} restart")
```

at the end of nfs_export, whereas calling systemctl would require copying that method and just changing the last line.
