### PR TITLE
Fix arch host class

### DIFF
--- a/lib/vagrant/hosts/arch.rb
+++ b/lib/vagrant/hosts/arch.rb
@@ -10,15 +10,6 @@ module Vagrant
         5
       end
 
-      # rewriting nfs? here since my system shows the filesystem as nfs
-      # or nfs4, not nfsd... is the Linux host broken?
-      def nfs?
-        retryable(:tries => 10, :on => TypeError) do
-          # Check procfs to see if NFS is a supported filesystem
-          system("cat /proc/filesystems | grep -q nfs 2>/dev/null")
-        end
-      end
-
       def nfs_export(id, ip, folders)
         output = TemplateRenderer.render('nfs/exports_linux',
                                          :uuid => id,


### PR DESCRIPTION
1. Detect os by /etc/os-release
2. Bring nfs_cleanup from parent class
3. Use systemd if available

I also had to re-implement `#nfs?` but I'm not really sure why.

This PR obviates #1081. I've not seen any of the issues I mention there with this approach.
