### PR TITLE
Fixes an exception issue when a non-directory appears in the boxes dir

### DIFF
--- a/lib/vagrant/box_collection.rb
+++ b/lib/vagrant/box_collection.rb
@@ -133,7 +133,7 @@ module Vagrant
       results = []
 
       @logger.debug("Finding all boxes in: #{@directory}")
-      @directory.children(true).each do |child|
+      @directory.children(true).select(&:directory?).each do |child|
         box_name = child.basename.to_s
 
         # If this is a V1 box, we still return that name, but specify

--- a/test/unit/vagrant/box_collection_test.rb
+++ b/test/unit/vagrant/box_collection_test.rb
@@ -135,6 +135,11 @@ describe Vagrant::BoxCollection do
       results = instance.all.sort
       results.should == [["bar", :virtualbox, :v1], ["foo", :vmware]]
     end
+
+    it 'does not raise an exception when a file appears in the boxes dir' do
+      Tempfile.new('a_file', environment.boxes_dir)
+      expect { instance.all }.to_not raise_error
+    end
   end
 
   describe "finding" do


### PR DESCRIPTION
I was perusing in my `boxes_dir` today and my awesome Macbook decides to leave a `.DS_Store` file in the directory (as it does everywhere else).  When running `vagrant box list`, an exception occurred in the following form:

```
[skim@master][~/lolcat/me/vm] vagrant box list
You're using a development version of Vagrant. This version
makes structural changes to the `~/.vagrant.d` folder such that
you will be _unable_ to downgrade back to a 1.0.x release. This
affects all Vagrant environments on your computer. Other users
of Vagrantfiles you create and use can continue to use 1.0.x without
issue so long as it is on a computer that has never run this
development version.

This message will be removed when this version is officially released.
If you're sure you'd like to continue, type 'Y' and then enter: y
/Users/skim/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/pathname.rb:397:in `open': Not a directory - /Users/skim/.vagrant.d/boxes/.DS_Store (Errno::ENOTDIR)
        from /Users/skim/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/pathname.rb:397:in `foreach'
        from /Users/skim/.rvm/rubies/ruby-1.9.3-p194/lib/ruby/1.9.1/pathname.rb:397:in `children'
        from /Users/skim/.rvm/gems/ruby-1.9.3-p194@vm/bundler/gems/vagrant-184f6dccb2d5/lib/vagrant/box_collection.rb:149:in `block in all'
        from /Users/skim/.rvm/gems/ruby-1.9.3-p194@vm/bundler/gems/vagrant-184f6dccb2d5/lib/vagrant/box_collection.rb:136:in `each'
        from /Users/skim/.rvm/gems/ruby-1.9.3-p194@vm/bundler/gems/vagrant-184f6dccb2d5/lib/vagrant/box_collection.rb:136:in `all'
        from /Users/skim/.rvm/gems/ruby-1.9.3-p194@vm/bundler/gems/vagrant-184f6dccb2d5/plugins/commands/box/command/list.rb:18:in `execute'
        from /Users/skim/.rvm/gems/ruby-1.9.3-p194@vm/bundler/gems/vagrant-184f6dccb2d5/plugins/commands/box/command/root.rb:47:in `execute'
        from /Users/skim/.rvm/gems/ruby-1.9.3-p194@vm/bundler/gems/vagrant-184f6dccb2d5/lib/vagrant/cli.rb:51:in `execute'
        from /Users/skim/.rvm/gems/ruby-1.9.3-p194@vm/bundler/gems/vagrant-184f6dccb2d5/lib/vagrant/environment.rb:182:in `cli'
        from /Users/skim/.rvm/gems/ruby-1.9.3-p194@vm/bundler/gems/vagrant-184f6dccb2d5/bin/vagrant:71:in `<top (required)>'
        from /Users/skim/.rvm/gems/ruby-1.9.3-p194@vm/bin/vagrant:19:in `load'
        from /Users/skim/.rvm/gems/ruby-1.9.3-p194@vm/bin/vagrant:19:in `<main>'
        from /Users/skim/.rvm/gems/ruby-1.9.3-p194@vm/bin/ruby_noexec_wrapper:14:in `eval'
        from /Users/skim/.rvm/gems/ruby-1.9.3-p194@vm/bin/ruby_noexec_wrapper:14:in `<main>'
```

I have fixed the issue in this PR.
