### PR TITLE
Re: Use existing ssh command if available on Windows platform instead of just failing

### DIFF
--- a/lib/vagrant/ssh.rb
+++ b/lib/vagrant/ssh.rb
@@ -55,15 +55,18 @@ module Vagrant
       # Get the SSH information and cache it here
       ssh_info = info
 
-      if Util::Platform.windows?
-        raise Errors::SSHUnavailableWindows, :host => ssh_info[:host],
-                                             :port => ssh_info[:port],
-                                             :username => ssh_info[:username],
-                                             :key_path => ssh_info[:private_key_path]
+	  if Util::Platform.windows?
+		# works well with http://miked.ict.rave.ac.uk/display/sshwindows/OpenSSH+for+Windows
+		if !Kernel.system("ssh -V > NUL 2>&1")
+		  raise Errors::SSHUnavailableWindows, :host => ssh_info[:host],
+											   :port => ssh_info[:port],
+											   :username => ssh_info[:username],
+											   :key_path => ssh_info[:private_key_path]
+		end
+	  else
+		raise Errors::SSHUnavailable if !Kernel.system("which ssh > /dev/null 2>&1")
       end
-
-      raise Errors::SSHUnavailable if !Kernel.system("which ssh > /dev/null 2>&1")
-
+	  
       # If plain mode is enabled then we don't do any authentication (we don't
       # set a user or an identity file)
       plain_mode = opts[:plain_mode]


### PR DESCRIPTION
This is the same patch as in #1083 but merges cleanly with `1-0-stable` rather than `master`.

The goal is to enable `vagrant ssh` on windows if a Cygwin ssh is avaible.

@mitchellh : any chance this would make it into `1.0.6`?
