### PR TITLE
Check exit codes of puppet provisioners

### DIFF
--- a/lib/vagrant/provisioners/puppet.rb
+++ b/lib/vagrant/provisioners/puppet.rb
@@ -151,7 +151,7 @@ module Vagrant
           facter = "#{facts.join(" ")} "
         end
 
-        command = "cd #{manifests_guest_path} && #{facter}puppet apply #{options}"
+        command = "cd #{manifests_guest_path} && #{facter}puppet apply #{options} --detailed-exitcodes || [ $? -eq 2 ]"
 
         env[:ui].info I18n.t("vagrant.provisioners.puppet.running_puppet",
                              :manifest => @manifest_file)

--- a/lib/vagrant/provisioners/puppet_server.rb
+++ b/lib/vagrant/provisioners/puppet_server.rb
@@ -66,7 +66,7 @@ module Vagrant
           facter = "#{facts.join(" ")} "
         end
 
-        command = "#{facter}puppetd #{options} --server #{config.puppet_server}"
+        command = "#{facter}puppetd #{options} --server #{config.puppet_server} --detailed-exitcodes || [ $? -eq 2 ]"
 
         env[:ui].info I18n.t("vagrant.provisioners.puppet_server.running_puppetd")
         env[:vm].channel.sudo(command) do |type, data|


### PR DESCRIPTION
Backport of https://github.com/mitchellh/vagrant/pull/1175 to 1-0-stable

Previously, failures in applying the puppet manifests would be
ignored, because puppet apply/agent don't have any useful exit codes
by default.  (Errors are printed, but vagrant continues.)

Use the option --detailed-exitcodes of puppet apply/agent to check for
success.
