### PR TITLE
Fix Windows shell provisioning

### DIFF
--- a/lib/vagrant/communication/ssh.rb
+++ b/lib/vagrant/communication/ssh.rb
@@ -78,7 +78,8 @@ module Vagrant
         # Do an SCP-based upload...
         connect do |connection|
           scp = Net::SCP.new(connection)
-          scp.upload!(from, to)
+	  # Open file read only to fix issue #1036
+          scp.upload!(File.open(from, "r"), to)
         end
       rescue Net::SCP::Error => e
         # If we get the exit code of 127, then this means SCP is unavailable.

--- a/lib/vagrant/provisioners/shell.rb
+++ b/lib/vagrant/provisioners/shell.rb
@@ -59,6 +59,10 @@ module Vagrant
         # Otherwise we have an inline script, we need to Tempfile it,
         # and handle it specially...
         file = Tempfile.new('vagrant-shell')
+        # Unless you set binmode, on a Windows host the shell script will
+        # have CRLF line endings instead of LF line endings, causing havoc
+        # when the guest executes it
+        file.binmode
         begin
           file.write(config.inline)
           file.fsync


### PR DESCRIPTION
Resolves [GH-1036] [GH-1164] [GH-1181]

I tested this vs. an installed version of Vagrant 1.0.5 on a 64 bit Windows 7 Ultimate by copying the two patched files into place. It allows the shell provisioner to complete correctly. See https://github.com/obscurerichard/vagrant-windows-shell-test for a concise test case.
