### PR TITLE
Fix change_host_name on Ubuntu Hardy

### DIFF
--- a/plugins/guests/ubuntu/guest.rb
+++ b/plugins/guests/ubuntu/guest.rb
@@ -29,7 +29,12 @@ module VagrantPlugins
           if !comm.test("sudo hostname | grep '#{name}'")
             comm.sudo("sed -i 's/.*$/#{name}/' /etc/hostname")
             comm.sudo("sed -i 's@^\\(127[.]0[.]1[.]1[[:space:]]\\+\\)@\\1#{name} #{name.split('.')[0]} @' /etc/hosts")
-            comm.sudo("service hostname start")
+            if comm.test("[ `lsb_release -c -s` = hardy ]")
+                # hostname.sh returns 1, so I grep for the right name in /etc/hostname just to have a 0 exitcode
+                comm.sudo("/etc/init.d/hostname.sh start; grep '#{name}' /etc/hostname")
+            else
+                comm.sudo("service hostname start")
+            end
             comm.sudo("hostname --fqdn > /etc/mailname")
           end
         end


### PR DESCRIPTION
On ubuntu hardy the service command is not available, you must use init.d script instead
