### PR TITLE
Call the VM something nice in virtualbox interface

### DIFF
--- a/plugins/kernel_v1/config/vm.rb
+++ b/plugins/kernel_v1/config/vm.rb
@@ -17,6 +17,7 @@ module VagrantPlugins
       attr_accessor :base_mac
       attr_accessor :boot_mode
       attr_accessor :host_name
+      attr_accessor :virtualbox_name
       attr_reader :forwarded_ports
       attr_reader :shared_folders
       attr_reader :networks

--- a/plugins/providers/virtualbox/action/default_name.rb
+++ b/plugins/providers/virtualbox/action/default_name.rb
@@ -11,7 +11,12 @@ module VagrantPlugins
 
         def call(env)
           @logger.info("Setting the default name of the VM")
-          name = env[:root_path].basename.to_s + "_#{Time.now.to_i}"
+          
+          if env[:vm].config.vm.virtualbox_name
+            name = env[:vm].config.vm.virtualbox_name
+          else
+            name = env[:root_path].basename.to_s + "_#{Time.now.to_i}"
+          end
           env[:machine].provider.driver.set_name(name)
 
           @app.call(env)


### PR DESCRIPTION
I use vagrant to instantiate multiVM environments (e.g. 16 VMs locally from top-level project folder).

At the moment it is very difficult to see which VM in the Virtualbox interface relates to which box, so I wanted the option to override the virtualbox box-name in Vagrantfile sensibly (as opposed to the vagrant box-name which is already done), so I can investigate things easily using the virtualbox gui.

I added support for a config.vm.virtualbox_name param to achieve this.

I am unfamiliar with this dev branch (it doesn't work for me at the moment), so have attempted the changes on master, but its a minimal change so shouldn't be hard to understand.
