### PR TITLE
Omit empty lines in Puppet provisioner output

### DIFF
--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -159,7 +159,8 @@ module VagrantPlugins
                                :manifest => @manifest_file)
 
           env[:machine].communicate.sudo(command) do |type, data|
-            env[:ui].info(data.chomp, :prefix => false)
+            data.chomp!
+            env[:ui].info(data, :prefix => false) if !data.empty?
           end
         end
 

--- a/plugins/provisioners/puppet/provisioner/puppet_server.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet_server.rb
@@ -71,7 +71,8 @@ module VagrantPlugins
 
           env[:ui].info I18n.t("vagrant.provisioners.puppet_server.running_puppetd")
           env[:vm].channel.sudo(command) do |type, data|
-            env[:ui].info(data.chomp, :prefix => false)
+            data.chomp!
+            env[:ui].info(data, :prefix => false) if !data.empty?
           end
         end
       end


### PR DESCRIPTION
The sudo() block and/or the Puppet provisioner often returns newline
characters as separate strings. This makes the chomp() ineffective and
results in extraneous spacing between the output lines.

Separate out the call to chomp() so that we only do it once. Then only
output info if that line is not an empty string.
## 

Here's an example of the previous behaviour using `pp` instead of `env[:ui].info`:

``` sh
$ vagrant provision ja01
[ja01] Running provisioner: Vagrant::Provisioners::Puppet...
[ja01] Running Puppet with /tmp/vagrant-puppet/manifests/site.pp...
"\e[0;36mnotice: /Firewall[100 ssh]/ensure: created\e[0m"
"\n"
"\e[0;36mnotice: /Firewall[999 default_policy]/ensure: created\e[0m"
"\n"
"\e[0;36mnotice: /Firewall[002 allow_icmp]/ensure: created\e[0m"
"\n"
"\e[0;36mnotice: /Firewall[500 tomcat]/ensure: created\e[0m"
"\n"
"\e[0;36mnotice: /Firewall[001 allow_loopback]/ensure: created\e[0m"
"\n"
"\e[0;36mnotice: Finished catalog run in 5.01 seconds\e[0m"
"\n"
""
```
