### PR TITLE
Environment refactor

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -414,6 +414,14 @@ module Vagrant
       @config = Config::Container.new(global, vm_configs)
     end
 
+    #
+    # Load a given configuration for a VM; accepts the config_loader object, a
+    # base configuration that is a hash that follows the parameters supplied to
+    # push_configuration, a key which is an arbitrary symbol which names the
+    # vm, and a subvm object which complies with the subvm interface.
+    #
+    # @return [VagrantPlugins::Kernel_V1::VMConfig]
+    #
     def load_config_for_vm(config_loader, base_config, load_key, subvm)
       # First pass, first run.
       config = push_configuration(
@@ -435,6 +443,12 @@ module Vagrant
       return config
     end
 
+    #
+    # Locates a box based on its name. If that box indicates that it needs to
+    # be upgraded, this method logs the action and does it automatically.
+    #
+    # @return [Vagrant::Box]
+    #
     def find_and_upgrade(box)
       boxes.find(box, :virtualbox)
     rescue Errors::BoxUpgradeRequired


### PR DESCRIPTION
Greetings, here are some patches to make Vagrant::Environment objects easier to manipulate without reading a `Vagrantfile`. It also contains a small patch to enable manipulating the UI object after an environment has been created, which should be handy if you have an environment where the output device might change, but the configuration won't.

I can't say I like all this code in the patch, but I think the end result is mostly simplified methods and an approach that allows people who want to manipulate the configuration as it's being evaluated the ability to do so, it's even entirely possible to run with zero user-supplied `Vagrantfile`s given the right code to do so.

I've attempted to document all methods and `rake` passes. I did not write any new tests. I did not run the acceptance tests.
