### PR TITLE
close ssh connection on halt

### DIFF
--- a/lib/vagrant/action/vm/halt.rb
+++ b/lib/vagrant/action/vm/halt.rb
@@ -12,6 +12,7 @@ module Vagrant
             if !env["force"]
               env[:ui].info I18n.t("vagrant.actions.vm.halt.graceful")
               env[:vm].guest.halt
+              env[:vm].channel.close
             end
 
             if env[:vm].state != :poweroff

--- a/lib/vagrant/communication/ssh.rb
+++ b/lib/vagrant/communication/ssh.rb
@@ -89,6 +89,13 @@ module Vagrant
           raise
       end
 
+      def close
+        unless @connection.nil?
+          @connection.close
+          @logger.info("Connection has been closed.")
+        end
+      end
+
       protected
 
       # Opens an SSH connection and yields it to a block.


### PR DESCRIPTION
Using Jruby, when reloading a VM or even halt/up process lead to ssh connection issues. Just closing the channel after halt it solve the problem.

Tested with Jruby 1.6.7
