### PR TITLE
Ignore 'extra' args in base command parser

### DIFF
--- a/lib/vagrant/command/base.rb
+++ b/lib/vagrant/command/base.rb
@@ -38,7 +38,7 @@ module Vagrant
       def parse_options(opts=nil)
         # Creating a shallow copy of the arguments so the OptionParser
         # doesn't destroy the originals.
-        argv = @argv.dup
+        argv = @argv.dup.take_while {|a| a != '--'}
 
         # Default opts to a blank optionparser if none is given
         opts ||= OptionParser.new

--- a/test/unit/vagrant/command/base_test.rb
+++ b/test/unit/vagrant/command/base_test.rb
@@ -24,6 +24,14 @@ describe Vagrant::Command::Base do
       options[:f].should be
       result.should == ["foo"]
     end
+    
+    it "ignores 'extra' args" do
+      options = {}
+      opts = OptionParser.new do |opts|
+        result = klass.new(["foo", "bar", "--", "baz"], nil).parse_options(opts)
+        result.should == ["foo", "bar"]
+      end
+    end
 
     it "creates an option parser if none is given" do
       result = klass.new(["foo"], nil).parse_options(nil)


### PR DESCRIPTION
Specifying a specific VM and extra args at the same time
was triggering a multi_vm_target_required because the extra
args were being returned by parse_options. This makes
parse_options drop the extra args.
