### PR TITLE
Spaces in project's path breaks NFS mount in BSD

### DIFF
--- a/plugins/guests/freebsd/guest.rb
+++ b/plugins/guests/freebsd/guest.rb
@@ -40,7 +40,7 @@ module VagrantPlugins
       def mount_nfs(ip, folders)
         folders.each do |name, opts|
           vm.channel.sudo("mkdir -p #{opts[:guestpath]}")
-          vm.channel.sudo("mount #{ip}:#{opts[:hostpath]} #{opts[:guestpath]}")
+          vm.channel.sudo("mount '#{ip}:#{opts[:hostpath]}' '#{opts[:guestpath]}'")
         end
       end
 


### PR DESCRIPTION
This was detected and fixed for Linux as part of Issue 293 https://github.com/mitchellh/vagrant/issues/293
But I found that it still happens on FreeBSD when mounting the v-root over NFS.
