### PR TITLE
Altered messages so they were _not_ self referencing.

### DIFF
--- a/plugins/commands/destroy/plugin.rb
+++ b/plugins/commands/destroy/plugin.rb
@@ -4,7 +4,10 @@ module VagrantPlugins
   module CommandDestroy
     class Plugin < Vagrant.plugin("2")
       name "destroy command"
-      description "The `destroy` command destroys your virtual machines."
+      description <<-DESC
+      The `destroy` command deletes and removes the files and record of your virtual machines.
+      All data is lost and a new VM will have to be created using `up`
+      DESC
 
       command("destroy") do
         require File.expand_path("../command", __FILE__)

--- a/plugins/commands/halt/plugin.rb
+++ b/plugins/commands/halt/plugin.rb
@@ -5,7 +5,8 @@ module VagrantPlugins
     class Plugin < Vagrant.plugin("2")
       name "halt command"
       description <<-DESC
-      The `halt` command halts your virtual machine.
+      The `halt` command shuts your virtual machine down forcefully.
+      The command `up` recreates it.
       DESC
 
       command("halt") do

--- a/plugins/commands/ssh/plugin.rb
+++ b/plugins/commands/ssh/plugin.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
     class Plugin < Vagrant.plugin("2")
       name "ssh command"
       description <<-DESC
-      The `ssh` command provides SSH access to the virtual machine.
+      The `ssh` command allows you to SSH in to your running virtual machine.
       DESC
 
       command("ssh") do

--- a/plugins/commands/status/plugin.rb
+++ b/plugins/commands/status/plugin.rb
@@ -5,8 +5,8 @@ module VagrantPlugins
     class Plugin < Vagrant.plugin("2")
       name "status command"
       description <<-DESC
-      The `status` command shows the status of all your virtual machines
-      in this environment.
+      The `status` command shows what the running state (running/saved/..)
+      is of all your virtual machines in this environment.
       DESC
 
       command("status") do

--- a/plugins/commands/suspend/plugin.rb
+++ b/plugins/commands/suspend/plugin.rb
@@ -5,7 +5,8 @@ module VagrantPlugins
     class Plugin < Vagrant.plugin("2")
       name "suspend command"
       description <<-DESC
-      The `suspend` command suspends a running virtual machine.
+      The `suspend` command suspends execution and puts it to sleep.
+      The command `resume` returns it to running status.
       DESC
 
       command("suspend") do


### PR DESCRIPTION
Altered messages so they were _not_ self referencing and included suggestions to reverse them as I understood them to work.

A bit like you do not want the definition of a word to include the word itself.

The `halt` command halts
The `destroy` command destroys
