### PR TITLE
Fix issue #964 for 1-0-stable branch.

### DIFF
--- a/lib/vagrant/provisioners/puppet.rb
+++ b/lib/vagrant/provisioners/puppet.rb
@@ -117,9 +117,9 @@ module Vagrant
       end
 
       def set_module_paths
-        @module_paths = {}
+        @module_paths = []
         @expanded_module_paths.each_with_index do |path, i|
-          @module_paths[path] = File.join(config.pp_path, "modules-#{i}")
+          @module_paths << [path, File.join(config.pp_path, "modules-#{i}")]
         end
       end
 
@@ -136,7 +136,8 @@ module Vagrant
 
       def run_puppet_client
         options = [config.options].flatten
-        options << "--modulepath '#{@module_paths.values.join(':')}'" if !@module_paths.empty?
+        module_paths = @module_paths.map { |_, to| to }
+        options << "--modulepath '#{module_paths.join(':')}'" if !@module_paths.empty?
         options << @manifest_file
         options = options.join(" ")
 


### PR DESCRIPTION
Fix problem that Puppet module-paths were re-ordered by Vagrant.

The issue is already fixed in master, but I would be happy to have it fixed in 1.0 too. Ruby 1.8 is still default on OS-X.

https://github.com/mitchellh/vagrant/pull/964
