### PR TITLE
Update v2/docs/config/vm/network.md

### DIFF
--- a/v2/docs/config/vm/network.md
+++ b/v2/docs/config/vm/network.md
@@ -62,3 +62,7 @@ options are:
 * `:bridge` - The full name of the network to bridge to. If this is specified,
   then Vagrant will not ask the user.
 * `:mac` - The MAC address to assign to this network adapter.
+
+A valid config line for OsX could be something like this:
+
+    config.vm.network :bridged, :bridge => 'en0: Ethernet'


### PR DESCRIPTION
Add a config line example to disambiguate the "full name of the network to bridge to" description
