### PR TITLE
Adds formatter option to Chef Provisioner

### DIFF
--- a/lib/vagrant/provisioners/chef.rb
+++ b/lib/vagrant/provisioners/chef.rb
@@ -42,6 +42,7 @@ module Vagrant
       def setup_config(template, filename, template_vars)
         config_file = TemplateRenderer.render(template, {
           :log_level => config.log_level.to_sym,
+          :formatter => config.formatter,
           :http_proxy => config.http_proxy,
           :http_proxy_user => config.http_proxy_user,
           :http_proxy_pass => config.http_proxy_pass,
@@ -104,6 +105,7 @@ module Vagrant
         attr_accessor :node_name
         attr_accessor :provisioning_path
         attr_accessor :log_level
+        attr_accessor :formatter
         attr_accessor :json
         attr_accessor :http_proxy
         attr_accessor :http_proxy_user

--- a/templates/provisioners/chef_client/client.erb
+++ b/templates/provisioners/chef_client/client.erb
@@ -28,5 +28,7 @@ https_proxy_pass <%= https_proxy_pass.inspect %>
 no_proxy <%= no_proxy.inspect %>
 
 pid_file           "/var/run/chef/chef-client.pid"
-
+<% if formatter %>
+formatter          "<%= formatter %>"
+<% end %>
 Mixlib::Log::Formatter.show_time = true

--- a/templates/provisioners/chef_solo/solo.erb
+++ b/templates/provisioners/chef_solo/solo.erb
@@ -23,3 +23,6 @@ https_proxy <%= https_proxy.inspect %>
 https_proxy_user <%= https_proxy_user.inspect %>
 https_proxy_pass <%= https_proxy_pass.inspect %>
 no_proxy <%= no_proxy.inspect %>
+<% if formatter %>
+formatter          "<%= formatter %>"
+<% end %>

--- a/test/unit_legacy/vagrant/provisioners/chef_test.rb
+++ b/test/unit_legacy/vagrant/provisioners/chef_test.rb
@@ -160,6 +160,17 @@ class ChefProvisionerTest < Test::Unit::TestCase
 
       @action.setup_config(@template, @filename, custom)
     end
+
+    should "allow custom formatting setting" do
+      Vagrant::Util::TemplateRenderer.expects(:render).returns("foo").with() do |template, vars|
+        assert vars.has_key?(:formatter)
+        assert_equal @config.formatter.to_sym, vars[:formatter]
+        true
+      end
+
+      @action.setup_config(@template, @filename, custom)
+    end
+
   end
 
   context "generating and uploading json" do


### PR DESCRIPTION
Adds the ability to specify in the Vagrantfile a formatter directive to control the verbosity/format of the Chef log.

Formats such as `summary`, `minimal` and `doc` are valid, and the directive is not required.

I tried taking a stab at the tests, but the test suite didn't seem very friendly to me today.
