### PR TITLE
Update v1/docs/getting-started/packaging.md

### DIFF
--- a/v1/docs/getting-started/packaging.md
+++ b/v1/docs/getting-started/packaging.md
@@ -39,18 +39,6 @@ Vagrant::Config.run do |config|
 end
 {% endhighlight %}
 
-<div class="info">
-  <h3>What's with the MAC address?</h3>
-  <p>
-    When an OS is installed, it typically sets up the MAC address associated
-    with the <code>eth0</code> network interface, which allows the VM to connect to the
-    internet. But when importing a base, VirtualBox changes the MAC address
-    to something new, which breaks <code>eth0</code>. The MAC address of the base must
-    be persisted in the box Vagrantfile so that Vagrant can setup the MAC address
-    to ensure internet connectivity.
-  </p>
-</div>
-
 ## Packaging the Project
 
 Run the following code to package the environment up:


### PR DESCRIPTION
Based on where the ("What's with the MAC address?") section came from (see https://github.com/mitchellh/vagrant/blob/8d5900a98f6f27cd5885ef6d2a1755b5133d1e3c/docs/getting-started/packaging.md#creating-the-vagrantfile), it looks like its no longer applicable to the documentation.

I've only recently started using Vagrant, and reading through the documentation the MAC address section seemed to be out of place.

Hope this helps! Thanks for your great work!
