### PR TITLE
Attempt to fix #1108, #1109, tcp and udp port on the same port number

### DIFF
--- a/plugins/providers/virtualbox/action/forward_ports.rb
+++ b/plugins/providers/virtualbox/action/forward_ports.rb
@@ -32,7 +32,8 @@ module VagrantPlugins
           # approach.
           guest_port_mapping = {}
           @env[:machine].config.vm.forwarded_ports.each do |options|
-            guest_port_mapping[options[:guestport]] = options
+            key = options[:protocol].to_s + options[:guestport].to_s
+            guest_port_mapping[key] = options
           end
 
           # Return the values, since the order doesn't really matter


### PR DESCRIPTION
when forwarded ports are squashed, if a tcp and udp port share the same port number one of them is forgotten
