### PR TITLE
Add support for automounting of shared folders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@
   - Work around bug in VirtualBox exposed by bug in OS X 10.8 where
     VirtualBox executables couldn't handle garbage being injected into
     stdout by OS X.
+  - Shared folders can now be marked for automounting using the `:automount`
+    flag.
 
 ## 1.0.5 (September 18, 2012)
 

--- a/lib/vagrant/action/vm/share_folders.rb
+++ b/lib/vagrant/action/vm/share_folders.rb
@@ -64,7 +64,8 @@ module Vagrant
             folders << {
               :name => name,
               :hostpath => File.expand_path(data[:hostpath], @env[:root_path]),
-              :transient => data[:transient]
+              :transient => data[:transient],
+              :automount => data[:automount]
             }
           end
 

--- a/lib/vagrant/config/vm.rb
+++ b/lib/vagrant/config/vm.rb
@@ -59,6 +59,7 @@ module Vagrant
           :group => nil,
           :nfs   => false,
           :transient => false,
+          :automount => false,
           :extra => nil
         }.merge(opts || {})
       end

--- a/lib/vagrant/driver/virtualbox_4_0.rb
+++ b/lib/vagrant/driver/virtualbox_4_0.rb
@@ -407,6 +407,7 @@ module Vagrant
                   "--hostpath",
                   folder[:hostpath]]
           args << "--transient" if folder.has_key?(:transient) && folder[:transient]
+          args << "--automount" if folder.has_key?(:automount) && folder[:automount]
           execute("sharedfolder", "add", @uuid, *args)
         end
       end

--- a/lib/vagrant/driver/virtualbox_4_1.rb
+++ b/lib/vagrant/driver/virtualbox_4_1.rb
@@ -407,6 +407,7 @@ module Vagrant
                   "--hostpath",
                   folder[:hostpath]]
           args << "--transient" if folder.has_key?(:transient) && folder[:transient]
+          args << "--automount" if folder.has_key?(:automount) && folder[:automount]
           execute("sharedfolder", "add", @uuid, *args)
         end
       end

--- a/lib/vagrant/driver/virtualbox_4_2.rb
+++ b/lib/vagrant/driver/virtualbox_4_2.rb
@@ -437,6 +437,7 @@ module Vagrant
                   "--hostpath",
                   folder[:hostpath]]
           args << "--transient" if folder.has_key?(:transient) && folder[:transient]
+          args << "--automount" if folder.has_key?(:automount) && folder[:automount]
           execute("sharedfolder", "add", @uuid, *args)
         end
       end


### PR DESCRIPTION
Tested by-hand on VirtualBox 4.2.  I didn't find any automated test
support for shared folder arguments; please let me know if I missed that
part of the suite.
