### PR TITLE
systemd support for Arch Linux guests

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -338,6 +338,11 @@ module Vagrant
       error_key(:ssh_unavailable_windows)
     end
 
+    class SSHConnectionClosed < VagrantError
+      status_code(78)
+      error_key(:ssh_connection_closed)
+    end
+
     class UIExpectsTTY < VagrantError
       status_code(73)
       error_key(:ui_expects_tty)

--- a/lib/vagrant/guest/arch.rb
+++ b/lib/vagrant/guest/arch.rb
@@ -57,6 +57,8 @@ module Vagrant
             return if count >= vm.config.linux.halt_timeout
             sleep vm.config.linux.halt_check_interval
           end
+        rescue IOError
+          raise Errors::SSHConnectionClosed.new
         end
       end
 

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -100,6 +100,8 @@ en:
         %{path}
 
         Please create the folder manually or specify another path to share.
+      ssh_connection_closed: |-
+        The SSH connection was unexpectedly closed.
       ssh_authentication_failed: |-
         SSH authentication failed! This is typically caused by the public/private
         keypair for the SSH user not being properly set on the guest VM. Please


### PR DESCRIPTION
Arch has recently changed to using systemd for the initialization process, and thus making /etc/rc.conf obsolete for their boot process.

The networking config support in vagrant depended on rc.conf being present, and also on using "netcfg". I changed it to support their new style, in accordance with the updated installation guides.

I also changed the hostname setup and shutdown to their recommendations.

The base box I was trying to create now works without any issues with this modifications.

Note these changes are based on 1-0-stable, as I wanted a quick fix for the issues I was having with 1.0.5, but I think they could be brought to master too.
