### PR TITLE
for the provider's vm name, use the vm's host_name if available

### DIFF
--- a/lib/vagrant/action/vm/default_name.rb
+++ b/lib/vagrant/action/vm/default_name.rb
@@ -11,7 +11,7 @@ module Vagrant
 
         def call(env)
           @logger.info("Setting the default name of the VM")
-          name = env[:root_path].basename.to_s + "_#{Time.now.to_i}"
+          name = (env[:vm].config.vm.host_name || env[:root_path].basename).to_s + "_#{Time.now.to_i}"
           env[:vm].driver.set_name(name)
 
           @app.call(env)


### PR DESCRIPTION
Hi,

When in a multi vm environment, all vms have the same name in virtualbox. This makes it tricky to know which machine is which.

This patch uses the vm's host_name if it is available.

A) This is based upon the 1.0 branch, since that is what I use. Please point me to the 1.1 (master) vs 1.0 (stable) branching strategy FAQ and I can rebase.

B) If you have an example of an action tested / and how much you want to mock out, please let me know. (I only saw some legacy tests that used the environment)

C) Also, I noticed that Environment#root_path is documented to return a String, but the existing code assumes a Pathname is coming out.This threw a wrench into my testing, so please advise and I can fix this as well.

Thanks for the great tool,
Keenan

(sorry about the bad previous pull request)
