### PR TITLE
Avoid cross device activity for box creation

### DIFF
--- a/lib/vagrant/box_collection.rb
+++ b/lib/vagrant/box_collection.rb
@@ -84,7 +84,7 @@ module Vagrant
 
       # Create a temporary directory since we're not sure at this point if
       # the box we're unpackaging already exists (if no provider was given)
-      Dir.mktmpdir("vagrant-") do |temp_dir|
+      Dir.mktmpdir(["vagrant-tmp-", provider.to_s]) do |temp_dir|
         temp_dir = Pathname.new(temp_dir)
 
         # Extract the box into a temporary directory.


### PR DESCRIPTION
This will cause issues on modern linux which uses a tmpfs-backed tmpdir.

This moves the temporary box creation to the same directory tree as the provider's directory.  This is an alternate solution to pull request #1199, and will not incur the speed penalty involved in a cross-filesystem mv, assuming a box provider's directory is one filesystem.  A better solution I suppose would be to test if /tmp is cross device first, but that adds more complexity for questionable benefit, I think.
