### PR TITLE
Fix for #1207 : puppet module_path overwrites default module path

### DIFF
--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -69,8 +69,7 @@ module VagrantPlugins
 
         def run_puppet_apply
           options = [config.options].flatten
-          module_paths = @module_paths.map { |_, to| to }
-          options << "--modulepath '#{module_paths.join(':')}'" if !@module_paths.empty?
+          options << "--modulepath '#{full_module_path}'" if !@module_paths.empty?
           options << @manifest_file
           options = options.join(" ")
 
@@ -104,6 +103,13 @@ module VagrantPlugins
             end
           end
         end
+
+        private
+          def full_module_path
+            default_puppet_module_path = @machine.communicate('puppet config print modulepath').chomp
+            module_paths = @module_paths.map { |_, to| to }
+            module_paths.join(':') << ':' << default_puppet_module_path
+          end
       end
     end
   end


### PR DESCRIPTION
I've changed the way `run_puppet_apply` computes the `--modulepath` value. 
Now, it should prepend the config modulepath to the system modulepath instead of clobbering it.

@mitchellh
This is my first commit to Vagrant. I couldn't find any tests for the `Puppet` class and am not sure if this is a good fix or not. Could you give me some suggestions on how I can verify whether this fixes the issue or not? And can I add an automated test somewhere?

Waiting to hear back. Happy to make further changes.
