### PR TITLE
Add test for invalid box file

### DIFF
--- a/test/unit/vagrant/box_collection_test.rb
+++ b/test/unit/vagrant/box_collection_test.rb
@@ -1,6 +1,8 @@
 require File.expand_path("../../base", __FILE__)
 
 require "pathname"
+require 'tempfile'
+require 'archive/tar/minitar'
 
 describe Vagrant::BoxCollection do
   include_context "unit"
@@ -105,7 +107,24 @@ describe Vagrant::BoxCollection do
     end
 
     it "should raise an exception if you add an invalid box file" do
-      pending "I don't know how to generate an invalid tar."
+      # Tar Header information
+      CHECKSUM_OFFSET = 148
+      CHECKSUM_LENGTH = 8
+
+      Tempfile.new(['vagrant_testing', '.tar']) do |f|
+        # Create a temp tar file
+        Archive::Tar::Minitar.pack('test', f)
+
+        # Minitar closes the Tempfile so reopen it
+        f = File.open(f.path, "wb")
+        # Corrupt the tar by writing over the checksum field
+        f.seek(CHECKSUM_OFFSET)
+        f.write("\0"*CHECKSUM_LENGTH)
+        f.close
+
+        expect { instance.add(path, "foo", :virtualbox) }.
+          to raise_error(Vagrant::Errors::BoxUnpackageFailure)
+      end
     end
   end
 


### PR DESCRIPTION
Filled in pending test. It creates a valid tar file, over-writes the
checksum field in the tar's header and then checks that the
`BoxUnpackageFailure` exception is thrown.
