### PR TITLE
Add download support using SCP

### DIFF
--- a/lib/vagrant/communication/ssh.rb
+++ b/lib/vagrant/communication/ssh.rb
@@ -75,11 +75,27 @@ module Vagrant
       def upload(from, to)
         @logger.debug("Uploading: #{from} to #{to}")
 
+        scp_execute do |scp|
+          scp.upload!(File.open(from, "r"), to)
+        end
+      end
+
+      def download(from, to)
+        @logger.debug("Downloading: #{from} to #{to}")
+
+        scp_execute do |scp|
+          scp.download!(from, to)
+        end
+      end
+
+      protected
+
+      def scp_execute
         # Do an SCP-based upload...
         connect do |connection|
           # Open file read only to fix issue #1036
           scp = Net::SCP.new(connection)
-          scp.upload!(File.open(from, "r"), to)
+          yield scp
         end
       rescue Net::SCP::Error => e
         # If we get the exit code of 127, then this means SCP is unavailable.
@@ -88,8 +104,6 @@ module Vagrant
           # Otherwise, just raise the error up
           raise
       end
-
-      protected
 
       # Opens an SSH connection and yields it to a block.
       def connect


### PR DESCRIPTION
Hey,

While working on [vagrant-notify](/fgrehm/vagrant-notify) I needed to [download a file](https://github.com/fgrehm/vagrant-notify/compare/267344485e...7adaf05571#L5L-1) from the guest machine and found out that it wasn't supported by vagrant.

Although I found out that the support is present on the master branch, I was wondering if by any chance you guys have plans to backport it to the 1.0 series.

Please let me know if you guys want me to implement the unit tests as well. I'll just need some help to get it working since I wasn't able to run the `unit_legacy` tests because of a bunch of:

```
ArgumentError: wrong number of arguments (2 for 3)
    /home/projects/oss/vagrant/lib/vagrant/box.rb:21:in `initialize'
    /home/projects/oss/vagrant/test/unit_legacy/vagrant/action/box/verify_test.rb:7:in `new'
    /home/projects/oss/vagrant/test/unit_legacy/vagrant/action/box/verify_test.rb:7:in `block in <class:VerifyBoxActionTest>'
    /home/fabio/.rbenv/versions/1.9.3-p327-patched/lib/ruby/gems/1.9.1/gems/contest-0.1.3/lib/contest.rb:22:in `instance_eval'
    /home/fabio/.rbenv/versions/1.9.3-p327-patched/lib/ruby/gems/1.9.1/gems/contest-0.1.3/lib/contest.rb:22:in `block in setup'
    /home/fabio/.rbenv/versions/1.9.3-p327-patched/lib/ruby/gems/1.9.1/gems/mocha-0.13.1/lib/mocha/integration/mini_test/version_230_to_2101.rb:34:in `run'
```

Cheers
