### PR TITLE
Return exit status of 1 on invalid command

### DIFF
--- a/lib/vagrant/cli.rb
+++ b/lib/vagrant/cli.rb
@@ -38,7 +38,7 @@ module Vagrant
 
       if !command_class || !@sub_command
         help
-        return 0
+        return 1
       end
       @logger.debug("Invoking command class: #{command_class} #{@sub_args.inspect}")
 

--- a/test/unit/vagrant/plugin/v1/cli_test.rb
+++ b/test/unit/vagrant/plugin/v1/cli_test.rb
@@ -1,0 +1,31 @@
+describe Vagrant::CLI do
+
+  describe "parsing options" do
+    let(:klass) do
+      Class.new(described_class)
+    end
+
+    let(:environment) do
+      ui = double("UI::Silent")
+      ui.stub(:info => "bar")
+      env = double("Vagrant::Environment")
+      env.stub(:ui => ui)
+      env.stub(:root_path => "foo")
+      env.stub(:machine_names => [])
+      env
+    end
+
+    it "returns a non-zero exit status if an invalid command is given" do
+      result = klass.new(["destroypp"], environment).execute
+      result.should_not == 0
+    end
+
+    it "returns an exit status of zero if a valid command is given" do
+      result = klass.new(["destroy"], environment).execute
+      result.should == 0
+    end
+
+  end
+    
+end
+


### PR DESCRIPTION
Makes `vagrant destroyjj` and similar invalid commands return an exit code of 1, so that `vagrant destroyjj && vagrant up` works as expected.  (i.e. the `vagrant up` is not executed.)

I don't really know Ruby so the test could be complete rubbish.  Are there really no existing tests for `Vagrant::CLI`?  I couldn't find any.
