### PR TITLE
Temp directory in a different partition than the destination will make rename fail

### DIFF
--- a/lib/vagrant/box_collection.rb
+++ b/lib/vagrant/box_collection.rb
@@ -131,7 +131,7 @@ module Vagrant
         final_dir.mkpath
 
         # Move to the final destination
-        File.rename(temp_dir, final_dir.to_s)
+        FileUtils.mv(temp_dir, final_dir.to_s)
 
         # Recreate the directory. This avoids a bug in Ruby where `mktmpdir`
         # cleanup doesn't check if the directory is already gone. Ruby bug


### PR DESCRIPTION
Rename is a simple hard-link + unlink at the old location. This does not work across different partitions/devices.

Example in my box:
ln ~/file.txt /tmp
ln: failed to create hard link ‘/tmp/test.txt’ => ‘/home/ereslibre/test.txt’: Invalid cross-device link

This is the exception that was being raised by vagrant when trying to move the downloaded image to my home directory.
