### PR TITLE
add verbose_logging config option to chef based provisioners

### DIFF
--- a/plugins/provisioners/chef/config/base.rb
+++ b/plugins/provisioners/chef/config/base.rb
@@ -6,6 +6,7 @@ module VagrantPlugins
         attr_accessor :node_name
         attr_accessor :provisioning_path
         attr_accessor :log_level
+        attr_accessor :verbose_logging
         attr_accessor :json
         attr_accessor :http_proxy
         attr_accessor :http_proxy_user
@@ -25,6 +26,7 @@ module VagrantPlugins
         def attempts; @attempts || 1; end
         def json; @json ||= {}; end
         def log_level; @log_level || :info; end
+        def verbose_logging; @verbose_logging || true; end
 
         # This returns the json that is merged with the defaults and the
         # user set data.

--- a/plugins/provisioners/chef/provisioner/base.rb
+++ b/plugins/provisioners/chef/provisioner/base.rb
@@ -49,6 +49,7 @@ module VagrantPlugins
         def setup_config(template, filename, template_vars)
           config_file = Vagrant::Util::TemplateRenderer.render(template, {
             :log_level        => @config.log_level.to_sym,
+            :verbose_logging  => @config.verbose_logging,
             :http_proxy       => @config.http_proxy,
             :http_proxy_user  => @config.http_proxy_user,
             :http_proxy_pass  => @config.http_proxy_pass,

--- a/templates/provisioners/chef_client/client.erb
+++ b/templates/provisioners/chef_client/client.erb
@@ -1,5 +1,6 @@
 log_level          <%= log_level.inspect %>
 log_location       STDOUT
+verbose_logging    <%= verbose_logging.inspect %>
 <% if node_name %>
 node_name          "<%= node_name %>"
 <% end %>

--- a/templates/provisioners/chef_solo/solo.erb
+++ b/templates/provisioners/chef_solo/solo.erb
@@ -5,6 +5,7 @@ file_cache_path "<%= provisioning_path %>"
 cookbook_path <%= cookbooks_path.inspect %>
 role_path <%= roles_path.inspect %>
 log_level <%= log_level.inspect %>
+verbose_logging    <%= verbose_logging.inspect %>
 
 encrypted_data_bag_secret "<%= encrypted_data_bag_secret %>"
 


### PR DESCRIPTION
This pull requests add the [verbose_logging](http://wiki.opscode.com/display/chef/Chef+Configuration+Settings#ChefConfigurationSettings-logoutput) option to the solo.rb/client.rb.

I really like this option to identify chef resources that are executed unnecessary in every run. Especially when optimizing bigger run_lists it really helps (together with `log_level: info`) to fade out all resources then are not executed.
