### PR TITLE
Reword the port collision resume message to address general programs

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -193,11 +193,11 @@ en:
         The plugin '%{name}' could not be found. Please install this plugin
         prior to attempting to do anything with it.
       port_collision_resume: |-
-        This VM cannot be resumed, because the forwarded ports would collide with
-        another running virtual machine. Normally, Vagrant will attempt to fix this
-        for you but VirtualBox only allows forwarded ports to change if the VM is
-        powered off. Therefore, please reload your VM or halt the other running
-        VMs to continue.
+        This VM cannot be resumed, because the forwarded ports would collide
+        with a running program (it could be another virtual machine). Normally,
+        Vagrant will attempt to fix this for you but VirtualBox only allows
+        forwarded ports to change if the VM is powered off. Therefore, please
+        reload your VM or stop the other program to continue.
       provider_not_found: |-
         The provider '%{provider}' could not be found, but was requested to
         back the machine '%{machine}'. Please use a provider that exists.


### PR DESCRIPTION
Port collision can also be caused by programs that listen to ports, so I reworded the message. Hope I didn't make it confusing.
