### PR TITLE
update net-ssh and net-scp dependencies to use recent dependencies

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "contest", ">= 0.1.2"
   s.add_development_dependency "minitest", "~> 2.5.1"
   s.add_development_dependency "mocha"
-  s.add_development_dependency "sys-proctable", "~> 0.9.0"
+  #s.add_development_dependency "sys-proctable", "~> 0.9.0"
   s.add_development_dependency "rspec-core", "~> 2.8.0"
   s.add_development_dependency "rspec-expectations", "~> 2.8.0"
   s.add_development_dependency "rspec-mocks", "~> 2.8.0"


### PR DESCRIPTION
you may be aware that net-ssh's author has pushed changes which break many pessimistic gem requirements.

http://solutious.com/blog/2013/02/06/net-ssh-gem-code-signed/

several tools like fog, chef, etc depend on these gems, and updated gems have been pushed to reflect the dependency.

Here's a post which explains the upgrade from opscode's point of view:

http://jtimberman.housepub.org/blog/2013/02/06/chef-and-net-ssh-dependency-broken/

Unfortunately I can't use vagrant with my other tooling in bundles, etc because of this.

I ran both the units and acceptance tests before and after the spec change -- there was no difference in the test output, although several acceptance tests failed before and after it.

I'm inclined to think there's no reason to avoid changing this, and the sooner the better. :)
