### PR TITLE
Allow non privileged user vagrant to run a shell provision

### DIFF
--- a/plugins/provisioners/shell/config.rb
+++ b/plugins/provisioners/shell/config.rb
@@ -5,9 +5,11 @@ module VagrantPlugins
       attr_accessor :path
       attr_accessor :upload_path
       attr_accessor :args
+      attr_accessor :privileged
 
       def initialize
         @upload_path = "/tmp/vagrant-shell"
+        @privileged  = true
       end
 
       def validate(machine)

--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -14,8 +14,7 @@ module VagrantPlugins
           @machine.communicate.tap do |comm|
             comm.upload(path.to_s, config.upload_path)
 
-            # Execute it with sudo
-            comm.sudo(command) do |type, data|
+            comm.execute(command, {:sudo => config.privileged}) do |type, data|
               if [:stderr, :stdout].include?(type)
                 # Output the data with the proper color based on the stream.
                 color = type == :stdout ? :green : :red


### PR DESCRIPTION
Sometimes, after provisioning the server, I need to make some initial configurations in the project, without superuser privileges. For example, bundle the project gems, import assets and/or db data from the integration server, etc. Some of these tasks are better performed by the user vagrant, and some of them don't even work when performed by root (because of ssh agent forwarding lost after sudo'ing and su'ing).

This pull request allows a shell provision by the unprivileged vagrant user:

```
config.vm.provision :shell, :path => 'path/to/my/script', :privileged => false
```
