### PR TITLE
Relax pinning of net-ssh to ~> 2.6.5 for compatibility with Chef 10.22.0

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "i18n", "~> 0.6.0"
   s.add_dependency "json", "~> 1.6.6"
   s.add_dependency "log4r", "~> 1.1.9"
-  s.add_dependency "net-ssh", "~> 2.2.2"
+  s.add_dependency "net-ssh", "~> 2.6.5"
   s.add_dependency "net-scp", "~> 1.0.4"
 
   s.add_development_dependency "rake"


### PR DESCRIPTION
Chef 10.22.0 and test-kitchen require net-ssh ~> 2.6, so they won't work with Vagrant:

$ kitchen test
/Users/jdunn/.rvm/rubies/ruby-1.9.3-p327/lib/ruby/1.9.1/rubygems/specification.rb:1637:in `raise_if_conflicts': Unable to activate chef-10.22.0, because net-ssh-2.2.2 conflicts with net-ssh (~> 2.6) (Gem::LoadError)

I tested vagrant with net-ssh 2.6.5 and it works great, so I think it's safe to bump it.
