### PR TITLE
Apply Internal Networking to the new Master Branch

### DIFF
--- a/plugins/kernel_v1/config/vm.rb
+++ b/plugins/kernel_v1/config/vm.rb
@@ -55,6 +55,8 @@ module VagrantPlugins
       def network(type, *args)
         if type == :hostonly
           @networks << [:private_network, args]
+		elsif type == :intnet
+          @networks << [:internal_network, args]
         elsif type == :bridged
           @networks << [:public_network, args]
         else

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -408,7 +408,7 @@ en:
         box_not_found: "The box '%{name}' could not be found."
         network_invalid: |-
           The network type '%{type}' is not valid. Please use
-          'hostonly' or 'bridged'.
+          'hostonly', 'intnet', or 'bridged'.
         network_ip_required: |-
           Host only networks require an IP as an argument.
         network_ip_invalid: |-


### PR DESCRIPTION
My organization really needs internal networking for multi-vm communication and host-only networking doesn't work due to security. I have applied the changes from [Pull Request 982](https://github.com/mitchellh/vagrant/pull/982) to the latest trunk as it looked like the baseline has been significantly modified since that pull request was submitted.
