### PR TITLE
Forks out the provisioning

### DIFF
--- a/lib/vagrant/action/vm/provision.rb
+++ b/lib/vagrant/action/vm/provision.rb
@@ -28,11 +28,14 @@ module Vagrant
 
           if enabled
             # Take prepared provisioners and run the provisioning
-            provisioners.each do |instance|
-              @env[:ui].info I18n.t("vagrant.actions.vm.provision.beginning",
-                                    :provisioner => instance.class)
-              instance.provision!
+	    p = fork do
+              provisioners.each do |instance|
+                @env[:ui].info I18n.t("vagrant.actions.vm.provision.beginning",
+                                      :provisioner => instance.class)
+                instance.provision!
+              end
             end
+            return p
           end
         end
 

--- a/lib/vagrant/action/warden.rb
+++ b/lib/vagrant/action/warden.rb
@@ -22,7 +22,7 @@ module Vagrant
       end
 
       def call(env)
-        return if @actions.empty?
+        return false if @actions.empty?
 
         begin
           # Call the next middleware in the sequence, appending to the stack
@@ -30,7 +30,9 @@ module Vagrant
           raise Errors::VagrantInterrupt if env[:interrupted]
           action = @actions.shift
           @logger.info("Calling action: #{action}")
-          @stack.unshift(action).first.call(env)
+          faction = @stack.unshift(action)
+          r = faction.first.call(env)
+          @logger.debug("action return #{r.to_s}")
           raise Errors::VagrantInterrupt if env[:interrupted]
         rescue SystemExit
           # This means that an "exit" or "abort" was called. In these cases,
@@ -45,6 +47,7 @@ module Vagrant
           begin_rescue(env)
           raise
         end
+        return r
       end
 
       # Begins the recovery sequence for all middlewares which have run.

--- a/lib/vagrant/command/up.rb
+++ b/lib/vagrant/command/up.rb
@@ -18,7 +18,11 @@ module Vagrant
         # Parse the options
         argv = parse_options(opts)
         return if !argv
+        
+        # set up array to hold pids of forks
+        pids = [];
 
+    
         # Go over each VM and bring it up
         @logger.debug("'Up' each target VM...")
         with_target_vms(argv) do |vm|
@@ -28,8 +32,16 @@ module Vagrant
             vm.start(options)
           else
             @logger.info("Creating: #{vm.name}")
-            vm.up(options)
+            r = vm.up(options)
+            pids.push(r)
+
           end
+        end
+
+        # if we have pids wait for them.
+        pids.each do | pid |
+          @logger.info("Waiting for pid #{pid.to_s} to complete")
+          Process.waitpid(pid) 
         end
 
         # Success, exit status 0


### PR DESCRIPTION
This pull requests creates a ruby fork for every provision called. The fork allows the main vagrant process to continue to run while the vm is being provisioned in the background. Once all the vms have been created the main vagrant process waits for each provision fork to complete before returning to the user.

With this modification I was able to reduce the up command of a simple mult vm setup of 1 mysql server and 1 apache/php server from 4 minutes to 3 minutes. As the provisioning process becomes more complex then this example the time saved by this patch grows exponentially.

I attempt to run the unit test before making the pull but even with a clean 1-0-stable checkout I was unable to get all the unit tests to pass. I am unsure if this patch will pass the unit test as a result.

This is my first time really working with ruby, so any modifications or suggestions you have I am willing to correct for this patch.
