### PR TITLE
Upgrade a dependency on json library to `~> 1.7.7`.

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.add_dependency "childprocess", "~> 0.3.7"
   s.add_dependency "erubis", "~> 2.7.0"
   s.add_dependency "i18n", "~> 0.6.0"
-  s.add_dependency "json", "~> 1.6.6"
+  s.add_dependency "json", "~> 1.7.7"
   s.add_dependency "log4r", "~> 1.1.9"
   s.add_dependency "net-ssh", "~> 2.2.2"
   s.add_dependency "net-scp", "~> 1.0.4"


### PR DESCRIPTION
There's a security issue in json library whose version vagrant requires (`~> 1.6.6`).

https://github.com/ruby/ruby/commit/062d2ee6f798205c3046730d0d348cfd0d0bc09d

This dependency on old version of json library prevents users from installing vagrant with Ruby 2.0.0-p0. This pull request should be merged as soon as possible, I think.
