### PR TITLE
Auto remove trailing slashes from synced folders id

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -101,7 +101,7 @@ module VagrantPlugins
       # @param [Hash] options Additional options.
       def synced_folder(hostpath, guestpath, options=nil)
         options ||= {}
-        options[:id] ||= guestpath
+        options[:id] ||= guestpath.to_s.gsub(/\/$/, '')
         options[:guestpath] = guestpath
         options[:hostpath]  = hostpath
 


### PR DESCRIPTION
VirtualBox provider was having a hard time mounting the folders down here.

This also ensures that guestpath and hostpath are `Pathname`s all the time.
