### PR TITLE
add Solaris detection to linux provider

### DIFF
--- a/plugins/guests/linux/guest.rb
+++ b/plugins/guests/linux/guest.rb
@@ -30,6 +30,7 @@ module VagrantPlugins
           return :redhat if comm.test("cat /etc/redhat-release")
           return :suse if comm.test("cat /etc/SuSE-release")
           return :arch if comm.test("cat /etc/arch-release")
+          return :solaris if comm.test("grep 'Solaris' /etc/release")
         end
 
         # Can't detect the distro, assume vanilla linux


### PR DESCRIPTION
in trying to stand up a Solaris vagrant vm, we ran into some issues:

 1:23.29 $ VAGRANT_LOG=info vagrant up sun-10u9
...
[sun-10u9] VM booted and ready for use!
 INFO subprocess: Starting process: ["VBoxManage", "showvminfo", "6cd48772-31b3-4995-a906-3f448030792a", "--machinereadable"]
...
ERROR warden: Error occurred: Networking features require support that is dependent on the operating
system running within the guest virtual machine. Vagrant has built-in support
for many operating systems: Debian, Ubuntu, Gentoo, and RedHat. The distro
of your VM couldn't be detected or doesn't support networking features.

Most of the time this is simply due to the fact that no one has contributed
back the logic necessary to set this up. Please report a bug as well as the
box you're using.

---

i noticed that solaris.rb existed in vagrant-1.0.5/lib/vagrant/guest/, but in  vagrant-1.0.5/lib/vagrant/guest/linux.rb, there was no corresponding return value

this patch adds the return value (though it does so in a slightly different way since the folder hierarchy in this area has changed in master)
