### PR TITLE
Updated net-scp and net-ssh deps in vagrant.gemspec

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -17,10 +17,10 @@ Gem::Specification.new do |s|
   s.add_dependency "childprocess", "~> 0.3.7"
   s.add_dependency "erubis", "~> 2.7.0"
   s.add_dependency "i18n", "~> 0.6.0"
-  s.add_dependency "json", ">= 1.5.1", "< 1.8.0"
+  s.add_dependency "json", ">= 1.7.7", "< 1.8.0"
   s.add_dependency "log4r", "~> 1.1.9"
-  s.add_dependency "net-ssh", "~> 2.2.2"
-  s.add_dependency "net-scp", "~> 1.0.4"
+  s.add_dependency "net-ssh", ">= 2.6.6"
+  s.add_dependency "net-scp", ">= 1.1.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "contest", ">= 0.1.2"


### PR DESCRIPTION
Veewee and a few other gems install newer versions of net-ssh and net-scp than what Vagrant had specified.

I changed the specs and from some basic functionality tests, things seem to work fine.

Before, running `vagrant` or any subcommand of it resulted in a `(Gem::LoadError)` that complained about conflicts:

<pre>
/Users/nick/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/specification.rb:1637:in `raise_if_conflicts': Unable to activate net-scp-1.1.0, because net-ssh-2.2.2 conflicts with net-ssh (>= 2.6.5) (Gem::LoadError)
    from /Users/nick/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/specification.rb:746:in `activate'
    from /Users/nick/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/specification.rb:780:in `block in activate_dependencies'
    from /Users/nick/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/specification.rb:766:in `each'
    from /Users/nick/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/specification.rb:766:in `activate_dependencies'
    from /Users/nick/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems/specification.rb:750:in `activate'
    from /Users/nick/.rbenv/versions/1.9.3-p392/lib/ruby/1.9.1/rubygems.rb:1232:in `gem'
    from /Users/nick/.rbenv/versions/1.9.3-p392/bin/vagrant:22:in `<main>'
</pre> 
