### PR TITLE
Fix shell provisioner's validation of args

### DIFF
--- a/plugins/provisioners/shell/config.rb
+++ b/plugins/provisioners/shell/config.rb
@@ -7,13 +7,14 @@ module VagrantPlugins
       attr_accessor :args
 
       def initialize
-        @args        = []
+        @args        = UNSET_VALUE
         @inline      = UNSET_VALUE
         @path        = UNSET_VALUE
         @upload_path = UNSET_VALUE
       end
 
       def finalize!
+        @args        = nil if @args == UNSET_VALUE
         @inline      = nil if @inline == UNSET_VALUE
         @path        = nil if @path == UNSET_VALUE
         @upload_path = "/tmp/vagrant-shell" if @upload_path == UNSET_VALUE


### PR DESCRIPTION
The shell provider will complain that args is not a string if the value was not set in a Vagrantfile invocation.
