### PR TITLE
Up the version of net-ssh and net-scp in 1.0 branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.0.8 (unreleased)
+
+IMPROVEMENTS:
+
+  - Using newer versions of net-ssh and net-scp. [GH-1436]
+
 ## 1.0.7 (March 13, 2013)
 
   - Detect if a newer version of Vagrant ran and error if it did,

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
   s.add_dependency "i18n", "~> 0.6.0"
   s.add_dependency "json", ">= 1.5.1", "< 1.8.0"
   s.add_dependency "log4r", "~> 1.1.9"
-  s.add_dependency "net-ssh", "~> 2.2.2"
-  s.add_dependency "net-scp", "~> 1.0.4"
+  s.add_dependency "net-ssh", "~> 2.6.6"
+  s.add_dependency "net-scp", "~> 1.1.0"
 
   s.add_development_dependency "rake"
   s.add_development_dependency "contest", ">= 0.1.2"


### PR DESCRIPTION
This fixes the version conflict between chef 10.24.0 and vagrant 1.0.7. Related to #1436
