### PR TITLE
Ability to install a vagrant plugin with a specific version and source

### DIFF
--- a/plugins/commands/plugin/command/install.rb
+++ b/plugins/commands/plugin/command/install.rb
@@ -17,6 +17,19 @@ module VagrantPlugins
                  "The name of the entry point file for loading the plugin.") do |entry_point|
               options[:entry_point] = entry_point
             end
+            o.on("--plugin-prerelease",
+                 "Install a prereleased version of the plugin") do |plugin_prerelease|
+              options[:plugin_prerelease] = plugin_prerelease
+            end
+            o.on("--plugin-version PLUGIN_VERSION", String,
+                 "Install a specific version of the plugin") do |plugin_version|
+              options[:plugin_version] = plugin_version
+            end
+            o.on("--plugin-source PLUGIN_SOURCE", String,
+                 "Add a ruby gem repository") do |plugin_source|
+              options[:plugin_sources] = [] if !options[:plugin_sources]
+              options[:plugin_sources] << plugin_source
+            end
           end
 
           # Parse the options
@@ -27,6 +40,9 @@ module VagrantPlugins
           # Install the gem
           action(Action.action_install, {
             :plugin_entry_point => options[:entry_point],
+            :plugin_prerelease => options[:plugin_prerelease],
+            :plugin_version => options[:plugin_version],
+            :plugin_sources => options[:plugin_sources],
             :plugin_name        => argv[0]
           })
 


### PR DESCRIPTION
Hi there, I was very excited to try the release candidate of berkshelf for vagrant-1.1
Here are my patches to be able to install berkshelf-1.3.0.rc1 with either one of those command-lines:

```
vagrant plugin install --gem-source http://rubygems.org/ --gem-version 1.3.0.rc1 berkshelf
vagrant plugin install --gem-source http://rubygems.org/ --gem-pre berkshelf
```

Note that for some reason, if I leave http://gems.hashicorp.com in the list of repositories, rubygems cannot locate berkshelf-1.3.0.rc1.
