### PR TITLE
Set default value for `type` to `:host` when it's nil

### DIFF
--- a/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -60,7 +60,9 @@ module VagrantPlugins
           paths = [paths] if paths.is_a?(String) || paths.first.is_a?(Symbol)
 
           results = []
-          paths.each do |type, path|
+          paths.each do |type = nil, path|
+            type ||= :host
+
             # Create the local/remote path based on whether this is a host
             # or VM path.
             local_path = nil


### PR DESCRIPTION
I got an error as below:

```
/Users/kentaro/.rbenv/versions/2.0.0-p0/lib/ruby/gems/2.0.0/gems/vagrant-1.1.0.dev/plugins/provisioners/chef/provisioner/chef_solo.rb:81:in `expand_path': no implicit conversion of nil into String (TypeError)
```

It occurs when users set `roles_path` like `chef.roles_path = "path/to/roles"`.

[This change](https://github.com/mitchellh/vagrant/commit/1af32555595a8c762b794e053d53441216e8085d#L1R65) assumes `type` is always set, but it can be not. It results `path` value is nil and `expand_path` raises the error above.

Uses who are using the version of Vagrant which includes the commit above can't set `roles_path` and `data_bags_path` as usual. There's a workaround to this problem. Just set it like:

```
config.vm.provision :chef_solo do |chef|
  chef.roles_path         = [[:host, "chef/roles"]]
  chef.data_bags_path = [[:host, "chef/data_bags"]]
end
```
