### PR TITLE
Allow override of default_provider

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -195,7 +195,7 @@ module Vagrant
     #
     # @return [Symbol] Name of the default provider.
     def default_provider
-      :virtualbox
+      (ENV['VAGRANT_DEFAULT_PROVIDER'] || :virtualbox).to_sym
     end
 
     # Returns the collection of boxes for the environment.


### PR DESCRIPTION
Set the VAGRANT_DEFAULT_PROVIDER environment variable to override the
value of default_provider.
