### PR TITLE
Faking user agent 'curl' to make dropbox http downloads work.

### DIFF
--- a/lib/vagrant/downloaders/http.rb
+++ b/lib/vagrant/downloaders/http.rb
@@ -29,7 +29,7 @@ module Vagrant
         http.start do |h|
           @ui.info I18n.t("vagrant.downloaders.http.download", :url => source_url)
 
-          headers = nil
+          headers = { 'User-Agent' => 'curl/7.29.0'}
           if uri.user && uri.password
             headers = {'Authorization' => 'Basic ' + Base64.encode64(uri.user + ':' + uri.password)}
           end


### PR DESCRIPTION
Dropbox assumes Vagrant is a browser, thus serving vagrant a download page instead of the linked file itself. Setting vagrant users agent to e.g. curl/7.29.0 solves this.
