### PR TITLE
Additional proxy_command option

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -281,6 +281,9 @@ module Vagrant
       info[:forward_agent] = @config.ssh.forward_agent
       info[:forward_x11]   = @config.ssh.forward_x11
 
+      # add in provided proxy command config
+      info[:proxy_command] = @config.ssh.proxy_command if @config.ssh.proxy_command
+
       # Set the private key path. If a specific private key is given in
       # the Vagrantfile we set that. Otherwise, we use the default (insecure)
       # private key, but only if the provider didn't give us one.

--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -5,6 +5,7 @@ require 'timeout'
 
 require 'log4r'
 require 'net/ssh'
+require 'net/ssh/proxy/command'
 require 'net/scp'
 
 require 'vagrant/util/ansi_escape_code_remover'
@@ -193,6 +194,7 @@ module VagrantPlugins
                   :logger  => ssh_logger,
                   :verbose => :debug
                 })
+                connect_opts[:proxy] = Net::SSH::Proxy::Command.new(ssh_info[:proxy_command]) if ssh_info[:proxy_command]
 
                 @logger.info("Attempting to connect to SSH: #{ssh_info[:host]}:#{ssh_info[:port]}")
                 Net::SSH.start(ssh_info[:host], ssh_info[:username], connect_opts)

--- a/plugins/kernel_v2/config/ssh.rb
+++ b/plugins/kernel_v2/config/ssh.rb
@@ -13,6 +13,7 @@ module VagrantPlugins
       attr_accessor :forward_agent
       attr_accessor :forward_x11
       attr_accessor :shell
+      attr_accessor :proxy_command
 
       def validate(machine)
         errors = []


### PR DESCRIPTION
This commit adds the bare minimum to get an ec2 instance running where corporate network has port 22 blocked and an ssh proxy is in place.  We use ~/.ssh/config ProxyCommand which takes care of any ssh/rsync system calls, but when net-ssh is in play we need to add this :proxy connection option to route correctly.
