### PR TITLE
Setting the `VAGRANT_DEFAULT_PROVIDER` environment variable breaks the unit tests

### DIFF
--- a/test/unit/vagrant/environment_test.rb
+++ b/test/unit/vagrant/environment_test.rb
@@ -224,12 +224,6 @@ describe Vagrant::Environment do
     end
   end
 
-  describe "default provider" do
-    it "should return virtualbox" do
-      instance.default_provider.should == :virtualbox
-    end
-  end
-
   describe "copying the private SSH key" do
     it "copies the SSH key into the home directory" do
       env = isolated_environment


### PR DESCRIPTION
To reproduce:

```
export VAGRANT_DEFAULT_PROVIDER='vmware_fusion'
rake
```

Results in the following broken test:

```
Failures:

  1) Vagrant::Environment default provider should return virtualbox
     Failure/Error: instance.default_provider.should == :virtualbox
       expected: :virtualbox
            got: :vmware_fusion (using ==)
       Diff:
       @@ -1,2 +1,2 @@
       -:virtualbox
       +:vmware_fusion
     # ./test/unit/vagrant/environment_test.rb:229:in `block (3 levels) in <top (required)>'

Finished in 5.16 seconds
432 examples, 1 failure, 1 pending
```

I think we can just delete the test because there is another test that already tests the same thing:

```
describe "default provider" do
  it "is virtualbox without any environmental variable" do
    with_temp_env("VAGRANT_DEFAULT_PROVIDER" => nil) do
      subject.default_provider.should == :virtualbox
    end
  end

  it "is whatever the environmental variable is if set" do
    with_temp_env("VAGRANT_DEFAULT_PROVIDER" => "foo") do
      subject.default_provider.should == :foo
    end
  end
end
```
