### PR TITLE
Fix ssh command for plain mode using multi-vm env.

### DIFF
--- a/plugins/commands/ssh/command.rb
+++ b/plugins/commands/ssh/command.rb
@@ -34,6 +34,7 @@ module VagrantPlugins
         # after the "--" as remaining ARGV, and Vagrant can think it is
         # a multi-vm name (wrong!)
         argv = [] if argv == ssh_args
+        argv = [argv.first] if argv.length > 1
 
         # Execute the actual SSH
         with_target_vms(argv, :single_target => true) do |vm|


### PR DESCRIPTION
This commit fixes an issue where the plain mode options were being
passed as machine names in a multi-machine environment.
