### PR TITLE
Make Ansible provisioner extra_vars a hash

### DIFF
--- a/plugins/provisioners/ansible/provisioner.rb
+++ b/plugins/provisioners/ansible/provisioner.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
         ssh = @machine.ssh_info
 
         options = %W[--private-key=#{ssh[:private_key_path]} --user=#{ssh[:username]}]
-        options << "--extra-vars=\"#{config.extra_vars}\"" if config.extra_vars
+        options << "--extra-vars=" + config.extra_vars.map{|k,v| "#{k}=#{v}"}.join(' ') if config.extra_vars
         options << "--inventory-file=#{config.inventory_file}" if config.inventory_file
         options << "--ask-sudo-pass" if config.ask_sudo_pass
 


### PR DESCRIPTION
This is a small tweak to the behavior of `extra_vars` for the Ansible provisioner: What was previously a string in the form of `key1=value key2=value` is now a hash, which enables users to plug in Vagrantfile config options as Ansible --extra-vars if desired.

I updated the documentation pull request to go along with this.
