### PR TITLE
fix root cause for error message when running in multi-vm environment

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -258,8 +258,6 @@ module Vagrant
       end
 
       # We set the defaults
-      info[:forward_agent] ||= @config.ssh.default.forward_agent
-      info[:forward_x11] ||= @config.ssh.default.forward_x11
       info[:host] ||= @config.ssh.default.host
       info[:port] ||= @config.ssh.default.port
       info[:private_key_path] ||= @config.ssh.default.private_key_path


### PR DESCRIPTION
The following error message occurred due to missing settings:

``` bash
SSH Defaults:
* The following settings don't exist: forward_agent, forward_x11
```

The default settings for forward_agent and forward_x11 have been removed in commit 41d6553 and thus are not accessible anymore.
This pull request removed the remaining references that are not needed anymore.
