### PR TITLE
Fix use of config.ssh.username and reset provisioning path permissions.

### DIFF
--- a/plugins/provisioners/chef/provisioner/base.rb
+++ b/plugins/provisioners/chef/provisioner/base.rb
@@ -42,7 +42,7 @@ module VagrantPlugins
         def chown_provisioning_folder
           @machine.communicate.tap do |comm|
             comm.sudo("mkdir -p #{@config.provisioning_path}")
-            comm.sudo("chown #{@machine.config.ssh.username} #{@config.provisioning_path}")
+            comm.sudo("chown -R #{@machine.ssh_info[:username]} #{@config.provisioning_path}")
           end
         end
 

--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -12,6 +12,11 @@ module VagrantPlugins
         with_script_file do |path|
           # Upload the script to the machine
           @machine.communicate.tap do |comm|
+            # Reset upload path permissions for the current ssh user
+            user = @machine.ssh_info[:username]
+            comm.sudo("chown -R #{user} #{config.upload_path}",
+                      :error_check => false)
+
             comm.upload(path.to_s, config.upload_path)
 
             if config.path


### PR DESCRIPTION
This commit contains two fixes:
- The Chef provisioner was incorrectly referencing config.ssh.username
  instead of machine.ssh_info[:username]. With the new change to default
  ssh configuration, if a user had not set config.ssh.username,
  provisioning would fail.
- The shell provisioner was not appropriately changing permissions to
  the upload path. If a different ssh user attempted to use a shell
  provisioner, provisioning would fail. The same case applied to
  the Chef provisioner -- while permissions were being reset, they
  were not done recursively.
