### PR TITLE
RHEL interfaces sometimes come up with the wrong IP 

### DIFF
--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -46,8 +46,8 @@ module VagrantPlugins
           # SSH never dies.
           interfaces.each do |interface|
             retryable(:on => Vagrant::Errors::VagrantError, :tries => 3, :sleep => 2) do
-              machine.communicate.sudo("/sbin/ifdown eth#{interface} 2> /dev/null", :error_check => false)
               machine.communicate.sudo("cat /tmp/vagrant-network-entry_#{interface} >> #{network_scripts_dir}/ifcfg-eth#{interface}")
+              machine.communicate.sudo("/sbin/ifdown eth#{interface} 2> /dev/null", :error_check => false)
               machine.communicate.sudo("/sbin/ifup eth#{interface} 2> /dev/null")
             end
 


### PR DESCRIPTION
in our Vagrantfile, we've specified that this host should have the IP address of 192.168.1.46, and while vagrant is doing the right thing in /etc/sysconfig/network-scripts/ifcfg-eth1, we're still coming up to the wrong (192.168.1.180) address. i can provide the Vagrantfile if you'd like, but effectively, we're calling:
        agent.vm.network     :hostonly, 192.168.1.46

by creating the proper content in ifcfg-eth1 before calling ifdown, i can no longer reproduce this issue. i don't fully understand this interaction (or why it seems to only happen under 'some' circumstances), but a strace shows ifdown definitely reading that file. i can reliably reproduce this issue (with 1.0.5 and 1.1.0) without the change i'm proposing, and can't reproduce it with the change -- and on the machines that didn't see this problem originally, my change doesn't introduce any issues. 

we've only seen this with RHEL boxes (5.5 and 6.2), so making change as closely scoped as possible. 

---

choran-kates@chorankates-wsl3:~/git/piab[isd/piab|unique-ips|e697b1f|U]
 6:22.12 $ vagrant ssh app
[vagrant@piab1-app1-1-piab ~]$ cat /etc/sysconfig/network-scripts/ifcfg-eth1 
# VAGRANT-BEGIN
# The contents below are automatically generated by Vagrant. Do not modify.

BOOTPROTO=static
IPADDR=192.168.1.46
NETMASK=255.255.255.0
DEVICE=eth1
# VAGRANT-END

[vagrant@piab1-app1-1-piab ~]$ /sbin/ifconfig | grep -i inet
          inet addr:10.0.2.15  Bcast:10.0.2.255  Mask:255.255.255.0
          inet addr:192.168.1.180  Bcast:192.168.1.255  Mask:255.255.255.0
          inet addr:127.0.0.1  Mask:255.0.0.0
