### PR TITLE
Load required chef_client options from Knife config

### DIFF
--- a/plugins/provisioners/chef/config/base.rb
+++ b/plugins/provisioners/chef/config/base.rb
@@ -1,3 +1,5 @@
+require File.expand_path("../chef_config", __FILE__)
+
 module VagrantPlugins
   module Chef
     module Config
@@ -59,6 +61,12 @@ module VagrantPlugins
           result.delete("json")
           result
         end
+
+        # Returns a hash that has symbolized keys from a chef config file.
+        def chef_config
+          @chef_config ||= ChefConfig.parse
+        end
+        alias_method :knife, :chef_config
       end
     end
   end

--- a/plugins/provisioners/chef/config/chef_client.rb
+++ b/plugins/provisioners/chef/config/chef_client.rb
@@ -21,6 +21,8 @@ module VagrantPlugins
         def file_cache_path; @file_cache_path || "/srv/chef/file_store"; end
         def file_backup_path; @file_backup_path || "/srv/chef/cache"; end
         def encrypted_data_bag_secret; @encrypted_data_bag_secret || "/tmp/encrypted_data_bag_secret"; end
+        def chef_server_url; @chef_server_url || knife[:chef_server_url]; end
+        def validation_key_path; @validation_key_path || knife[:validation_key]; end
 
         def validate(machine)
           errors = []

--- a/plugins/provisioners/chef/config/chef_config.rb
+++ b/plugins/provisioners/chef/config/chef_config.rb
@@ -1,0 +1,67 @@
+module VagrantPlugins
+  module Chef
+    # Handles loading configuration values from a Chef config file
+    class ChefConfig < Hash
+      DEFAULT_PATHS = %w[
+        ./.chef/knife.rb
+        ~/.chef/knife.rb
+        /etc/chef/solo.rb
+        /etc/chef/client.rb
+      ]
+
+      def self.parse(path = nil)
+        new(path).parse
+      end
+
+      def initialize(path = nil)
+        @path = path
+      end
+
+      # Parse the file for the path and store symbolicated keys for knife
+      # configuration options.
+      def parse
+        parse_file
+        self
+      end
+
+      private
+
+      def parse_file
+        lines.each { |line| parse_line line }
+      end
+
+      def parse_line(line)
+        eval line, scope, path
+      rescue
+      end
+
+      def method_missing(key, value = nil)
+        store key.to_sym, value if value
+      end
+
+      def lines
+        file_contents.lines.to_a
+      end
+
+      def file_contents
+        File.read(file_path)
+      rescue
+        ""
+      end
+
+      def file_path
+        File.expand_path(path)
+      end
+
+      def path
+        @path ||= DEFAULT_PATHS.find { |path|
+          File.exist?(File.expand_path(path))
+        }
+      end
+
+      def scope
+        @scope ||= binding
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a chef_config/knife method to both chef solo and chef client provisioners, which returns a hash with symbolized keys. For instance, I have a file at `~/.chef/knife.rb`, which I think looks like most user's Knife config:

``` rb
current_dir = File.dirname(__FILE__)
validation_key  "#{current_dir}/justincampbell-validator.pem"
chef_server_url "https://api.opscode.com/organizations/justincampbell"
```

This causes `knife` to return a hash of:

``` rb
{
  :validation_key => "~/.chef/justincampbell-validator.pem",
  :chef_server_url => "https://api.opscode.com/organizations/justincampbell"
}
```

You can now omit these options in a `:chef_client` provisioner block:

``` rb
config.vm.provision :chef_client do |chef|
  chef.run_list = ["recipe[my_cookbook::default]"]
end
```

You could potentially also use knife[:key] in your Vagrantfile.
