### PR TITLE
request a PTY for sudo ssh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.2.0 (unreleased)
+## 1.2.0 (April 16, 2013)
 
 BACKWARDS INCOMPATIBILITIES:
 

--- a/lib/vagrant/version.rb
+++ b/lib/vagrant/version.rb
@@ -2,5 +2,5 @@ module Vagrant
   # This will always be up to date with the current version of Vagrant,
   # since it is used to generate the gemspec and is also the source of
   # the version for `vagrant -v`
-  VERSION = "1.2.0.dev"
+  VERSION = "1.2.0"
 end


### PR DESCRIPTION
I expect to use vagrant to help bootstrap test environments. The requirement to have a prepared image to get around this section in sudoers:

```
#
# Disable "ssh hostname sudo <cmd>", because it will show the password in clear.
#         You have to run "ssh -t hostname sudo <cmd>".
#
Defaults    requiretty
```

doesn't seem necessary.

I expect chef to come along and get rid of that pesky line.

I tried to run tests, but I found a few syntax errors when patching at HEAD.

``` sh
/usr/lib/ruby/gems/1.8/gems/rspec-core-2.11.1/lib/rspec/core/configuration.rb:780:in `load': /home/david/src/vagrant/test/unit/vagrant/action/hook_test.rb:110: syntax error, unexpected ':', expecting ')' (SyntaxError)
      subject.apply(builder, no_prepend_or_append: true)
                                                  ^
    from /usr/lib/ruby/gems/1.8/gems/rspec-core-2.11.1/lib/rspec/core/configuration.rb:780:in `load_spec_files'
    from /usr/lib/ruby/gems/1.8/gems/rspec-core-2.11.1/lib/rspec/core/configuration.rb:780:in `map'
    from /usr/lib/ruby/gems/1.8/gems/rspec-core-2.11.1/lib/rspec/core/configuration.rb:780:in `load_spec_files'
    from /usr/lib/ruby/gems/1.8/gems/rspec-core-2.11.1/lib/rspec/core/command_line.rb:22:in `run'
    from /usr/lib/ruby/gems/1.8/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:69:in `run'
    from /usr/lib/ruby/gems/1.8/gems/rspec-core-2.11.1/lib/rspec/core/runner.rb:8:in `autorun'
    from /usr/bin/rspec:19
rake aborted!
```
