### PR TITLE
Remove vim modeline from Vagrantfile

### DIFF
--- a/templates/commands/init/Vagrantfile.erb
+++ b/templates/commands/init/Vagrantfile.erb
@@ -1,6 +1,3 @@
-# -*- mode: ruby -*-
-# vi: set ft=ruby :
-
 Vagrant.configure("2") do |config|
   # All Vagrant configuration is done here. The most common configuration
   # options are documented and commented below. For a complete reference,


### PR DESCRIPTION
This isn't really necessary, and creates noise for users who are not
using Vim. There's even a global fix for Vim users in the repo:
https://github.com/mitchellh/vagrant/blob/master/contrib/vim/vagrantfile.vim
