### PR TITLE
Fix empty encrypted_data_bag_secret_key_path

### DIFF
--- a/plugins/provisioners/chef/provisioner/chef_client.rb
+++ b/plugins/provisioners/chef/provisioner/chef_client.rb
@@ -19,7 +19,7 @@ module VagrantPlugins
           chown_provisioning_folder
           create_client_key_folder
           upload_validation_key
-          upload_encrypted_data_bag_secret if @config.encrypted_data_bag_secret_key_path
+          upload_encrypted_data_bag_secret if @config.encrypted_data_bag_secret_key_path.is_a?(String)
           setup_json
           setup_server_config
           run_chef_client


### PR DESCRIPTION
If there's no `encrypted_data_bag_secret_key_path` set in the
`Vagrantfile`, `@config.encrypted_data_bag_secret_key_path` returns an
`Object`, and Vagrant tries to upload the key nonetheless.

This commit checks that `@config.encrypted_data_bag_secret_key_path` is
a `String` before attempting the upload.
