### PR TITLE
Allow user to specify default machines for commands in multi-machine environments

### DIFF
--- a/config/default.rb
+++ b/config/default.rb
@@ -1,5 +1,6 @@
 Vagrant.configure("2") do |config|
   config.vagrant.host = :detect
+  config.vagrant.default_machines = []
 
   config.ssh.forward_agent = false
   config.ssh.forward_x11 = false

--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -439,6 +439,17 @@ module Vagrant
       nil
     end
 
+    # A list of machines commands should operate on by default. Defaults to
+    # all machines if not set in the config.
+    #
+    # @return [Array<Symbol>] Default machines names.
+    def default_machines
+      defaults = config_global.vagrant.default_machines
+      defaults = [defaults] unless defaults.is_a?(Array)
+      defaults = machine_names if defaults.empty?
+      defaults
+    end
+
     # Unload the environment, running completion hooks. The environment
     # should not be used after this (but CAN be, technically). It is
     # recommended to always immediately set the variable to `nil` after

--- a/lib/vagrant/plugin/v2/command.rb
+++ b/lib/vagrant/plugin/v2/command.rb
@@ -157,10 +157,19 @@ module Vagrant
               end
             end
           else
-            # No name was given, so we return every VM in the order
-            # configured.
-            @logger.debug("Loading all machines...")
-            machines = @env.machine_names.map do |machine_name|
+            # No name was given, so we return default VMs in the order
+            # configured. If no default machines were specified, or the invoking
+            # command is non-destructive and safe to run against all machines,
+            # all machines are returned instead.
+            @logger.debug("Loading default machines...")
+
+            if options[:safe_for_all_machines]
+              machines_method = :machine_names
+            else
+              machines_method = :default_machines
+            end
+
+            machines = @env.public_send(machines_method).map do |machine_name|
               get_machine.call(machine_name)
             end
           end

--- a/plugins/commands/status/command.rb
+++ b/plugins/commands/status/command.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
 
         state = nil
         results = []
-        with_target_vms(argv) do |machine|
+        with_target_vms(argv, :safe_for_all_machines => true) do |machine|
           state = machine.state if !state
           results << "#{machine.name.to_s.ljust(25)}#{machine.state.short_description} (#{machine.provider_name})"
         end

--- a/plugins/kernel_v2/config/vagrant.rb
+++ b/plugins/kernel_v2/config/vagrant.rb
@@ -4,6 +4,7 @@ module VagrantPlugins
   module Kernel_V2
     class VagrantConfig < Vagrant.plugin("2", :config)
       attr_accessor :host
+      attr_accessor :default_machines
 
       def to_s
         "Vagrant"

--- a/test/unit/vagrant/cli_test.rb
+++ b/test/unit/vagrant/cli_test.rb
@@ -10,7 +10,7 @@ describe Vagrant::CLI do
       env = double("Vagrant::Environment")
       env.stub(:ui => ui)
       env.stub(:root_path => "foo")
-      env.stub(:machine_names => [])
+      env.stub(:default_machines => [])
       env
     end
 


### PR DESCRIPTION
When running a `vagrant` command from the shell in a multi-machine environment, Vagrant operates on all VMs by default if you don't specify one. This is dangerous if you're using a multi-machine setup to provision a development and production environment (say, with VMware Fusion in development and AWS in production), because you could accidentally run it on production simply by forgetting to specify your development VM. It would be great if you could declare in the Vagrantfile that a given VM should not have `vagrant` commands applied to it unless specified explicitly.

Another idea, though probably not backwards-compatible, would be to change the default behavior so that leaving out a VM name makes the command a no-op. Maybe instead, there could be a flag like `--all` to indicate that you want to run the command on all VMs, without having to list all their names.

I'd be happy to submit this as a pull request if you like the idea.

Edit: I've started work on a pull request for a configuration option for "default machines."
