### PR TITLE
VirtualBox Plugin - Concurrent Base Box Import

### DIFF
--- a/plugins/providers/virtualbox/driver/version_4_2.rb
+++ b/plugins/providers/virtualbox/driver/version_4_2.rb
@@ -162,7 +162,29 @@ module VagrantPlugins
           output = ""
           total = ""
           last  = 0
-          execute("import", ovf) do |type, data|
+          
+          output = execute("import", "-n", ovf)
+          output =~ /Suggested VM name "(.+?)"/
+          suggested_name = $1.to_s
+          specified_name = "#{suggested_name}_#{(Time.now.to_f * 1000.0).to_i}_#{rand(100000)}" #Millisecond + Random
+          
+          #Build the specified name param list
+          name_params = Array.new
+          name_params << "--vsys" << "0" << "--vmname" << specified_name
+
+          #Extract the disks list and build the disk target params
+          disk_params = Array.new
+          disks = output.scan(/(\d+): Hard disk image: source image=.+, target path=(.+),/)
+          disks.each do |unit_num, path|
+             disk_params << "--vsys"
+              disk_params << "0"  #Derive vsys num .. do we support OVF's with multiple machines?
+              disk_params << "--unit"
+              disk_params << unit_num
+              disk_params << "--disk"
+              disk_params << path.sub("/#{suggested_name}/", "/#{specified_name}/")
+          end
+
+          execute("import", ovf , *name_params, *disk_params) do |type, data|
             if type == :stdout
               # Keep track of the stdout so that we can get the VM name
               output << data
@@ -186,16 +208,9 @@ module VagrantPlugins
             end
           end
 
-          # Find the name of the VM name
-          if output !~ /Suggested VM name "(.+?)"/
-            @logger.error("Couldn't find VM name in the output.")
-            return nil
-          end
-
-          name = $1.to_s
-
           output = execute("list", "vms")
-          if output =~ /^"#{Regexp.escape(name)}" \{(.+?)\}$/
+
+          if output =~ /^"#{Regexp.escape(specified_name)}" \{(.+?)\}$/
             return $1.to_s
           end
 


### PR DESCRIPTION
I have a Jenkins server that attempts to vagrant up several environments concurrently from the same base box.  This is to smoketest various chef recipes.  

When the the OVF import is called down in the virtualbox driver, it will create a folder that uses the base boxes name in the VirtualBox VM's folder.  While that base box folder exists it will not be possible to bring up any other system that uses that same base box.  Doing so will start to overwrite the files in the base box folder and cause bad things to happen.

This is an attempt to import the box into a unique(ish) folder name so that less bad things happen.  There are still other issues with attempting to bring multiple machines up at once with VirtualBox, but I hope this is a helpful step in the right direction.
