### PR TITLE
Proposed #1639 fix

### DIFF
--- a/plugins/guests/solaris/guest.rb
+++ b/plugins/guests/solaris/guest.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
     # Contributed by Blake Irvin <b.irvin@modcloth.com>
     class Guest < Vagrant.plugin("2", :guest)
       def detect?(machine)
-        machine.communicate.test("grep 'Solaris' /etc/release")
+        machine.communicate.test("uname -o|grep Solaris")
       end
     end
   end


### PR DESCRIPTION
/etc/release file may not contain string 'Solaris' on Solaris-like OSes such as SmartOS, OmniOS, OpenIndiana, etc.

uname -o on the other hand returns 'Solaris' on Solaris 10, SmartOS, OmniOS, OpenIndiana, etc. 
