### PR TITLE
Add missing note about `Vagrant::Environment::VAGRANT_HOME` deprecation to the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ BACKWARDS INCOMPATIBILITIES:
     To work around this, either set `VAGRANT_HOME` to your Cygwin ".vagrant.d"
     folder or move your ".vagrant.d" folder to `USERPROFILE`. The latter is
     recommended for long-term support.
+  - The constant `Vagrant::Environment::VAGRANT_HOME` was removed in favor of
+    `Vagrant::Environment#default_vagrant_home`.
 
 FEATURES:
 


### PR DESCRIPTION
[This commit](https://github.com/mitchellh/vagrant/commit/fbdd46a130890f03eada3bd607d61ef7a4b75671) removed the constant and since I've seen quite a few people relying on it for things like [apt packages cache](https://gist.github.com/millisami/3798773) I think it is worth mentioning on the changelog ;-)
