### PR TITLE
Add an option for the bridge interface to drop the default route via the NAT interface (debian)

### DIFF
--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -118,11 +118,12 @@ module VagrantPlugins
 
         def bridged_config(options)
           return {
-            :auto_config                     => true,
-            :bridge                          => nil,
-            :mac                             => nil,
-            :nic_type                        => nil,
-            :use_dhcp_assigned_default_route => false
+            :auto_config                      => true,
+            :bridge                           => nil,
+            :mac                              => nil,
+            :nic_type                         => nil,
+            :use_dhcp_assigned_default_route  => false,
+            :drop_nat_interface_default_route => false
           }.merge(options || {})
         end
 
@@ -202,7 +203,8 @@ module VagrantPlugins
         def bridged_network_config(config)
           return {
             :type => :dhcp,
-            :use_dhcp_assigned_default_route => config[:use_dhcp_assigned_default_route]
+            :use_dhcp_assigned_default_route  => config[:use_dhcp_assigned_default_route],
+            :drop_nat_interface_default_route => config[:drop_nat_interface_default_route]
           }
         end
 

--- a/templates/guests/debian/network_dhcp.erb
+++ b/templates/guests/debian/network_dhcp.erb
@@ -8,4 +8,8 @@ iface eth<%= options[:interface] %> inet dhcp
     # needed as some newer distribution do not properly load routes, ubuntu 12.04
     post-up dhclient $IFACE
 <% end %>
+<% if options[:drop_nat_interface_default_route] %>
+    post-up route del default dev eth0
+    pre-down route add default dev eth0
+<% end %>
 #VAGRANT-END


### PR DESCRIPTION
This adds an option, :drop_nat_interface_default_route, to the bridged virtualbox configuration hash. If enabled the bridged interface will have the following options set in /etc/network/interfaces:

```
post-up route del default if eth0
pre-down route add default if eth0
```

This has the effect that all traffic, apart from vagrant's ssh via the NAT, will go over the bridge, rather than the NAT, once it has come up.

I have found the default route via the NAT problematic when operating in networks with multiple subnets. If I try to point someone on another subnet at an application accessible via my bridged interface it will fail because the return traffic attempts to route via the wrong interface.
