### PR TITLE
Setting hostname on OmniOS fails

### DIFF
--- a/plugins/guests/solaris/cap/change_host_name.rb
+++ b/plugins/guests/solaris/cap/change_host_name.rb
@@ -8,7 +8,7 @@ module VagrantPlugins
           # Only do this if the hostname is not already set
           if !machine.communicate.test("#{su_cmd} hostname | grep '#{name}'")
             machine.communicate.execute("#{su_cmd} sh -c \"echo '#{name}' > /etc/nodename\"")
-            machine.communicate.execute("#{su_cmd} uname -S #{name}")
+            machine.communicate.execute("#{su_cmd} uname -S #{name} || #{su_cmd} hostname #{name}")
           end
         end
       end


### PR DESCRIPTION
When attempting to boot an OmniOS Vagrant box [0], the `up` command fails with:

```
[riak1] Setting hostname...
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

sudo uname -S riak1
```

It appears that the `-S` option is available for `uname` on SmartOS, but not OmniOS.

[0] http://omnios.omniti.com/media/omnios-latest.box
