### PR TITLE
Fix DHCP adapter type handling for VirtualBox provider

### DIFF
--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -396,6 +396,7 @@ module VagrantPlugins
           this_netaddr = network_address(config[:ip], config[:netmask])
 
           @env[:machine].provider.driver.read_host_only_interfaces.each do |interface|
+            return interface if config[:adapter_ip] && config[:adapter_ip] == interface[:ip]
             return interface if config[:name] && config[:name] == interface[:name]
             return interface if this_netaddr == \
               network_address(interface[:ip], interface[:netmask])


### PR DESCRIPTION
This PR fixes some issues for adapter with DHCP type for VirtualBox provider.
- removes hardcoded IP 172.28.128.1 
- fixes DHCP server ip calculation
- fixes searching for matching network
