### PR TITLE
More reliable Ubuntu and Debian guest detection

### DIFF
--- a/plugins/guests/debian/guest.rb
+++ b/plugins/guests/debian/guest.rb
@@ -2,7 +2,7 @@ module VagrantPlugins
   module GuestDebian
     class Guest < Vagrant.plugin("2", :guest)
       def detect?(machine)
-        machine.communicate.test("cat /proc/version | grep 'Debian'")
+        machine.communicate.test("cat /etc/issue | grep 'Debian'")
       end
     end
   end

--- a/plugins/guests/ubuntu/guest.rb
+++ b/plugins/guests/ubuntu/guest.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
   module GuestUbuntu
     class Guest < VagrantPlugins::GuestDebian::Guest
       def detect?(machine)
-        machine.communicate.test("cat /proc/version | grep 'Ubuntu'")
+        machine.communicate.test("cat /etc/issue | grep 'Ubuntu'")
       end
 
       def mount_shared_folder(name, guestpath, options)


### PR DESCRIPTION
When dealing with lxc containers, '/proc/version' will have information about the host machine kernel that can possibly have information about an Ubuntu / Debian host, messing up with guest container detection.
