### PR TITLE
Add read_mac_addresses to the 4.2 driver.

### DIFF
--- a/plugins/providers/virtualbox/driver/version_4_2.rb
+++ b/plugins/providers/virtualbox/driver/version_4_2.rb
@@ -319,6 +319,19 @@ module VagrantPlugins
           nil
         end
 
+        def read_mac_addresses
+          macs = {}
+          info = execute("showvminfo", @uuid, "--machinereadable", :retryable => true)
+          info.split("\n").each do |line|
+            if matcher = /^macaddress(\d+)="(.+?)"$/.match(line)
+              adapter = matcher[1].to_i
+              mac = matcher[2].to_s
+              macs[adapter] = mac
+            end
+          end
+          macs
+        end
+
         def read_machine_folder
           execute("list", "systemproperties", :retryable => true).split("\n").each do |line|
             if line =~ /^Default machine folder:\s+(.+?)$/i


### PR DESCRIPTION
read_mac_addresses is required by the vagrant-windows plugin to match up adapters with ip address settings. This was previously merged in for the 4.0 and 4.1 drivers, but is not present in the 4.2 driver. 
