### PR TITLE
more concise message for BoxNotFound error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ FEATURES:
 
 IMPROVEMENTS:
 
+  - Added provider to BoxNotFound error message.
   - Setting hostnames works properly on OmniOS. [GH-1672]
   - Better VBoxManage error detection on Windows systems. This avoids
     some major issues where Vagrant would sometimes "lose" your VM. [GH-1669]

--- a/lib/vagrant/box_collection.rb
+++ b/lib/vagrant/box_collection.rb
@@ -261,6 +261,7 @@ module Vagrant
     # If the given box is found but is not a V1 box then `true` is returned
     # because this just works fine.
     #
+    # @param [String] name Name of the box (logical name).
     # @return [Boolean] `true` otherwise an exception is raised.
     def upgrade(name)
       with_collection_lock do
@@ -268,7 +269,7 @@ module Vagrant
         box_dir = @directory.join(name)
 
         # If the box doesn't exist at all, raise an exception
-        raise Errors::BoxNotFound, :name => name if !box_dir.directory?
+        raise Errors::BoxNotFound, :name => name, :provider => "virtualbox" if !box_dir.directory?
 
         if v1_box?(box_dir)
           @logger.debug("V1 box #{name} found. Upgrading!")

--- a/plugins/commands/box/command/remove.rb
+++ b/plugins/commands/box/command/remove.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
             retry
           end
 
-          raise Vagrant::Errors::BoxNotFound, :name => argv[0] if !b
+          raise Vagrant::Errors::BoxNotFound, :name => argv[0], :provider => argv[1].to_sym if !b
           @env.ui.info(I18n.t("vagrant.commands.box.removing",
                               :name => argv[0],
                               :provider => argv[1]))

--- a/plugins/commands/box/command/repackage.rb
+++ b/plugins/commands/box/command/repackage.rb
@@ -28,7 +28,7 @@ module VagrantPlugins
             retry
           end
 
-          raise Vagrant::Errors::BoxNotFound, :name => box_name if !box
+          raise Vagrant::Errors::BoxNotFound, :name => box_name, :provider => box_provider if !box
 
           # Repackage the box
           output_path = Pathname.new(File.expand_path(@env.config_global.package.name, FileUtils.pwd))

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -134,7 +134,7 @@ en:
         box file format can be found at the URL below:
 
         http://docs.vagrantup.com/v2/boxes/format.html
-      box_not_found: Box '%{name}' could not be found.
+      box_not_found: Box '%{name}' with '%{provider}' provider could not be found.
       box_provider_doesnt_match: |-
         The box you attempted to add doesn't match the provider you specified.
 


### PR DESCRIPTION
Now we have different providers, but the error message didn't tell
anything about it. Suppose I want to remove one of my boxes:

```
vagrant box remove opscode-ubuntu-12.04 vritualbox
```

There is a typo in provider name. The error message is:

```
Box 'opscode-ubuntu-12.04' could not be found.
```

Therefore I need to double check the box name, and only than I will see
the typo.

This commit make the error message looks like this:

```
Box 'opscode-ubuntu-12.04' with 'vritualbox' provider could not be found.
```
