### PR TITLE
Support more Ansible options

### DIFF
--- a/plugins/provisioners/ansible/config.rb
+++ b/plugins/provisioners/ansible/config.rb
@@ -10,6 +10,7 @@ module VagrantPlugins
       attr_accessor :sudo_user
       attr_accessor :verbose
       attr_accessor :tags
+      attr_accessor :skip_tags
       attr_accessor :start_at_task
 
       # Joker attribute, used to pass unsupported arguments to ansible anyway
@@ -25,6 +26,7 @@ module VagrantPlugins
         @sudo_user      = UNSET_VALUE
         @verbose        = UNSET_VALUE
         @tags           = UNSET_VALUE
+        @skip_tags      = UNSET_VALUE
         @start_at_task  = UNSET_VALUE
         @raw_arguments  = UNSET_VALUE
       end
@@ -39,6 +41,7 @@ module VagrantPlugins
         @sudo_user      = nil if @sudo_user == UNSET_VALUE
         @verbose        = nil if @verbose == UNSET_VALUE
         @tags           = nil if @tags == UNSET_VALUE
+        @skip_tags      = nil if @skip_tags == UNSET_VALUE
         @start_at_task  = nil if @start_at_task == UNSET_VALUE
         @raw_arguments  = nil if @raw_arguments == UNSET_VALUE
       end

--- a/plugins/provisioners/ansible/provisioner.rb
+++ b/plugins/provisioners/ansible/provisioner.rb
@@ -15,6 +15,7 @@ module VagrantPlugins
         options << "--inventory-file=#{config.inventory_file}" if config.inventory_file
         options << "--ask-sudo-pass" if config.ask_sudo_pass
         options << "--tags=#{as_list_argument(config.tags)}" if config.tags
+        options << "--skip-tags=#{as_list_argument(config.skip_tags)}" if config.skip_tags
         options << "--limit=#{as_list_argument(config.limit)}" if config.limit
         options << "--start-at-task=#{config.start_at_task}" if config.start_at_task
         options << "--sudo" if config.sudo


### PR DESCRIPTION
This pull request aims to solve (parts of) #1674 from @kernel164. These first commits are not thought as final, but more as discussion base (see open points below). Let me know what do you prefer (feature branch will be rebased at the very end ;-):
- I'm not sure which ansible-playbook options make sense in Vagrant context (all?). So far I didn't take time to review this point (since I was personally first interested in `tags` support). Comments and votes are welcome! Once I get the list, I can add the wanted options.
- `tags` addition: In order to keep the code as DRY as possible, I introduced `as_list_argument` private method. It could also be "inline" implemented (e.g. `"--tags=#{config.tags.kind_of?(Array) ? config.tags.join(',') : config.tags}"`), but it does not help to enforce code-style unity. I also thought about very small addition somewhere in lib/vagrant/util/... : `join_if_needed(variable, separator)` (that sounds overkill to me). @mitchellh please, let me know what is good for you...
- `verbose` change: I'm not sure if it is correct to mix boolean and string type for the same Vagrant option, but two different options would be "horrible", no? Should this attribute be more validated (raise an exception when invalid). Note, that I did not restrict to `/^v{1,3}$/`, since `ansible-playbooks` deals with improbable things like `-vvvvv`.
- `raw_arguments` addition: Like Vagrant, Ansible project is going very very fast... and I think that it will often occur (like to me for the `--tags` option), that some recent features are not already supported by latest Vagrant. Therefore, I'd like to add this unsafe joker card in the deck. About the precedence, I'm open to any minds. I intentionally put it in the middle to "debate" on this aspect. The most elegant is maybe to give it the lowest priority (even for `--user` and `--private-key`, unlike current implementation), so that any new official options will automatically overtake. @mitchellh: if such kind of parameter is considered as bad practice for Vagrant configuration file, just tell me and I remove 66715de from this request (I always can try to convince you later with a separated pull request, if absolutely needed ;-) 
