### PR TITLE
fix uninitialized constant error for gentoo plugin

### DIFF
--- a/plugins/guests/gentoo/cap/change_host_name.rb
+++ b/plugins/guests/gentoo/cap/change_host_name.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
-  module GuestFreeBSD
+  module GuestGentoo
     module Cap
       class ChangeHostName
         def self.change_host_name(machine, name)

--- a/plugins/guests/gentoo/cap/configure_networks.rb
+++ b/plugins/guests/gentoo/cap/configure_networks.rb
@@ -3,9 +3,9 @@ require "tempfile"
 require "vagrant/util/template_renderer"
 
 module VagrantPlugins
-  module GuestFreeBSD
+  module GuestGentoo
     module Cap
-      class ChangeHostName
+      class ConfigureNetworks
         include Vagrant::Util
 
         def self.configure_networks(machine, networks)


### PR DESCRIPTION
While trying to 

```
vagrant up
```

a gentoo vm I got the following error:

```
/Applications/Vagrant/embedded/gems/gems/vagrant-1.2.2/plugins/guests/gentoo/plugin.rb:23:in `block in <class:Plugin>': uninitialized constant VagrantPlugins::GuestGentoo::Cap::ConfigureNetworks (NameError)
```

I then had a look at the gentoo plugin and found out that indeed GuestGentoo was not defined. After applying the changes in the pull request the vm did start without errors.
