### PR TITLE
Allow user to define if the box_url is insecure

### DIFF
--- a/lib/vagrant/action/builtin/handle_box_url.rb
+++ b/lib/vagrant/action/builtin/handle_box_url.rb
@@ -29,6 +29,7 @@ module Vagrant
             # raise a terrible runtime error.
             box_name = env[:machine].config.vm.box
             box_url  = env[:machine].config.vm.box_url
+            box_download_insecure = env[:machine].config.vm.box_download_insecure
 
             lock.synchronize do
               # First see if we actually have the box now.
@@ -55,7 +56,8 @@ module Vagrant
                   env[:action_runner].run(Vagrant::Action.action_box_add, {
                     :box_name     => box_name,
                     :box_provider => env[:machine].provider_name,
-                    :box_url      => box_url
+                    :box_url      => box_url,
+                    :box_download_insecure => box_download_insecure
                   })
                 rescue Errors::BoxAlreadyExists
                   # Just ignore this, since it means the next part will succeed!

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -16,6 +16,7 @@ module VagrantPlugins
       attr_accessor :base_mac
       attr_accessor :box
       attr_accessor :box_url
+      attr_accessor :box_download_insecure
       attr_accessor :graceful_halt_retry_count
       attr_accessor :graceful_halt_retry_interval
       attr_accessor :guest


### PR DESCRIPTION
Currently, it's possible to download a box from an insecure server using the command:

```
vagrant box add mybox  https://insecureserver.com/mybox.box --insecure
```

But I think set it in a Vagrantfile is a good feature.

``` ruby
Vagrant.configure("2") do |config|
  config.vm.box = "mybox"
  config.vm.box_url = "https://insecureserver.com/mybox.box"
  config.vm.box_download_insecure = true
end
```
