### PR TITLE
Fix to the #1639 fix

### DIFF
--- a/plugins/guests/solaris/guest.rb
+++ b/plugins/guests/solaris/guest.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
     # Contributed by Blake Irvin <b.irvin@modcloth.com>
     class Guest < Vagrant.plugin("2", :guest)
       def detect?(machine)
-        machine.communicate.test("uname -o | grep Solaris")
+        machine.communicate.test("uname -s | grep SunOS")
       end
     end
   end


### PR DESCRIPTION
Had "uname" from GNU coreutils in my default PATH on Solaris boxes. Previous fix was not correct.
