### PR TITLE
Emit Ubuntu Upstart 'vagrant-mounted' for newer versions

### DIFF
--- a/plugins/guests/ubuntu/cap/mount_nfs.rb
+++ b/plugins/guests/ubuntu/cap/mount_nfs.rb
@@ -1,0 +1,18 @@
+require_relative '../../linux/cap/mount_nfs'
+
+module VagrantPlugins
+  module GuestUbuntu
+    module Cap
+      class MountNFS < GuestLinux::Cap::MountNFS
+        def self.mount_nfs_folder(machine, ip, folders)
+          super
+          # Emit an upstart events if upstart is available
+          folders.each do |name, opts|
+            real_guestpath =  machine.guest.capability(:shell_expand_guest_path, opts[:guestpath])
+            machine.communicate.sudo("[ -x /sbin/initctl ] && /sbin/initctl emit vagrant-mounted MOUNTPOINT=#{real_guestpath}")
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/ubuntu/cap/mount_virtualbox_shared_folder.rb
+++ b/plugins/guests/ubuntu/cap/mount_virtualbox_shared_folder.rb
@@ -1,0 +1,14 @@
+require_relative '../../linux/cap/mount_virtualbox_shared_folder'
+
+module VagrantPlugins
+  module GuestUbuntu
+    module Cap
+      class MountVirtualBoxSharedFolder < GuestLinux::Cap::MountVirtualBoxSharedFolder
+        def self.mount_virtualbox_shared_folder(machine, name, guestpath, options)
+          super
+          machine.communicate.sudo("[ -x /sbin/initctl ] && /sbin/initctl emit vagrant-mounted MOUNTPOINT=#{guestpath}")
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/ubuntu/plugin.rb
+++ b/plugins/guests/ubuntu/plugin.rb
@@ -15,6 +15,17 @@ module VagrantPlugins
         require_relative "cap/change_host_name"
         Cap::ChangeHostName
       end
+
+      guest_capability("ubuntu", "mount_virtualbox_shared_folder") do
+        require_relative "cap/mount_virtualbox_shared_folder"
+        Cap::MountVirtualBoxSharedFolder
+      end
+
+      #I don't know if this works or not
+      #guest_capability("linux", "mount_nfs_folder") do
+      #  require_relative "cap/mount_nfs"
+      #  Cap::MountNFS
+      #end
     end
   end
 end


### PR DESCRIPTION
Vagrant used to emit a 'vagrant-mounted' event after mounting shared folders on Ubuntu, but newer versions don't. This commit adds the same functionality to the "capabilities" for the ubuntu plugin. It does this for both "regular" and NFS, but I've commented out the NFS capability because I'm not able to test that it works. The only testing I've done with the regular type is to see that it works on my machine.

I don't really know what I'm doing here; I'm not familiar with the codebase or how Vagrant's inner parts work. I figured out there's a difference between the Ubuntu "guest" and "plugin" functionality and that the newer version I installed uses "plugin", so I duplicated the functionality in "guest". There may be a better way to do it.
