### PR TITLE
Ability to generate coherent ansible inventory file (ansible.inventory_file parameter is now optional)

### DIFF
--- a/templates/provisioners/ansible/inventory.erb
+++ b/templates/provisioners/ansible/inventory.erb
@@ -1,0 +1,1 @@
+<%= host_name %> ansible_ssh_host=<%= ssh_host %> ansible_ssh_port=<%= ssh_port %>


### PR DESCRIPTION
Advantages to use auto-generated Ansible inventory file:
- more DRY configuration files between Vagrant and Ansible settings
- ensure that vagrant will only provision VMs managed by vagrant itself
- works fine in multi-machine mode (each provision step can only connect to related VM)

Note: So far, I opened 3 separated pull requests (see #1697 and #1699). Let me know if you prefer to treat them together in a single pull request.
