### PR TITLE
Retry ssh on Errno::ENETUNREACH

### DIFF
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -173,6 +173,7 @@ module VagrantPlugins
             Errno::ECONNREFUSED,
             Errno::ECONNRESET,
             Errno::EHOSTUNREACH,
+            Errno::ENETUNREACH,
             Net::SSH::Disconnect,
             Timeout::Error
           ]


### PR DESCRIPTION
Had issues from Mac OS X with Errno::ENETUNREACH during `vagrant up --provider=cloudstack` when connecting to Cloudstack VM's _(with [vagrant-cloudstack](https://github.com/klarna/vagrant-cloudstack) plugin)_.

Similiar the same fix has been used in [puppetlabs-cloud-provisioner](https://github.com/bodepd/puppetlabs-cloud-provisioner) with the fix [retry ssh when Errno::ENETUNREACH is encountered](https://github.com/bodepd/puppetlabs-cloud-provisioner/commit/7a239f061d9c59d53b2acc8e2dff5840c18a74c9).
