### PR TITLE
No TemplateRenderer for arch's configure_networks

### DIFF
--- a/plugins/guests/arch/cap/configure_networks.rb
+++ b/plugins/guests/arch/cap/configure_networks.rb
@@ -6,6 +6,8 @@ module VagrantPlugins
   module GuestArch
     module Cap
       class ConfigureNetworks
+        include Vagrant::Util
+
         def self.configure_networks(machine, networks)
           networks.each do |network|
             entry = TemplateRenderer.render("guests/arch/network_#{network[:type]}",


### PR DESCRIPTION
I have a basic little playbook:

``` ruby
Vagrant.configure("2") do |config|
  config.vm.provision :ansible do |ansible|
    ansible.playbook = "playbook.yml"
    ansible.inventory_file = "blah"
    ansible.sudo_user = "vagrant"
  end

  config.vm.box = "arch64"
  config.vm.box_url = "http://vagrant.pouss.in/archlinux_2012-07-02.box"
end
```

When I run it with `vagrant up` I'm told

```
[default] Configuring and enabling network interfaces...
[default] Forcing shutdown of VM...
[default] Destroying VM and associated drives...
/opt/vagrant/embedded/gems/gems/vagrant-1.2.2/plugins/guests/arch/cap/configure_networks.rb:7:in `block in configure_networks': uninitialized constant VagrantPlugins::GuestArch::Cap::ConfigureNetworks::TemplateRenderer (NameError)
    from /opt/vagrant/embedded/gems/gems/vagrant-1.2.2/plugins/guests/arch/cap/configure_networks.rb:6:in `each'
```

It looks like it's simply missing a `require` or two.
