### PR TITLE
Private Network bugfix in Fedora

### DIFF
--- a/templates/guests/fedora/network_static.erb
+++ b/templates/guests/fedora/network_static.erb
@@ -5,7 +5,7 @@ BOOTPROTO=none
 ONBOOT=yes
 IPADDR=<%= options[:ip] %>
 NETMASK=<%= options[:netmask] %>
-DEVICE=p7p<%= options[:interface] %>
+DEVICE=eth<%= options[:interface] %>
 <%= options[:gateway] ? "GATEWAY=#{options[:gateway]}" : '' %>
 <%= options[:mac_address] ? "HWADDR=#{options[:mac_address]}" : '' %>
 <%= options[:dns1] ? "DNS1=#{options[:dns1]}" : 'DNS1=8.8.4.4' %>


### PR DESCRIPTION
If you try and start fedora with a :private_network, it will fail saying the 'p7p1 device doesn't exist'. Fixed with changing device to eth.
