### PR TITLE
Static ip addresses on public networks

### DIFF
--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -200,6 +200,17 @@ module VagrantPlugins
         end
 
         def bridged_network_config(config)
+          if config[:ip]
+            options = {
+                :auto_config => true,
+                :mac         => nil,
+                :netmask     => "255.255.255.0",
+                :type        => :static
+            }.merge(config)
+            options[:type] = options[:type].to_sym
+            return options
+          end
+
           return {
             :type => :dhcp,
             :use_dhcp_assigned_default_route => config[:use_dhcp_assigned_default_route]


### PR DESCRIPTION
This patch allows users to specify an ip address and netmask for an ip address on a public network
