### PR TITLE
fixed networking issues of Arch Linux with netctl changes

### DIFF
--- a/plugins/guests/arch/cap/configure_networks.rb
+++ b/plugins/guests/arch/cap/configure_networks.rb
@@ -13,8 +13,9 @@ module VagrantPlugins
             temp.close
 
             machine.communicate.upload(temp.path, "/tmp/vagrant_network")
-            machine.communicate.sudo("mv /tmp/vagrant_network /etc/network.d/interfaces/eth#{network[:interface]}")
-            machine.communicate.sudo("netcfg interfaces/eth#{network[:interface]}")
+            machine.communicate.sudo("ln -sf /dev/null /etc/udev/rules.d/80-net-name-slot.rules")
+            machine.communicate.sudo("mv /tmp/vagrant_network /etc/netctl/eth#{network[:interface]}")
+            machine.communicate.sudo("netctl start eth#{network[:interface]}")
           end
         end
       end

--- a/templates/guests/arch/network_dhcp.erb
+++ b/templates/guests/arch/network_dhcp.erb
@@ -1,4 +1,4 @@
-CONNECTION='ethernet'
-DESCRIPTION='A basic dhcp ethernet connection'
-INTERFACE='eth<%= options[:interface] %>'
-IP='dhcp'
+Description='A basic dhcp ethernet connection'
+Interface=eth<%= options[:interface] %>
+Connection=ethernet
+IP=dhcp

--- a/templates/guests/arch/network_static.erb
+++ b/templates/guests/arch/network_static.erb
@@ -1,6 +1,5 @@
-CONNECTION='ethernet'
-DESCRIPTION='A basic static ethernet connection'
-INTERFACE='eth<%= options[:interface] %>'
-IP='static'
-ADDR='<%= options[:ip]%>'
-NETMASK='<%= options[:netmask] %>'
+Connection=ethernet
+Description='A basic static ethernet connection'
+Interface=eth<%= options[:interface] %>
+IP=static
+Address=('<%= options[:ip]%>/24')


### PR DESCRIPTION
Arch Linux has migrated from netcfg to netctl which changed the directories network profiles were in and the profile syntax. This commit also fixates interface names to prevent random names caused by systemd-197 as mentioned in this [mail](https://mailman.archlinux.org/pipermail/arch-dev-public/2013-January/024231.html).
