### PR TITLE
SSH RequestTTY Support

### DIFF
--- a/config/default.rb
+++ b/config/default.rb
@@ -3,6 +3,7 @@ Vagrant.configure("2") do |config|
 
   config.ssh.forward_agent = false
   config.ssh.forward_x11 = false
+  config.ssh.request_tty = false
   config.ssh.guest_port = 22
   config.ssh.keep_alive = true
   config.ssh.max_tries = 100

--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -271,9 +271,10 @@ module Vagrant
       info[:port] = @config.ssh.port if @config.ssh.port
       info[:username] = @config.ssh.username if @config.ssh.username
 
-      # We also set some fields that are purely controlled by Varant
+      # We also set some fields that are purely controlled by Vagrant
       info[:forward_agent] = @config.ssh.forward_agent
       info[:forward_x11]   = @config.ssh.forward_x11
+      info[:request_tty] = @config.ssh.request_tty
 
       # Set the private key path. If a specific private key is given in
       # the Vagrantfile we set that. Otherwise, we use the default (insecure)

--- a/lib/vagrant/util/ssh.rb
+++ b/lib/vagrant/util/ssh.rb
@@ -130,6 +130,7 @@ module Vagrant
         #
         # Without having extra_args be last, the user loses this ability
         command_options += ["-o", "ForwardAgent=yes"] if ssh_info[:forward_agent]
+        command_options += ["-o", "RequestTTY=force"] if ssh_info[:request_tty]
         command_options.concat(opts[:extra_args]) if opts[:extra_args]
 
         # Build up the host string for connecting

--- a/plugins/commands/ssh_config/command.rb
+++ b/plugins/commands/ssh_config/command.rb
@@ -33,7 +33,8 @@ module VagrantPlugins
             :ssh_user => ssh_info[:username],
             :private_key_path => ssh_info[:private_key_path],
             :forward_agent => ssh_info[:forward_agent],
-            :forward_x11   => ssh_info[:forward_x11]
+            :forward_x11   => ssh_info[:forward_x11],
+            :request_tty   => ssh_info[:request_tty]
           }
 
           # Render the template and output directly to STDOUT

--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -260,6 +260,15 @@ module VagrantPlugins
 
         # Open the channel so we can execute or command
         channel = connection.open_channel do |ch|
+          if @machine.config.ssh.request_tty
+            ch.request_pty do |ch2, success|
+              if success
+                @logger.debug("Forced RequestTTY successfully obtained")
+              else
+                @logger.info("Could not obtain required TTY")
+              end
+            end
+          end
           ch.exec(shell) do |ch2, _|
             # Setup the channel callbacks so we can get data and exit status
             ch2.on_data do |ch3, data|

--- a/plugins/kernel_v1/config/ssh.rb
+++ b/plugins/kernel_v1/config/ssh.rb
@@ -13,6 +13,7 @@ module VagrantPlugins
       attr_accessor :private_key_path
       attr_accessor :forward_agent
       attr_accessor :forward_x11
+      attr_accessor :request_tty
       attr_accessor :shell
 
       def initialize
@@ -26,6 +27,7 @@ module VagrantPlugins
         @private_key_path = UNSET_VALUE
         @forward_agent    = UNSET_VALUE
         @forward_x11      = UNSET_VALUE
+        @request_tty      = UNSET_VALUE
         @shell            = UNSET_VALUE
       end
 
@@ -39,6 +41,7 @@ module VagrantPlugins
         new.ssh.private_key_path = @private_key_path if @private_key_path != UNSET_VALUE
         new.ssh.forward_agent    = @forward_agent if @forward_agent != UNSET_VALUE
         new.ssh.forward_x11      = @forward_x11 if @forward_x11 != UNSET_VALUE
+        new.ssh.request_tty      = @request_tty if @request_tty != UNSET_VALUE
         new.ssh.shell            = @shell if @shell != UNSET_VALUE
       end
     end

--- a/plugins/kernel_v2/config/ssh.rb
+++ b/plugins/kernel_v2/config/ssh.rb
@@ -7,6 +7,7 @@ module VagrantPlugins
     class SSHConfig < SSHConnectConfig
       attr_accessor :forward_agent
       attr_accessor :forward_x11
+      attr_accessor :request_tty
       attr_accessor :guest_port
       attr_accessor :keep_alive
       attr_accessor :max_tries
@@ -20,6 +21,7 @@ module VagrantPlugins
 
         @forward_agent    = UNSET_VALUE
         @forward_x11      = UNSET_VALUE
+        @request_tty      = UNSET_VALUE
         @guest_port = UNSET_VALUE
         @keep_alive = UNSET_VALUE
         @max_tries  = UNSET_VALUE
@@ -41,6 +43,7 @@ module VagrantPlugins
 
         @forward_agent = false if @forward_agent == UNSET_VALUE
         @forward_x11   = false if @forward_x11 == UNSET_VALUE
+        @request_tty   = false if @request_tty == UNSET_VALUE
         @guest_port = nil if @guest_port == UNSET_VALUE
         @keep_alive = false if @keep_alive == UNSET_VALUE
         @max_tries  = nil if @max_tries == UNSET_VALUE

--- a/templates/commands/ssh_config/config.erb
+++ b/templates/commands/ssh_config/config.erb
@@ -14,3 +14,6 @@ Host <%= host_key %>
 <% if forward_x11 -%>
   ForwardX11 yes
 <% end -%>
+<% if request_tty -%>
+  RequestTTY force
+<% end -%>

--- a/test/unit/vagrant/machine_test.rb
+++ b/test/unit/vagrant/machine_test.rb
@@ -328,6 +328,13 @@ describe Vagrant::Machine do
         instance.ssh_info[:forward_x11].should == false
       end
 
+      it "should set the configured request TTY settings" do
+        provider_ssh_info[:request_tty] = true
+        instance.config.ssh.request_tty = false
+
+        instance.ssh_info[:request_tty].should == false
+      end
+
       it "should return the provider private key if given" do
         provider_ssh_info[:private_key_path] = "/foo"
 


### PR DESCRIPTION
Having run into the issue with syncing folders on RHEL-based machines and EC2 instances, and noticing the number of concerns related to this on the issue board, I have attempted to resolve this issue.  I followed 'forward_agent' as a template and as a result may have overdone it on where to put this option.  In particular, I added this to kernel_v1, but wasn't sure if I should probably leave that alone.

My testing is limited to a few Linux distros at present, so if issues are found on other platforms I can take some time to look into that.

RequestTTY can be invoked in the Vagrantfile by using:
  config.ssh.request_tty = true

Also note that that while SSH supports a few choices for this option, I have limited it to two (false = No, true = Force).
