### PR TITLE
Improved autocompletion for bash

### DIFF
--- a/contrib/bash/completion.sh
+++ b/contrib/bash/completion.sh
@@ -1,3 +1,31 @@
 # Autocompletion for Vagrant just put this line in your ~/.profile or link this file into it like:
 # source /path/to/vagrant/contrib/bash/completion.sh
-complete -W "$(echo `vagrant --help | awk '/^     /{print $1}'`;)" vagrant
+_vagrant() {
+
+    cur="${COMP_WORDS[COMP_CWORD]}"
+    prev="${COMP_WORDS[COMP_CWORD-1]}"
+    preprev="${COMP_WORDS[COMP_CWORD-2]}"
+
+    commands=$(vagrant --help | awk '/^     /{print $1}')
+
+    if [ $COMP_CWORD == 1 ] ; then
+      COMPREPLY=( $(compgen -W "${commands}" -- ${cur}) )
+      return 0
+    fi
+
+    if [ $COMP_CWORD == 2 ] ; then
+        local sub_commands=$(vagrant $prev --help | awk '/^     /{print $1}')
+        COMPREPLY=( $(compgen -W "${sub_commands}" -- ${cur}) )
+        return 0
+    fi
+
+    if [[ ${cur} == -* ]] ; then
+        local command_opts=$(vagrant $preprev $prev --help | grep -E -o "((-\w{1}|--(\w|-)*=?)){1,2}")
+        COMPREPLY=( $(compgen -W "${command_opts}" -- ${cur}) )
+        return 0
+    fi
+}
+
+complete -F _vagrant vagrant
+
+# /* vim: set filetype=sh : */


### PR DESCRIPTION
Now it works this way:

```
$ vagrant [TAB][TAB]
box         destroy     halt        init        package
plugin      provision   reload
resume      ssh         ssh-config  status      suspend     up 

$ vagrant b[TAB]
$ vagrant box

$ vagrant box [TAB][TAB]
add        list       remove     repackage

$ vagrant box a[TAB]
$ vagrant box add

$ vagrant box add -[TAB][TAB]
-f          --force     -h          --help      --insecure  --provider

$ vagrant box add --pr[TAB]
$ vagrant box add --provider
```
