### PR TITLE
Ignore nfs option for vm.sync_folder on windows.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ BUG FIXES:
 	defined. [GH-1665]
   - Finding V1 boxes now works properly again to avoid "box not found"
     errors. [GH-1691]
+  - Ignore nfs option for config.vm.sync_folder on windows. [GH-1748]
 
 ## 1.2.2 (April 23, 2013)
 

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -4,6 +4,7 @@ require "set"
 
 require "vagrant"
 require "vagrant/config/v2/util"
+require "vagrant/util/platform"
 
 require File.expand_path("../vm_provisioner", __FILE__)
 require File.expand_path("../vm_subvm", __FILE__)
@@ -120,6 +121,8 @@ module VagrantPlugins
         options ||= {}
         options[:guestpath] = guestpath.to_s.gsub(/\/$/, '')
         options[:hostpath]  = hostpath
+        # ignore nfs option on windows
+        options[:nfs] &&= !Vagrant::Util::Platform.windows?
 
         @__synced_folders[options[:guestpath]] = options
       end

--- a/test/unit/plugins/kernel_v2/config/vm_test.rb
+++ b/test/unit/plugins/kernel_v2/config/vm_test.rb
@@ -1,0 +1,28 @@
+require File.expand_path("../../../../base", __FILE__)
+require File.expand_path("../../../../../../plugins/kernel_v2/config/vm", __FILE__)
+
+describe VagrantPlugins::Kernel_V2::VMConfig do
+  let(:instance) { described_class.new }
+  describe '.synced_folder' do
+    let(:hostpath) { 'hostpath' }
+    let(:guestpath) { 'guestpath' }
+    let(:options) { nil }
+    subject { instance.synced_folder(hostpath, guestpath, options ) }
+
+    it { should eq({guestpath: guestpath, hostpath: hostpath}) }
+
+    context 'when passed {nfs: true} as options' do
+      let(:options) { {nfs: true} }
+
+      context 'when on windows' do
+        before { Vagrant::Util::Platform.stub(:windows?) { true } }
+        it { should eq({guestpath: guestpath, hostpath: hostpath, nfs: false}) }
+      end
+
+      context 'when not on windows' do
+        before { Vagrant::Util::Platform.stub(:windows?) { false } }
+        it { should eq({guestpath: guestpath, hostpath: hostpath, nfs: true}) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This patch will change the sync_folder behavior to the one described in the [documentation](http://docs.vagrantup.com/v2/synced-folders/nfs.html).
Without that patch windows users will get an error when `nfs: true` is set for a shared folder.

This solves #1748 .
