### PR TITLE
fixes the status command output formatting

### DIFF
--- a/plugins/commands/status/command.rb
+++ b/plugins/commands/status/command.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
         results = []
         with_target_vms(argv) do |machine|
           state = machine.state if !state
-          results << "#{machine.name.to_s.ljust(25)}#{machine.state.short_description} (#{machine.provider_name})"
+          results << "#{machine.name.to_s.ljust(25)} #{machine.state.short_description} (#{machine.provider_name})"
         end
 
         message = nil


### PR DESCRIPTION
the result line needs space between the name of the VM and short_description - otherwise the formatting of the output breaks when the name of the VM is too long - the name of the VM gets smashed together with the short_description rendering
