### PR TITLE
Defining the group of a shared folder

### DIFF
--- a/plugins/guests/linux/cap/mount_virtualbox_shared_folder.rb
+++ b/plugins/guests/linux/cap/mount_virtualbox_shared_folder.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
             :shell_expand_guest_path, guestpath)
 
           # Determine the permission string to attach to the mount command
-          mount_options = "-o uid=`id -u #{options[:owner]}`,gid=`id -g #{options[:group]}`"
+          mount_options = "-o uid=`id -u #{options[:owner]}`,gid=`getent group #{options[:group]} | cut -d: -f3`"
           mount_options += ",#{options[:extra]}" if options[:extra]
           mount_command = "mount -t vboxsf #{mount_options} #{name} #{expanded_guest_path}"
 
@@ -32,7 +32,7 @@ module VagrantPlugins
 
           # Chown the directory to the proper user
           machine.communicate.sudo(
-            "chown `id -u #{options[:owner]}`:`id -g #{options[:group]}` #{expanded_guest_path}")
+            "chown `id -u #{options[:owner]}`:`getent group #{options[:group]} | cut -d: -f3` #{expanded_guest_path}")
         end
       end
     end


### PR DESCRIPTION
_Symtom_: The group ID for groups that are not backed by a user account (e.g. admin) cannot be obtained from the id command.

_Consequence_: The shared folder group can only be set to a group where by a user account of the same name exists.

_Solution_: Correcting the method to define the group ID by looking up the group ID via the group name.
