### PR TITLE
add ssh agent sample to Vagrantfile

### DIFF
--- a/templates/commands/init/Vagrantfile.erb
+++ b/templates/commands/init/Vagrantfile.erb
@@ -27,6 +27,10 @@ Vagrant.configure("2") do |config|
   # your network.
   # config.vm.network :public_network
 
+  # If true, then any SSH connections made will enable agent forwarding.
+  # Default value: false
+  # config.ssh.forward_agent = true
+
   # Share an additional folder to the guest VM. The first argument is
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third


### PR DESCRIPTION
it's hard to find how to enable it, only info about it is in old [1.0 docs](http://docs-v1.vagrantup.com/v1/docs/config/ssh/forward_agent.html), nothing about it in current [1.2](http://docs.vagrantup.com/v2/) version
