### PR TITLE
Added support for sending the hostname in a DHCP request for bridged adapters in RedHat guests.

### DIFF
--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -28,6 +28,14 @@ module VagrantPlugins
             machine.communicate.sudo("cat /tmp/vagrant-ifcfg-eth#{network[:interface]} > #{network_scripts_dir}/ifcfg-eth#{network[:interface]}")
             machine.communicate.sudo("rm /tmp/vagrant-ifcfg-eth#{network[:interface]}")
 
+            # Add hostname to network so template can access it, if it has been requested
+            # to be included in the DHCP request.
+            if network[:send_hostname_in_dhcp_request] && !machine.config.vm.hostname.nil?
+              network = {
+                  :hostname => machine.config.vm.hostname
+              }.merge(network)
+            end
+
             # Render and upload the network entry file to a deterministic
             # temporary location.
             entry = TemplateRenderer.render("guests/redhat/network_#{network[:type]}",

--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -202,7 +202,8 @@ module VagrantPlugins
         def bridged_network_config(config)
           return {
             :type => :dhcp,
-            :use_dhcp_assigned_default_route => config[:use_dhcp_assigned_default_route]
+            :use_dhcp_assigned_default_route => config[:use_dhcp_assigned_default_route],
+            :send_hostname_in_dhcp_request   => config[:send_hostname_in_dhcp_request]  ? config[:send_hostname_in_dhcp_request] : false
           }
         end
 

--- a/templates/guests/redhat/network_dhcp.erb
+++ b/templates/guests/redhat/network_dhcp.erb
@@ -3,4 +3,7 @@
 BOOTPROTO=dhcp
 ONBOOT=yes
 DEVICE=eth<%= options[:interface] %>
+<% if options[:hostname] %>
+DHCP_HOSTNAME=<%= options[:hostname] %>
+<% end %>
 #VAGRANT-END


### PR DESCRIPTION
Added support for sending the hostname in a DHCP request for bridged adapters in RedHat guests.

Usage:

Vagrant.configure("2") do |config|
  config.vm.box = "CentOS 6.3 Minimal"
  config.vm.hostname = "host.example.dev"
  config.vm.network :public_network, :send_hostname_in_dhcp_request => true
end
