### PR TITLE
Set ARPCHECK=no as an environment variable with doing ifup #921

### DIFF
--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -48,7 +48,7 @@ module VagrantPlugins
             retryable(:on => Vagrant::Errors::VagrantError, :tries => 3, :sleep => 2) do
               machine.communicate.sudo("/sbin/ifdown eth#{interface} 2> /dev/null", :error_check => false)
               machine.communicate.sudo("cat /tmp/vagrant-network-entry_#{interface} >> #{network_scripts_dir}/ifcfg-eth#{interface}")
-              machine.communicate.sudo("/sbin/ifup eth#{interface} 2> /dev/null")
+              machine.communicate.sudo("ARPCHECK=no /sbin/ifup eth#{interface} 2> /dev/null")
             end
 
             machine.communicate.sudo("rm /tmp/vagrant-network-entry_#{interface}")


### PR DESCRIPTION
Without this vnet0 vbox interface responds to the arping command in /etc/sysconfig/ifup-eth and the ifup command errors out.

Should affect Centos and RHEL.
