### PR TITLE
adding explicit name of API_VERSION in Vagrantfile. fixes #1835

### DIFF
--- a/templates/commands/init/Vagrantfile.erb
+++ b/templates/commands/init/Vagrantfile.erb
@@ -1,7 +1,8 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
+API_VERSION = "2"
 
-Vagrant.configure("2") do |config|
+Vagrant.configure(API_VERSION) do |config|
   # All Vagrant configuration is done here. The most common configuration
   # options are documented and commented below. For a complete reference,
   # please see the online documentation at vagrantup.com.


### PR DESCRIPTION
This is just a small change, but I think it has some value in communicating that Vagrant has a versioned API. Users starting out with version 2 might not be as aware.
