### PR TITLE
Update CFEngine bootstrap for 3.5 compatibility

### DIFF
--- a/plugins/provisioners/cfengine/provisioner.rb
+++ b/plugins/provisioners/cfengine/provisioner.rb
@@ -87,7 +87,7 @@ module VagrantPlugins
 
         @machine.ui.info(I18n.t("vagrant.cfengine_bootstrapping",
                                 policy_server: policy_server_address))
-        result = cfagent("--bootstrap --policy-server #{policy_server_address}", error_check: false)
+        result = cfagent("--bootstrap #{policy_server_address}", error_check: false)
         raise Vagrant::Errors::CFEngineBootstrapFailed if result != 0
 
         # Policy hubs need to do additional things before they're ready


### PR DESCRIPTION
CFEngine 3.5 bootstrap removed the policy-server option
http://cfengine.com/blog/cfengine-is-very-easy-to-install-and-now-so-is-bootstrapping
