### PR TITLE
Correct Vagrant::Plugin::V2::Config#merge order

### DIFF
--- a/lib/vagrant/plugin/v2/config.rb
+++ b/lib/vagrant/plugin/v2/config.rb
@@ -46,7 +46,7 @@ module Vagrant
           result = self.class.new
 
           # Set all of our instance variables on the new class
-          [self, other].each do |obj|
+          [other, self].each do |obj|
             obj.instance_variables.each do |key|
               # Ignore keys that start with a double underscore. This allows
               # configuration classes to still hold around internal state


### PR DESCRIPTION
Without this commit, the Vagrant::Plugin::V2::Config#merge method does not
merge as described.

Per the description, this method accepts a different config object as an
argument, and will merge the two together resulting in a new config
object. The merge will take place in such a manner that values from the
config object supplied as an argument will be overridden by values from
the current object when there is a value conflict.

The order in which the current config object and the passed config
object are applied to the resulting object does not reflect this overriding
behavior as described. The order in which they will apply will cause
the passed config object to overwrite the values in the current object.

This commit reverses the order in which the values from the two config
objects are applied. This will cause the resulting merged config object
to properly contain the values from the two original object as described.
