### PR TITLE
Remove JSON gem dependency

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |s|
   s.add_dependency "childprocess", "~> 0.3.7"
   s.add_dependency "erubis", "~> 2.7.0"
   s.add_dependency "i18n", "~> 0.6.0"
-  s.add_dependency "json", ">= 1.5.1", "< 1.8.0"
   s.add_dependency "log4r", "~> 1.1.9"
   s.add_dependency "net-ssh", "~> 2.6.6"
   s.add_dependency "net-scp", "~> 1.1.0"


### PR DESCRIPTION
Since the Ruby 1.9 stdlib includes the JSON gem, can we just rely on that instead of the JSON gem?
