### PR TITLE
Vagrant::Action::Builder RDoc correction

### DIFF
--- a/lib/vagrant/action/builder.rb
+++ b/lib/vagrant/action/builder.rb
@@ -131,7 +131,7 @@ module Vagrant
 
       # Converts the builder stack to a runnable action sequence.
       #
-      # @param [Vagrant::Action::Environment] env The action environment
+      # @param [Hash] env The action environment hash
       # @return [Object] A callable object
       def to_app(env)
         app_stack = nil


### PR DESCRIPTION
The RDoc comments for `Vagrant::Action::Builder#to_app` reference an
instance of `Vagrant::Action::Environment` as the passed paramter. There
is no class `Vagrant::Action::Environment` available. The param being
passed is actually a `Hash` that represents the "action environment".

This commit corrects the RDoc lines for
`Vagrant::Action::Builder#to_app` to correctly reference the passed
`Hash`.
