### PR TITLE
allow inventory_file of Ansible provisioner to be a directory

### DIFF
--- a/plugins/provisioners/ansible/config.rb
+++ b/plugins/provisioners/ansible/config.rb
@@ -59,7 +59,7 @@ module VagrantPlugins
         # Validate the existence of the inventory_file, if specified
         if inventory_file
           expanded_path = Pathname.new(inventory_file).expand_path(machine.env.root_path)
-          if !expanded_path.file?
+          if !expanded_path.exist?
             errors << I18n.t("vagrant.provisioners.ansible.inventory_file_path_invalid",
                               :path => expanded_path)
           end


### PR DESCRIPTION
Ansible supports directories as inventory files as well. This is something which is especially useful when you require multiple inventory sources, e.g. dynamic and static ones.

This PR fixes the Ansible provisioner to not only allow regular files as inventory_file but directories, too.
