### PR TITLE
Raise a proper SSH error on EHOSTUNREACH

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -455,6 +455,10 @@ module Vagrant
       error_key(:ssh_key_type_not_supported)
     end
 
+    class SSHNoRoute < VagrantError
+      error_key(:ssh_no_route)
+    end
+
     class SSHNotReady < VagrantError
       error_key(:ssh_not_ready)
     end

--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -235,6 +235,9 @@ module VagrantPlugins
         rescue Errno::EHOSTDOWN
           # This is raised if we get an ICMP DestinationUnknown error.
           raise Vagrant::Errors::SSHHostDown
+        rescue Errno::EHOSTUNREACH
+          # This is raised if we can't work out how to route traffic.
+          raise Vagrant::Errors::SSHNoRoute
         rescue NotImplementedError
           # This is raised if a private key type that Net-SSH doesn't support
           # is used. Show a nicer error.

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -426,6 +426,10 @@ en:
         usually indicates that SSH within the guest machine was unable to
         properly start up. Please boot the VM in GUI mode to check whether
         it is booting properly.
+      ssh_no_route: |-
+        While attempting to connect with SSH, a "no route to host" (EHOSTUNREACH)
+        error was received. Please verify your network settings are correct
+        and try again.
       ssh_host_down: |-
         While attempting to connect with SSH, a "host is down" (EHOSTDOWN)
         error was received. Please verify your SSH settings are correct


### PR DESCRIPTION
When using providers different from Virtualbox or Vmware Fusion/Workstation, it is perfectly possible to have the guest VM behind a routed network. In that case, in the event of a boot failure or a network misconfiguration, ssh connection attempts will probably fail with `Errno::EHOSTUNREACH` (No route to host) exception. That exception is not currently rescued in the ssh communicator, while probably it should be.
