### PR TITLE
Stop ruby regex error on "Fedora Core" releases.

### DIFF
--- a/plugins/hosts/fedora/host.rb
+++ b/plugins/hosts/fedora/host.rb
@@ -34,7 +34,7 @@ module VagrantPlugins
         release_file = Pathname.new("/etc/redhat-release")
         begin
           release_file.open("r") do |f|
-            version_number = /Fedora release ([0-9]+)/.match(f.gets)[1].to_i
+            version_number = /Fedora.*release ([0-9]+)/.match(f.gets)[1].to_i
             if version_number >= 16
               # "service nfs-server" will redirect properly to systemctl
               # when "service nfs-server restart" is called.


### PR DESCRIPTION
The version_number regex was causing an error because my /etc/redhat-release looks like this:

Fedora Core release 6 (Zod)

This fix allowed initialize to run just fine on my ridiculously old release.
