### PR TITLE
support for chef solo environments, upcoming in chef 11.6

### DIFF
--- a/plugins/provisioners/chef/config/chef_solo.rb
+++ b/plugins/provisioners/chef/config/chef_solo.rb
@@ -11,6 +11,8 @@ module VagrantPlugins
         attr_accessor :nfs
         attr_accessor :encrypted_data_bag_secret_key_path
         attr_accessor :encrypted_data_bag_secret
+        attr_accessor :environments_path
+        attr_accessor :environment
 
         def initialize
           super
@@ -22,7 +24,8 @@ module VagrantPlugins
           @encrypted_data_bag_secret = UNSET_VALUE
           @encrypted_data_bag_secret_key_path = UNSET_VALUE
           @nfs                       = UNSET_VALUE
-
+          @environments_path         = UNSET_VALUE
+          @environment               = UNSET_VALUE
           @__defaulted_cookbooks_path = false
         end
 
@@ -34,6 +37,7 @@ module VagrantPlugins
           super
 
           @recipe_url = nil if @recipe_url == UNSET_VALUE
+          @environment = nil if @environment == UNSET_VALUE
 
           if @cookbooks_path == UNSET_VALUE
             @cookbooks_path = []
@@ -42,13 +46,15 @@ module VagrantPlugins
             @__defaulted_cookbooks_path = true
           end
 
-          @data_bags_path = [] if @data_bags_path == UNSET_VALUE
-          @roles_path     = [] if @roles_path == UNSET_VALUE
+          @data_bags_path    = [] if @data_bags_path == UNSET_VALUE
+          @roles_path        = [] if @roles_path == UNSET_VALUE
+          @environments_path = [] if @environments_path == UNSET_VALUE or @recipe_url == nil
 
           # Make sure the path is an array.
-          @cookbooks_path = prepare_folders_config(@cookbooks_path)
-          @data_bags_path = prepare_folders_config(@data_bags_path)
-          @roles_path     = prepare_folders_config(@roles_path)
+          @cookbooks_path    = prepare_folders_config(@cookbooks_path)
+          @data_bags_path    = prepare_folders_config(@data_bags_path)
+          @roles_path        = prepare_folders_config(@roles_path)
+          @environments_path = prepare_folders_config(@environments_path)
 
           @encrypted_data_bag_secret = "/tmp/encrypted_data_bag_secret" if \
             @encrypted_data_bag_secret == UNSET_VALUE
@@ -61,7 +67,8 @@ module VagrantPlugins
           errors = _detected_errors
           errors << I18n.t("vagrant.config.chef.cookbooks_path_empty") if \
             !cookbooks_path || [cookbooks_path].flatten.empty?
-
+          errors << I18n.t("vagrant.config.chef.environment_path_required") if \
+            environment and (!environments_path || [environments_path].flatten.empty?)
           { "chef solo provisioner" => errors }
         end
 

--- a/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
       class ChefSolo < Base
         extend Vagrant::Util::Counter
         include Vagrant::Util::Counter
-
+        attr_reader :environments_folders
         attr_reader :cookbook_folders
         attr_reader :role_folders
         attr_reader :data_bags_folders
@@ -25,16 +25,18 @@ module VagrantPlugins
           @cookbook_folders  = expanded_folders(@config.cookbooks_path, "cookbooks")
           @role_folders      = expanded_folders(@config.roles_path, "roles")
           @data_bags_folders = expanded_folders(@config.data_bags_path, "data_bags")
+          @environments_folders = expanded_folders(@config.environments_path, "environments")
 
           share_folders(root_config, "csc", @cookbook_folders)
           share_folders(root_config, "csr", @role_folders)
           share_folders(root_config, "csdb", @data_bags_folders)
+          share_folders(root_config, "cse", @environments_folders)
         end
 
         def provision
           # Verify that the proper shared folders exist.
           check = []
-          [@cookbook_folders, @role_folders, @data_bags_folders].each do |folders|
+          [@cookbook_folders, @role_folders, @data_bags_folders, @environments_folders].each do |folders|
             folders.each do |type, local_path, remote_path|
               # We only care about checking folders that have a local path, meaning
               # they were shared from the local machine, rather than assumed to
@@ -122,7 +124,7 @@ module VagrantPlugins
           cookbooks_path = guest_paths(@cookbook_folders)
           roles_path = guest_paths(@role_folders).first
           data_bags_path = guest_paths(@data_bags_folders).first
-
+          environments_path = guest_paths(@environments_folders).first
           setup_config("provisioners/chef_solo/solo", "solo.rb", {
             :node_name => @config.node_name,
             :provisioning_path => @config.provisioning_path,
@@ -131,6 +133,8 @@ module VagrantPlugins
             :roles_path => roles_path,
             :data_bags_path => data_bags_path,
             :encrypted_data_bag_secret => @config.encrypted_data_bag_secret,
+            :environments_path => environments_path,
+            :environment => @config.environment,
           })
         end
 

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -586,6 +586,7 @@ en:
         error_empty: "`%{field}` must be not be empty."
       chef:
         cookbooks_path_empty: "Must specify a cookbooks path for chef solo."
+        environment_path_required: "When 'environment' is specified, you must provide 'environments_path'."
         cookbooks_path_missing: |-
           Cookbook path doesn't exist: %{path}
         server_url_empty: "Chef server URL must be populated."

--- a/templates/provisioners/chef_solo/solo.erb
+++ b/templates/provisioners/chef_solo/solo.erb
@@ -18,6 +18,14 @@ data_bag_path <%= data_bags_path.inspect %>
 recipe_url "<%= recipe_url %>"
 <% end -%>
 
+<% if environments_path %>
+environment_path <%= environments_path.inspect %>
+<% end -%>
+
+<% if environment %>
+environment "<%= environment %>"
+<% end -%>
+
 http_proxy <%= http_proxy.inspect %>
 http_proxy_user <%= http_proxy_user.inspect %>
 http_proxy_pass <%= http_proxy_pass.inspect %>


### PR DESCRIPTION
Add support for new chef solo provisioner configuration options, `environment` and `environments_path`. This allows for  chef environments to be used in chef-solo provisioned VMs.

The necessary chef-solo support for environments is available in the upcoming 11.6 chef release.   If `environment` is specified for a VM using an earlier version of chef, provisioning will fail with a missing client pem error during the chef-client run. 
