### PR TITLE
Add helpful info about which command to run when another command fails.

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -654,7 +654,7 @@ en:
         vm_already_running: |-
           VirtualBox VM is already running.
         vm_not_created: "VM not created. Moving on..."
-        vm_not_running: "VM is not currently running. Please bring it up to run this command."
+        vm_not_running: "VM is not currently running. Please, first bring it up with `vagrant up` then run this command."
       box:
         remove_must_specify_provider: |-
           Multiple providers were found for the box '%{name}'. Please specify


### PR DESCRIPTION
This provides the suggested command to run in order to proceed with a failed command.

I'm new to the project and ran `vagrant provision` but the error message didn't tell me exactly what to do. I've altered it to specify the exact command to run.
