### PR TITLE
Add support for remote shell provisioner script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ FEATURES:
     `knife` if configured to do so.
   - `vagrant up` has a `--no-destroy-on-error` flag that will not destroy
     the VM if a fatal error occurs. [GH-2011]
+  - Support for remote shell provisioning scripts [GH-1787]
 
 IMPROVEMENTS:
 

--- a/plugins/provisioners/shell/config.rb
+++ b/plugins/provisioners/shell/config.rb
@@ -1,3 +1,5 @@
+require 'uri'
+
 module VagrantPlugins
   module Shell
     class Config < Vagrant.plugin("2", :config)
@@ -33,8 +35,8 @@ module VagrantPlugins
           errors << I18n.t("vagrant.provisioners.shell.no_path_or_inline")
         end
 
-        # Validate the existence of a script to upload
-        if path
+        # If it is not an URL, we validate the existence of a script to upload
+        if path && ! remote?
           expanded_path = Pathname.new(path).expand_path(machine.env.root_path)
           if !expanded_path.file?
             errors << I18n.t("vagrant.provisioners.shell.path_invalid",
@@ -53,6 +55,10 @@ module VagrantPlugins
         end
 
         { "shell provisioner" => errors }
+      end
+
+      def remote?
+        path =~ URI::regexp(["ftp", "http", "https"])
       end
     end
   end


### PR DESCRIPTION
With these changes Vagrant should be able to provision machine using remote scripts passed in as the `path` option:

``` ruby
Vagrant.configure('2') do |config|
  config.vm.box = "raring64"
  config.vm.provision :shell, path: 'https://gist.github.com/a-user/some-gist'
end
```

PS: This PR should also close #1787 :)
