### PR TITLE
When top-of-branch vagrant tries to execute a command, which does not exist in PATH, error report does not display the executable name.

### DIFF
--- a/lib/vagrant/util/subprocess.rb
+++ b/lib/vagrant/util/subprocess.rb
@@ -25,12 +25,13 @@ module Vagrant
       end
 
       def initialize(*command)
+        progname = command[0]
         @options = command.last.is_a?(Hash) ? command.pop : {}
         @command = command
         @command[0] = Which.which(@command[0]) if !File.file?(@command[0])
         if !@command[0]
-          raise Errors::CommandUnavailableWindows, file: command[0] if Platform.windows?
-          raise Errors::CommandUnavailable, file: command[0]
+          raise Errors::CommandUnavailableWindows, file: progname if Platform.windows?
+          raise Errors::CommandUnavailable, file: progname
         end
 
         @logger  = Log4r::Logger.new("vagrant::util::subprocess")

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -168,11 +168,11 @@ en:
 
         %{help}
       command_unavailable: |-
-        The executable '%(file)' Vagrant is trying to run was not
+        The executable '%{file}' Vagrant is trying to run was not
         found in the PATH variable. This is an error. Please verify
         this software is installed and on the path.
       command_unavailable_windows: |-
-        The executable '%(file)' Vagrant is trying to run was not
+        The executable '%{file}' Vagrant is trying to run was not
         found in the %PATH% variable. This is an error. Please verify
         this software is installed and on the path.
       config_invalid: |-


### PR DESCRIPTION
In failure case at line lib/vagrant/util/subprocess.rb:30 command[0] is set to nil. But you still need to display the executable name.

The simplest solution: store the executable name in a temp variable, and display it in a failure case.
