### PR TITLE
DHCP renewal on Debian/Ubuntu after setting hostname

### DIFF
--- a/plugins/guests/debian/cap/change_host_name.rb
+++ b/plugins/guests/debian/cap/change_host_name.rb
@@ -9,6 +9,7 @@ module VagrantPlugins
               comm.sudo("sed -i 's/.*$/#{name.split('.')[0]}/' /etc/hostname")
               comm.sudo("hostname -F /etc/hostname")
               comm.sudo("hostname --fqdn > /etc/mailname")
+              comm.sudo("ifdown -a; ifup -a")
             end
           end
         end

--- a/plugins/guests/ubuntu/cap/change_host_name.rb
+++ b/plugins/guests/ubuntu/cap/change_host_name.rb
@@ -14,6 +14,7 @@ module VagrantPlugins
                 comm.sudo("service hostname start")
               end
               comm.sudo("hostname --fqdn > /etc/mailname")
+              comm.sudo("ifdown -a; ifup -a")
             end
           end
         end


### PR DESCRIPTION
On Debian and Ubuntu guests, when the new hostname of the guest box is set, the DHCP client (isc-dhcp-client) won't renew its DHCP lease with the new hostname. Executing "ifdown -a; ifup -a" to reinitialize all auto interfaces fixes this issue.

Furthermore, as vagrant will now actually wait until a DHCP lease is acquired, it is guaranteed that the the correct domainname is set from DHCP before calling other provisioners like puppet, that rely on it. This fixes puppet/facter sometimes failing to find the fqdn fact on an LXC guest when the DHCP server is responding too slow.
