### PR TITLE
pass guest_ip option from config to driver [GH-1121]

### DIFF
--- a/plugins/providers/virtualbox/action/forward_ports.rb
+++ b/plugins/providers/virtualbox/action/forward_ports.rb
@@ -69,6 +69,7 @@ module VagrantPlugins
             # Add the options to the ports array to send to the driver later
             ports << {
               :adapter   => fp.adapter,
+              :guestip   => fp.guest_ip,
               :guestport => fp.guest_port,
               :hostip    => fp.host_ip,
               :hostport  => fp.host_port,

--- a/plugins/providers/virtualbox/model/forwarded_port.rb
+++ b/plugins/providers/virtualbox/model/forwarded_port.rb
@@ -24,6 +24,11 @@ module VagrantPlugins
         # @return [String]
         attr_reader :protocol
 
+        # The IP that the forwarded port will connect to on the guest machine.
+        #
+        # @return [String]
+        attr_reader :guest_ip
+
         # The port on the guest to be exposed on the host.
         #
         # @return [Integer]
@@ -48,6 +53,7 @@ module VagrantPlugins
           @auto_correct = true
           @auto_correct = options[:auto_correct] if options.has_key?(:auto_correct)
           @adapter  = (options[:adapter] || 1).to_i
+          @guest_ip = options[:guest_ip] || nil
           @host_ip = options[:host_ip] || nil
           @protocol = options[:protocol] || "tcp"
         end


### PR DESCRIPTION
plugins/providers/virtualbox/driver/ now see guestip option.
but plugins/providers/virtualbox/action/forward_ports.rb and plugins/providers/virtualbox/model/forwarded_port.rb do not pass guest_ip option from config to driver.
