### PR TITLE
Add basic multiple box urls support [GH-1174]

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -231,6 +231,9 @@ en:
       downloader_interrupted: |-
         The download was interrupted by an external signal. It did not
         complete.
+      download_failed_not_last_box_url: |-
+          An error occurred while downloading the remote file from %{url}. Trying
+          another url.
       environment_locked: |-
         An instance of Vagrant is already running. Only one instance of Vagrant
         may run at any given time to avoid problems with VirtualBox inconsistencies


### PR DESCRIPTION
Example Vagrantfile:

``` ruby
Vagrant.configure("2") do |config|
  config.vm.box = "some_unknown_vagrant_box"
  config.vm.box_url = ["ftp://192.168.0.111/fileasd.box", "http://files.vagrantup.com/unknownbox.box", "http://files.vagrantup.com/precise64.box"]
end
```

Vagrant output:

```
Bringing machine 'test' up with 'virtualbox' provider...
[test] Box 'some_unknown_vagrant_box' was not found. Fetching box from specified URL for
the provider 'virtualbox'. Note that if the URL does not have
a box for this provider, you should interrupt Vagrant now and add
the box yourself. Otherwise Vagrant will attempt to download the
full box prior to discovering this error.
Downloading or copying the box...
[test] An error occurred while downloading the remote file from ftp://192.168.0.111/fileasd.box. Trying
another url.
Downloading or copying the box...
[test] An error occurred while downloading the remote file from http://files.vagrantup.com/unknownbox.box. Trying
another url.
Downloading or copying the box...
Progress: 0% (Rate: 12172/s, Estimated time remaining: 8:09:38)^CWaiting for cleanup before exiting...
Box download was interrupted. Exiting.
Vagrant exited after cleanup due to external interrupt.
```

Output when no downloadable urls provided:

```
Bringing machine 'test' up with 'virtualbox' provider...
[test] Box 'some_unknown_vagrant_box' was not found. Fetching box from specified URL for
the provider 'virtualbox'. Note that if the URL does not have
a box for this provider, you should interrupt Vagrant now and add
the box yourself. Otherwise Vagrant will attempt to download the
full box prior to discovering this error.
Downloading or copying the box...
An error occurred while downloading the remote file. The error
message, if any, is reproduced below. Please fix this error and try
again.

The requested URL returned error: 403
```
