### PR TITLE
Fedora 19 UTF-8 redhat-release

### DIFF
--- a/plugins/hosts/fedora/host.rb
+++ b/plugins/hosts/fedora/host.rb
@@ -1,3 +1,8 @@
+if RUBY_VERSION =~ /1.9/
+  Encoding.default_external = Encoding::UTF_8
+  Encoding.default_internal = Encoding::UTF_8
+end
+
 require "pathname"
 
 require "vagrant"


### PR DESCRIPTION
There is a UTF-8 character in redhat-release causing vagrant to bail out on #L15 in version 1.2.4.  The contents of redhat-release for Fedora 19 is `Fedora release 19 (Schrödinger’s Cat)`.

Error output when running from kitchen/kitchen-vagrant.

```
[wolfe21@wolfe21-ig88 mumail]$ kitchen test -d never
-----> Starting Kitchen (v1.0.0.beta.1)
>>>>>> ------Exception-------
>>>>>> Class: Kitchen::ShellOut::ShellCommandFailed
>>>>>> Message: Expected process to exit with [0], but received '1'
---- Begin output of vagrant --version ----                                                                                                                                                                                                  
STDOUT:                                                                                                                                                                                                                                      
STDERR: /opt/vagrant/embedded/gems/gems/vagrant-1.2.4/plugins/hosts/fedora/host.rb:15:in `block in match?': invalid byte sequence in US-ASCII (ArgumentError)                                                                                
---- End output of vagrant --version ----                                                                                                                                                                                                    
Ran vagrant --version returned 1                                                                                                                                                                                                             
>>>>>> ----------------------
>>>>>> Please see .kitchen/logs/kitchen.log for more details
```
