### PR TITLE
adds extra verbosity option to ansible provisioner

### DIFF
--- a/plugins/provisioners/ansible/provisioner.rb
+++ b/plugins/provisioners/ansible/provisioner.rb
@@ -19,7 +19,9 @@ module VagrantPlugins
 
         options << "--sudo" if config.sudo
         options << "--sudo-user=#{config.sudo_user}" if config.sudo_user
-        options << "--verbose" if config.verbose
+        if config.verbose
+          options << (config.verbose == :extra ?  "-vvv" :  "--verbose")
+        end
 
         # Assemble the full ansible-playbook command
         command = (%w(ansible-playbook) << options << config.playbook).flatten


### PR DESCRIPTION
Ansible has two levels of verbosity when running `ansible-playback`.  Vagrant supports `--vagrant` but not the more verbose `-vvv` option.  This patch exposes this flag to vagrant with an `config.extra_verbose = true` option.  It may be better to allow for `config.verbose = :extra` instead of adding the additional `extra_verbose` option.  Thoughts?  /cc @commandtab
