### PR TITLE
fix regression chowning chef provisioning directory

### DIFF
--- a/plugins/provisioners/chef/provisioner/base.rb
+++ b/plugins/provisioners/chef/provisioner/base.rb
@@ -42,7 +42,7 @@ module VagrantPlugins
         def chown_provisioning_folder
           @machine.communicate.tap do |comm|
             comm.sudo("mkdir -p #{@config.provisioning_path}")
-            comm.sudo("chown -R #{@machine.ssh_info[:username]} #{@config.provisioning_path}")
+            comm.sudo("chown #{@machine.ssh_info[:username]} #{@config.provisioning_path}")
           end
         end
 


### PR DESCRIPTION
if the provisioning directory is mounted before this method is called, and the mounted filesystem is of a type that doesn't support chown (e.g. vmhgfs for vmware or hfs) then this method will fail.
