### PR TITLE
Improvement: Display a plugin's post install message if available

### DIFF
--- a/plugins/commands/plugin/action/install_gem.rb
+++ b/plugins/commands/plugin/action/install_gem.rb
@@ -60,6 +60,19 @@ module VagrantPlugins
                                   :name => plugin_spec.name,
                                   :version => plugin_spec.version.to_s))
 
+          # If the plugin's spec includes a post-install message display it
+          if (post_install_message = plugin_spec.post_install_message)
+            post_install_message = if post_install_message.kind_of? Array
+                                     post_install_message.join(" ")
+                                   else
+                                     post_install_message.to_s
+                                   end
+
+            env[:ui].info(I18n.t("vagrant.commands.plugin.post_install",
+                                 :name => plugin_spec.name,
+                                 :message => post_install_message))
+          end
+
           # Continue
           @app.call(env)
         end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -728,6 +728,7 @@ en:
           Uninstalling the '%{name}' plugin...
         post_install: |-
           Post install message from the '%{name}' plugin:
+
           %{message}
       status:
         aborted: |-


### PR DESCRIPTION
This change checks if the `Gem::Specification` was given a post install message (`spec.post_install_message = "Thanks for installing!"`). If it's found it is printed to the screen using `env[:ui].info`. This helps plugins that need just a bit of extra set up explaint to the user. See my latest pull request on Bindler [fgrehm/bindler#14](https://github.com/fgrehm/bindler/pull/14).
