### PR TITLE
fix regression preventing boxes that specify support for multiple formats

### DIFF
--- a/lib/vagrant/box_collection.rb
+++ b/lib/vagrant/box_collection.rb
@@ -135,7 +135,7 @@ module Vagrant
               found = false
               formats.each do |format|
                 # Verify that the given provider matches what the box has.
-                if box_provider.to_sym == format
+                if box_provider.to_sym == format.to_sym
                   found = true
                   break
                 end


### PR DESCRIPTION
don't know if this is the right place for this fix.  maybe formats should be an array of symbols.
