### PR TITLE
Fix Ansible provisioner exit code reporting

### DIFF
--- a/plugins/provisioners/ansible/provisioner.rb
+++ b/plugins/provisioners/ansible/provisioner.rb
@@ -31,13 +31,13 @@ module VagrantPlugins
         }
 
         begin
-          exit_status = Vagrant::Util::Subprocess.execute(*command) do |type, data|
+          result = Vagrant::Util::Subprocess.execute(*command) do |type, data|
             if type == :stdout || type == :stderr
               @machine.env.ui.info(data, :new_line => false, :prefix => false)
             end
           end
 
-          raise Vagrant::Errors::AnsibleFailed if exit_status != 0
+          raise Vagrant::Errors::AnsibleFailed if result.exit_code != 0
         rescue Vagrant::Util::Subprocess::LaunchError
           raise Vagrant::Errors::AnsiblePlaybookAppNotFound
         end


### PR DESCRIPTION
In eb70c0d6bbc8 we were trying to compare a `Subprocess::Result` to a `Fixnum`, resulting in Vagrant always reporting failure regardless of Ansible's exit code.
