### PR TITLE
Puppet modules owned by root when mounted in sync'ed folder.

### DIFF
--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -29,14 +29,14 @@ module VagrantPlugins
 
           # Share the manifests directory with the guest
           root_config.vm.synced_folder(
-            @expanded_manifests_path, manifests_guest_path)
+            @expanded_manifests_path, manifests_guest_path, { :owner => 'root' } )
 
           # Share the module paths
           count = 0
           @module_paths.each do |from, to|
             # Sorry for the cryptic key here, but VirtualBox has a strange limit on
             # maximum size for it and its something small (around 10)
-            root_config.vm.synced_folder(from, to)
+            root_config.vm.synced_folder(from, to, { :owner => 'root' } )
             count += 1
           end
         end


### PR DESCRIPTION
Added :owner => root to mount options. 

In my experience, when using puppetmaster it can be really tricky to have puppet files owned by someone different than "root" (because files that should be owned by root in the "agent" become owned by "vagrant").

This is using puppet apply instead of puppetmaster, but anyway looks safer to me... It's just an idea, feel free to discard this pull request if you disagree.
