### PR TITLE
Forcing eth0 to come up

### DIFF
--- a/plugins/guests/debian/cap/change_host_name.rb
+++ b/plugins/guests/debian/cap/change_host_name.rb
@@ -9,7 +9,7 @@ module VagrantPlugins
               comm.sudo("sed -i 's/.*$/#{name.split('.')[0]}/' /etc/hostname")
               comm.sudo("hostname -F /etc/hostname")
               comm.sudo("hostname --fqdn > /etc/mailname")
-              comm.sudo("ifdown -a; ifup -a; ifup -a --allow=hotplug")
+              comm.sudo("ifdown -a; ifup -a; ifup eth0")
             end
           end
         end


### PR DESCRIPTION
For https://github.com/mitchellh/vagrant/issues/1974

I don't really like hardwiring `eth0` but for me, it works. No idea why the first interface - which is set as `allow-hotplug`    - is not brought up by `ifup --allow=hotplug`
