### PR TITLE
Ansible inventory can be a directory, not just a file

### DIFF
--- a/plugins/provisioners/ansible/config.rb
+++ b/plugins/provisioners/ansible/config.rb
@@ -59,7 +59,7 @@ module VagrantPlugins
         # Validate the existence of the inventory_file, if specified
         if inventory_file
           expanded_path = Pathname.new(inventory_file).expand_path(machine.env.root_path)
-          if !expanded_path.file?
+          unless expanded_path.file? || expanded_path.directory?
             errors << I18n.t("vagrant.provisioners.ansible.inventory_file_path_invalid",
                               :path => expanded_path)
           end


### PR DESCRIPTION
It is an under-documented feature that one can specify a directory as the Ansible inventory source, not just a single file. In that case, Ansible merges the contents of flat files and any executable inventory plugins found in the directory.

This is useful, for instance, to put localhost in your inventory for use with `local_action` even if your entire infrastructure is otherwise on EC2 or some other dynamic inventory source. I also use a flat file to create aliases for host groups automatically generated from the EC2 API, like "staging" for `tag_Environment_staging`.
