### PR TITLE
Support verify_vmware_hgfs in darwin guest.

### DIFF
--- a/plugins/guests/darwin/cap/verify_vmware_hgfs.rb
+++ b/plugins/guests/darwin/cap/verify_vmware_hgfs.rb
@@ -1,0 +1,12 @@
+module VagrantPlugins
+  module GuestDarwin
+    module Cap
+      class VerifyVmwareHgfs
+        def self.verify_vmware_hgfs(machine)
+          kext_bundle_id = "com.vmware.kext.vmhgfs"
+          machine.communicate.test("kextstat -b #{kext_bundle_id} -l | grep #{kext_bundle_id}")
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/darwin/plugin.rb
+++ b/plugins/guests/darwin/plugin.rb
@@ -40,6 +40,11 @@ module VagrantPlugins
         require_relative "cap/shell_expand_guest_path"
         Cap::ShellExpandGuestPath
       end
+
+      guest_capability("darwin", "verify_vmware_hgfs") do
+        require_relative "cap/verify_vmware_hgfs"
+        Cap::VerifyVmwareHgfs
+      end
     end
   end
 end


### PR DESCRIPTION
The vmhgfs functionality is loaded as a kernel extension like in Linux, and the test for whether it's loaded is practically the same as using lsmod under Linux.
