### PR TITLE
Remove CRLF scrubbing as the default behavior.

### DIFF
--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -61,9 +61,6 @@ module VagrantPlugins
           script = config.inline
         end
 
-        # Replace Windows line endings with Unix ones
-        script.gsub!(/\r\n?$/, "\n")
-
         # Otherwise we have an inline script, we need to Tempfile it,
         # and handle it specially...
         file = Tempfile.new('vagrant-shell')


### PR DESCRIPTION
Remove the default CRLF scrubbing behavior.  I propose that provisioners should only get their file contents mutated if they explicitly ask for it.
