### PR TITLE
Updates Chef provisioner configuration option formatter for Chef 11

### DIFF
--- a/templates/provisioners/chef_client/client.erb
+++ b/templates/provisioners/chef_client/client.erb
@@ -33,7 +33,7 @@ pid_file           "/var/run/chef/chef-client.pid"
 Mixlib::Log::Formatter.show_time = true
 
 <% if formatter %>
-formatter "<%= formatter %>"
+add_formatter "<%= formatter %>"
 <% end %>
 
 <% if custom_configuration -%>

--- a/templates/provisioners/chef_solo/solo.erb
+++ b/templates/provisioners/chef_solo/solo.erb
@@ -29,7 +29,7 @@ https_proxy_pass <%= https_proxy_pass.inspect %>
 no_proxy <%= no_proxy.inspect %>
 
 <% if formatter %>
-formatter "<%= formatter %>"
+add_formatter "<%= formatter %>"
 <% end %>
 
 <% if custom_configuration -%>


### PR DESCRIPTION
Refs #1250.

Will correctly produce the desired result on Chef 11.x and above, as the
original directive was written against Chef 10.x, and released in Vagrant 1.2.7.

While this will continue to work for Chef 10.x, since this is not the 'mainline'
release track, and the alternative would be to write more conditional code in
the configuration file to detect the version and place the correct directive, this
changes the directive to support the current releases of Chef 11 and above.
