### PR TITLE
allow port-forwarding of the same port number but with different protocols [GH-1108]

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -163,7 +163,7 @@ module VagrantPlugins
           if type == :forwarded_port
             # For forwarded ports, set the default ID to the
             # host port so that host ports overwrite each other.
-            default_id = options[:host]
+            default_id = options[:host].to_s + (options[:protocol] || "tcp").to_s
           end
 
           options[:id] = default_id || SecureRandom.uuid
@@ -383,7 +383,7 @@ module VagrantPlugins
 
         # Validate networks
         has_fp_port_error = false
-        fp_host_ports     = Set.new
+        fp_host_ports_and_protocol  = Set.new
         valid_network_types = [:forwarded_port, :private_network, :public_network]
 
         networks.each do |type, options|
@@ -399,12 +399,12 @@ module VagrantPlugins
             end
 
             if options[:host]
-              if fp_host_ports.include?(options[:host])
+              if fp_host_ports_and_protocol.include?(options[:host].to_s + (options[:protocol] || "tcp").to_s)
                 errors << I18n.t("vagrant.config.vm.network_fp_host_not_unique",
-                                :host => options[:host].to_s)
+                                :host => options[:host].to_s + (options[:protocol] || "tcp").to_s)
               end
 
-              fp_host_ports.add(options[:host])
+              fp_host_ports_and_protocol.add(options[:host].to_s + (options[:protocol] || "tcp").to_s)
             end
           end
 

--- a/plugins/providers/virtualbox/util/compile_forwarded_ports.rb
+++ b/plugins/providers/virtualbox/util/compile_forwarded_ports.rb
@@ -15,10 +15,11 @@ module VagrantPlugins
             if type == :forwarded_port
               guest_port = options[:guest]
               host_port  = options[:host]
+              protocol   = options[:protocol] || "tcp"
               options    = scoped_hash_override(options, :virtualbox)
               id         = options[:id]
 
-              mappings[host_port] =
+              mappings[host_port.to_s + protocol.to_s] =
                 Model::ForwardedPort.new(id, host_port, guest_port, options)
             end
           end


### PR DESCRIPTION
The (already closed) issue 1108 has reappeard in vagrant 1.2.7. With this fix, using the same host port for different protocol is possible again.
