### PR TITLE
fix broken regexp from 2a9d0c9

### DIFF
--- a/plugins/hosts/fedora/host.rb
+++ b/plugins/hosts/fedora/host.rb
@@ -36,7 +36,7 @@ module VagrantPlugins
         release_file = Pathname.new("/etc/redhat-release")
         begin
           release_file.open("r") do |f|
-            version_number = /[CentOS|Fedora].*release ([0-9]+)/.match(f.gets)[1].to_i
+            version_number = /(CentOS|Fedora).*release ([0-9]+)/.match(f.gets)[1].to_i
             if version_number >= 16
               # "service nfs-server" will redirect properly to systemctl
               # when "service nfs-server restart" is called.


### PR DESCRIPTION
2a9d0c9 is obviously flawed. `[]` is for character list defining one letter of (in any order): `C,e,n,t,O,S,|,F,d,o,r,a,`
