### PR TITLE
GH-2088: Use proper regex capture group to detect OS version of RHEL family

### DIFF
--- a/plugins/hosts/fedora/host.rb
+++ b/plugins/hosts/fedora/host.rb
@@ -36,7 +36,7 @@ module VagrantPlugins
         release_file = Pathname.new("/etc/redhat-release")
         begin
           release_file.open("r") do |f|
-            version_number = /(CentOS|Fedora).*release ([0-9]+)/.match(f.gets)[1].to_i
+            version_number = /(CentOS|Fedora).*release ([0-9]+)/.match(f.gets)[2].to_i
             if version_number >= 16
               # "service nfs-server" will redirect properly to systemctl
               # when "service nfs-server restart" is called.


### PR DESCRIPTION
This fixes issue https://github.com/mitchellh/vagrant/issues/2088.  See also https://github.com/mitchellh/vagrant/issues/2008 (200**8**, not 20**88**), which introduced the bug that this pull request fixes.
