### PR TITLE
GH-2087: Update host.rb to detect RHEL (in addition to CentOS and Fedora)

### DIFF
--- a/plugins/hosts/fedora/host.rb
+++ b/plugins/hosts/fedora/host.rb
@@ -15,6 +15,7 @@ module VagrantPlugins
             contents = f.gets
             return true if contents =~ /^Fedora/
             return true if contents =~ /^CentOS/
+            return true if contents =~ /^Red Hat Enterprise Linux Server/
           end
         end
 
@@ -36,7 +37,7 @@ module VagrantPlugins
         release_file = Pathname.new("/etc/redhat-release")
         begin
           release_file.open("r") do |f|
-            version_number = /(CentOS|Fedora).*release ([0-9]+)/.match(f.gets)[2].to_i
+            version_number = /(CentOS|Fedora|Red Hat Enterprise Linux Server).*release ([0-9]+)/.match(f.gets)[2].to_i
             if version_number >= 16
               # "service nfs-server" will redirect properly to systemctl
               # when "service nfs-server restart" is called.


### PR DESCRIPTION
This patch adds RHEL support to `plugins/hosts/fedora/host.rb`.

Note that this patch already includes the fix to issue https://github.com/mitchellh/vagrant/issues/2088 (Update host.rb to use proper capture group for OS version regex of RHEL family).

If needed I can also rebase this pull request on vagrant's master branch.  However the regex used in master is broken anyways as of now because of the incorrect regex capture group, so it doesn't seem to make a lot of sense not to fix issue https://github.com/mitchellh/vagrant/issues/2088 first.
