### PR TITLE
Remove dead code from Guest

### DIFF
--- a/lib/vagrant/plugin/v2/guest.rb
+++ b/lib/vagrant/plugin/v2/guest.rb
@@ -14,63 +14,8 @@ module Vagrant
         # is running within the machine.
         #
         # @return [Boolean]
-        def guest?(machine)
+        def detect?(machine)
           false
-        end
-
-        # Halt the machine. This method should gracefully shut down the
-        # operating system. This method will cause `vagrant halt` and associated
-        # commands to _block_, meaning that if the machine doesn't halt
-        # in a reasonable amount of time, this method should just return.
-        #
-        # If when this method returns, the machine's state isn't "powered_off,"
-        # Vagrant will proceed to forcefully shut the machine down.
-        def halt
-          raise BaseError, :_key => :unsupported_halt
-        end
-
-        # Mounts a shared folder.
-        #
-        # This method should create, mount, and properly set permissions
-        # on the shared folder. This method should also properly
-        # adhere to any configuration values such as `shared_folder_uid`
-        # on `config.vm`.
-        #
-        # @param [String] name The name of the shared folder.
-        # @param [String] guestpath The path on the machine which the user
-        #   wants the folder mounted.
-        # @param [Hash] options Additional options for the shared folder
-        #   which can be honored.
-        def mount_shared_folder(name, guestpath, options)
-          raise BaseError, :_key => :unsupported_shared_folder
-        end
-
-        # Mounts a shared folder via NFS. This assumes that the exports
-        # via the host are already done.
-        def mount_nfs(ip, folders)
-          raise BaseError, :_key => :unsupported_nfs
-        end
-
-        # Configures the given list of networks on the virtual machine.
-        #
-        # The networks parameter will be an array of hashes where the hashes
-        # represent the configuration of a network interface. The structure
-        # of the hash will be roughly the following:
-        #
-        # {
-        #   :type      => :static,
-        #   :ip        => "192.168.33.10",
-        #   :netmask   => "255.255.255.0",
-        #   :interface => 1
-        # }
-        #
-        def configure_networks(networks)
-          raise BaseError, :_key => :unsupported_configure_networks
-        end
-
-        # Called to change the hostname of the virtual machine.
-        def change_host_name(name)
-          raise BaseError, :_key => :unsupported_host_name
         end
       end
     end

--- a/plugins/guests/ubuntu/guest.rb
+++ b/plugins/guests/ubuntu/guest.rb
@@ -8,25 +8,6 @@ module VagrantPlugins
       def detect?(machine)
         machine.communicate.test("cat /etc/issue | grep 'Ubuntu'")
       end
-
-      def mount_shared_folder(name, guestpath, options)
-        # Mount it like normal
-        super
-
-        # Emit an upstart event if upstart is available
-        vm.communicate.sudo("[ -x /sbin/initctl ] && /sbin/initctl emit vagrant-mounted MOUNTPOINT=#{guestpath}")
-      end
-
-      def mount_nfs(ip, folders)
-        # Mount it like normal
-        super
-
-        # Emit an upstart events if upstart is available
-        folders.each do |name, opts|
-          real_guestpath = expanded_guest_path(opts[:guestpath])
-          vm.communicate.sudo("[ -x /sbin/initctl ] && /sbin/initctl emit vagrant-mounted MOUNTPOINT=#{real_guestpath}")
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
While thinking about host capabilities stuff and looking around the codebase I found those guys which I believe have all been converted to guest capabilities. Some "grep"ping showed me no references to them so unless there is a chance that they are possible in use by third party plugins I think it is safe to remove them by now ;)
