### PR TITLE
changed Vagrantfile template to use "site.pp"

### DIFF
--- a/templates/commands/init/Vagrantfile.erb
+++ b/templates/commands/init/Vagrantfile.erb
@@ -75,7 +75,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #
   # config.vm.provision :puppet do |puppet|
   #   puppet.manifests_path = "manifests"
-  #   puppet.manifest_file  = "init.pp"
+  #   puppet.manifest_file  = "site.pp"
   # end
 
   # Enable provisioning with chef solo, specifying a cookbooks path, roles


### PR DESCRIPTION
This seems to be the de facto standard and is used overall in the puppet documentation.
It is also explicitly mentioned in the [Puppet Best Practices Wiki](http://projects.puppetlabs.com/projects/1/wiki/Puppet_Best_Practice2#File-Hierarchy).
