### PR TITLE
Remove 'v' prefix on version number in vagrant -v

### DIFF
--- a/bin/vagrant
+++ b/bin/vagrant
@@ -62,7 +62,7 @@ end
 
 # Fast path the version of Vagrant
 if ARGV.include?("-v") || ARGV.include?("--version")
-  puts "Vagrant v#{Vagrant::VERSION}"
+  puts "Vagrant #{Vagrant::VERSION}"
   exit 0
 end
 


### PR DESCRIPTION
Commit 896ae7b9baebf8467ddf01eeff32d565e2a4e261 changed the output of vagrant -v which broke the kitchen-vagrant driver for test-kitchen. For simplicity's sake, it is a one-character commit to fix this in vagrant itself (which did not prefix version numbers with a "v" prior to this commit)… Also, reporting the version number alone makes it more faithful to the traditional Gem version number format… For use with Gem::Version.new() etc.

git reset --hard d9d9264747585ef1b390608323774edb595b8e3a
HEAD is now at d9d9264 Update CHANGELOG

bundle exec vagrant -v
You appear to be running Vagrant in a Bundler environment. Because
Vagrant should be run within installers (outside of Bundler), Vagrant
will assume that you're developing plugins and will change its behavior
in certain ways to better assist plugin development.

Vagrant version 1.3.0.dev

git reset --hard 896ae7b9baebf8467ddf01eeff32d565e2a4e261
HEAD is now at 896ae7b core: vagrant -v no longer loads Vagrantfile

(greg.poirier@oppie)(~/dev/vagrant)(version_number_fix)
bundle exec vagrant -v
Vagrant v1.3.0.dev
