### PR TITLE
Fix NFS /etc/exports option no_subtree_check on Linux hosts

### DIFF
--- a/plugins/hosts/linux/host.rb
+++ b/plugins/hosts/linux/host.rb
@@ -39,7 +39,7 @@ module VagrantPlugins
       def nfs_export(id, ips, folders)
         folders.each do |k, opts|
           if !opts[:linux__nfs_options]
-            opts[:linux__nfs_options] ||= ["rw", "no_subtree", "check", "all_squash"]
+            opts[:linux__nfs_options] ||= ["rw", "no_subtree_check", "all_squash"]
           end
 
           # Only automatically set anonuid/anongid if they weren't


### PR DESCRIPTION
The previous /etc/exports options used--"no_subtree" and "check"--do not exist on Linux hosts. The correct option is "no_subtree_check".

Fixes #2151
