### PR TITLE
[GH-1977] revert and alternate fix

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -1,6 +1,3 @@
-# Set the default encoding for Vagrant to UTF-8
-Encoding.default_internal = Encoding::UTF_8
-
 require 'log4r'
 
 # Enable logging if it is requested. We do this before

--- a/plugins/hosts/fedora/host.rb
+++ b/plugins/hosts/fedora/host.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
         release_file = Pathname.new("/etc/redhat-release")
 
         if release_file.exist?
-          release_file.open("r") do |f|
+          release_file.open("r:ISO-8859-1:UTF-8") do |f|
             contents = f.gets
             return true if contents =~ /^Fedora/
             return true if contents =~ /^CentOS/
@@ -36,7 +36,7 @@ module VagrantPlugins
         # proper NFS binary. This checks to see if we need to do that.
         release_file = Pathname.new("/etc/redhat-release")
         begin
-          release_file.open("r") do |f|
+          release_file.open("r:ISO-8859-1:UTF-8") do |f|
             version_number = /(CentOS|Fedora|Red Hat Enterprise Linux Server).*release ([0-9]+)/.match(f.gets)[2].to_i
             if version_number >= 16
               # "service nfs-server" will redirect properly to systemctl


### PR DESCRIPTION
@mitchellh, the internal encoding doesn't seem to work.  Therefore,
I reverted that previous change to vagrant.rb.

However, I found two alternate solutions.  Either transcoding,
`/etc/redhat-release` to ISO-8859-1 on open, or using something
like File.binread to transcode the file contents to raw.
