### PR TITLE
Put nfs opts setup in separate function 

### DIFF
--- a/plugins/hosts/arch/host.rb
+++ b/plugins/hosts/arch/host.rb
@@ -24,6 +24,7 @@ module VagrantPlugins
       end
 
       def nfs_export(id, ips, folders)
+        nfs_opts_setup(folders)
         output = TemplateRenderer.render('nfs/exports_linux',
                                          :uuid => id,
                                          :ips => ips,

--- a/plugins/hosts/linux/host.rb
+++ b/plugins/hosts/linux/host.rb
@@ -36,7 +36,7 @@ module VagrantPlugins
         end
       end
 
-      def nfs_export(id, ips, folders)
+      def nfs_opts_setup(folders)
         folders.each do |k, opts|
           if !opts[:linux__nfs_options]
             opts[:linux__nfs_options] ||= ["rw", "no_subtree_check", "all_squash"]
@@ -55,7 +55,10 @@ module VagrantPlugins
           opts[:linux__nfs_options] << "anongid=#{opts[:map_gid]}" if !hasgid
           opts[:linux__nfs_options] << "fsid=#{opts[:uuid]}"
         end
+      end
 
+      def nfs_export(id, ips, folders)
+        nfs_opts_setup(folders)
         output = TemplateRenderer.render('nfs/exports_linux',
                                          :uuid => id,
                                          :ips => ips,


### PR DESCRIPTION
Configured function to be called by both generic linux and arch nfs_options.  Fixes undefined method join exception in arch
