### PR TITLE
core: fix NoMethodError in Vagrant.has_plugin? [GH-1736]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+  - core: Fix NoMethodError in the new `Vagrant.has_plugin?` method [GH-1736]
   - hosts/arch: NFS exporting works properly, no exceptions. [GH-2161]
   - hosts/fedora: Fix host detection encoding issues. [GH-1977]
   - hosts/linux: Fix NFS export problems with `no_subtree_check`. [GH-2156]

--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -133,7 +133,7 @@ module Vagrant
   # be used from the Vagrantfile to easily branch based on plugin
   # availability.
   def self.has_plugin?(name)
-    plugin("2").registered.include?(name)
+    plugin("2").manager.registered.any? { |plugin| plugin.name == name }
   end
 
   # Returns a superclass to use when creating a plugin for Vagrant.

--- a/test/unit/vagrant_test.rb
+++ b/test/unit/vagrant_test.rb
@@ -53,4 +53,22 @@ describe Vagrant do
         to raise_error(Vagrant::Errors::PluginLoadFailed)
     end
   end
+
+  describe "has_plugin?" do
+    after(:each) do
+      described_class.plugin('2').manager.reset!
+    end
+
+    it "should return true if the plugin is installed" do
+      plugin = Class.new(described_class.plugin('2')) do
+        name "i_am_installed"
+      end
+
+      described_class.has_plugin?("i_am_installed").should be_true
+    end
+
+    it "should return false if the plugin is not installed" do
+      described_class.has_plugin?("i_dont_exist").should be_false
+    end
+  end
 end


### PR DESCRIPTION
This should fix the error raised new `Vagrant.has_plugin?` method

It's my first submission to this project; tried to do my best to follow all the conventions I saw. Happy to make any changes as necessary though.
