### PR TITLE
root user dependency for /etc/exports changes

### DIFF
--- a/plugins/hosts/bsd/host.rb
+++ b/plugins/hosts/bsd/host.rb
@@ -122,8 +122,6 @@ module VagrantPlugins
         output.split("\n").each do |line|
           line.gsub!('"', '\"')
           line.gsub!("'", "'\\\\''")
-          # system(%Q[sudo su root -c "echo '#{line}' >> /etc/exports"])
-          # Update to Bypass Security Check
           system(%Q[sudo -s -- "echo '#{line}' >> /etc/exports"])
         end
 


### PR DESCRIPTION
I ran into an issue where I had local administrator rights on my mac, but due to a security policy I couldn't login as root.

WORKSTATION:~ user$ sudo su root
Password:
WORKSTATION:~ user$  

Vagrant would assume the file was changed since there was no error thrown, but /etc/exports would remain the same.

Debug Output 

```
[default] Exporting NFS shared folders...
DEBUG bsd: Compiling map of sub-directories for NFS exports...
 INFO bsd: Exporting the following for NFS...
 INFO bsd: NFS DIR: ["/Users/user/Desktop/Project"]
 INFO bsd: NFS OPTS: {:create=>true, :nfs=>true, :mount_options=>["nolock", "actimeo=1"], :guestpath=>"/var/app/current", :hostpath=>"/Users/user/Desktop/Project", :map_uid=>1268977990, :map_gid=>42967409, :nfs_version=>3, :uuid=>"2250416753", :bsd__nfs_options=>["alldirs", "mapall=1268977990:42967409"], :bsd__compiled_nfs_options=>"-alldirs -mapall=1268977990:42967409"}
 INFO interface: info: Preparing to edit /etc/exports. Administrator privileges will be required...
Preparing to edit /etc/exports. Administrator privileges will be required...
 INFO interface: info: Mounting NFS shared folders...
[default] Mounting NFS shared folders...
DEBUG ssh: Checking whether SSH is ready...
DEBUG ssh: Re-using SSH connection.
 INFO ssh: SSH is ready!
 INFO guest: Execute capability: mount_nfs_folder (ubuntu)
DEBUG guest: Searching for cap: mount_nfs_folder
DEBUG guest: Checking in: ubuntu
DEBUG guest: Found cap: mount_nfs_folder in ubuntu
DEBUG ssh: Checking whether SSH is ready...
DEBUG ssh: Re-using SSH connection.
 INFO ssh: SSH is ready!
```

Let me know if this a generic solution that can work for everyone.

Thank you!
