### PR TITLE
clarification: don't -> shouldn't

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -658,7 +658,7 @@ en:
 #-------------------------------------------------------------------------------
     config:
       common:
-        bad_field: "The following settings don't exist: %{fields}"
+        bad_field: "The following settings shouldn't exist: %{fields}"
         error_empty: "`%{field}` must be not be empty."
       chef:
         cookbooks_path_empty: "Must specify a cookbooks path for chef solo."


### PR DESCRIPTION
Hey Mitchell,

i changed the wording for the "bad_field" error for clarification. The example (ssh) message "\* The following settings don't exist: max_tries, timeout" implies that "max_tries" and "timeout" are missing, but they should actually be removed.

Cheers,
tpltnt
