### PR TITLE
Call the rest of the middleware stack all the time

### DIFF
--- a/plugins/providers/virtualbox/action/destroy_unused_network_interfaces.rb
+++ b/plugins/providers/virtualbox/action/destroy_unused_network_interfaces.rb
@@ -13,8 +13,8 @@ module VagrantPlugins
           if env[:machine].provider_config.destroy_unused_network_interfaces
             @logger.info("Destroying unused network interfaces...")
             env[:machine].provider.driver.delete_unused_host_only_networks
-            @app.call(env)
           end
+          @app.call(env)
         end
       end
     end


### PR DESCRIPTION
The virtualbox provider isn't calling the rest of the middleware handlers unless destroy_unused_network_interfaces is on.
