### PR TITLE
add ansible.host_key_checking configuration parameter

### DIFF
--- a/plugins/provisioners/ansible/config.rb
+++ b/plugins/provisioners/ansible/config.rb
@@ -12,38 +12,41 @@ module VagrantPlugins
       attr_accessor :tags
       attr_accessor :skip_tags
       attr_accessor :start_at_task
+      attr_accessor :host_key_checking
 
       # Joker attribute, used to pass unsupported arguments to ansible anyway
       attr_accessor :raw_arguments
 
       def initialize
-        @playbook       = UNSET_VALUE
-        @extra_vars     = UNSET_VALUE
-        @inventory_path = UNSET_VALUE
-        @ask_sudo_pass  = UNSET_VALUE
-        @limit          = UNSET_VALUE
-        @sudo           = UNSET_VALUE
-        @sudo_user      = UNSET_VALUE
-        @verbose        = UNSET_VALUE
-        @tags           = UNSET_VALUE
-        @skip_tags      = UNSET_VALUE
-        @start_at_task  = UNSET_VALUE
-        @raw_arguments  = UNSET_VALUE
+        @playbook          = UNSET_VALUE
+        @extra_vars        = UNSET_VALUE
+        @inventory_path    = UNSET_VALUE
+        @ask_sudo_pass     = UNSET_VALUE
+        @limit             = UNSET_VALUE
+        @sudo              = UNSET_VALUE
+        @sudo_user         = UNSET_VALUE
+        @verbose           = UNSET_VALUE
+        @tags              = UNSET_VALUE
+        @skip_tags         = UNSET_VALUE
+        @start_at_task     = UNSET_VALUE
+        @raw_arguments     = UNSET_VALUE
+        @host_key_checking = "true"
       end
 
       def finalize!
-        @playbook       = nil if @playbook == UNSET_VALUE
-        @extra_vars     = nil if @extra_vars == UNSET_VALUE
-        @inventory_path = nil if @inventory_path == UNSET_VALUE
-        @ask_sudo_pass  = nil if @ask_sudo_pass == UNSET_VALUE
-        @limit          = nil if @limit == UNSET_VALUE
-        @sudo           = nil if @sudo == UNSET_VALUE
-        @sudo_user      = nil if @sudo_user == UNSET_VALUE
-        @verbose        = nil if @verbose == UNSET_VALUE
-        @tags           = nil if @tags == UNSET_VALUE
-        @skip_tags      = nil if @skip_tags == UNSET_VALUE
-        @start_at_task  = nil if @start_at_task == UNSET_VALUE
-        @raw_arguments  = nil if @raw_arguments == UNSET_VALUE
+        @playbook          = nil if @playbook == UNSET_VALUE
+        @extra_vars        = nil if @extra_vars == UNSET_VALUE
+        @inventory_path    = nil if @inventory_path == UNSET_VALUE
+        @ask_sudo_pass     = nil if @ask_sudo_pass == UNSET_VALUE
+        @limit             = nil if @limit == UNSET_VALUE
+        @sudo              = nil if @sudo == UNSET_VALUE
+        @sudo_user         = nil if @sudo_user == UNSET_VALUE
+        @verbose           = nil if @verbose == UNSET_VALUE
+        @tags              = nil if @tags == UNSET_VALUE
+        @skip_tags         = nil if @skip_tags == UNSET_VALUE
+        @start_at_task     = nil if @start_at_task == UNSET_VALUE
+        @raw_arguments     = nil if @raw_arguments == UNSET_VALUE
+        @host_key_checking = nil if @host_key_checking == UNSET_VALUE
       end
 
       def validate(machine)

--- a/plugins/provisioners/ansible/provisioner.rb
+++ b/plugins/provisioners/ansible/provisioner.rb
@@ -38,7 +38,7 @@ module VagrantPlugins
 
         # Write stdout and stderr data, since it's the regular Ansible output
         command << {
-          :env => { "ANSIBLE_FORCE_COLOR" => "true" },
+          :env => { "ANSIBLE_FORCE_COLOR" => "true" , "ANSIBLE_HOST_KEY_CHECKING" => "#{config.host_key_checking}" },
           :notify => [:stdout, :stderr],
           :workdir => @machine.env.root_path.to_s
         }

--- a/website/docs/source/v2/provisioning/ansible.html.md
+++ b/website/docs/source/v2/provisioning/ansible.html.md
@@ -141,3 +141,4 @@ by the sudo command.
 * `ansible.raw_arguments` is an *unsafe wildcard* string that can be used to take advantage of `ansible-playbook` arguments that are not (yet) supported by this Vagrant provisioner plugin. This can be very useful when integrating with bleeding edge Ansible versions. Following precedence rules apply:
   * Any supported options (described above) will override conflicting `raw_arguments` value (e.g. `--tags` or `--start-at-task`)
   * Vagrant default user authentication can be overridden via `raw_arguments` (with custom values for `--user` and `--private-key`)
+* `ansible.host_key_checking` can be set to `false` which will disable host key checking and prevent `"FAILED: (25, 'Inappropriate ioctl for device')"` errors from being reported during provisioner runs.  The default value is `true`, which matches the default behavior of Ansible 1.2.1 and later.


### PR DESCRIPTION
Ansible 1.2.1 enables SSH host key checking by default, which results in the following errors when it is used as a provisioner with official boxes:

```
[default] Running provisioner: ansible...

PLAY [graphite.local] ********************************************************* 

GATHERING FACTS *************************************************************** 
fatal: [192.168.100.10] => {'msg': "FAILED: (25, 'Inappropriate ioctl for device')", 'failed': True}

TASK: [apt update_cache=yes cache_valid_time=86400] *************************** 
FATAL: no hosts matched or all hosts have already failed -- aborting


PLAY RECAP ******************************************************************** 
           to retry, use: --limit @/var/tmp/ansible/playbook.retry

192.168.100.10             : ok=0    changed=0    unreachable=1    failed=0   

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```

While this improves the default security stance of Ansible, it disrupts the flow of Vagrant runs.  The host key checking behavior of Ansible can be over-ridden by setting the following environment variable:

```
export ANSIBLE_HOST_KEY_CHECKING=false
```

This patch adds a new configuration parameter `ansible.host_key_checking` to the Ansible provisioner that controls the value of this environment variable.  It defaults to true, to match the default configuration and security stance of Ansible, but it can be set to false to allow smooth Vagrant runs with official boxes.
