### PR TITLE
need_configure should return true when master_config is defined as well.

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -59,7 +59,7 @@ module VagrantPlugins
       end
 
       def need_configure
-        @config.minion_config or @config.minion_key
+        @config.minion_config or @config.minion_key or @config.master_config or @config.master_key
       end
 
       def need_install


### PR DESCRIPTION
This fixes #2204 and fixes saltstack/salty-vagrant#100
