### PR TITLE
Clean up 'sentinel' files during destroy ...

### DIFF
--- a/lib/vagrant/action/builtin/provisioner_cleanup.rb
+++ b/lib/vagrant/action/builtin/provisioner_cleanup.rb
@@ -28,6 +28,18 @@ module Vagrant
 
           # Continue, we need the VM to be booted.
           @app.call(env)
+
+          # Clean up sentinel files
+          [ "action_provision",
+            "action_set_name",
+          ].each do |filename|
+            @logger.info("Looking for provisioner sentinel #{filename}")
+            sentinel = env[:machine].data_dir.join(filename)
+            if sentinel.file?
+              @logger.info("Sentinel found! Removing...")
+              sentinel.delete
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
... so that provisioners are run normally during the next 'up'.

These files are used to skip running provisioners and changing the
hostname on second and subsequent vagrant up's to make halt/up and
suspend/up cycles faster.  As these files are not cleaned up during a
destroy, the provisioners were being skipped during destroy/up cycles as
well.

See #2223 and https://github.com/mitchellh/vagrant/issues/1776#issuecomment-24642298

(I'm aware this is a bit hackish; I can look at having Vagrant::Action::Builtin::Provision and VagrantPlugins::ProviderVirtualBox::Action::SetName push 
their sentinel file names into env and collect them here if that's more agreeable).
