### PR TITLE
fix vagrant mount command

### DIFF
--- a/plugins/guests/linux/cap/mount_virtualbox_shared_folder.rb
+++ b/plugins/guests/linux/cap/mount_virtualbox_shared_folder.rb
@@ -29,7 +29,7 @@ module VagrantPlugins
 
             mount_commands.each do |command|
               machine.communicate.sudo(command) do |type, data|
-                success = false if type == :stderr && data =~ /No such device/i
+                success = (type == :stderr && data =~ /No such device/i)
               end
 
               break if success


### PR DESCRIPTION
Correct the PR #2197. See my comment. Problem is that the `success`variable is set to false and not set back to true when the second command run correctly.
