### PR TITLE
Dont replace Windows newlines to Unix if shell is set as binary

### DIFF
--- a/plugins/provisioners/shell/config.rb
+++ b/plugins/provisioners/shell/config.rb
@@ -8,6 +8,7 @@ module VagrantPlugins
       attr_accessor :upload_path
       attr_accessor :args
       attr_accessor :privileged
+      attr_accessor :binary
 
       def initialize
         @args        = UNSET_VALUE
@@ -15,6 +16,7 @@ module VagrantPlugins
         @path        = UNSET_VALUE
         @upload_path = UNSET_VALUE
         @privileged  = UNSET_VALUE
+        @binary      = UNSET_VALUE
       end
 
       def finalize!
@@ -23,6 +25,7 @@ module VagrantPlugins
         @path        = nil if @path == UNSET_VALUE
         @upload_path = "/tmp/vagrant-shell" if @upload_path == UNSET_VALUE
         @privileged  = true if @privileged == UNSET_VALUE
+        @binary      = false if @binary == UNSET_VALUE
       end
 
       def validate(machine)

--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -71,8 +71,8 @@ module VagrantPlugins
           script = config.inline
         end
 
-        # Replace Windows line endings with Unix ones
-        script.gsub!(/\r\n?$/, "\n")
+        # Replace Windows line endings with Unix ones unless binary file
+        script.gsub!(/\r\n?$/, "\n") unless config.binary
 
         # Otherwise we have an inline script, we need to Tempfile it,
         # and handle it specially...


### PR DESCRIPTION
Implemented option (as suggested from #2045) to skip the CRLF to LF replacement in shell provisioner.

config.vm.provision "shell", path: "makeself.run", binary: true
