### PR TITLE
Update CFEngine provisioners plugin for SuSE install compatibility

### DIFF
--- a/plugins/provisioners/cfengine/cap/suse/cfengine_install.rb
+++ b/plugins/provisioners/cfengine/cap/suse/cfengine_install.rb
@@ -1,0 +1,17 @@
+module VagrantPlugins
+  module CFEngine
+    module Cap
+      module SuSE
+        module CFEngineInstall
+          def self.cfengine_install(machine, config)
+            machine.communicate.tap do |comm|
+              comm.sudo("GPGFILE=$(mktemp) && wget -O $GPGFILE #{config.repo_gpg_key_url} && rpm --import $GPGFILE; rm -f $GPGFILE")
+              comm.sudo("zypper addrepo -t YUM #{config.yum_repo_url} cfengine-repository")
+              comm.sudo("zypper se #{config.package_name} && zypper -n install #{config.package_name}")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/provisioners/cfengine/plugin.rb
+++ b/plugins/provisioners/cfengine/plugin.rb
@@ -33,6 +33,11 @@ module VagrantPlugins
         Cap::RedHat::CFEngineInstall
       end
 
+      guest_capability("suse", "cfengine_install") do
+        require_relative "cap/suse/cfengine_install"
+        Cap::SuSE::CFEngineInstall
+      end
+
       provisioner(:cfengine) do
         require_relative "provisioner"
         Provisioner


### PR DESCRIPTION
Update to the CFEngine provisioners plugin in order to add SuSE install compatibility.
