### PR TITLE
Resolving #2194 (Ansible buffering output if run as subprocess)

### DIFF
--- a/plugins/provisioners/ansible/provisioner.rb
+++ b/plugins/provisioners/ansible/provisioner.rb
@@ -41,7 +41,10 @@ module VagrantPlugins
         command << {
           :env => {
             "ANSIBLE_FORCE_COLOR" => "true",
-            "ANSIBLE_HOST_KEY_CHECKING" => "#{config.host_key_checking}"
+            "ANSIBLE_HOST_KEY_CHECKING" => "#{config.host_key_checking}",
+            # Ensure Ansible output isn't buffered so that we receive ouput
+            # on a task-by-task basis.
+            "PYTHONUNBUFFERED" => 1
           },
           :notify => [:stdout, :stderr],
           :workdir => @machine.env.root_path.to_s


### PR DESCRIPTION
Adding `PYTHONUNBUFFERED` environment variable to Ansible provisioner's execution environment. This ensures that we receive output on a task-by-task basis rather than at the end of provisioning (or sometimes at seemingly random intervals during provisioning).

This solution was discovered from the [Ansible Google group](https://groups.google.com/forum/#!topic/ansible-project/aXutTmXAbR0).

I think this should be the default behaviour as this allows us to easily identify bottlenecks in Ansible provisioning and allows us to know how far through provisioning Ansible is.
