### PR TITLE
Update LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-The MIT License
+The Expat License (MIT License)
 
 Copyright (c) 2010-2013 Mitchell Hashimoto
 


### PR DESCRIPTION
Fix ambiguous naming of license.

There are many licenses called "The MIT License", but only one called "The Expat License", and what you have here is the latter.

See http://www.gnu.org/licenses/license-list.html#Expat

Incidentally, please consider using a copyleft license.
