### PR TITLE
Fix salt provision permissions error

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -193,6 +193,7 @@ module VagrantPlugins
 
           bootstrap_path = get_bootstrap
           bootstrap_destination = File.join(config_dir, "bootstrap_salt.sh")
+          @machine.communicate.sudo("rm -f %s" % bootstrap_destination)
           @machine.communicate.upload(bootstrap_path.to_s, bootstrap_destination)
           @machine.communicate.sudo("chmod +x %s" % bootstrap_destination)
           bootstrap = @machine.communicate.sudo("%s %s" % [bootstrap_destination, options]) do |type, data|


### PR DESCRIPTION
`vagrant provision` fails if a temp file left by initial `vagrant up` is not removed, for example:

```
$ time vagrant provision
[default] Rsyncing folder: /home/ianh/Projects/Artabase/website/tmp/salt/ => /srv/salt...
[default] Rsyncing folder: /home/ianh/Projects/Artabase/website/tmp/pillar/ => /srv/pillar...
[default] Running provisioner: salt...
Copying salt minion config to vm.
Checking if salt-minion is installed
salt-minion found
Checking if salt-call is installed
salt-call found
Using Bootstrap Options:  -c /tmp -C
Salt binaries found. Configuring only.
Failed to upload a file to the guest VM via SCP due to a permissions
error. This is normally because the user running Vagrant doesn't have
read permission on the file. Please set proper permissions on the file:

/opt/vagrant/embedded/gems/gems/vagrant-1.3.1/plugins/provisioners/salt/bootstrap-salt.sh

real    0m36.001s
user    0m1.188s
sys 0m0.088s
```

This fix removes the old /tmp/bootstrap_salt.sh before the normal upload of a fresh copy occurs. It is interesting that `vagrant up` leaves it owned by root, but `vagrant provision` leaves it owned by vagrant.
