### PR TITLE
Default Ansible provisioner verbosity should not be `--verbose`

### DIFF
--- a/plugins/provisioners/ansible/provisioner.rb
+++ b/plugins/provisioners/ansible/provisioner.rb
@@ -27,7 +27,7 @@ module VagrantPlugins
         options << "--inventory-file=#{self.setup_inventory_file}"
         options << "--sudo" if config.sudo
         options << "--sudo-user=#{config.sudo_user}" if config.sudo_user
-        options << "#{self.get_verbosity_argument}"
+        options << "#{self.get_verbosity_argument}" if config.verbose
         options << "--ask-sudo-pass" if config.ask_sudo_pass
         options << "--tags=#{as_list_argument(config.tags)}" if config.tags
         options << "--skip-tags=#{as_list_argument(config.skip_tags)}" if config.skip_tags


### PR DESCRIPTION
I think the default verbosity of the Ansible provisioner should no longer default to `--verbose`. I personally feel it makes more sense to use default verbosity of Ansible and only increase if specified in the `Vagrantfile`.

This is effectively reverting https://github.com/mitchellh/vagrant/commit/ee9fc00a046f62efa5b9a63c061383644e55aaed. This change was made as part of efforts to resolve https://github.com/mitchellh/vagrant/issues/2194.
