### PR TITLE
Default verbosity level should be --verbose if no special value specified

### DIFF
--- a/plugins/provisioners/ansible/provisioner.rb
+++ b/plugins/provisioners/ansible/provisioner.rb
@@ -90,8 +90,9 @@ module VagrantPlugins
         elsif config.verbose.to_s == 'extra'
           return '-vvv'
         else
-          # fall back to default verbosity (which is no verbosity)
-          return ''
+          # Use default verbose verbosity if no extra-verbose value has been specified
+          # for config.verbose.
+          return '--verbose'
         end
       end
 


### PR DESCRIPTION
This forms the other half of the fix for https://github.com/mitchellh/vagrant/pull/2308.

The default verbosity level should be `--verbose` if no 'special' verbosity has been specified in `config.verbose`.
