### PR TITLE
set HTML charset to UTF-8

### DIFF
--- a/website/docs/source/layouts/layout.erb
+++ b/website/docs/source/layouts/layout.erb
@@ -1,6 +1,8 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<meta charset="utf-8">
+
 		<title><%= current_page.data.page_title ? " #{current_page.data.page_title} - " : "" %>Vagrant Documentation</title>
 
 		<!-- meta -->


### PR DESCRIPTION
Fixes rendering issues with the `tree` output used as an example on some pages, which otherwise displayed Â characters in some places when encoding wasn't detected properly by the browser.

Fixes #2352.
