### PR TITLE
Disallow dot and hyphen as first character of hostnames

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -353,7 +353,7 @@ module VagrantPlugins
         errors << I18n.t("vagrant.config.vm.box_not_found", :name => box) if \
           box && !box_url && !machine.box
         errors << I18n.t("vagrant.config.vm.hostname_invalid_characters") if \
-          @hostname && @hostname !~ /^[-.a-z0-9]+$/i
+          @hostname && @hostname !~ /^[a-z0-9][-.a-z0-9]+$/i
 
         has_nfs = false
         used_guest_paths = Set.new

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -691,7 +691,7 @@ en:
         box_not_found: "The box '%{name}' could not be found."
         hostname_invalid_characters: |-
           The hostname set for the VM should only contain letters, numbers,
-          and hyphens.
+          hyphens or dots. It cannot start with a hyphen or dot.
         network_invalid: |-
           The network type '%{type}' is not valid. Please use
           'hostonly' or 'bridged'.


### PR DESCRIPTION
- Causes hostname to be set to an invalid value on some systems which
  also causes malfunction of hostname -f so it cannot be changed

So I spent many hours yesterday trying to debug what I assumed was a folder related to synced folders. After having a good night's sleep (6h is what we all get right?) I realized I had actually messed up the hostname.

Initially I misremembered the key name for ENV so I set it to something like `config.vm.hostname = "#{ENV['username']}-starter"` which probably caused some command to fail with a lovely "No Error" in pagefuls of Vagrant log output. Some sort of sedding of /etc/hosts and /etc/hostname had already taken place though. This meant that even after I noticed my hostname was dodgy I couldn't change it through the config because hostname -f would fail. I guess the the function that changes the hostname could be made more robust by assuming that hostname -f can fail or something but I concluded that the biggest culprit here was that you can set a hostname that starts with a dash. I was also skeptical about having a hostname that starts with a dot so I added that as a bonus.
