### PR TITLE
Fix seed_master key file name

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -93,7 +93,7 @@ module VagrantPlugins
           @machine.communicate.sudo("mkdir -p -m777 #{seed_dir}")
           @config.seed_master.each do |name, keyfile|
             sourcepath = expanded_path(keyfile).to_s
-            dest = "#{seed_dir}/seed-#{name}.pub"
+            dest = "#{seed_dir}/#{name}"
             @machine.communicate.upload(sourcepath, dest)
           end
           options = "#{options} -k #{seed_dir}"


### PR DESCRIPTION
As per https://github.com/saltstack/salty-vagrant/pull/98 and https://github.com/saltstack/salty-vagrant/issues/97 the expected file name for minion is 'minion', not 'seed-minion.pub'
