### PR TITLE
docs/plugins: Correct a broken link in the development basics section

### DIFF
--- a/website/docs/source/v2/plugins/development-basics.html.md
+++ b/website/docs/source/v2/plugins/development-basics.html.md
@@ -24,7 +24,7 @@ upgrades and use a stable API.
 
 Plugins are written using [Ruby](http://www.ruby-lang.org/en/) and are packaged
 using [RubyGems](http://rubygems.org/). Familiarity with Ruby is required,
-but the [packaging and distribution](#) section should help
+but the [packaging and distribution](/v2/plugins/packaging.html) section should help
 guide you to packaging your plugin into a RubyGem.
 
 ## Plugin Definition


### PR DESCRIPTION
I'm assuming the link is supposed to point to the packaging
and distribution section. With this patch, it does!
