### PR TITLE
Move exception raising back into retryable block in VirtualBox driver command execution

### DIFF
--- a/plugins/providers/virtualbox/driver/base.rb
+++ b/plugins/providers/virtualbox/driver/base.rb
@@ -284,10 +284,10 @@ module VagrantPlugins
           # Variable to store our execution result
           r = nil
 
-          # If there is an error with VBoxManage, this gets set to true
-          errored = false
-
           retryable(:on => Vagrant::Errors::VBoxManageError, :tries => tries, :sleep => 1) do
+            # If there is an error with VBoxManage, this gets set to true
+            errored = false
+            
             # Execute the command
             r = raw(*command, &block)
 
@@ -322,14 +322,14 @@ module VagrantPlugins
                 errored = true
               end
             end
-          end
-
-          # If there was an error running VBoxManage, show the error and the
-          # output.
-          if errored
-            raise Vagrant::Errors::VBoxManageError,
-              :command => command.inspect,
-              :stderr  => r.stderr
+            
+            # If there was an error running VBoxManage, show the error and the
+            # output.
+            if errored
+              raise Vagrant::Errors::VBoxManageError,
+                :command => command.inspect,
+                :stderr  => r.stderr
+            end
           end
 
           # Return the output, making sure to replace any Windows-style


### PR DESCRIPTION
For some reason the actual raising of the exception was moved outside of the retryable block by @mitchellh in commit bc2a9fe780e44fcf3fb989178b0582a8f2514895 which broke the ability to retry VirtualBox commands if they fail and are marked as retryable.

I discovered this issue when looking at issue #1622 and discovered that this solution for that issue, retrying the command, was not functioning.
