### PR TITLE
docs/plugins: Remove sentence about commands in packaging section

### DIFF
--- a/website/docs/source/v2/plugins/packaging.html.md
+++ b/website/docs/source/v2/plugins/packaging.html.md
@@ -5,7 +5,6 @@ sidebar_current: "plugins-packaging"
 
 # Plugin Development: Packaging & Distribution
 
-This page documents how to add new commands to Vagrant, invokable.
 This page documents how to organize the file structure of your plugin
 and distribute it so that it is installable using
 [standard installation methods](/v2/plugins/usage.html).


### PR DESCRIPTION
Seems like the result of an unfortunate copy&paste from the commands
section.
