### PR TITLE
fix nfs mount fail with FreeBSD9.1 (synced_folder).

### DIFF
--- a/plugins/guests/freebsd/cap/mount_nfs_folder.rb
+++ b/plugins/guests/freebsd/cap/mount_nfs_folder.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
         def self.mount_nfs_folder(machine, ip, folders)
           folders.each do |name, opts|
             machine.communicate.sudo("mkdir -p #{opts[:guestpath]}")
-            machine.communicate.sudo("mount '#{ip}:#{opts[:hostpath]}' '#{opts[:guestpath]}'")
+            machine.communicate.sudo("mount -t nfs '#{ip}:#{opts[:hostpath]}' '#{opts[:guestpath]}'")
           end
         end
       end


### PR DESCRIPTION
following error occurs in mount of nfs.

```
[default] Mounting NFS shared folders...
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

mount '10.0.0.1:/Users/foo/bar' '/vagrant'

Stdout from the command:



Stderr from the command:

mount: 10.0.0.1:/Users/foo/bar: No such file or directory
```
