### PR TITLE
Sleep to avoid 100% CPU in waiting time of 'vagrant up'

### DIFF
--- a/lib/vagrant/action/builtin/wait_for_communicator.rb
+++ b/lib/vagrant/action/builtin/wait_for_communicator.rb
@@ -52,6 +52,7 @@ module Vagrant
           # Wait for a result or an interrupt
           env[:ui].info I18n.t("vagrant.boot_waiting")
           while ready_thr.alive? && states_thr.alive?
+            sleep 1
             return if env[:interrupted]
           end
 


### PR DESCRIPTION
When vagrant up is waiting for the vbox to start up, the ruby process constantly consumes 100% CPU.
Add a sleep to save some energy.
