### PR TITLE
document '_detected_errors' pattern in plugin configuration guide.

### DIFF
--- a/website/docs/source/v2/plugins/configuration.html.md
+++ b/website/docs/source/v2/plugins/configuration.html.md
@@ -148,11 +148,12 @@ class Config < Vagrant.plugin("2", :config)
   # ...
 
   def validate(machine)
+    errors = _detected_errors
     if @widgets <= 5
-      return { "foo" => ["widgets must be greater than 5"] }
+      errors << "widgets must be greater than 5"
     end
 
-    {}
+    { "foo" => errors }
   end
 end
 ```
@@ -161,6 +162,8 @@ The validation method is given a `machine` object, since validation is
 done for each machine that Vagrant is managing. This allows you to
 conditionally validate some keys based on the state of the machine and so on.
 
+The `_detected_errors` method returns any errors already detected by Vagrant, like unknown configuration keys.
+
 The return value is a Ruby Hash object, where the key is a section name,
 and the value is a list of error messages. These will be displayed by
-Vagrant. If there are no errors, an empty hash must be returned.
+Vagrant. The hash must not contain any values if there are no errors.


### PR DESCRIPTION
It took me a little while to figure out how to validate the keys for https://github.com/mitchellh/vagrant-rackspace/pull/43.  It turned out there is a commonly used pattern that solves this, but it isn't mentioned in the validation guide.

This PR documents the pattern in the guide, and also clarifies that the returned hash may have section keys with no values (this is the behavior of many core plugins).
