### PR TITLE
Automatically enable symlinks on vboxsf for VirtualBox 4.1

### DIFF
--- a/plugins/providers/virtualbox/driver/version_4_1.rb
+++ b/plugins/providers/virtualbox/driver/version_4_1.rb
@@ -427,7 +427,12 @@ module VagrantPlugins
               "--hostpath",
               folder[:hostpath]]
             args << "--transient" if folder.has_key?(:transient) && folder[:transient]
+
+            # Add the shared folder
             execute("sharedfolder", "add", @uuid, *args)
+
+            # Enable symlinks on the shared folder
+            execute("setextradata", @uuid, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/#{folder[:name]}", "1")
           end
         end
 


### PR DESCRIPTION
See #713 and 387692f9c8fa4031050646e2773b3d2d9b2c994e

Note, VirtualBox 4.1 is still used for example in Ubuntu 12.04 LTS.
