### PR TITLE
compatibility with rubygems 2.x

### DIFF
--- a/plugins/commands/plugin/action/install_gem.rb
+++ b/plugins/commands/plugin/action/install_gem.rb
@@ -1,6 +1,10 @@
 require "rubygems"
 require "rubygems/dependency_installer"
-require "rubygems/format"
+begin
+  require "rubygems/format"
+rescue LoadError
+  # rubygems 2.x
+end
 
 require "log4r"
 
@@ -26,8 +30,13 @@ module VagrantPlugins
           if plugin_name =~ /\.gem$/
             # If we're installing from a gem file, determine the name
             # based on the spec in the file.
-            pkg = Gem::Format.from_file_by_path(plugin_name)
+            pkg = if defined?(Gem::Format)
+              Gem::Format.from_file_by_path(plugin_name)
+            else
+              Gem::Package.new(plugin_name)
+            end
             find_plugin_name = pkg.spec.name
+            version = pkg.spec.version
           end
 
           # Install the gem

--- a/plugins/commands/plugin/action/prune_gems.rb
+++ b/plugins/commands/plugin/action/prune_gems.rb
@@ -126,6 +126,10 @@ module VagrantPlugins
 
           if prune_specs.length > 0
             env[:gem_helper].with_environment do
+
+              # due to a bug in rubygems 2.0, we need to load the specifications before removing any
+              Gem::Specification.to_a
+
               prune_specs.each do |prune_spec|
                 uninstaller = Gem::Uninstaller.new(prune_spec.name, {
                   :all         => true,


### PR DESCRIPTION
This patch makes the vagrant plugin system compatible with Rubygems 2.x. Even though the Vagrant bundles Rubygems, this makes integration in some platforms that don't have "official" packages (like Gentoo) easier. It should also help for when you decide to upgrade the bundled Rubygems version.

I will try to get that Rubygems bug patched upstream.
