### PR TITLE
Store the final `provision_enabled` value to env

### DIFF
--- a/lib/vagrant/action/builtin/provision.rb
+++ b/lib/vagrant/action/builtin/provision.rb
@@ -42,8 +42,13 @@ module Vagrant
             end
           end
 
-          # If we explicitly specified, take that value.
-          enabled = env[:provision_enabled] if env.has_key?(:provision_enabled)
+          if env.has_key?(:provision_enabled)
+            # If we explicitly specified, take that value.
+            enabled = env[:provision_enabled]
+          else
+            # Otherwise store the value so that other actions can use it.
+            env[:provision_enabled] = enabled
+          end
 
           # Ask the provisioners to modify the configuration if needed
           provisioner_instances.each do |p|


### PR DESCRIPTION
Since 1.3.0 Vagrant uses a sentinel file to decide if it should run the provisioners or not (unless the user explicitly passes `--[no-]provision`). Store that knowledge back to the env to let other middleware actions to use it.

Now for example  vagrant-berkshelf does the cookbook dependency resolving and installing on every `vagrant up/reload` unless `--no-provision` is specified ([code](https://github.com/RiotGames/vagrant-berkshelf/blob/v1.3.4/lib/berkshelf/vagrant/env_helpers.rb#L60)).
