### PR TITLE
Add shortcut for setting the memory size for VirtualBox VM

### DIFF
--- a/plugins/providers/virtualbox/config.rb
+++ b/plugins/providers/virtualbox/config.rb
@@ -76,6 +76,14 @@ module VagrantPlugins
         @network_adapters[slot] = [type, args]
       end
 
+      # Shortcut for setting memory size for the virtual machine.
+      # Calls #customize internally.
+      #
+      # @param size [Integer, String] the memory size in MB
+      def memory=(size)
+        customize "pre-boot", ["modifyvm", :id, "--memory", size]
+      end
+
       # This is the hook that is called to finalize the object before it
       # is put into use.
       def finalize!

--- a/website/docs/source/v2/virtualbox/configuration.html.md
+++ b/website/docs/source/v2/virtualbox/configuration.html.md
@@ -61,3 +61,12 @@ more than 50% would be used on your own host machine. Some details:
 
 * Multiple `customize` directives can be used. They will be executed in the
   order given.
+
+There is also a shortcut for specifying the memory size (MB) for the virtual
+machine:
+
+```ruby
+config.vm.provider "virtualbox" do |v|
+  v.memory = 1024
+end
+```


### PR DESCRIPTION
Maybe I'm not the only one who is too lazy to always google for the correct syntax for setting the memory size of a VM. So here is a shortcut for it:

``` ruby
config.vm.provider :virtualbox do |vbox|
  vbox.memory = 1024
end
```

I would love to see the same implemented for VMware providers. ;)
