### PR TITLE
Machine ID should always be a string

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -220,7 +220,7 @@ module Vagrant
       end
 
       # Store the ID locally
-      @id = value
+      @id = value.to_s
 
       # Notify the provider that the ID changed in case it needs to do
       # any accounting from it.


### PR DESCRIPTION
In a provider implementation, while creating a new machine, the ID coming from provider logic could be of any type (in many cases is a `Fixnum`). Without a proper cast this could cause weird failures on subsequent actions.
