### PR TITLE
Plugins loaded hook

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -272,6 +272,7 @@ module Vagrant
     # against the given name will be run in the context of this environment.
     #
     # @param [Symbol] name Name of the hook.
+    # @param [Action::Runner] action_runner A custom action runner for running hooks.
     def hook(name, runner = action_runner)
       @logger.info("Running hook: #{name}")
       callable = Action::Builder.new

--- a/test/unit/vagrant/environment_test.rb
+++ b/test/unit/vagrant/environment_test.rb
@@ -308,6 +308,14 @@ describe Vagrant::Environment do
 
       instance.hook(:bar).should == :foo
     end
+
+    it "should allow passing in a custom action runner" do
+      instance.action_runner.should_not_receive(:run)
+      other_runner = mock
+      other_runner.should_receive(:run).with(:bar).and_return(:foo)
+
+      instance.hook(:bar, other_runner).should == :foo
+    end
   end
 
   describe "primary machine name" do


### PR DESCRIPTION
As I just wrote on the [mailing list](https://groups.google.com/d/msg/vagrant-up/-1DQRhzihZo/5ssgqmVqZFsJ) about a potential "vagrant-dotenv" plugin and based on [what we had to do on Bindler](https://github.com/fgrehm/bindler/blob/master/lib/bindler/bend_vagrant.rb#L7-L16) I propose that we add a new hook to `Environment` that gets triggered after loading plugins but prior to loading `Vagrantfile`s.

This will allow plugin developers to do all sorts of "magic" before configurations from Vagrantfiles are parsed. The current [`:environment_load`](https://github.com/mitchellh/vagrant/blob/master/lib/vagrant/environment.rb#L135) hook [ends](https://github.com/mitchellh/vagrant/blob/master/lib/vagrant/environment.rb#L271) up [parsing](https://github.com/mitchellh/vagrant/blob/master/lib/vagrant/environment.rb#L513) the Vagrantfiles and we can't use that.

I hope that's enough information for this to get merged but I'd be fine to provide use cases if needed :D
