### PR TITLE
Add `--debug` option as a shortcut for `VAGRANT_LOG=debug`

### DIFF
--- a/bin/vagrant
+++ b/bin/vagrant
@@ -5,6 +5,13 @@
 # initializing which have historically resulted in stack traces.
 Signal.trap("INT") { exit 1 }
 
+# Set logging level to `debug`. This is done before loading 'vagrant', as it
+# sets up the logging system.
+if ARGV.include?("--debug")
+  ARGV.delete("--debug")
+  ENV["VAGRANT_LOG"] = "debug"
+end
+
 require 'log4r'
 require 'vagrant'
 require 'vagrant/cli'

--- a/website/docs/source/v2/debugging.html.md
+++ b/website/docs/source/v2/debugging.html.md
@@ -37,6 +37,14 @@ $ vagrant up
 ...
 ```
 
+You can also get the debug level output using the `--debug` command line
+option. For example:
+
+```
+$ vagrant up --debug
+...
+```
+
 If you plan on submitting a bug report, please submit debug-level logs
 along with the report using [gist](https://gist.github.com/) or
 some other paste service.


### PR DESCRIPTION
When asking or submitting debug information, a command line switch is easier and faster than using an environment variable.
