### PR TITLE
Update host.rb

### DIFF
--- a/plugins/hosts/bsd/host.rb
+++ b/plugins/hosts/bsd/host.rb
@@ -83,7 +83,7 @@ module VagrantPlugins
 
           hasmapall = false
           opts[:bsd__nfs_options].each do |opt|
-            if opt =~ /^mapall=/
+            if opt =~ /^mapall=/ || opt =~ /^maproot=/
               hasmapall = true
               break
             end


### PR DESCRIPTION
mapall= and maproot= are mutually exclusive options. Currently, when trying to use maproot=, mapall= is getting automatically added, which prevents us from using the NFS mount. This change turns off the adding of mapall= if maproot= has been specified as an option.
