### PR TITLE
Move ProvisionerCleanup on the return path

### DIFF
--- a/lib/vagrant/action/builtin/provisioner_cleanup.rb
+++ b/lib/vagrant/action/builtin/provisioner_cleanup.rb
@@ -16,7 +16,7 @@ module Vagrant
         end
 
         def call(env)
-          @env = env
+          @app.call(env)
 
           # Ask the provisioners to modify the configuration if needed
           provisioner_instances.each do |p|
@@ -25,9 +25,6 @@ module Vagrant
               name: provisioner_type_map[p].to_s))
             p.cleanup
           end
-
-          # Continue, we need the VM to be booted.
-          @app.call(env)
         end
       end
     end


### PR DESCRIPTION
In my opinion it makes more sense to have the provisioner cleanup action on the return path.

I see this action as something that should run at the very last step of the destroy stack.
