### PR TITLE
Safer default VM names for Virtualbox

### DIFF
--- a/plugins/providers/virtualbox/action/set_name.rb
+++ b/plugins/providers/virtualbox/action/set_name.rb
@@ -23,7 +23,8 @@ module VagrantPlugins
           if !name
             prefix = "#{env[:root_path].basename.to_s}_#{env[:machine].name}"
             prefix.gsub!(/[^-a-z0-9_]/i, "")
-            name = prefix + "_#{Time.now.to_i}"
+            # milliseconds + random number suffix to allow for simultaneous `vagrant up` of the same box in different dirs
+            name = prefix + "_#{(Time.now.to_f * 1000.0).to_i}_#{rand(100000)}"
           end
 
           # Verify the name is not taken


### PR DESCRIPTION
If the same Vagrantfile is up'd in the same second, in the same basedir, there is a conflict in the name provided to Virtualbox.

It may sound rare, but all Jenkins jobs sit in a directory named  `workspace/` and if they're listening for the same trigger, they'll run into this issue.

This changes the name suffix from seconds to milliseconds and + `rand(100000)`
