### PR TITLE
Use Retryable for Virtualbox customize & sane_defaults actions

### DIFF
--- a/plugins/providers/virtualbox/action/customize.rb
+++ b/plugins/providers/virtualbox/action/customize.rb
@@ -25,11 +25,12 @@ module VagrantPlugins
                 arg.to_s
               end
 
-              result = env[:machine].provider.driver.execute_command(processed_command)
-              if result.exit_code != 0
+              begin
+                env[:machine].provider.driver.execute_command(processed_command + [:retryable => true])
+              rescue Vagrant::Errors::VBoxManageError => e
                 raise Vagrant::Errors::VMCustomizationFailed, {
-                  :command => processed_command.inspect,
-                  :error   => result.stderr
+                  :command => command,
+                  :error   => e.inspect
                 }
               end
             end

--- a/plugins/providers/virtualbox/driver/base.rb
+++ b/plugins/providers/virtualbox/driver/base.rb
@@ -108,6 +108,11 @@ module VagrantPlugins
 
         # Execute a raw command straight through to VBoxManage.
         #
+        # Accepts a :retryable => true option if the command should be retried
+        # upon failure.
+        #
+        # Raises a VBoxManage error if it fails.
+        #
         # @param [Array] command Command to execute.
         def execute_command(command)
         end

--- a/plugins/providers/virtualbox/driver/version_4_0.rb
+++ b/plugins/providers/virtualbox/driver/version_4_0.rb
@@ -129,7 +129,7 @@ module VagrantPlugins
         end
 
         def execute_command(command)
-          raw(*command)
+          execute(*command)
         end
 
         def export(path)

--- a/plugins/providers/virtualbox/driver/version_4_1.rb
+++ b/plugins/providers/virtualbox/driver/version_4_1.rb
@@ -129,7 +129,7 @@ module VagrantPlugins
         end
 
         def execute_command(command)
-          raw(*command)
+          execute(*command)
         end
 
         def export(path)

--- a/plugins/providers/virtualbox/driver/version_4_2.rb
+++ b/plugins/providers/virtualbox/driver/version_4_2.rb
@@ -127,7 +127,7 @@ module VagrantPlugins
         end
 
         def execute_command(command)
-          raw(*command)
+          execute(*command)
         end
 
         def export(path)

--- a/plugins/providers/virtualbox/driver/version_4_3.rb
+++ b/plugins/providers/virtualbox/driver/version_4_3.rb
@@ -127,7 +127,7 @@ module VagrantPlugins
         end
 
         def execute_command(command)
-          raw(*command)
+          execute(*command)
         end
 
         def export(path)


### PR DESCRIPTION
When starting several boxes at once, `VBoxManage modifyvm` gets cranky and throws random lock errors. 

This adds the existing Retryable logic to the `customize` and `sane_defaults` actions, both of which fire a bunch of
`modifyvm` commands, all of which are fine to run multiple times.

This changes the VirtualBox driver's `execute_command` to accept a `:retryable => true` option. This also means it will throw `Vagrant::Errors::VBoxManageError` instead of returning the last exit status. I think this is the right behavior, because consumers of the driver shouldn't care about exit status (mostly because `VBoxManage` has inconsistent exit status handling, which should all be managed by the driver). Consumers should only care about failure or success.
