### PR TITLE
Restart NFS on Gentoo host instead of starting

### DIFF
--- a/plugins/hosts/gentoo/host.rb
+++ b/plugins/hosts/gentoo/host.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
           @nfs_start_command = "/usr/bin/systemctl start nfsd rpc-mountd rpcbind"
         else
           @nfs_check_command = "/etc/init.d/nfs status"
-          @nfs_start_command = "/etc/init.d/nfs start"
+          @nfs_start_command = "/etc/init.d/nfs restart"
         end
       end
 


### PR DESCRIPTION
In the case that NFS is already started on a Gentoo host, /etc/init.d/nfs start will not reload exports, but fail. /etc/init.d/nfs reload is known to fail for some esoteric configurations of /etc/exports, restart should be safe for existing connections.
