### PR TITLE
[Provisioner][Shell] add keep_color option to allow custom color output

### DIFF
--- a/plugins/provisioners/shell/config.rb
+++ b/plugins/provisioners/shell/config.rb
@@ -9,6 +9,7 @@ module VagrantPlugins
       attr_accessor :args
       attr_accessor :privileged
       attr_accessor :binary
+      attr_accessor :keep_color
 
       def initialize
         @args        = UNSET_VALUE
@@ -17,6 +18,7 @@ module VagrantPlugins
         @upload_path = UNSET_VALUE
         @privileged  = UNSET_VALUE
         @binary      = UNSET_VALUE
+        @keep_color  = UNSET_VALUE
       end
 
       def finalize!
@@ -26,6 +28,7 @@ module VagrantPlugins
         @upload_path = "/tmp/vagrant-shell" if @upload_path == UNSET_VALUE
         @privileged  = true if @privileged == UNSET_VALUE
         @binary      = false if @binary == UNSET_VALUE
+        @keep_color  = false if @keep_color == UNSET_VALUE
       end
 
       def validate(machine)

--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -37,9 +37,15 @@ module VagrantPlugins
 
                 # Note: Be sure to chomp the data to avoid the newlines that the
                 # Chef outputs.
-                @machine.env.ui.info(
-                  data,
-                  :color => color, :new_line => false, :prefix => false)
+                if config.keep_color
+                  @machine.env.ui.info(
+                      data,
+                      :new_line => false, :prefix => false)
+                else
+                  @machine.env.ui.info(
+                      data,
+                      :color => color, :new_line => false, :prefix => false)
+                end
               end
             end
           end

--- a/website/docs/source/v2/provisioning/shell.html.md
+++ b/website/docs/source/v2/provisioning/shell.html.md
@@ -45,6 +45,10 @@ The remainder of the available options are optional:
   be uploaded to. The script is uploaded as the SSH user over SCP, so this
   location must be writable to that user. By default this is "/tmp/vagrant-shell"
 
+* `keep_color` (boolean) - Vagrant automatically color output in green and
+  red (errors). If this is true, then Vagrant will not do this. By default
+  this is "false". This allow you to have custom colored output.
+
 <a name="inline-scripts"></a>
 ## Inline Scripts
 


### PR DESCRIPTION
Hi,

This add a new option for the shell provisioner: `keep_color`

This option allow you to have shell script with colors, and prevent vagrant from coloring output in green or red ;)

This is useful for example when running ansible script directly on the vm
