### PR TITLE
Add resumable downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ IMPROVEMENTS:
   - commands/provision: Add `--no-parallel` option to disable provider
     parallelization if the provider supports it. [GH-2404]
   - providers/virtualbox: Enable symlinks for VirtualBox 4.1. [GH-2414]
+  - core: Support resumable downloads [GH-57]
 
 BUG FIXES:
 

--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -37,7 +37,8 @@ module Vagrant
           "--location",
           "--max-redirs", "10",
           "--user-agent", USER_AGENT,
-          "--output", @destination
+          "--output", @destination,
+          "--continue-at", "-"
         ]
 
         options << "--insecure" if @insecure


### PR DESCRIPTION
Since VM images can be fairly large and connections rather flaky, it would be
nice to support resumable downloads whereby, if a download is interrupted for
some reason, on the next attempt, it picks up where it left off.

To implement this, the following changes were made:
- The temporary download filename is now constructed from a SHA1 of the
  `box_url` instead of a timestamp. This allows separate invocations of
  Vagrant to 'share' the download-path if the URLs exactly match.
- Add `--continue-at -" option to`curl` which tells it to automatically resume
  downloading where it left off
- Modify the `recover` method in `box_add` to not remove the temporary
  download path if the download was interrupted

Known Issue:
- The progress on a resumed download will look a bit wonky in the sense that,
  it starts at 0% each time, instead of where it left off. Since Vagrant is
  pulling this directly from `curl`, this is more of an upstream issue.

Fixes #57
