### PR TITLE
fix network interface name on fedora. issue #2520

### DIFF
--- a/templates/guests/fedora/network_static.erb
+++ b/templates/guests/fedora/network_static.erb
@@ -5,7 +5,7 @@ BOOTPROTO=none
 ONBOOT=yes
 IPADDR=<%= options[:ip] %>
 NETMASK=<%= options[:netmask] %>
-DEVICE=eth<%= options[:interface] %>
+DEVICE=p7p<%= options[:interface] %>
 <%= options[:gateway] ? "GATEWAY=#{options[:gateway]}" : '' %>
 <%= options[:mac_address] ? "HWADDR=#{options[:mac_address]}" : '' %>
 PEERDNS=no


### PR DESCRIPTION
fix network interface name on fedora

[issue ticket #2520](https://github.com/mitchellh/vagrant/issues/2520)
