### PR TITLE
Make salt bootstrap work on systems without python

### DIFF
--- a/plugins/provisioners/salt/bootstrap-salt.sh
+++ b/plugins/provisioners/salt/bootstrap-salt.sh
@@ -1,6 +1,12 @@
 #!/bin/sh -
 
 # We just download the bootstrap script by default and execute that.
-python \
-    -c 'import urllib; print urllib.urlopen("http://bootstrap.saltstack.org").read()' \
-    | sh -s -- "$@"
+if [ -x /usr/bin/fetch ]; then
+    /usr/bin/fetch -o - http://bootstrap.saltstack.org | sh -s -- "$@"
+elif [ -x /usr/bin/curl ]; then
+    /usr/bin/curl -L http://bootstrap.saltstack.org | sh -s -- "$@"
+else
+    python \
+        -c 'import urllib; print urllib.urlopen("http://bootstrap.saltstack.org").read()' \
+        | sh -s -- "$@"
+fi


### PR DESCRIPTION
The old script did not work on FreeBSD because Python is not installed by default. FreeBSD has fetch. I added a curl branch as well.
