### PR TITLE
Allow the FreeBSD plugin to install without bash [GH-2485]

### DIFF
--- a/plugins/guests/freebsd/cap/change_host_name.rb
+++ b/plugins/guests/freebsd/cap/change_host_name.rb
@@ -3,9 +3,9 @@ module VagrantPlugins
     module Cap
       class ChangeHostName
         def self.change_host_name(machine, name)
-          if !machine.communicate.test("hostname -f | grep '^#{name}$' || hostname -s | grep '^#{name}$'")
-            machine.communicate.sudo("sed -i '' 's/^hostname=.*$/hostname=#{name}/' /etc/rc.conf")
-            machine.communicate.sudo("hostname #{name}")
+          if !machine.communicate.test("hostname -f | grep '^#{name}$' || hostname -s | grep '^#{name}$'", {:shell => "sh"})
+            machine.communicate.sudo("sed -i '' 's/^hostname=.*$/hostname=#{name}/' /etc/rc.conf", {:shell => "sh"})
+            machine.communicate.sudo("hostname #{name}", {:shell => "sh"})
           end
         end
       end

--- a/plugins/guests/freebsd/cap/configure_networks.rb
+++ b/plugins/guests/freebsd/cap/configure_networks.rb
@@ -10,7 +10,7 @@ module VagrantPlugins
 
         def self.configure_networks(machine, networks)
           # Remove any previous network additions to the configuration file.
-          machine.communicate.sudo("sed -i '' -e '/^#VAGRANT-BEGIN/,/^#VAGRANT-END/ d' /etc/rc.conf")
+          machine.communicate.sudo("sed -i '' -e '/^#VAGRANT-BEGIN/,/^#VAGRANT-END/ d' /etc/rc.conf", {:shell => "sh"})
 
           networks.each do |network|
             entry = TemplateRenderer.render("guests/freebsd/network_#{network[:type]}",
@@ -22,14 +22,14 @@ module VagrantPlugins
             temp.write(entry)
             temp.close
 
-            machine.communicate.upload(temp.path, "/tmp/vagrant-network-entry")
-            machine.communicate.sudo("su -m root -c 'cat /tmp/vagrant-network-entry >> /etc/rc.conf'")
-            machine.communicate.sudo("rm /tmp/vagrant-network-entry")
+            machine.communicate.upload(temp.path, "/tmp/vagrant-network-entry", {:shell => "sh"})
+            machine.communicate.sudo("su -m root -c 'cat /tmp/vagrant-network-entry >> /etc/rc.conf'", {:shell => "sh"})
+            machine.communicate.sudo("rm /tmp/vagrant-network-entry", {:shell => "sh"})
 
             if network[:type].to_sym == :static
-              machine.communicate.sudo("ifconfig em#{network[:interface]} inet #{network[:ip]} netmask #{network[:netmask]}")
+              machine.communicate.sudo("ifconfig em#{network[:interface]} inet #{network[:ip]} netmask #{network[:netmask]}", {:shell => "sh"})
             elsif network[:type].to_sym == :dhcp
-              machine.communicate.sudo("dhclient em#{network[:interface]}")
+              machine.communicate.sudo("dhclient em#{network[:interface]}", {:shell => "sh"})
             end
           end
         end

--- a/plugins/guests/freebsd/cap/halt.rb
+++ b/plugins/guests/freebsd/cap/halt.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class Halt
         def self.halt(machine)
           begin
-            machine.communicate.sudo("shutdown -p now")
+            machine.communicate.sudo("shutdown -p now", {:shell => "sh"})
           rescue IOError
             # Do nothing because SSH connection closed and it probably
             # means the VM just shut down really fast.

--- a/plugins/guests/freebsd/cap/mount_nfs_folder.rb
+++ b/plugins/guests/freebsd/cap/mount_nfs_folder.rb
@@ -4,8 +4,8 @@ module VagrantPlugins
       class MountNFSFolder
         def self.mount_nfs_folder(machine, ip, folders)
           folders.each do |name, opts|
-            machine.communicate.sudo("mkdir -p #{opts[:guestpath]}")
-            machine.communicate.sudo("mount -t nfs '#{ip}:#{opts[:hostpath]}' '#{opts[:guestpath]}'")
+            machine.communicate.sudo("mkdir -p #{opts[:guestpath]}", {:shell => "sh"})
+            machine.communicate.sudo("mount -t nfs '#{ip}:#{opts[:hostpath]}' '#{opts[:guestpath]}'", {:shell => "sh"})
           end
         end
       end

--- a/plugins/guests/freebsd/guest.rb
+++ b/plugins/guests/freebsd/guest.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
     # Contributed by Kenneth Vestergaard <kvs@binarysolutions.dk>
     class Guest < Vagrant.plugin("2", :guest)
       def detect?(machine)
-        machine.communicate.test("uname -s | grep 'FreeBSD'")
+        machine.communicate.test("uname -s | grep 'FreeBSD'", {:shell => "sh"})
       end
     end
   end


### PR DESCRIPTION
The default shell is "bash -l" which does not get installed by default
on FreeBSD. This change allows the plugin to override the default shell
and use a known installed shell (sh).
