### PR TITLE
Sometimes, ifdown is not enough.

### DIFF
--- a/plugins/guests/debian/cap/configure_networks.rb
+++ b/plugins/guests/debian/cap/configure_networks.rb
@@ -44,6 +44,7 @@ module VagrantPlugins
             # SSH never dies.
             interfaces.each do |interface|
               comm.sudo("/sbin/ifdown eth#{interface} 2> /dev/null")
+              comm.sudo("/sbin/ip addr flush dev eth#{interface} 2> /dev/null")
             end
 
             comm.sudo("cat /tmp/vagrant-network-entry >> /etc/network/interfaces")


### PR DESCRIPTION
Changing network configuration in the Vagrantfile doesn't change network on the Debian virtualbox. `/sbin/ifrequest eth1` show the right configuration, but `/sbin/ifconfig` an old one.

The hidden error is : `RTNETLINK answers: File exists`

A simple provisioning shell can fix this bug :
`config.vm.provision :shell, inline: "sudo /sbin/ifdown eth1 && sudo /sbin/ifup eth1"`

This patch flush each network interfaces.
