### PR TITLE
provisioners/shell: fix validation for args [GH-1949]

### DIFF
--- a/plugins/provisioners/shell/config.rb
+++ b/plugins/provisioners/shell/config.rb
@@ -55,12 +55,18 @@ module VagrantPlugins
           errors << I18n.t("vagrant.provisioners.shell.upload_path_not_set")
         end
 
-        # If there are args and its not a string, that is a problem
-        if args && (!args.is_a?(String) || !args.is_a?(Array))
+        unless args_valid?
           errors << I18n.t("vagrant.provisioners.shell.args_bad_type")
         end
 
         { "shell provisioner" => errors }
+      end
+
+      # Args are optional, but if they're provided we only support them as a
+      # string or as an array.
+      def args_valid?
+        return true unless args
+        args.is_a?(String) || args.is_a?(Array)
       end
 
       def remote?

--- a/test/unit/plugins/provisioners/shell/config_test.rb
+++ b/test/unit/plugins/provisioners/shell/config_test.rb
@@ -1,0 +1,57 @@
+require File.expand_path("../../../../base", __FILE__)
+
+describe "VagrantPlugins::Shell::Config" do
+  let(:described_class) do
+    VagrantPlugins::Shell::Plugin.components.configs[:provisioner][:shell]
+  end
+
+  let(:machine)          { double('machine', env: Vagrant::Environment.new) }
+  let(:file_that_exists) { File.expand_path(__FILE__)                       }
+
+  subject { described_class.new }
+
+  describe "validate" do
+    it "passes with no args" do
+      subject.path = file_that_exists
+      subject.finalize!
+
+      result = subject.validate(machine)
+
+      result["shell provisioner"].should == []
+    end
+
+    it "passes with string args" do
+      subject.path = file_that_exists
+      subject.args = "a string"
+      subject.finalize!
+
+      result = subject.validate(machine)
+
+      result["shell provisioner"].should == []
+    end
+
+    it "passes with array args" do
+      subject.path = file_that_exists
+      subject.args = ["an", "array"]
+      subject.finalize!
+
+      result = subject.validate(machine)
+
+      result["shell provisioner"].should == []
+    end
+
+    it "returns an error if args is neither a string nor an array" do
+      neither_array_nor_string = Object.new
+
+      subject.path = file_that_exists
+      subject.args = neither_array_nor_string
+      subject.finalize!
+
+      result = subject.validate(machine)
+
+      result["shell provisioner"].should == [
+        I18n.t("vagrant.provisioners.shell.args_bad_type")
+      ]
+    end
+  end
+end


### PR DESCRIPTION
The logic change in 57d477514067a37665386968ef0a37abf86e3380 introduced
a bug where neither strings nor arrays provided as `args` for shell
provisioners would pass validation.

This fixes that problem along with a few extras:
- split out arg validation into a private method
- update comment describing valid args
- add a few unit tests around config validation
