### PR TITLE
salt-bootstrap.sh: options are only allowed before install arguments

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -79,11 +79,6 @@ module VagrantPlugins
       def bootstrap_options(install, configure, config_dir)
         options = ""
 
-        ## Any extra options passed to bootstrap
-        if @config.bootstrap_options
-          options = "%s %s" % [options, @config.bootstrap_options]
-        end
-
         if configure
           options = "%s -c %s" % [options, config_dir]
         end
@@ -124,6 +119,11 @@ module VagrantPlugins
           if @config.install_args
             options = "%s %s" % [options, @config.install_args]
           end
+        end
+
+        ## Any extra options passed to bootstrap
+        if @config.bootstrap_options
+          options = "%s %s" % [options, @config.bootstrap_options]
         end
 
         if @config.verbose


### PR DESCRIPTION
salt-bootstrap.sh expect to have options at the very last position
