### PR TITLE
Set I18n.config.enforce_available_locales to true to avoid an annoying deprecation warning

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -263,6 +263,10 @@ end
 # Default I18n to load the en locale
 I18n.load_path << File.expand_path("templates/locales/en.yml", Vagrant.source_root)
 
+# Make sure only available locales are used. This will be the default in the
+# future but we need this to silence a deprecation warning from 0.6.9
+I18n.config.enforce_available_locales = true
+
 # A lambda that knows how to load plugins from a single directory.
 plugin_load_proc = lambda do |directory|
   # We only care about directories


### PR DESCRIPTION
I was working on a plugin and after a bundle update and a I18n bump to 0.6.9 I started getting an annoying message about a deprecation warning:

```
$ be vagrant status
[deprecated] I18n.enforce_available_locales will default to true in the future. If you really 
want to skip validation of your locale you can set I18n.enforce_available_locales = false 
to avoid this message.
```

Looks like this was introduced on https://github.com/svenfuchs/i18n/pull/223 and an alternative would be to restrict the version on the gemspec.
