### PR TITLE
Add missing argument to ProviderVirtualBox::SyncedFolder#driver call

### DIFF
--- a/plugins/providers/virtualbox/synced_folder.rb
+++ b/plugins/providers/virtualbox/synced_folder.rb
@@ -62,7 +62,7 @@ module VagrantPlugins
       end
 
       def cleanup(machine)
-        driver.clear_shared_folders
+        driver(machine).clear_shared_folders
       end
 
       protected


### PR DESCRIPTION
GH-2577 missed passing the `machine` to the `driver` method.

I'm also having other issues with synced folder with both VirtualBox and Fusion providers, but it's getting too late tonight for me to debug if it's because of a plugin or Vagrant itself...
