### PR TITLE
Arch netctl fix

### DIFF
--- a/plugins/guests/arch/cap/configure_networks.rb
+++ b/plugins/guests/arch/cap/configure_networks.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require "tempfile"
 
 require "vagrant/util/template_renderer"
@@ -18,20 +19,23 @@ module VagrantPlugins
             temp.write(entry)
             temp.close
 
-            # Only consider nth line of sed's output below. There certainly is a
-            # better way to do this
-            snth = network[:interface] + 1
-
             machine.communicate.upload(temp.path, "/tmp/vagrant_network")
             machine.communicate.sudo("mv /tmp/vagrant_network /etc/netctl/eth#{network[:interface]}")
 
-            # A hack not to rely on udev rule 80-net-name-slot.rules masking:
-            # ln -sf /dev/null /etc/udev/80-net-name-slot.rules that
+            # Only consider nth line of sed's output below. There's always an
+            # offset of two lines in the below sed command given the current
+            # interface number -> 1: lo, 2: nat device,
+            snth = network[:interface] + 2
+
+            # A hack not to rely on udev rule 80-net-name-slot.rules masking
+            # (ln -sf /dev/null /etc/udev/80-net-name-slot.rules).
             # I assume this to be the most portable solution because
             # otherwise we would need to rely on the Virtual Machine implementation
             # to provide details on the configured interfaces, e.g mac address
-            # to write a custom udev rule.
-            machine.communicate.sudo("sed -i s/eth#{network[:interface]}/`systemctl list-units -t device | sed -n 's/.*subsystem.net-devices-\\(.*\\).device.*/\\1/p' | sed -n #{snth}p`/g /etc/netctl/eth#{network[:interface]}")
+            # to write a custom udev rule. Templating the netcfg files and
+            # replacing the correct interface name within ruby seems more
+            # complicted too (I'm far from being a ruby expert though).
+            machine.communicate.sudo("sed -i \"s/eth#{network[:interface]}/`ip link | sed -n 's/.*:\\s\\(.*\\): <.*/\\1/p' | sed -n #{snth}p`/g\" /etc/netctl/eth#{network[:interface]}")
             machine.communicate.sudo("netctl start eth#{network[:interface]}")
           end
         end


### PR DESCRIPTION
This should address issues #1760 and #2563.

It is merely a hack not to rely on `udev` rule overrides, i.e.  `ln -sf /dev/null /etc/udev/80-net-name-slot.rules` by using `sed`. Unfortunately masking the 80-\* rule does not rewrite the device names properly. The solution should work no matter what arch version the guest is running as long as `netctl` is available. This was the same requirement before anyways. It also adheres to the [predictable network names](http://www.freedesktop.org/wiki/Software/systemd/PredictableNetworkInterfaceNames/) standard because it doesn't alter the device interface names. Ok, it names the `netctl` config files in `/etc/netctl/*` `ethN` but that's just to avoid writing virtual machine provider dependent code in vagrant.

The outlined solution is not ideal in that:
1. it relies on a helper variable `snth` (see diff) to offset the _nth_ interface of the output of `sed`. An experienced ruby developer might help to eliminate this. I'm not.
2. the command is long and not really pretty

An alternative to 2. would have been to write the command like so: 

```
x="`ip link | sed -n 's/.*:\s\(.*\): <.*/\1/p' | sed -n 3p`" bash -c 'sudo sed -i "s/eth1/$x/g" /etc/netctl/eth1'` 
```

I'm not sure this makes it clearer though.

I've tested it with a random combination of `:private_network` and `:public_network` network interface specs in `Vagrantfile`. 
