### PR TITLE
Fix testing if initctl exists

### DIFF
--- a/plugins/guests/linux/cap/mount_virtualbox_shared_folder.rb
+++ b/plugins/guests/linux/cap/mount_virtualbox_shared_folder.rb
@@ -71,8 +71,10 @@ module VagrantPlugins
           machine.communicate.sudo(chown_commands[1]) if exit_status != 0
 
           # Emit an upstart event if we can
-          machine.communicate.sudo("[ -x /sbin/initctl ] && " +
-            "/sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=#{guestpath}")
+          if machine.communicate.test("test -x /sbin/initctl")
+            machine.communicate.sudo(
+              "/sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=#{guestpath}")
+          end
         end
       end
     end


### PR DESCRIPTION
If _/sbin/initctl_ was not found, the command (`false && ...`) returned non-zero exit code leading to Vagrant throwing an exception.

Fixes a bug introduced in #2502.
