### PR TITLE
Print info message if provisioning is skipped by the sentinel file

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1138,6 +1138,7 @@ en:
           persisting: "Persisting the VM UUID (%{uuid})..."
         provision:
           beginning: "Running provisioner: %{provisioner}..."
+          disabled_by_sentinel: "VM already provisioned. Run `vagrant provision` or use `--provision` to force it"
         resume:
           resuming: Resuming suspended VM...
           unpausing: |-


### PR DESCRIPTION
Tell the user if the VM has already been provisioned and no `--[no-]provision` option has been specified. This should reduce the confusion of the 1.3+ functionality.

I changed the method logic to use `env[:provision_enabled]` so we can delay the message to the same phase where the provisioners would be run normally.
