### PR TITLE
Run "ip link set [eth1] down" before running "netctl start [eth1]" in Ar...

### DIFF
--- a/plugins/guests/arch/cap/configure_networks.rb
+++ b/plugins/guests/arch/cap/configure_networks.rb
@@ -20,6 +20,7 @@ module VagrantPlugins
             temp.close
 
             machine.communicate.upload(temp.path, "/tmp/vagrant_network")
+            machine.communicate.sudo("ln -sf /dev/null /etc/udev/rules.d/80-net-name-slot.rules")
             machine.communicate.sudo("mv /tmp/vagrant_network /etc/netctl/eth#{network[:interface]}")
 
             # Only consider nth line of sed's output below. There's always an


### PR DESCRIPTION
...ch guest network configuration

I got the idea [here](http://www.linuxquestions.org/questions/arch-29/arch-liux-netctl-failure-for-static-ip-4175461355/#post4966401).
