### PR TITLE
guests/redhat: Don't error if ifdown fails [GH-2614]

### DIFF
--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -21,10 +21,10 @@ module VagrantPlugins
           networks.each do |network|
             interfaces.add(network[:interface])
 
-            # Down the interface before munging the config file
-            retryable(:on => Vagrant::Errors::VagrantError, :tries => 3, :sleep => 2) do
-              machine.communicate.sudo("/sbin/ifdown eth#{network[:interface]} 2> /dev/null")
-            end
+            # Down the interface before munging the config file. This might fail
+            # if the interface is not actually set up yet so ignore errors.
+            machine.communicate.sudo(
+              "/sbin/ifdown eth#{network[:interface]} 2> /dev/null", error_check: false)
 
             # Remove any previous vagrant configuration in this network interface's
             # configuration files.
@@ -52,7 +52,7 @@ module VagrantPlugins
           interfaces.each do |interface|
             retryable(:on => Vagrant::Errors::VagrantError, :tries => 3, :sleep => 2) do
               # The interface should already be down so this probably
-              # won't do anything, so we run it with error_check false.j
+              # won't do anything, so we run it with error_check false.
               machine.communicate.sudo(
                 "/sbin/ifdown eth#{interface} 2> /dev/null", error_check: false)
 


### PR DESCRIPTION
Further fix for [GH-2614].

Removed retrying of ifdown on the basis that in most cases the interface is probably missing and it adds an unnecessary 4 seconds to the setup time for the VM. The case where the interface is present and being removed by a config change would appear to be quite rare.

If someone can come up with a good way to distinguish both error cases I can to implement retrying in a more clever way.
