### PR TITLE
fix path to acceptance test contexts in example

### DIFF
--- a/vagrant-spec.config.example.rb
+++ b/vagrant-spec.config.example.rb
@@ -3,5 +3,5 @@ require_relative "test/acceptance/base"
 Vagrant::Spec::Acceptance.configure do |c|
   c.provider "virtualbox",
     box: "<PATH TO MINIMAL BOX>",
-    contexts: ["provider/virtualbox"]
+    contexts: ["provider-context/virtualbox"]
 end


### PR DESCRIPTION
Failed on attempt to run an acceptance test components list, based off the provided example.
