### PR TITLE
Rename docker_client and docker_installer

### DIFF
--- a/plugins/provisioners/docker/client.rb
+++ b/plugins/provisioners/docker/client.rb
@@ -2,7 +2,7 @@ require 'digest/sha1'
 
 module VagrantPlugins
   module Docker
-    class DockerClient
+    class Client
       def initialize(machine)
         @machine = machine
       end

--- a/plugins/provisioners/docker/installer.rb
+++ b/plugins/provisioners/docker/installer.rb
@@ -1,6 +1,6 @@
 module VagrantPlugins
   module Docker
-    class DockerInstaller
+    class Installer
       def initialize(machine, version)
         @machine = machine
         @version = version

--- a/plugins/provisioners/docker/provisioner.rb
+++ b/plugins/provisioners/docker/provisioner.rb
@@ -1,5 +1,5 @@
-require_relative "docker_client"
-require_relative "docker_installer"
+require_relative "client"
+require_relative "installer"
 
 module VagrantPlugins
   module Docker
@@ -13,9 +13,8 @@ module VagrantPlugins
       def initialize(machine, config, installer = nil, client = nil)
         super(machine, config)
 
-        # TODO: Rename to installer / client (drop docker suffix)
-        @installer = installer || DockerInstaller.new(@machine, config.version)
-        @client    = client    || DockerClient.new(@machine)
+        @installer = installer || Installer.new(@machine, config.version)
+        @client    = client    || Client.new(@machine)
       end
 
       def provision


### PR DESCRIPTION
We can rename those classes and remove the docker_ prefix as they
already have a module namespace.

review @fgrehm @mitchellh
