### PR TITLE
If using from sources, ruby2 is needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ If you want the bleeding edge version of Vagrant, we try to keep master pretty s
 and you're welcome to give it a shot. The following is an example showing how to do this:
 
     rake install
+    
+Ruby 2.0 is needed.
 
 ## Contributing to Vagrant
 


### PR DESCRIPTION
In OS packages ruby2 comes embedded, but if you install vagrant from sources, you should execute vagrant with ruby2.

At least, with ruby 1.9.1 and using docker as a provisioner, it gives the error:

/var/lib/gems/1.9.1/gems/vagrant-1.4.1.dev/plugins/provisioners/docker/plugin.rb:13:in `require_relative': /var/lib/gems/1.9.1/gems/vagrant-1.4.1.dev/plugins/provisioners/docker/config.rb:23: syntax error, unexpected tPOW (SyntaxError)
      def run(name, **options)
