### PR TITLE
Enterprise Linux short hostname set to qualified hostname

### DIFF
--- a/plugins/guests/redhat/cap/change_host_name.rb
+++ b/plugins/guests/redhat/cap/change_host_name.rb
@@ -5,11 +5,12 @@ module VagrantPlugins
         def self.change_host_name(machine, name)
           machine.communicate.tap do |comm|
             # Only do this if the hostname is not already set
-            if !comm.test("sudo hostname | grep --line-regexp '#{name}'")
+            if !comm.test("sudo hostname -f | grep --line-regexp '#{name}'")
+              short_name = name.split('.')[0]
               comm.sudo("sed -i 's/\\(HOSTNAME=\\).*/\\1#{name}/' /etc/sysconfig/network")
-              comm.sudo("hostname #{name}")
-              comm.sudo("sed -i 's@^\\(127[.]0[.]0[.]1[[:space:]]\\+\\)@\\1#{name} #{name.split('.')[0]} @' /etc/hosts")
-              comm.sudo("sed -i 's/\\(DHCP_HOSTNAME=\\).*/\\1\"#{name.split('.')[0]}\"/' /etc/sysconfig/network-scripts/ifcfg-*")
+              comm.sudo("hostname #{short_name}")
+              comm.sudo("sed -i 's@^\\(127[.]0[.]0[.]1[[:space:]]\\+\\)@\\1#{name} #{short_name} @' /etc/hosts")
+              comm.sudo("sed -i 's/\\(DHCP_HOSTNAME=\\).*/\\1\"#{short_name}\"/' /etc/sysconfig/network-scripts/ifcfg-*")
               comm.sudo("service network restart")
             end
           end


### PR DESCRIPTION
It seems that on Enterprise Linux instances, with a qualified name set as the `config.vm.hostname`, the short name (from `hostname`) is set to the same value as the full name (as you get with `hostname -f`). 

Using this [Vagrantfile](https://gist.github.com/acharlieh/7950826), you will see that the *_fqdn vms exhibit this property (i.e. `centos510.example.com` and `centos65.example.com`)

If you provision a RHEL or CentOS box from EC2, `hostname` will return the short name, and `hostname -f` will return the fully qualified hostname. (e.g. `ip-172-31-15-147` and `ip-172-31-15-147.us-west-2.compute.internal` respectively)

Looking in the code, it seems that we might be able to tweak the `plugins/guests/redhat/cap/change_host_name.rb` file, to check the results of `hostname -f` and pass the short name (first segment only) to `hostname` when setting and that seems to resolve things. (

Vagrant 1.4.1.dev at d321b9199e928bc42054c1b63beedf61e63686a0
VirtualBox 4.3.4
