### PR TITLE
Ansible Provisioner: Fix a bug in `raw_arguments` option

### DIFF
--- a/plugins/provisioners/ansible/provisioner.rb
+++ b/plugins/provisioners/ansible/provisioner.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
         options = %W[--private-key=#{ssh[:private_key_path][0]} --user=#{ssh[:username]}]
 
         # Joker! Not (yet) supported arguments can be passed this way.
-        options << "#{config.raw_arguments}" if config.raw_arguments
+        options.concat(self.as_array(config.raw_arguments)) if config.raw_arguments
 
         # Append Provisioner options (highest precedence):
         options << "--inventory-file=#{self.setup_inventory_file}"
@@ -122,6 +122,10 @@ module VagrantPlugins
 
       def as_list_argument(v)
         v.kind_of?(Array) ? v.join(',') : v
+      end
+
+      def as_array(v)
+        v.kind_of?(Array) ? v : [v]
       end
     end
   end

--- a/website/docs/source/v2/provisioning/ansible.html.md
+++ b/website/docs/source/v2/provisioning/ansible.html.md
@@ -143,7 +143,7 @@ by the sudo command.
 * `ansible.tags` can be set to a string or an array of tags. Only plays, roles and tasks tagged with these values will be executed.
 * `ansible.skip_tags` can be set to a string or an array of tags. Only plays, roles and tasks that *do not match* these values will be executed.
 * `ansible.start_at_task` can be set to a string corresponding to the task name where the playbook provision will start.
-* `ansible.raw_arguments` is an *unsafe wildcard* string that can be used to take advantage of `ansible-playbook` arguments that are not (yet) supported by this Vagrant provisioner plugin. This can be very useful when integrating with bleeding edge Ansible versions. Following precedence rules apply:
+* `ansible.raw_arguments` can be set to an array of strings corresponding to a list of `ansible-playbook` arguments (e.g. `['--check', '-M /my/modules']`). It is an *unsafe wildcard* that can be used to apply Ansible options that are not (yet) supported by this Vagrant provisioner. Following precedence rules apply:
   * Any supported options (described above) will override conflicting `raw_arguments` value (e.g. `--tags` or `--start-at-task`)
   * Vagrant default user authentication can be overridden via `raw_arguments` (with custom values for `--user` and `--private-key`)
 * `ansible.groups` can be used to pass a hash of group names and group members to be included in the generated inventory file.  For example:


### PR DESCRIPTION
Without this change, it is not possible to pass more than one "raw" argument, which was not the expected behavior. In addition to Array format, a String is still accepted (but for a single argument, of course).

Note: Due to low/expert usage of this option, I think that it is (for now) not necessary to add more robust validation on this parameter (e.g. Array of String type checking or argument syntax pattern matching). Even though, it is maybe a good idea to address these validation questions, but I would like to treat in a separate issue, with a more global perspective (all options of Ansible provisioner, comparing/unifying with other provisioners, etc.)

@mitchellh please let me know, if this fix is good enough. Or if I should word/implement it differently...
