### PR TITLE
Force rm of chef config files #2669

### DIFF
--- a/plugins/provisioners/chef/provisioner/base.rb
+++ b/plugins/provisioners/chef/provisioner/base.rb
@@ -79,7 +79,7 @@ module VagrantPlugins
 
           remote_file = File.join(config.provisioning_path, filename)
           @machine.communicate.tap do |comm|
-            comm.sudo("rm #{remote_file}", :error_check => false)
+            comm.sudo("rm -f #{remote_file}", :error_check => false)
             comm.upload(temp.path, remote_file)
           end
         end
@@ -100,7 +100,7 @@ module VagrantPlugins
 
           remote_file = File.join(@config.provisioning_path, "dna.json")
           @machine.communicate.tap do |comm|
-            comm.sudo("rm #{remote_file}", :error_check => false)
+            comm.sudo("rm -f #{remote_file}", :error_check => false)
             comm.upload(temp.path, remote_file)
           end
         end

--- a/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -116,7 +116,7 @@ module VagrantPlugins
         def upload_encrypted_data_bag_secret
           @machine.env.ui.info I18n.t("vagrant.provisioners.chef.upload_encrypted_data_bag_secret_key")
           @machine.communicate.tap do |comm|
-            comm.sudo("rm #{@config.encrypted_data_bag_secret}", :error_check => false)
+            comm.sudo("rm -f #{@config.encrypted_data_bag_secret}", :error_check => false)
             comm.upload(encrypted_data_bag_secret_key_path,
                         @config.encrypted_data_bag_secret)
           end


### PR DESCRIPTION
As discussed in issue #2669, this pull request changes the chef-solo provisioner's use of `rm` to `rm -f` so as to avoid a user prompt if the system has aliased `rm` to `rm -i`.
