### PR TITLE
Do not prepend default path because it can override modules.

### DIFF
--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -98,9 +98,6 @@ module VagrantPlugins
           options = [config.options].flatten
           module_paths = @module_paths.map { |_, to| to }
           if !@module_paths.empty?
-            # Prepend the default module path
-            module_paths.unshift("/etc/puppet/modules")
-
             # Add the command line switch to add the module path
             options << "--modulepath '#{module_paths.join(':')}'"
           end


### PR DESCRIPTION
It is common for Puppet to manage itself. If the puppet code you are
deploying pushes files to /etc/puppet/modules/, then prepending this
path can break deployment because it will override the module path if
the deployment code is changing. There is no good reason to include this
path. Puppet has built in defaults for this reason.
