### PR TITLE
Show more informative error if plugin.json parsing fails

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -460,6 +460,10 @@ module Vagrant
       error_key(:plugin_not_installed)
     end
 
+    class PluginStateFileParseError < VagrantError
+      error_key(:plugin_state_file_not_parsable)
+    end
+
     class SCPPermissionDenied < VagrantError
       error_key(:scp_permission_denied)
     end

--- a/plugins/commands/plugin/state_file.rb
+++ b/plugins/commands/plugin/state_file.rb
@@ -10,7 +10,13 @@ module VagrantPlugins
 
         @data = {}
         if @path.exist?
-          @data = JSON.parse(@path.read)
+          begin
+            @data = JSON.parse(@path.read)
+          rescue JSON::ParserError => e
+            raise Vagrant::Errors::PluginStateFileParseError,
+              :path => path, :message => e.message
+          end
+
           upgrade_v0! if !@data["version"]
         end
 

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -501,6 +501,12 @@ en:
         prior to attempting to do anything with it.
       plugin_not_installed: |-
         The plugin '%{name}' is not installed. Please install it first.
+      plugin_state_file_not_parsable: |-
+        Failed to parse the state file "%{path}":
+        %{message}
+
+        Please remove the file and reinstall the plugins.
+        If this error recurs, please report a bug.
       port_collision_resume: |-
         This VM cannot be resumed, because the forwarded ports would collide
         with a running program (it could be another virtual machine). Normally,

--- a/test/unit/plugins/commands/plugin/state_file_test.rb
+++ b/test/unit/plugins/commands/plugin/state_file_test.rb
@@ -70,4 +70,17 @@ describe VagrantPlugins::CommandPlugin::StateFile do
       expect(plugins["foo"]["vagrant_version"]).to eql("0")
     end
   end
+
+  context "with parse errors" do
+    before do
+      path.open("w+") do |f|
+        f.write("I'm not json")
+      end
+    end
+
+    it "should raise a VagrantError" do
+      expect { subject }.
+        to raise_error(Vagrant::Errors::PluginStateFileParseError)
+    end
+  end
 end


### PR DESCRIPTION
Ref: #2603

Suggestions/corrections to the message welcome. =)

@mitchellh, btw, I find it a bit strange that _state_file.rb_ is located under the plugin command, while it's (also) used directly by the very core Environment class. Dunno.
