### PR TITLE
resolving #2739 for Ubuntu based distros with ruby 2.0.0p353

### DIFF
--- a/plugins/providers/virtualbox/action.rb
+++ b/plugins/providers/virtualbox/action.rb
@@ -148,9 +148,9 @@ module VagrantPlugins
             b2.use ClearForwardedPorts
             b2.use PrepareNFSValidIds
             b2.use SyncedFolderCleanup
-            b2.use Package
             b2.use Export
             b2.use PackageVagrantfile
+            b2.use Package
           end
         end
       end


### PR DESCRIPTION
``` ruby
b2.use
```

include order matters for setting up the system environment. Was causing an `internal consistency` error.
