### PR TITLE
Correctly detect fedora 19 and 20

### DIFF
--- a/plugins/guests/fedora/guest.rb
+++ b/plugins/guests/fedora/guest.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
   module GuestFedora
     class Guest < Vagrant.plugin("2", :guest)
       def detect?(machine)
-        machine.communicate.test("grep 'Fedora release 1[678]' /etc/redhat-release")
+        machine.communicate.test("grep 'Fedora release [12][67890]' /etc/redhat-release")
       end
     end
   end


### PR DESCRIPTION
Previously, only Fedora 16-18 would be detected as Fedora. This PR fixes that suck that F16-F20 are all correctly detected.
