### PR TITLE
Replace `exit 1` with `abort`

### DIFF
--- a/bin/vagrant
+++ b/bin/vagrant
@@ -3,7 +3,7 @@
 # Trap interrupts to quit cleanly. This will be overriden at some point
 # by Vagrant. This is made to catch any interrupts while Vagrant is
 # initializing which have historically resulted in stack traces.
-Signal.trap("INT") { exit 1 }
+Signal.trap("INT") { abort }
 
 # Split arguments by "--" if its there, we'll recombine them later
 argv = ARGV.dup


### PR DESCRIPTION
According to the documentation, Kernel.abort calls Kernel.exit(false). The failure status 1 is an implementation detail on Unix-like systems. In theory, a future system could exist where 1 indicates a successful exit and 0 indicates a failure.
