### PR TITLE
Update README to note running Vagrant in a bundle disables plugins by default.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ If you want to run Vagrant without having to install the gem, you may use `bundl
 like so:
 
     bundle exec vagrant help
+    
+**NOTE:** By default running Vagrant in via `bundle` will disable plugins (e.g. `vagrant-berkshelf1`).
 
 ### Acceptance Tests
 


### PR DESCRIPTION
Is there a way to make Vagrant run full-blown in a bundle? If so, I'll update the docs and README with those notes. My searching didn't turn up much beyond plugin development.
