### PR TITLE
Allow `vagrant (un)install plugin1 plugin2 plugin3`

### DIFF
--- a/plugins/commands/plugin/command/install.rb
+++ b/plugins/commands/plugin/command/install.rb
@@ -23,14 +23,16 @@ module VagrantPlugins
           return if !argv
           raise Vagrant::Errors::CLIInvalidUsage, :help => opts.help.chomp if argv.length < 1
 
-          # Install the gem
-          action(Action.action_install, {
-            :plugin_entry_point => options[:entry_point],
-            :plugin_prerelease  => options[:plugin_prerelease],
-            :plugin_version     => options[:plugin_version],
-            :plugin_sources     => options[:plugin_sources],
-            :plugin_name        => argv[0]
-          })
+          # Install the gems
+          argv.each do |gem|
+            action(Action.action_install, {
+              :plugin_entry_point => options[:entry_point],
+              :plugin_prerelease  => options[:plugin_prerelease],
+              :plugin_version     => options[:plugin_version],
+              :plugin_sources     => options[:plugin_sources],
+              :plugin_name        => gem,
+            })
+          end
 
           # Success, exit status 0
           0

--- a/plugins/commands/plugin/command/uninstall.rb
+++ b/plugins/commands/plugin/command/uninstall.rb
@@ -16,8 +16,8 @@ module VagrantPlugins
           return if !argv
           raise Vagrant::Errors::CLIInvalidUsage, :help => opts.help.chomp if argv.length < 1
 
-          # Uninstall the gem
-          action(Action.action_uninstall, :plugin_name => argv[0])
+          # Uninstall the gems
+          argv.each{ |gem| action(Action.action_uninstall, :plugin_name => gem) }
 
           # Success, exit status 0
           0


### PR DESCRIPTION
The current `vagrant install` or `uninstall` only works on one plugin at a time. 

This modification allows for any number >=1 plugins to be installed/uninstalled at the same time.
