### PR TITLE
Update change_host_name.rb

### DIFF
--- a/plugins/guests/redhat/cap/change_host_name.rb
+++ b/plugins/guests/redhat/cap/change_host_name.rb
@@ -49,7 +49,7 @@ module VagrantPlugins
         end
 
         def update_hostname
-          sudo "hostname #{short_hostname}"
+          sudo "hostname #{fqdn}"
         end 
 
         # /etc/hosts should resemble:


### PR DESCRIPTION
This was introduced in 1.4.1 with https://github.com/mitchellh/vagrant/commit/d26c1471d74ec26a7a1386200f21e1fa3d8f5711.

This PR sets the active hostname back to the name specified in the Vagrantfile (fqdn).

Setting it to the short name causes loads of problems while configuring the system.  I've had issues with sudoers hostname matching, Weblogic certificate generation and a few others.  Even if I changed all of the Chef recipes, the fqdn is set in /etc/sysconfig/network so the active hostname will switch to the fqdn after a reboot.
