### PR TITLE
Pass intnet as String

### DIFF
--- a/website/docs/source/v2/networking/private_network.html.md
+++ b/website/docs/source/v2/networking/private_network.html.md
@@ -62,7 +62,7 @@ VirtualBox provider.
 ```ruby
 Vagrant.configure("2") do |config|
   config.vm.network "private_network", ip: "192.168.50.4",
-    virtualbox__intnet: true
+    virtualbox__intnet: "true"
 end
 ```
 


### PR DESCRIPTION
Otherwise we get:

```
/Applications/Vagrant/embedded/gems/gems/childprocess-0.3.9/lib/childprocess/abstract_process.rb:36:in `initialize': all arguments must be String: ["/usr/bin/VBoxManage", "modifyvm", "099abf87-2cc9-467a-bf7e-ef23ff620c90", "--nic1", "nat", "--nic2", "intnet", "--intnet2", true] (ArgumentError)
```
