### PR TITLE
Change hostname back to what is specified in the Vagrantfile for redhat guests.

### DIFF
--- a/plugins/guests/redhat/cap/change_host_name.rb
+++ b/plugins/guests/redhat/cap/change_host_name.rb
@@ -34,7 +34,7 @@ module VagrantPlugins
         def get_current_hostname
           hostname = ''
           block = lambda do |type, data|
-            if type == :stdout 
+            if type == :stdout
               hostname += data.chomp
             end
           end
@@ -49,8 +49,8 @@ module VagrantPlugins
         end
 
         def update_hostname
-          sudo "hostname #{short_hostname}"
-        end 
+          sudo "hostname #{fqdn}"
+        end
 
         # /etc/hosts should resemble:
         # 127.0.0.1   host.fqdn.com host localhost ...


### PR DESCRIPTION
I originally submitted this PR as https://github.com/mitchellh/vagrant/pull/2777.  Github was giving me lots of problems today and at some point I dropped the original fork and reforked the project.  I'll close the old PR. 

This PR sets the active hostname back to the name specified in the Vagrantfile (fqdn) and updates the unit tests.

Setting it to the short name causes loads of problems while configuring the system. I've had issues with sudoers hostname matching, Weblogic certificate generation and a few others. Even if I changed all of the Chef recipes, the fqdn is set in /etc/sysconfig/network so the active hostname will switch to the fqdn after a reboot.

The CentOs and Redhat deployment guide states that HOSTNAME=<value> (in /etc/sysconfig/network) should be the FQDN but can be whatever hostname is necessary.  The hostname stored there will be the one used in "/proc/sys/kernel/hostname" or returned from executing "hostname" on the command line after a reboot. I don't think it makes sense to set the hostname for the system to the short name for the first boot.  

Setting it from the hostname specified in the Vagrantfile means that you can assign the hostname to either the shortname or the FQDN.  

http://www.centos.org/docs/5/html/5.2/Deployment_Guide/s2-sysconfig-network.html

https://access.redhat.com/site/documentation/en-US/Red_Hat_Enterprise_Linux/5/pdf/Deployment_Guide/Red_Hat_Enterprise_Linux-5-Deployment_Guide-en-US.pdf

Excerpt from page 505:
HOSTNAME=<value>, where <value> should be the Fully Qualified Domain Name (FQDN), such as
hostname.expample.com, but can be whatever hostname is necessary.
