### PR TITLE
Reintroduce `name` attribute for the `Guest`

### DIFF
--- a/lib/vagrant/capability_host.rb
+++ b/lib/vagrant/capability_host.rb
@@ -25,7 +25,8 @@ module Vagrant
     #   is a hash where the key is the name of the capability and the value
     #   is the class/module implementing it.
     def initialize_capabilities!(host, hosts, capabilities, *args)
-      @cap_logger = Log4r::Logger.new("vagrant::capability_host::#{self.class}")
+      @cap_logger = Log4r::Logger.new(
+        "vagrant::capability_host::#{self.class.to_s.downcase}")
 
       if host && !hosts[host]
         raise Errors::CapabilityHostExplicitNotDetected, value: host.to_s
@@ -113,7 +114,7 @@ module Vagrant
     protected
 
     def autodetect_capability_host(hosts, *args)
-      @cap_logger.info("Autodetecting guest for machine: #{@machine}")
+      @cap_logger.info("Autodetecting host type for #{args.inspect}")
 
       # Get the mapping of hosts with the most parents. We start searching
       # with the hosts with the most parents first.

--- a/lib/vagrant/guest.rb
+++ b/lib/vagrant/guest.rb
@@ -22,7 +22,6 @@ module Vagrant
     include CapabilityHost
 
     def initialize(machine, guests, capabilities)
-      @logger       = Log4r::Logger.new("vagrant::guest")
       @capabilities = capabilities
       @guests       = guests
       @machine      = machine
@@ -31,8 +30,6 @@ module Vagrant
     # This will detect the proper guest OS for the machine and set up
     # the class to actually execute capabilities.
     def detect!
-      @logger.info("Detect guest for machine: #{@machine}")
-
       guest_name = @machine.config.vm.guest
       initialize_capabilities!(guest_name, @guests, @capabilities, @machine)
     end


### PR DESCRIPTION
Maintain compatibility for vagrant-vbguest plugin which uses it. vagrant-vbguest doesn't use the caps system (to keep compatibility with older Vagrant versions), but includes similar functionality itself.

The second commit tweaks logging a bit:
- Use downcase logger name as everywhere else
- Remove duplicate logging from the Guest
