### PR TITLE
core: Respect VAGRANT_HOME everywhere

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -599,7 +599,7 @@ module Vagrant
     # @return [Pathname]
     def setup_home_path
       @home_path = Util::Platform.fs_real_path(
-        @home_path || ENV["VAGRANT_HOME"] || Vagrant.user_data_path)
+        @home_path || Vagrant.user_data_path)
       @logger.info("Home path: #{@home_path}")
 
       # Setup the list of child directories that need to be created if they

--- a/lib/vagrant/shared_helpers.rb
+++ b/lib/vagrant/shared_helpers.rb
@@ -20,15 +20,19 @@ module Vagrant
   #
   # @return [Pathname]
   def self.user_data_path
-    path = "~/.vagrant.d"
+    # Use user spcified env var if available
+    path = ENV["VAGRANT_HOME"]
 
     # On Windows, we default ot the USERPROFILE directory if it
     # is available. This is more compatible with Cygwin and sharing
     # the home directory across shells.
-    if ENV["USERPROFILE"]
+    if !path && ENV["USERPROFILE"]
       path = "#{ENV["USERPROFILE"]}/.vagrant.d"
     end
 
-    return Pathname.new(path).expand_path
+    # Fallback to the default
+    path ||= "~/.vagrant.d"
+
+    Pathname.new(path).expand_path
   end
 end


### PR DESCRIPTION
Use `VAGRANT_HOME`env var also for `Plugin::Manager` etc., not only in the `Environment` class.
