### PR TITLE
nfs_apply :: exportfs sometimes leaves exports behind

### DIFF
--- a/plugins/hosts/linux/cap/nfs.rb
+++ b/plugins/hosts/linux/cap/nfs.rb
@@ -8,7 +8,7 @@ module VagrantPlugins
         extend Vagrant::Util::Retryable
 
         def self.nfs_apply_command(env)
-          "/usr/bin/exportfs -r"
+          "/usr/bin/exportfs -ar"
         end
 
         def self.nfs_check_command(env)


### PR DESCRIPTION
On my machine i had a case where /etc/exports was updated but the old
exports were still there. This was leading to
"exportfs: duplicated export entries" and eventually leading to nfs
being not available for the box.

changing the command exportfs -r to exportfs -ar seems to address this
issue.

Signed-off-by: BlackEagle ike.devolder@gmail.com
