### PR TITLE
Fix for network.rb options object not being converted correctly

### DIFF
--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -86,7 +86,8 @@ module VagrantPlugins
             @logger.info("Network slot #{slot}. Type: #{type}.")
 
             # Get the normalized configuration for this type
-            config = send("#{type}_config", options)
+            # apparently by now options is an array and we need a hash
+            config = send("#{type}_config", options[0])
             config[:adapter] = slot
             @logger.debug("Normalized configuration: #{config.inspect}")
 


### PR DESCRIPTION
Hi there

I was trying to create a secondary adapter for the vagrant virtualbox provider and consistently failing. After some help from one of our ruby guys, we realised that the method called expects a hash and it actually receives and array with a hash inside. This pull request fixes this. 

Example (Vagrantfile):

<pre>
  config.vm.provider "virtualbox" do |v|
    v.network_adapter 2, :bridged, { auto_config: true }
  end
</pre>
