### PR TITLE
Fixed Issue #2860: dup string if frozen when formatting output for machine.

### DIFF
--- a/lib/vagrant/ui.rb
+++ b/lib/vagrant/ui.rb
@@ -84,6 +84,7 @@ module Vagrant
         # Prepare the data by replacing characters that aren't outputted
         data.each_index do |i|
           data[i] = data[i].to_s
+          data[i] = data[i].dup if data[i].frozen?
           data[i].gsub!(",", "%!(VAGRANT_COMMA)")
           data[i].gsub!("\n", "\\n")
           data[i].gsub!("\r", "\\r")


### PR DESCRIPTION
JSON parser return frozen strings for hash keys. Duplicate frozen strings to avoid the error.

```
vagrant@node01:~/vagrant$ vagrant box list --machine-readable
1390142590,,box-name,precise32
1390142590,,box-provider,virtualbox
1390142590,,box-info,url,http://files.vagrantup.com/precise32.box
1390142590,,box-info,downloaded_at,2014-01-19 14:04:53 UTC
```
