### PR TITLE
Avoid nuking synced folders which specify the default impl

### DIFF
--- a/lib/vagrant/action/builtin/mixin_synced_folders.rb
+++ b/lib/vagrant/action/builtin/mixin_synced_folders.rb
@@ -96,7 +96,8 @@ module Vagrant
               raise Errors::NoDefaultSyncedFolderImpl, types: types
             end
 
-            folders[default_impl] = folders[""]
+            folders[default_impl] ||= {}
+            folders[default_impl].merge!(folders[""])
             folders.delete("")
           end
 


### PR DESCRIPTION
If two synced folders are specified, one of which explicitly sets its type
to be the same as the default implementation which is later selected, the
folder which relies on the implicit selection of an implementation will
overwrite the one that was explicit in its desires.
