### PR TITLE
OpenBSD is not a Linux derivative

### DIFF
--- a/plugins/guests/openbsd/cap/insert_public_key.rb
+++ b/plugins/guests/openbsd/cap/insert_public_key.rb
@@ -1,0 +1,21 @@
+require "vagrant/util/shell_quote"
+
+module VagrantPlugins
+  module GuestOpenBSD
+    module Cap
+      class InsertPublicKey
+        def self.insert_public_key(machine, contents)
+          contents = Vagrant::Util::ShellQuote.escape(contents, "'")
+          contents = contents.gsub("\n", "\\n")
+
+          machine.communicate.tap do |comm|
+            comm.execute("mkdir -p ~/.ssh")
+            comm.execute("chmod 0700 ~/.ssh")
+            comm.execute("printf '#{contents}' >> ~/.ssh/authorized_keys")
+            comm.execute("chmod 0600 ~/.ssh/authorized_keys")
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/openbsd/plugin.rb
+++ b/plugins/guests/openbsd/plugin.rb
@@ -26,6 +26,11 @@ module VagrantPlugins
         Cap::Halt
       end
 
+      guest_capability("openbsd", "insert_public_key") do
+        require_relative "cap/insert_public_key"
+        Cap::InsertPublicKey
+      end
+
       guest_capability("openbsd", "mount_nfs_folder") do
         require_relative "cap/mount_nfs_folder"
         Cap::MountNFSFolder


### PR DESCRIPTION
This seems like a copy/paste bug in 52f3847.

If the OpenBSD guest plugin relies on Linux capabilities, they should be copied. I have never used OpenBSD boxes so would be nice if someone (@tsahara-iij?) could check that this doesn't break anything.
