### PR TITLE
Force up all interfaces after vagrant network config

### DIFF
--- a/plugins/guests/debian/cap/configure_networks.rb
+++ b/plugins/guests/debian/cap/configure_networks.rb
@@ -54,6 +54,8 @@ module VagrantPlugins
             interfaces.each do |interface|
               comm.sudo("/sbin/ifup eth#{interface}")
             end
+            # Bring up all the interfaces
+            comm.sudo("/sbin/ifup --force -a")
           end
         end
       end


### PR DESCRIPTION
Chef creates several ethernet aliases (eg. eth1:12, eth1:13) for us (to run various applications off). They're configured in /etc/network/interfaces. However, vagrant brings down eth1, configures it, then brings it back up, without bringing back up the aliases.

This patch forces up all the interfaces to ensure that the networking reflects what's in the interfaces file.

(note - needs a --force since the system still thinks eth1:12 etc are still up, so refuses to bring them up again)
