### PR TITLE
Fix https://github.com/mitchellh/vagrant/issues/2108

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -494,10 +494,6 @@ module VagrantPlugins
                 errors << I18n.t("vagrant.config.vm.network_ip_required")
               end
             end
-
-            if options[:ip] && options[:ip].end_with?(".1")
-              errors << I18n.t("vagrant.config.vm.network_ip_ends_in_one")
-            end
           end
         end
 

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -868,9 +868,6 @@ en:
           that `nfsd` is installed on your machine, and try again. If you're
           on Windows, NFS isn't supported. If the problem persists, please
           contact Vagrant support.
-        network_ip_ends_in_one: |-
-          Static IPs cannot end in ".1" since that address is always
-          reserved for the router. Please use another ending.
         network_ip_required: |-
           An IP is required for a private network.
         network_fp_host_not_unique: |-


### PR DESCRIPTION
Remove "vm: \* Static IPs cannot end in ".1" since that address is
always reserved for the router. Please use another ending." error.
IP conflicts are always a risk. Nothing special about .1. Just a
convention.
