### PR TITLE
Make sure synced folder types are always symbols

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -150,6 +150,8 @@ module VagrantPlugins
         options = options.dup
         options[:guestpath] = guestpath.to_s.gsub(/\/$/, '')
         options[:hostpath]  = hostpath
+        # Make sure the type is a symbol
+        options[:type] = options[:type].to_sym if options[:type]
 
         @__synced_folders[options[:guestpath]] = options
       end
@@ -323,9 +325,6 @@ module VagrantPlugins
           if options[:nfs]
             options[:type] = :nfs
           end
-
-          # Make sure the type is a symbol
-          options[:type] = options[:type].to_sym if options[:type]
 
           # Ignore NFS on Windows
           if options[:type] == :nfs && Vagrant::Util::Platform.windows?


### PR DESCRIPTION
This will make sure that third party plugins that define synced folders after this config object has been finalized won't have trouble because of forgetting to use symbols instead of strings. It would have saved me a lot around 2 hours of debugging trying to understand what was going on on https://github.com/fgrehm/vagrant-cachier/issues/76 :-P
