### PR TITLE
Iterate through NFS exported folders by length

### DIFF
--- a/plugins/hosts/bsd/cap/nfs.rb
+++ b/plugins/hosts/bsd/cap/nfs.rb
@@ -25,7 +25,7 @@ module VagrantPlugins
           # We build up this mapping within the following hash.
           logger.debug("Compiling map of sub-directories for NFS exports...")
           dirmap = {}
-          folders.sort { |(_,a),(_,b)| a[:hostpath] <=> b[:hostpath] }.each do |_,opts|
+          folders.sort_by { |_, opts| opts[:hostpath] }.each do |_,opts|
             hostpath = opts[:hostpath].dup
             hostpath.gsub!('"', '\"')
 


### PR DESCRIPTION
With a synced folder configuration like so:

 synced_folder ".", "/vagrant", :nfs => true
 synced_folder "#{ENV['HOME']}/mirror", "/mirror", :nfs => true
 synced_folder ENV['HOME'], "/home/#{ENV['USER']}", :nfs => true

on OSX, vagrant writes two overlapping exports to /etc/exports which then fail the export check.

Iterating through the list of folders in order of host path length builds a correct, single exports entry.

This line reads fairly badly, maybe there's a better way of expressing the same change?
