### PR TITLE
clean up usage

### DIFF
--- a/lib/vagrant/cli.rb
+++ b/lib/vagrant/cli.rb
@@ -55,12 +55,12 @@ module Vagrant
       # an optionparser above because I don't think the performance hits
       # of creating a whole object are worth checking only a couple flags.
       opts = OptionParser.new do |o|
-        o.banner = "Usage: vagrant [-v] [-h] command [<args>]"
+        o.banner = "Usage: vagrant [options] <command> [<args>]"
         o.separator ""
         o.on("-v", "--version", "Print the version and exit.")
         o.on("-h", "--help", "Print this help.")
         o.separator ""
-        o.separator "Common subcommands:"
+        o.separator "Common commands:"
 
         # Add the available subcommands as separators in order to print them
         # out as well.

--- a/plugins/commands/box/command/add.rb
+++ b/plugins/commands/box/command/add.rb
@@ -8,14 +8,16 @@ module VagrantPlugins
           options = {}
 
           opts = OptionParser.new do |o|
-            o.banner = "Usage: vagrant box add <url> [-h]"
+            o.banner = "Usage: vagrant box add [options] <url>"
+            o.separator ""
+            o.separator "Options:"
             o.separator ""
 
             o.on("-c", "--clean", "Clean any temporary download files") do |c|
               options[:clean] = c
             end
 
-            o.on("-f", "--force", "Overwrite an existing box if it exists.") do |f|
+            o.on("-f", "--force", "Overwrite an existing box if it exists") do |f|
               options[:force] = f
             end
 
@@ -23,20 +25,20 @@ module VagrantPlugins
               options[:insecure] = i
             end
 
-            o.on("--cacert certfile", String, "CA certificate for SSL download") do |c|
+            o.on("--cacert FILE", String, "CA certificate for SSL download") do |c|
               options[:ca_cert] = c
             end
 
-            o.on("--cert certfile", String,
+            o.on("--cert FILE", String,
                  "A client SSL cert, if needed") do |c|
               options[:client_cert] = c
             end
 
-            o.on("--provider VALUE", String, "Provider the box should satisfy") do |p|
+            o.on("--provider PROVIDER", String, "Provider the box should satisfy") do |p|
               options[:provider] = p
             end
 
-            o.on("--box-version VALUE", String, "Constrain version of the added box") do |v|
+            o.on("--box-version VERSION", String, "Constrain version of the added box") do |v|
               options[:version] = v
             end
 
@@ -45,15 +47,15 @@ module VagrantPlugins
             o.separator "and not using a Vagrant server or a box structured like 'user/box':"
             o.separator ""
 
-            o.on("--checksum VALUE", String, "Checksum for the box") do |c|
+            o.on("--checksum CHECKSUM", String, "Checksum for the box") do |c|
               options[:checksum] = c
             end
 
-            o.on("--checksum-type VALUE", String, "Checksum type (md5, sha1, sha256)") do |c|
+            o.on("--checksum-type TYPE", String, "Checksum type (md5, sha1, sha256)") do |c|
               options[:checksum_type] = c.to_sym
             end
 
-            o.on("--name VALUE", String, "Name of the box") do |n|
+            o.on("--name BOX", String, "Name of the box") do |n|
               options[:name] = n
             end
           end

--- a/plugins/commands/box/command/list.rb
+++ b/plugins/commands/box/command/list.rb
@@ -8,10 +8,12 @@ module VagrantPlugins
           options = {}
 
           opts = OptionParser.new do |o|
-            o.banner = "Usage: vagrant box list"
+            o.banner = "Usage: vagrant box list [options]"
+            o.separator ""
+            o.separator "Options:"
             o.separator ""
 
-            o.on("-i", "--box-info", "Displays additional information about the boxes.") do |i|
+            o.on("-i", "--box-info", "Displays additional information about the boxes") do |i|
               options[:info] = i
             end
           end

--- a/plugins/commands/box/command/outdated.rb
+++ b/plugins/commands/box/command/outdated.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
             o.separator "Options:"
             o.separator ""
 
-            o.on("--global", "Check all boxes installed.") do |g|
+            o.on("--global", "Check all boxes installed") do |g|
               options[:global] = g
             end
           end

--- a/plugins/commands/box/command/remove.rb
+++ b/plugins/commands/box/command/remove.rb
@@ -9,14 +9,16 @@ module VagrantPlugins
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant box remove <name>"
             o.separator ""
+            o.separator "Options:"
+            o.separator ""            
 
-            o.on("--provider VALUE", String,
-                 "The specific provider type for the box to remove.") do |p|
+            o.on("--provider PROVIDER", String,
+                 "The specific provider type for the box to remove") do |p|
               options[:provider] = p
             end
 
-            o.on("--box-version VALUE", String,
-                 "The specific version of the box to remove.") do |v|
+            o.on("--box-version VERSION", String,
+                 "The specific version of the box to remove") do |v|
               options[:version] = v
             end
           end

--- a/plugins/commands/box/command/root.rb
+++ b/plugins/commands/box/command/root.rb
@@ -64,7 +64,7 @@ module VagrantPlugins
         # Prints the help out for this command
         def help
           opts = OptionParser.new do |opts|
-            opts.banner = "Usage: vagrant box <command> [<args>]"
+            opts.banner = "Usage: vagrant box <subcommand> [<args>]"
             opts.separator ""
             opts.separator "Available subcommands:"
 
@@ -78,7 +78,7 @@ module VagrantPlugins
             end
 
             opts.separator ""
-            opts.separator "For help on any individual command run `vagrant box COMMAND -h`"
+            opts.separator "For help on any individual subcommand run `vagrant box <subcommand> -h`"
           end
 
           @env.ui.info(opts.help, :prefix => false)

--- a/plugins/commands/box/command/update.rb
+++ b/plugins/commands/box/command/update.rb
@@ -20,11 +20,11 @@ module VagrantPlugins
             o.separator "Options:"
             o.separator ""
 
-            o.on("--box VALUE", String, "Update a specific box") do |b|
+            o.on("--box BOX", String, "Update a specific box") do |b|
               options[:box] = b
             end
 
-            o.on("--provider VALUE", String, "Update box with specific provider.") do |p|
+            o.on("--provider PROVIDER", String, "Update box with specific provider") do |p|
               options[:provider] = p.to_sym
             end
           end

--- a/plugins/commands/destroy/command.rb
+++ b/plugins/commands/destroy/command.rb
@@ -10,7 +10,9 @@ module VagrantPlugins
         options[:force] = false
 
         opts = OptionParser.new do |o|
-          o.banner = "Usage: vagrant destroy [vm-name]"
+          o.banner = "Usage: vagrant destroy [options] [name]"
+          o.separator ""
+          o.separator "Options:"
           o.separator ""
 
           o.on("-f", "--force", "Destroy without confirmation.") do |f|

--- a/plugins/commands/halt/command.rb
+++ b/plugins/commands/halt/command.rb
@@ -12,7 +12,9 @@ module VagrantPlugins
         options[:force] = false
 
         opts = OptionParser.new do |o|
-          o.banner = "Usage: vagrant halt [vm-name] [--force] [-h]"
+          o.banner = "Usage: vagrant halt [options] [name]"
+          o.separator ""
+          o.separator "Options:"
           o.separator ""
 
           o.on("-f", "--force", "Force shut down (equivalent of pulling power)") do |f|

--- a/plugins/commands/init/command.rb
+++ b/plugins/commands/init/command.rb
@@ -13,10 +13,13 @@ module VagrantPlugins
         options = { output: "Vagrantfile" }
 
         opts = OptionParser.new do |o|
-          o.banner = "Usage: vagrant init [box-name] [box-url]"
+          o.banner = "Usage: vagrant init [name] [url]"
+          o.separator ""
+          o.separator "Options:"
+          o.separator ""
 
-          o.on("--output FILENAME", String,
-               "Output path for the box. '-' for stdout.") do |output|
+          o.on("--output FILE", String,
+               "Output path for the box. '-' for stdout") do |output|
             options[:output] = output
           end
         end

--- a/plugins/commands/package/command.rb
+++ b/plugins/commands/package/command.rb
@@ -11,9 +11,9 @@ module VagrantPlugins
         options = {}
 
         opts = OptionParser.new do |o|
-          o.banner = "Usage: vagrant package [vm-name] [--base name] [--output name.box]"
-          o.separator "                       [--include one,two,three] [--vagrantfile file]"
-
+          o.banner = "Usage: vagrant package [options] [name]"
+          o.separator ""
+          o.separator "Options:"
           o.separator ""
 
           o.on("--base NAME", "Name of a VM in virtualbox to package as a base box") do |b|
@@ -24,11 +24,11 @@ module VagrantPlugins
             options[:output] = output
           end
 
-          o.on("--include x,y,z", Array, "Additional files to package with the box.") do |i|
+          o.on("--include FILE...", Array, "Additional files to package with the box") do |i|
             options[:include] = i
           end
 
-          o.on("--vagrantfile file", "Vagrantfile to package with the box.") do |v|
+          o.on("--vagrantfile FILE", "Vagrantfile to package with the box") do |v|
             options[:vagrantfile] = v
           end
         end

--- a/plugins/commands/ssh/command.rb
+++ b/plugins/commands/ssh/command.rb
@@ -11,15 +11,16 @@ module VagrantPlugins
         options = {}
 
         opts = OptionParser.new do |o|
-          o.banner = "Usage: vagrant ssh [vm-name] [-c command] [-- extra ssh args]"
-
+          o.banner = "Usage: vagrant ssh [options] [name] [-- extra ssh args]"
+          o.separator ""
+          o.separator "Options:"
           o.separator ""
 
-          o.on("-c", "--command COMMAND", "Execute an SSH command directly.") do |c|
+          o.on("-c", "--command COMMAND", "Execute an SSH command directly") do |c|
             options[:command] = c
           end
 
-          o.on("-p", "--plain", "Plain mode, leaves authentication up to user.") do |p|
+          o.on("-p", "--plain", "Plain mode, leaves authentication up to user") do |p|
             options[:plain_mode] = p
           end
         end

--- a/plugins/commands/ssh_config/command.rb
+++ b/plugins/commands/ssh_config/command.rb
@@ -15,10 +15,12 @@ module VagrantPlugins
         options = {}
 
         opts = OptionParser.new do |o|
-          o.banner = "Usage: vagrant ssh-config [vm-name] [--host name]"
+          o.banner = "Usage: vagrant ssh-config [options] [name]"
           o.separator ""
+          o.separator "Options:"
+          o.separator ""                    
 
-          o.on("--host COMMAND", "Name the host for the config..") do |h|
+          o.on("--host NAME", "Name the host for the config") do |h|
             options[:host] = h
           end
         end

--- a/plugins/commands/status/command.rb
+++ b/plugins/commands/status/command.rb
@@ -9,7 +9,7 @@ module VagrantPlugins
 
       def execute
         opts = OptionParser.new do |o|
-          o.banner = "Usage: vagrant status [machine-name]"
+          o.banner = "Usage: vagrant status [name]"
         end
 
         # Parse the options

--- a/plugins/commands/suspend/command.rb
+++ b/plugins/commands/suspend/command.rb
@@ -9,7 +9,7 @@ module VagrantPlugins
 
       def execute
         opts = OptionParser.new do |o|
-          o.banner = "Usage: vagrant suspend [vm-name]"
+          o.banner = "Usage: vagrant suspend [name]"
         end
 
         # Parse the options

--- a/plugins/commands/up/command.rb
+++ b/plugins/commands/up/command.rb
@@ -20,23 +20,25 @@ module VagrantPlugins
         options[:provision_ignore_sentinel] = false
 
         opts = OptionParser.new do |o|
-          o.banner = "Usage: vagrant up [vm-name] [options] [-h]"
+          o.banner = "Usage: vagrant up [options] [name]"
+          o.separator ""
+          o.separator "Options:"
           o.separator ""
 
           build_start_options(o, options)
 
           o.on("--[no-]destroy-on-error",
-               "Destroy machine if any fatal error happens (default to true).") do |destroy|
+               "Destroy machine if any fatal error happens (default to true)") do |destroy|
             options[:destroy_on_error] = destroy
           end
 
           o.on("--[no-]parallel",
-               "Enable or disable parallelism if provider supports it.") do |parallel|
+               "Enable or disable parallelism if provider supports it") do |parallel|
             options[:parallel] = parallel
           end
 
-          o.on("--provider provider", String,
-               "Back the machine with a specific provider.") do |provider|
+          o.on("--provider PROVIDER", String,
+               "Back the machine with a specific provider") do |provider|
             options[:provider] = provider
           end
         end


### PR DESCRIPTION
I cleaned up the usage by making the text more consistent:
- Replaced the specific options from the first line with `[options]`
- Removed punctuation marks from the option usages.
- Capitalized and renamed the values of options
