### PR TITLE
Fixing ssh_config, proxy_command is not included

### DIFF
--- a/plugins/commands/ssh_config/command.rb
+++ b/plugins/commands/ssh_config/command.rb
@@ -37,7 +37,8 @@ module VagrantPlugins
             :ssh_user => ssh_info[:username],
             :private_key_path => ssh_info[:private_key_path],
             :forward_agent => ssh_info[:forward_agent],
-            :forward_x11   => ssh_info[:forward_x11]
+            :forward_x11   => ssh_info[:forward_x11],
+            :proxy_command => ssh_info[:proxy_command]
           }
 
           # Render the template and output directly to STDOUT

--- a/templates/commands/ssh_config/config.erb
+++ b/templates/commands/ssh_config/config.erb
@@ -20,3 +20,6 @@ Host <%= host_key %>
 <% if forward_x11 -%>
   ForwardX11 yes
 <% end -%>
+<% if proxy_command -%>
+  ProxyCommand <%= proxy_command %>
+<% end -%>


### PR DESCRIPTION
Recently added proxy_command option to ssh works great, however there is one small bug, when using ssh_config command, it is ignoring this set and therefore ssh config is incorrect
