### PR TITLE
Update to support .ssh/config in ready?

### DIFF
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -201,7 +201,7 @@ module VagrantPlugins
         # Build the options we'll use to initiate the connection via Net::SSH
         opts = {
           :auth_methods          => ["none", "publickey", "hostbased", "password"],
-          :config                => false,
+          :config                => true,
           :forward_agent         => ssh_info[:forward_agent],
           :keys                  => ssh_info[:private_key_path],
           :keys_only             => true,


### PR DESCRIPTION
Openstack provider plugin (https://github.com/cloudbau/vagrant-openstack-plugin) was failing to check that a server was ready as, in my case, login requires .ssh/config (but the server was started, and I could '''vagrant ssh''' to it, so my .ssh/config was working). Changing this to true, so Net::SSH can see the .ssh/config resolved the issue.

Maybe there's a good reason for the '''false''' in there but I can't think of it right now, so have a PR :)
