### PR TITLE
detect latest version of coreos

### DIFF
--- a/plugins/guests/coreos/guest.rb
+++ b/plugins/guests/coreos/guest.rb
@@ -2,7 +2,7 @@ module VagrantPlugins
   module GuestCoreOS
     class Guest < Vagrant.plugin("2", :guest)
       def detect?(machine)
-        machine.communicate.test("cat /etc/gentoo-release | grep CoreOS || cat /etc/os-release | grep CoreOS")
+        machine.communicate.test("cat /etc/os-release | grep ID=coreos")
       end
     end
   end


### PR DESCRIPTION
The latest version of coreos doesn't include the `/etc/gentoo-release` file which the current coreos guest is using to detect that the OS is coreos.

It's been renamed to `/etc/os-release`.

This PR adds support for the latest coreos, as well as providing backwards compatibility for previous releases.

A virtualbox image with the new file change can be downloaded at: http://storage.core-os.net/coreos/amd64-generic/228.0.0/coreos_production_vagrant.box
