### PR TITLE
It isn't certain that the script has the same encoding as Ruby think it ...

### DIFF
--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -84,6 +84,14 @@ module VagrantPlugins
           script = config.inline
         end
 
+        # Ruby may have guessed wrong about the encoding
+        if !script.valid_encoding?
+          script.force_encoding('UTF-8')
+        end
+        if !script.valid_encoding?
+          script.force_encoding('iso-8859-15')
+        end
+
         # Replace Windows line endings with Unix ones unless binary file
         script.gsub!(/\r\n?$/, "\n") if !config.binary
 


### PR DESCRIPTION
...has.

Try to work around this by checking that the script's encoding is valid. If
it isn't if will first try UTF-8 and if that fails iso-8859-15.

See issue #3000
