### PR TITLE
Fix "options are only allowed before install arguments" error.

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -79,8 +79,13 @@ module VagrantPlugins
       def bootstrap_options(install, configure, config_dir)
         options = ""
 
+        ## Any extra options passed to bootstrap
+        if @config.bootstrap_options
+          options = "%s %s" % [options, @config.bootstrap_options]
+        end
+
         if configure
-          options = " -c %s %s" % [config_dir, options]
+          options = "%s -c %s" % [options, config_dir]
         end
 
         if @config.seed_master and @config.install_master
@@ -119,11 +124,6 @@ module VagrantPlugins
           if @config.install_args
             options = "%s %s" % [options, @config.install_args]
           end
-        end
-
-        ## Any extra options passed to bootstrap
-        if @config.bootstrap_options
-          options = "%s %s" % [options, @config.bootstrap_options]
         end
 
         if @config.verbose


### PR DESCRIPTION
Looks like creating the salt bootstrap script option string has been changed a little here. I believe the original plugin had it right. Hence, this reverts feb748f488 and 7cd7077467. 

`bootstrap_options` is meant for flag options such as `-D`. This is demonstrated in the example Vagrantfile from the original plugin: https://github.com/saltstack/salty-vagrant/blob/develop/example/complete/Vagrantfile. Flag options must be appended to the options string before install args such as `install_type` and `install_args`.

Not sure, but I'm guessing 7cd7077467 was created because @ticosax might not have been aware of `install_type` and `install_args` and was trying to put these _arguments_ where the _options_ belong.
