### PR TITLE
Do not to_s the machine id if it is nil

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -230,7 +230,7 @@ module Vagrant
       end
 
       # Store the ID locally
-      @id = value.to_s
+      @id = value.nil? ? nil : value.to_s
 
       # Notify the provider that the ID changed in case it needs to do
       # any accounting from it.


### PR DESCRIPTION
When destroying a machine, the machine id is set to nil.  The to_s then causes it to be set to empty string.  This can cause inconsistent behavior in anything (such as a plugin) that tests the machine id.
