### PR TITLE
Prevent duplicate dirs in /etc/exports [GH-2871]

### DIFF
--- a/plugins/hosts/bsd/host.rb
+++ b/plugins/hosts/bsd/host.rb
@@ -75,6 +75,7 @@ module VagrantPlugins
         # Sort all the keys by length so that the directory closest to
         # the root is exported first.
         dirmap.each do |dirs, _|
+          dirs.uniq!
           dirs.sort_by! { |d| d.length }
         end
 


### PR DESCRIPTION
Note: This is currently based against the '1.4.3' tag in Vagrant.  I see now that the file you'd need to patch would probably be https://github.com/mitchellh/vagrant/blob/master/plugins/hosts/bsd/cap/nfs.rb

Consider the case where you export the same directory on the host
to different directories in the guest, such as the following:

```
config.vm.synced_folder ".", "/vagrant", type: "nfs"
config.vm.synced_folder ".", "/data", type: "nfs"
```

Vagrant was creating `/etc/exports` entries like this:

```
"/Users/username/project" "/Users/username/project" 172.16.93.129 -alldirs -mapall=503:20
```

By removing duplicates while processing directories being exported, Vagrant will export this instead:

```
"/Users/username/project" 172.16.93.129 -alldirs -mapall=503:20
```
