### PR TITLE
Read box file in binary mode for checksum

### DIFF
--- a/lib/vagrant/util/file_checksum.rb
+++ b/lib/vagrant/util/file_checksum.rb
@@ -26,7 +26,7 @@ class FileChecksum
   def checksum
     digest = @digest_klass.new
 
-    File.open(@path, "r") do |f|
+    File.open(@path, "rb") do |f|
       while !f.eof
         begin
           buf = f.readpartial(BUFFER_SIZE)


### PR DESCRIPTION
On my Windows 7 machine, this fixes the box's MD5 sum not being calculated correctly.

I think this might also fix #2936.

In case you want to test this yourself, I can provide the box file that triggers the error.
