### PR TITLE
Set param -name automatically (docker run)

### DIFF
--- a/plugins/provisioners/docker/client.rb
+++ b/plugins/provisioners/docker/client.rb
@@ -77,10 +77,11 @@ module VagrantPlugins
       def create_container(config)
         args = "-cidfile=#{config[:cidfile]} "
         args << "-d " if config[:daemonize]
+        args << "-name #{config[:name]} " if config[:name]
         args << config[:args] if config[:args]
         @machine.communicate.sudo %[
           rm -f #{config[:cidfile]}
-          docker run #{args} -name #{config[:name]} #{config[:image]} #{config[:cmd]}
+          docker run #{args} #{config[:image]} #{config[:cmd]}
         ]
       end
 


### PR DESCRIPTION
`-name` ist needed for linking containers, i.e. see http://docs.docker.io/en/latest/use/working_with_links_names/#working-with-links-names
