### PR TITLE
Add autostart as an option for vagrant boxes

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -422,6 +422,16 @@ module Vagrant
       vagrantfile.machine_names
     end
 
+    # This returns a list of the configured machines for this environment
+    # that do not have "autostart" set to false.
+    # Each of the names returned by this method is valid to be used with
+    # the {#machine} method.
+    #
+    # @return [Array<Symbol>] Configured autostart machine names.
+    def autostart_machine_names
+      vagrantfile.autostart_machine_names
+    end
+
     # This returns the name of the machine that is the "primary." In the
     # case of  a single-machine environment, this is just the single machine
     # name. In the case of a multi-machine environment, then this can

--- a/lib/vagrant/vagrantfile.rb
+++ b/lib/vagrant/vagrantfile.rb
@@ -197,6 +197,20 @@ module Vagrant
       @config.vm.defined_vm_keys.dup
     end
 
+    # Returns a list of the machines that are defined within this
+    # Vagrantfile that do not have "autostart" set to false.
+    #
+    # @return [Array<Symbol>]
+    def autostart_machine_names
+      machines = []
+      # Remove any machines that have autostart set to false from machine_names
+      @config.vm.defined_vms.each do |name, subvm|
+        machines << name if subvm.options[:autostart] == nil or subvm.options[:autostart] == true
+      end
+
+      return machines
+    end
+
     # Returns the name of the machine that is designated as the
     # "primary."
     #

--- a/plugins/commands/up/command.rb
+++ b/plugins/commands/up/command.rb
@@ -55,7 +55,11 @@ module VagrantPlugins
 
         # Build up the batch job of what we'll do
         @env.batch(options[:parallel]) do |batch|
-          with_target_vms(argv, :provider => options[:provider]) do |machine|
+          names = argv
+          if names.empty? then
+            names = @env.autostart_machine_names
+          end
+          with_target_vms(names, :provider => options[:provider]) do |machine|
             @env.ui.info(I18n.t(
               "vagrant.commands.up.upping",
               :name => machine.name,

--- a/test/unit/vagrant/environment_test.rb
+++ b/test/unit/vagrant/environment_test.rb
@@ -953,5 +953,22 @@ VF
       env = isolated_env.create_vagrant_env
       env.machine_names.should == [:foo, :bar]
     end
+
+    it "should return only the machine names configured to autostart" do
+      # Create the config
+      isolated_env = isolated_environment do |e|
+        e.vagrantfile(<<-VF)
+Vagrant.configure("2") do |config|
+  config.vm.define "foo"
+  config.vm.define "bar", autostart: false
+  config.vm.define "baz", autostart: true
+end
+VF
+      end
+
+      env = isolated_env.create_vagrant_env
+      env.autostart_machine_names.should == [:foo, :baz]
+    end
+
   end
 end

--- a/test/unit/vagrant/vagrantfile_test.rb
+++ b/test/unit/vagrant/vagrantfile_test.rb
@@ -295,6 +295,29 @@ describe Vagrant::Vagrantfile do
     end
   end
 
+  describe "#autostart_machine_names" do
+    it "returns machine_names if no autostart values where set" do
+      configure do |config|
+        config.vm.define "foo"
+        config.vm.define "bar"
+      end
+
+      expect(subject.autostart_machine_names).to eq(
+        subject.machine_names)
+    end
+
+    it "returns only machine_names without autostart or autostart true" do
+      configure do |config|
+        config.vm.define "foo"
+        config.vm.define "bar", autostart: false
+        config.vm.define "baz", autostart: true
+      end
+
+      expect(subject.autostart_machine_names).to eq(
+        [:foo, :baz])
+    end
+  end
+
   describe "#primary_machine_name" do
     it "returns the default name when single-VM" do
       configure { |config| }


### PR DESCRIPTION
When boxes are defined in the vagrantfile, the "vagrant up" command without arguments always selects all boxes.

With this change, there is an option to add "autostart: false" to a box, in which case it wil only start if specifically used as an argument to vagrant up.

The purpose of this is to allow boxes in the configuration that are used for a specific purpose, but are not needed for regular developers to start.
- Added specs for the environment and vagrantfile.
- Added a methd to retrieve autostart_machine_names.
- Changed the plugin up/command to use autostart_machine_names when no argument was given to the command.
### warning

I am not a Ruby developer, so I'll need some help with this:
The tests pass, including the new specs I added, but I can't seem to run vagrant with "bundle exec vagrant" without getting an error. I don't know if the code actually works.
