### PR TITLE
Synced folders SMB ACL Fixes

### DIFF
--- a/lib/vagrant/action/builtin/synced_folders.rb
+++ b/lib/vagrant/action/builtin/synced_folders.rb
@@ -54,9 +54,11 @@ module Vagrant
           end
 
           # Go through each folder and prepare the folders
+          @implementer = {}
           folders.each do |impl_name, fs|
             @logger.info("Invoking synced folder prepare for: #{impl_name}")
-            plugins[impl_name.to_sym][0].new.prepare(env[:machine], fs, impl_opts(impl_name, env))
+            @implementer[impl_name.to_sym] ||= plugins[impl_name.to_sym][0].new
+            @implementer[impl_name.to_sym].prepare(env[:machine], fs, impl_opts(impl_name, env))
           end
 
           # Continue, we need the VM to be booted.
@@ -65,7 +67,8 @@ module Vagrant
           # Once booted, setup the folder contents
           folders.each do |impl_name, fs|
             @logger.info("Invoking synced folder enable: #{impl_name}")
-            plugins[impl_name.to_sym][0].new.enable(env[:machine], fs, impl_opts(impl_name, env))
+            @implementer[impl_name.to_sym] ||= plugins[impl_name.to_sym][0].new
+            @implementer[impl_name.to_sym].enable(env[:machine], fs, impl_opts(impl_name, env))
           end
         end
       end

--- a/plugins/synced_folders/smb/scripts/set_share.ps1
+++ b/plugins/synced_folders/smb/scripts/set_share.ps1
@@ -23,6 +23,18 @@ $grant = "Everyone,Full"
 if (![string]::IsNullOrEmpty($host_share_username)) {
     $computer_name = $(Get-WmiObject Win32_Computersystem).name
     $grant         = "$computer_name\$host_share_username,Full"
+
+    # Here we need to set the proper ACL for this folder.
+    # ACL lets the system grant privileges for the current host_share_username for this
+    # folder
+    Get-ChildItem $path -recurse -Force |% {
+        $current_acl = Get-ACL $_.fullname
+        $permission = "$computer_name\$host_share_username","FullControl","ContainerInherit,ObjectInherit","None","Allow"
+        $acl_access_rule = New-Object System.Security.AccessControl.FileSystemAccessRule $permission
+        $current_acl.SetAccessRule($acl_access_rule)
+        $current_acl | Set-Acl $_.fullname
+    }
+
 }
 
 $result = net share $share_name=$path /unlimited /GRANT:$grant

--- a/plugins/synced_folders/smb/synced_folder.rb
+++ b/plugins/synced_folders/smb/synced_folder.rb
@@ -31,6 +31,10 @@ module VagrantPlugins
       def prepare(machine, folders, opts)
         script_path = File.expand_path("../scripts/set_share.ps1", __FILE__)
 
+        if smb_credentials_required?(folders)
+          fetch_smb_credentials(machine)
+        end
+
         folders.each do |id, data|
           hostpath = data[:hostpath]
 
@@ -39,6 +43,7 @@ module VagrantPlugins
           args = []
           args << "-path" << hostpath.gsub("/", "\\")
           args << "-share_name" << data[:smb_id]
+          args << "-host_share_username" << (data[:smb_username] || smb_credentials[:username])
           #args << "-host_share_username" << "mitchellh"
 
           r = Vagrant::Util::PowerShell.execute(script_path, *args)
@@ -82,21 +87,8 @@ module VagrantPlugins
           end
         end
 
-        # If we need auth information, then ask the user
-        username = nil
-        password = nil
-        need_auth = false
-        folders.each do |id, data|
-          if !data[:smb_username] || !data[:smb_password]
-            need_auth = true
-            break
-          end
-        end
-
-        if need_auth
-          machine.ui.detail(I18n.t("vagrant_sf_smb.warning_password") + "\n ")
-          username = machine.ui.ask("Username: ")
-          password = machine.ui.ask("Password (will be hidden): ", echo: false)
+        if smb_credentials_required?(folders)
+          fetch_smb_credentials(machine)
         end
 
         # This is used for defaulting the owner/group
@@ -105,8 +97,8 @@ module VagrantPlugins
         folders.each do |id, data|
           data = data.dup
           data[:smb_host] ||= host_ip
-          data[:smb_username] ||= username
-          data[:smb_password] ||= password
+          data[:smb_username] ||= smb_credentials[:username]
+          data[:smb_password] ||= smb_credentials[:password]
 
           # Default the owner/group of the folder to the SSH user
           data[:owner] ||= ssh_info[:username]
@@ -137,6 +129,33 @@ module VagrantPlugins
         end
 
         JSON.parse(r.stdout)["ip_addresses"]
+      end
+
+      def smb_credentials_required?(folders)
+        # If we need auth information, then ask the user
+        username = nil
+        password = nil
+        need_auth = false
+        folders.each do |id, data|
+          if !data[:smb_username] || !data[:smb_password]
+            need_auth = true
+            break
+          end
+        end
+        need_auth
+      end
+
+      def fetch_smb_credentials(machine)
+        if @smb_credentials.nil?
+          machine.ui.detail(I18n.t("vagrant_sf_smb.warning_password") + "\n ")
+          username = machine.ui.ask("Username: ")
+          password = machine.ui.ask("Password (will be hidden): ", echo: false)
+          @smb_credentials = { username: username, password: password }
+        end
+      end
+
+      def smb_credentials
+        @smb_credentials
       end
 
 =begin


### PR DESCRIPTION
SMB shared folders works by creating a shared folder for an user account and by mounting it in the remote VM using the same user accounts credentials.

Hence user credentials has to be passed both during enabling the share and providing the share.
While enabling the shared folders in the host all files (recursive) within the host has to shared for an user account with a proper ACL and only then the guest will have the permission to access the shared folder.

I added a fix by calling a method to check if SMB credentials are required and caching the instance of SMB implementer class so that when the same is called during providing the share, user need not type the same credentials again.
