### PR TITLE
Check if the returned IP from PowerShell is valid

### DIFF
--- a/plugins/providers/hyperv/action/wait_for_ip_address.rb
+++ b/plugins/providers/hyperv/action/wait_for_ip_address.rb
@@ -24,7 +24,8 @@ module VagrantPlugins
               network_info = env[:machine].provider.driver.execute(
                 "get_network_config.ps1", VmId: env[:machine].id)
               guest_ip = network_info["ip"]
-              break if guest_ip && guest_ip != ""
+              # Check if the guest IP is a valid IP Address.
+              break if guest_ip && !(/\d+(\.)\d+(\.)\d+(\.)\d+/.match(guest_ip).nil?)
 
               sleep 1
             end


### PR DESCRIPTION
The first response which the Get network PowerShell call gives the proper
IP address, so wait until the response returns a valid one.

NOTE: Here the check is applied for IP(V4) Format. May be in future this condition has to be revisited.
