### PR TITLE
Ansible Provisioner: Improve management of ANSIBLE_SSH_ARGS

### DIFF
--- a/plugins/provisioners/ansible/config.rb
+++ b/plugins/provisioners/ansible/config.rb
@@ -15,8 +15,10 @@ module VagrantPlugins
       attr_accessor :groups
       attr_accessor :host_key_checking
 
-      # Joker attribute, used to pass unsupported arguments to ansible anyway
+      # Joker attribute, used to pass unsupported arguments to ansible-playbook anyway
       attr_accessor :raw_arguments
+      # Joker attribute, used to set additional SSH parameters for ansible-playbook anyway
+      attr_accessor :raw_ssh_args
 
       def initialize
         @playbook          = UNSET_VALUE
@@ -30,9 +32,10 @@ module VagrantPlugins
         @tags              = UNSET_VALUE
         @skip_tags         = UNSET_VALUE
         @start_at_task     = UNSET_VALUE
-        @raw_arguments     = UNSET_VALUE
         @groups            = UNSET_VALUE
         @host_key_checking = "false"
+        @raw_arguments     = UNSET_VALUE
+        @raw_ssh_args      = UNSET_VALUE
       end
 
       def finalize!
@@ -47,9 +50,10 @@ module VagrantPlugins
         @tags              = nil if @tags == UNSET_VALUE
         @skip_tags         = nil if @skip_tags == UNSET_VALUE
         @start_at_task     = nil if @start_at_task == UNSET_VALUE
-        @raw_arguments     = nil if @raw_arguments == UNSET_VALUE
         @groups            = {}  if @groups == UNSET_VALUE
         @host_key_checking = nil if @host_key_checking == UNSET_VALUE
+        @raw_arguments     = nil if @raw_arguments == UNSET_VALUE
+        @raw_ssh_args      = nil if @raw_ssh_args == UNSET_VALUE
       end
 
       def validate(machine)

--- a/plugins/provisioners/ansible/provisioner.rb
+++ b/plugins/provisioners/ansible/provisioner.rb
@@ -189,6 +189,9 @@ module VagrantPlugins
         # SSH Forwarding
         ssh_options << "-o ForwardAgent=yes" if @ssh_info[:forward_agent]
 
+        # Unchecked SSH Parameters
+        ssh_options.concat(self.as_array(config.raw_ssh_args)) if config.raw_ssh_args
+
         # Re-enable ControlPersist Ansible defaults,
         # which are lost when ANSIBLE_SSH_ARGS is defined.
         unless ssh_options.empty?

--- a/website/docs/source/v2/provisioning/ansible.html.md
+++ b/website/docs/source/v2/provisioning/ansible.html.md
@@ -192,6 +192,7 @@ by the sudo command.
 * `ansible.raw_arguments` can be set to an array of strings corresponding to a list of `ansible-playbook` arguments (e.g. `['--check', '-M /my/modules']`). It is an *unsafe wildcard* that can be used to apply Ansible options that are not (yet) supported by this Vagrant provisioner. Following precedence rules apply:
   * Any supported options (described above) will override conflicting `raw_arguments` value (e.g. `--tags` or `--start-at-task`)
   * Vagrant default user authentication can be overridden via `raw_arguments` (with custom values for `--user` and `--private-key`)
+* `ansible.raw_ssh_args` can be set to an array of strings corresponding to a list of OpenSSH client parameters (e.g. `['-o ControlMaster=no']`). It is an *unsafe wildcard* that can be used to pass additional SSH settings to Ansible via `ANSIBLE_SSH_ARGS` environment variable.
 * `ansible.host_key_checking` can be set to `true` which will enable host key checking. As Vagrant 1.5, the default value is `false`, to avoid connection problems when creating new virtual machines.
 
 ## Tips and Tricks


### PR DESCRIPTION
- Ansible Default settings for SSH ControlPersist won't be lost when using SSH-forwarding or multiple SSH keys.
- People can add more custom SSH parameters via `ansible.raw_ssh_args` 
