### PR TITLE
Fix salt provisioning validation

### DIFF
--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -92,12 +92,12 @@ module VagrantPlugins
 
         if @minion_key || @minion_pub
           if !@minion_key || !@minion_pub
-            errors << @minion_pub
+            errors << I18n.t("vagrant.provisioners.salt.missing_key")
           end
         end
 
-        if @master_key && @master_pub
-          if !@minion_key && !@minion_pub
+        if @master_key || @master_pub
+          if !@master_key || !@master_pub
             errors << I18n.t("vagrant.provisioners.salt.missing_key")
           end
         end


### PR DESCRIPTION
The problem was that I wanted to have a salt-master only (no salt-minion). So in this case, it should be allowed to set only the master keys (and no minion keys).

See: #2790
