### PR TITLE
[Docs] Fix gem path in Gemfile

### DIFF
--- a/website/docs/source/v2/plugins/development-basics.html.md
+++ b/website/docs/source/v2/plugins/development-basics.html.md
@@ -45,7 +45,7 @@ group :development do
 end
 
 group :plugins do
-  gem "my-vagrant-plugin", path: "."
+  gem "my-vagrant-plugin", :path => "."
 end
 ```
 


### PR DESCRIPTION
I kept getting a syntax error by following the documentation until I changed this line. 

```
Gemfile syntax error:
Gemfile:11: syntax error, unexpected ':', expecting kEND
  gem "my-plugin", path: "."    
```

From the bundler documentation it looks like the syntax was wrong. Once I made this switch it started to work correctly. 
