### PR TITLE
Vagrant 1.5: NFS exports broken under Ubuntu Saucy

### DIFF
--- a/plugins/hosts/linux/cap/nfs.rb
+++ b/plugins/hosts/linux/cap/nfs.rb
@@ -94,7 +94,7 @@ module VagrantPlugins
 
           # Use sed to just strip out the block of code which was inserted
           # by Vagrant
-          system("sudo sed -r -e '/^# VAGRANT-BEGIN:( #{user})? #{id}/,/^# VAGRANT-END:( #{user})? #{id}/ d' -ibak /etc/exports")
+          system("sudo sed -r -e '\\\x1a^# VAGRANT-BEGIN:( #{user})? #{id}\x1a\\\x1a^# VAGRANT-END:( #{user})? #{id}\x1a d' -ibak /etc/exports")
         end
 
         def self.nfs_opts_setup(folders)


### PR DESCRIPTION
exportfs is installed under /usr/sbin under Ubuntu. I don't know about other distros. I can create a symlink to work around this one.

The more serious issue is that the shell out to sed to prune /etc/exports is still broken in this release. The hack to filter the identifiers with Regex.escape did not fix it because it doesn't escape forward slashes as they are not regex meta-characters. They are special only to sed for expression delimiters for address ranges and search/replace expressions.
