### PR TITLE
use global namespace for class IO naming conflict

### DIFF
--- a/plugins/guests/darwin/cap/configure_networks.rb
+++ b/plugins/guests/darwin/cap/configure_networks.rb
@@ -18,7 +18,7 @@ module VagrantPlugins
           machine.communicate.download("/tmp/vagrant.interfaces",tmpints)
 
           devlist = []
-          ints = IO.read(tmpints)
+          ints = ::IO.read(tmpints)
           ints.split(/\n\n/m).each do |i|
             if i.match(/Hardware/) and not i.match(/Ethernet/).nil?
               devmap = {}


### PR DESCRIPTION
Fixes #3143.
