### PR TITLE
Vagrant 1.5: Fix Linux NFS exports pruning due to bad `sed` expression

### DIFF
--- a/plugins/hosts/linux/cap/nfs.rb
+++ b/plugins/hosts/linux/cap/nfs.rb
@@ -94,7 +94,7 @@ module VagrantPlugins
 
           # Use sed to just strip out the block of code which was inserted
           # by Vagrant
-          system("sudo sed -r -e '/^# VAGRANT-BEGIN:( #{user})? #{id}/,/^# VAGRANT-END:( #{user})? #{id}/ d' -ibak /etc/exports")
+          system("sudo sed -r -e '\\\x01^# VAGRANT-BEGIN:( #{user})? #{id}\x01,\\\x01^# VAGRANT-END:( #{user})? #{id}\x01 d' -ibak /etc/exports")
         end
 
         def self.nfs_opts_setup(folders)


### PR DESCRIPTION
The mount id is a file path which will contain forward slashes. A
previous attempt (although notably missing in the Linux host plugin) at
fixing this used `String.gsub` to escape the forward slashes; however,
the solution that eventually made its way into the 1.5 release uses
`Regexp.escape` which doesn't escape forward slashes.

The Ruby `Regexp.escape` method does not escape forward slashes because
they are not RE meta-characters; their special meaning is specific to
sed expressions as delimiters. To avoid the issue entirely, we can use
an alternative delimiter by prefixing the address expression with a
backslash with the desired delimiter character following.

Use control character (ASCII code point `0x01`) as expression delimiter
so it is very unlikely an identifier will have a conflicting character
within it.
