### PR TITLE
Adds warning to VirtualBox docs

### DIFF
--- a/website/docs/source/v2/virtualbox/index.html.md
+++ b/website/docs/source/v2/virtualbox/index.html.md
@@ -18,4 +18,15 @@ VirtualBox can be installed by [downloading](https://www.virtualbox.org/wiki/Dow
 a package or installer for your operating system and using standard procedures
 to install that package.
 
+<div class="alert alert-block alert-warning">
+<p>
+<strong>Hanging Vagrant commands on Windows?</strong> If your prompt hangs on a 
+Vagrant command on Windows when using the VirtualBox provider this may be caused 
+by a permissions problem within VirtualBox, starting VirtualBox normally or as 
+a Windows administrator will prevent you from accessing it the opposite way. 
+Please keep in mind that when a Vagrant command interacts with VirtualBox it 
+will access VirtualBox with the access level of your Windows console.
+</p>
+</div>
+
 Use the navigation to the left to find a specific VirtualBox topic to read more about.


### PR DESCRIPTION
The warning box in the docs explains an issue with permissions for VirtualBox on Windows.

This came up through #3135
