### PR TITLE
config.vm.box_url can use local files

### DIFF
--- a/website/docs/source/v2/vagrantfile/machine_settings.html.md
+++ b/website/docs/source/v2/vagrantfile/machine_settings.html.md
@@ -72,6 +72,10 @@ This can also be an array of multiple URLs. The URLs will be tried in
 order. Note that any client certificates, insecure download settings, and
 so on will apply to all URLs in this list.
 
+`config.vm.box_url` can point to local files:
+```
+file:///tmp/test.box
+```
 <hr>
 
 `config.vm.box_version` - The version of the box to use. This defaults to


### PR DESCRIPTION
Updated the documentation to show that box_url can use "file://". This ability was added via in issue #1087 that was added 2 years ago.

https://github.com/mitchellh/vagrant/pull/1087
