### PR TITLE
website/docs: link to real vagrant cloud url

### DIFF
--- a/website/docs/source/v2/boxes.html.md
+++ b/website/docs/source/v2/boxes.html.md
@@ -14,7 +14,7 @@ boxes. You can read the documentation on the [vagrant box](/v2/cli/box.html)
 command for more information.
 
 The easiest way to use a box is to add a box from the
-[publicly available catalog of Vagrant boxes](http://www.vagrantcloud.com).
+[publicly available catalog of Vagrant boxes](https://vagrantcloud.com).
 You can also add and share your own customized boxes on this website.
 
 Boxes also support versioning so that members of your team using Vagrant
@@ -27,7 +27,7 @@ sub-pages in the navigation to the left.
 ## Discovering Boxes
 
 The easiest way to find boxes is to look on the
-[public Vagrant box catalog](http://www.vagrantcloud.com)
+[public Vagrant box catalog](https://vagrantcloud.com)
 for a box matching your use case. The catalog contains most major operating
 systems as bases, as well as specialized boxes to get you up and running
 quickly with LAMP stacks, Ruby, Python, etc.

--- a/website/docs/source/v2/boxes/base.html.md
+++ b/website/docs/source/v2/boxes/base.html.md
@@ -185,7 +185,7 @@ provider-specific guides are linked to towards the top of this page.
 You can distribute the box file however you'd like. However, if you want
 to support versioning, putting multiple providers at a single URL, pushing
 updates, analytics, and more, we recommend you add the box to
-[Vagrant Cloud](http://www.vagrantcloud.com).
+[Vagrant Cloud](https://vagrantcloud.com).
 
 You can upload both public and private boxes to this service.
 

--- a/website/docs/source/v2/boxes/format.html.md
+++ b/website/docs/source/v2/boxes/format.html.md
@@ -38,7 +38,7 @@ providers from a single file, and more.
 
 <div class="alert alert-block alert-info">
 <strong>You don't need to manually make the metadata.</strong> If you
-have an account with <a href="http://www.vagrantcloud.com">Vagrant Cloud</a>, you
+have an account with <a href="https://vagrantcloud.com">Vagrant Cloud</a>, you
 can create boxes there, and Vagrant Cloud automatically creates
 the metadata for you. The format is still documented here.
 </div>

--- a/website/docs/source/v2/cli/box.html.md
+++ b/website/docs/source/v2/cli/box.html.md
@@ -26,10 +26,10 @@ This adds a box with the given address to Vagrant. The address can be
 one of three things:
 
 * A shorthand name from the
-[public catalog of available Vagrant images](http://www.vagrantcloud.com),
+[public catalog of available Vagrant images](https://vagrantcloud.com),
 such as "hashicorp/precise64".
 
-* File path or HTTP URL to a box in a [catalog](http://www.vagrantcloud.com).
+* File path or HTTP URL to a box in a [catalog](https://vagrantcloud.com).
 For HTTP, basic authentication is supported and `http_proxy` environmental
 variables are respected. HTTPS is also supported.
 

--- a/website/docs/source/v2/cli/login.html.md
+++ b/website/docs/source/v2/cli/login.html.md
@@ -8,7 +8,7 @@ sidebar_current: "cli-login"
 **Command: `vagrant login`**
 
 The login command is used to authenticate with a
-[Vagrant Cloud](http://www.vagrantcloud.com) server. Logging is only
+[Vagrant Cloud](https://vagrantcloud.com) server. Logging is only
 necessary if you're accessing protected boxes or using
 [Vagrant Share](/v2/share/index.html).
 

--- a/website/docs/source/v2/getting-started/boxes.html.md
+++ b/website/docs/source/v2/getting-started/boxes.html.md
@@ -27,7 +27,7 @@ $ vagrant box add hashicorp/precise32
 ```
 
 This will download the box named "hashicorp/precise32" from
-[Vagrant Cloud](http://www.vagrantcloud.com), a place where you can find
+[Vagrant Cloud](https://vagrantcloud.com), a place where you can find
 and host boxes. While it is easiest to download boxes from Vagrant Cloud
 you can also add boxes from a local file, custom URL, etc.
 
@@ -64,7 +64,7 @@ For the remainder of this getting started guide, we'll only use the
 this getting started guide, the first question you'll probably have is
 "where do I find more boxes?"
 
-The best place to find more boxes is [Vagrant Cloud](http://www.vagrantcloud.com).
+The best place to find more boxes is [Vagrant Cloud](https://vagrantcloud.com).
 Vagrant Cloud has a public directory of freely available boxes that
 run various platorms and technologies. Vagrant Cloud also has a great search
 feature to allow you to find the box you care about.

--- a/website/docs/source/v2/getting-started/share.html.md
+++ b/website/docs/source/v2/getting-started/share.html.md
@@ -18,7 +18,7 @@ environment from any device in the world that is connected to the internet.
 ## Login to Vagrant Cloud
 
 Before being able to share your Vagrant environment, you'll need an account on
-[Vagrant Cloud](http://www.vagrantcloud.com). Don't worry, it's free.
+[Vagrant Cloud](https://vagrantcloud.com). Don't worry, it's free.
 
 Once you have an account, log in using `vagrant login`:
 

--- a/website/docs/source/v2/hyperv/usage.html.md
+++ b/website/docs/source/v2/hyperv/usage.html.md
@@ -17,5 +17,5 @@ admin rights. Vagrant will show you an error if it doesn't have the proper
 permissions.
 
 Boxes for Hyper-V can be easily found on
-[Vagrant Cloud](http://www.vagrantcloud.com). To get started, you might
+[Vagrant Cloud](https://vagrantcloud.com). To get started, you might
 want to try the `hashicorp/precise64` box.

--- a/website/docs/source/v2/share/index.html.md
+++ b/website/docs/source/v2/share/index.html.md
@@ -34,4 +34,4 @@ to the left. We also have a section where we go into detail about the
 security implications of this feature.
 
 Vagrant Share requires an account with
-[Vagrant Cloud](http://www.vagrantcloud.com) to be used.
+[Vagrant Cloud](https://vagrantcloud.com) to be used.

--- a/website/docs/source/v2/vagrantfile/machine_settings.html.md
+++ b/website/docs/source/v2/vagrantfile/machine_settings.html.md
@@ -20,7 +20,7 @@ for the machine to boot and be accessible. By default this is 300 seconds.
 `config.vm.box` - This configures what [box](/v2/boxes.html) the
 machine will be brought up against. The value here should be the name
 of an installed box or a shorthand name of a box in
-[Vagrant Cloud](http://www.vagrantcloud.com).
+[Vagrant Cloud](https://vagrantcloud.com).
 
 <hr>
 
@@ -28,7 +28,7 @@ of an installed box or a shorthand name of a box in
 the configured box on every `vagrant up`. If an update is found, Vagrant
 will tell the user. By default this is true. Updates will only be checked
 for boxes that properly support updates (boxes from
-[Vagrant Cloud](http://www.vagrantcloud.com)
+[Vagrant Cloud](https://vagrantcloud.com)
 or some other versioned box).
 
 <hr>
@@ -63,7 +63,7 @@ URL, then SSL certs will be verified.
 <hr>
 
 `config.vm.box_url` - The URL that the configured box can be found at.
-If `config.vm.box` is a shorthand to a box in [Vagrant Cloud](http://www.vagrantcloud.com)
+If `config.vm.box` is a shorthand to a box in [Vagrant Cloud](https://vagrantcloud.com)
 then this value doesn't need to be specified. Otherwise, it should
 point to the proper place where the box can be found if it isn't
 installed.


### PR DESCRIPTION
This is mostly for cookies and google. If you're logged in to
www, you won't be logged in to apex, and visa versa. Also a Vagrant
Cloud bug but wanted to make it consistent on this end.

![cookies](https://encrypted-tbn3.gstatic.com/images?q=tbn:ANd9GcTKt-3ayAFFzjEXjwy3Q-3WjfdIrDxgTZ2chgmqZeBPi81mLSC65Q)
