### PR TITLE
Fixed broken PowerShell execution

### DIFF
--- a/lib/vagrant/util/powershell.rb
+++ b/lib/vagrant/util/powershell.rb
@@ -21,7 +21,7 @@ module Vagrant
           "powershell",
           "-NoProfile",
           "-ExecutionPolicy", "Bypass",
-          "'#{path}'",
+          "&('#{path}')",
           args
         ].flatten
 


### PR DESCRIPTION
Commit 621369eb which is supposed to fix issue #3100 actually seems to break execution completely. While trying to solve #3139 I encountered the same problem as in #3192 where the JSON couldn't be parsed.

I dumped stdout from the process into a file (`File.write("C:/test.txt", r.stdout)`) and the output was the path to the actual script and not the generated JSON. It seems like wrapping the path in single quotation marks just passes it as a string to PowerShell, who have no clue what to do and just throws the string back at you.

I did a quick search and proper way to execute scripts with "spaced paths" [seems to be this way](http://blogs.technet.com/b/heyscriptingguy/archive/2012/08/07/powertip-run-a-powershell-script-with-space-in-the-path.aspx). This commit should fix the problem encountered in #3192 and actually fix #3100.
