### PR TITLE
Make shared folder type smb work for non-english windows

### DIFF
--- a/plugins/synced_folders/smb/scripts/set_share.ps1
+++ b/plugins/synced_folders/smb/scripts/set_share.ps1
@@ -19,7 +19,12 @@ if ($existing_share) {
     net share $share_name /delete /y
 }
 
-$grant = "Everyone,Full"
+# The names of the user are language dependent!
+$objSID = New-Object System.Security.Principal.SecurityIdentifier("S-1-1-0")
+$objUser = $objSID.Translate([System.Security.Principal.NTAccount])
+
+$grant = "$objUser,Full"
+
 if (![string]::IsNullOrEmpty($host_share_username)) {
     $computer_name = $(Get-WmiObject Win32_Computersystem).name
     $grant         = "$computer_name\$host_share_username,Full"
@@ -38,7 +43,7 @@ if (![string]::IsNullOrEmpty($host_share_username)) {
 }
 
 $result = net share $share_name=$path /unlimited /GRANT:$grant
-if ($result -Match "$share_name was shared successfully.") {
+if ($LastExitCode -eq 0) {
     exit 0
 }
 


### PR DESCRIPTION
the grant "Everyone,Full" does not work on localized versions of windows, in German it is "Jeder" in Spanish "Todos". Also the net share command returns localized texts, so the -Match does not work for non-english Windows. 

I could not test exactly that version, copied relevant bits from my modified lokal version.
