### PR TITLE
#3244 Fix SMB shared folder mount error with password containing symbols.

### DIFF
--- a/plugins/guests/linux/cap/mount_smb_shared_folder.rb
+++ b/plugins/guests/linux/cap/mount_smb_shared_folder.rb
@@ -26,7 +26,7 @@ module VagrantPlugins
           options[:mount_options] ||= []
           options[:mount_options] << "sec=ntlm"
           options[:mount_options] << "username=#{options[:smb_username]}"
-          options[:mount_options] << "pass=#{options[:smb_password]}"
+          options[:mount_options] << "pass='#{options[:smb_password]}'"
 
           # First mount command uses getent to get the group
           mount_options = "-o uid=#{mount_uid},gid=#{mount_gid}"


### PR DESCRIPTION
Put quotes around the password to fix smb mount errors when a password contains symbols.
