### PR TITLE
Allow provisioner plugins to register without config

### DIFF
--- a/plugins/kernel_v2/config/vm_provisioner.rb
+++ b/plugins/kernel_v2/config/vm_provisioner.rb
@@ -49,6 +49,7 @@ module VagrantPlugins
         if !@config_class
           @logger.info(
             "Provisioner config for '#{@name}' not found. Ignoring config.")
+          @config_class = Vagrant::Config::V2::DummyConfig
         end
       end
 

--- a/test/unit/plugins/kernel_v2/config/vm_test.rb
+++ b/test/unit/plugins/kernel_v2/config/vm_test.rb
@@ -3,6 +3,8 @@ require File.expand_path("../../../../base", __FILE__)
 require Vagrant.source_root.join("plugins/kernel_v2/config/vm")
 
 describe VagrantPlugins::Kernel_V2::VMConfig do
+  include_context "unit"
+
   subject { described_class.new }
 
   let(:machine) { double("machine") }
@@ -208,6 +210,24 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
       r = subject.provisioners
       expect(r.length).to eql(1)
       expect(r[0]).to be_invalid
+    end
+
+    it "allows provisioners that don't define any config" do
+      register_plugin("2") do |p|
+        p.name "foo"
+        # This plugin registers a dummy provisioner
+        # without registering a provisioner config
+        p.provisioner(:foo) do
+          Class.new Vagrant::plugin("2", :provisioner)
+        end
+      end
+
+      subject.provision("foo") do |c|
+        c.bar = "baz"
+      end
+
+      # This should succeed without errors
+      expect{ subject.finalize! }.to_not raise_error
     end
 
     describe "merging" do


### PR DESCRIPTION
Hello, while maintaining the [vagrant-hostmanager](https://github.com/smdahlen/vagrant-hostmanager) plugin, I noticed that vagrant 1.5 breaks when a provisioner plugin is registered without a provisioner config.

The init code in vm_provisioner.rb implies that it's okay not to have a config for the provisioner, but then it breaks in [#add_config](https://github.com/pbitty/vagrant/blob/10d5416a9037233a8610f9b16cb28c948fa1c533/plugins/kernel_v2/config/vm_provisioner.rb#L51) if the config class is nil.

I wrote a failing test for it and then added DummyConfig as the default config class.

Would this be the way to go in fixing it?  I'm happy to make any changes to the PR.
