### PR TITLE
Update virtualbox boxes docs

### DIFF
--- a/website/docs/source/v2/virtualbox/boxes.html.md
+++ b/website/docs/source/v2/virtualbox/boxes.html.md
@@ -67,7 +67,7 @@ guest additions. For example, for Linux on x86, it is the following:
 $ sudo sh /media/cdrom/VBoxLinuxAdditions.run
 ```
 
-If the commands succeeds, then the guest additions are now installed!
+If the command succeeds, then the guest additions are now installed!
 
 #### To install via the command line:
 


### PR DESCRIPTION
I referenced the [current docs for creating a VirtualBox base box](http://docs.vagrantup.com/v2/virtualbox/boxes.html) in the process of creating [my own base box](https://vagrantcloud.com/sincerely/precise64), and ran into a few gotchas:
1. I needed the `dkms` package installed in order to build the guest additions (see: http://askubuntu.com/questions/98416/error-kernel-headers-not-found-but-they-are-in-place)
2. It also looks like `linux-headers-generic` should suffice, as opposed to `linux-headers-$(uname -r)`
3. I added instructions for downloading and building the latest guest additions via the command line (as opposed to a GUI)

Feel free to tweak or improve as you see fit.
