### PR TITLE
Fixed issue 3285

### DIFF
--- a/lib/vagrant/plugin/manager.rb
+++ b/lib/vagrant/plugin/manager.rb
@@ -72,9 +72,11 @@ module Vagrant
           install_lambda.call
         end
 
-        # If the version constraint is just a specific version, don't
+        # If the version constraint is just a specific (non prerelease) version, don't
         # store the constraint.
-        opts.delete(:version) if opts[:version] && opts[:version] =~ /^\d/
+        if opts[:version] && opts[:version] =~ /^\d/ && !Gem::Requirement.parse(opts[:version])[1].prerelease?
+          opts.delete(:version)
+        end
 
         # Add the plugin to the state file
         @user_file.add_plugin(


### PR DESCRIPTION
Fixed issue #3285. When using prerelease gems we need to ensure we store the gem version otherwise Bundler won't use the correct gem version since prerelease gems are not available by default. By storing the gem version for prerelease gems, we allow Bundler to properly resolve prerelease gems and not give potentially confusing errors to Vagrant users using prerelease plugins.
