### PR TITLE
Don't reorder config in /etc/network/interfaces

### DIFF
--- a/plugins/guests/debian/cap/configure_networks.rb
+++ b/plugins/guests/debian/cap/configure_networks.rb
@@ -13,9 +13,8 @@ module VagrantPlugins
           machine.communicate.tap do |comm|
             # First, remove any previous network modifications
             # from the interface file.
-            comm.sudo("sed -e '/^#VAGRANT-BEGIN/,/^#VAGRANT-END/ d' /etc/network/interfaces > /tmp/vagrant-network-interfaces")
-            comm.sudo("su -c 'cat /tmp/vagrant-network-interfaces > /etc/network/interfaces'")
-            comm.sudo("rm -f /tmp/vagrant-network-interfaces")
+            comm.sudo("sed -e '/^#VAGRANT-BEGIN/,$ d' /etc/network/interfaces > /tmp/vagrant-network-interfaces.pre")
+            comm.sudo("sed -ne '/^#VAGRANT-END/,$ p' /etc/network/interfaces | tail -n +2 > /tmp/vagrant-network-interfaces.post")
 
             # Accumulate the configurations to add to the interfaces file as
             # well as what interfaces we're actually configuring since we use that
@@ -47,8 +46,8 @@ module VagrantPlugins
               comm.sudo("/sbin/ip addr flush dev eth#{interface} 2> /dev/null")
             end
 
-            comm.sudo("cat /tmp/vagrant-network-entry >> /etc/network/interfaces")
-            comm.sudo("rm -f /tmp/vagrant-network-entry")
+            comm.sudo('cat /tmp/vagrant-network-interfaces.pre /tmp/vagrant-network-entry /tmp/vagrant-network-interfaces.post > /etc/network/interfaces')
+            comm.sudo('rm -f /tmp/vagrant-network-interfaces.pre /tmp/vagrant-network-entry /tmp/vagrant-network-interfaces.post')
 
             # Bring back up each network interface, reconfigured
             interfaces.each do |interface|


### PR DESCRIPTION
On Debian the network interface configuration is rewritten, with the Vagrant section appended, every reboot. But the network interface file is order dependent when additional virtual interfaces are added by installed packages (`ucarp` being my motivating example). Moving the Vagrant section to the end breaks virtual interfaces (like `ucarp`'s virtual IP).

This patch changes this so that it effectively rewrites the Vagrant section in `/etc/network/interfaces` in place rather than moving it to the end of the file.

If the section doesn't exist, it still gets appended as before.
