### PR TITLE
display version by default when listing boxes

### DIFF
--- a/plugins/commands/box/command/list.rb
+++ b/plugins/commands/box/command/list.rb
@@ -45,7 +45,7 @@ module VagrantPlugins
           # important for the user to know what boxes need to be upgraded
           # and which don't, since we plan on doing that transparently.
           boxes.each do |name, version, provider|
-            @env.ui.info("#{name.ljust(longest_box_length)} (#{provider})")
+            @env.ui.info("#{name.ljust(longest_box_length)} (#{provider}) [#{version}]")
 
             @env.ui.machine("box-name", name)
             @env.ui.machine("box-provider", provider)


### PR DESCRIPTION
example usage:

$ vagrant box list
berendt/ubuntu-14.04-amd64 (virtualbox) [0.1.3]
berendt/ubuntu-14.04-amd64 (virtualbox) [0.1.4]
berendt/ubuntu-14.04-amd64 (virtualbox) [0.1.5]

related to issue #3313
