### PR TITLE
Fix for issue #3322, a followup to issue #2591.

### DIFF
--- a/plugins/guests/arch/cap/configure_networks.rb
+++ b/plugins/guests/arch/cap/configure_networks.rb
@@ -21,6 +21,7 @@ module VagrantPlugins
 
             machine.communicate.upload(temp.path, "/tmp/vagrant_network")
             machine.communicate.sudo("ln -sf /dev/null /etc/udev/rules.d/80-net-name-slot.rules")
+            machine.communicate.sudo("udevadm control --reload")
             machine.communicate.sudo("mv /tmp/vagrant_network /etc/netctl/eth#{network[:interface]}")
 
             # Only consider nth line of sed's output below. There's always an


### PR DESCRIPTION
Arch linux will rename its eth0 device unless an empty file is placed in `/etc/udev/rules.d/`.
In order for the new rules to take effect, we need call `udevadm control --reload`.
