### PR TITLE
communicators/ssh: Set the Terminals default encoding to UTF-8 [GH-3295]

### DIFF
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -423,6 +423,9 @@ module VagrantPlugins
             # Set the terminal
             ch2.send_data "export TERM=vt100\n"
 
+            # Default terminal encoding to UTF-8 [GH-3295]
+            ch2.send_data "export LANG=UTF-8\n"
+
             # Set SSH_AUTH_SOCK if we are in sudo and forwarding agent.
             # This is to work around often misconfigured boxes where
             # the SSH_AUTH_SOCK env var is not preserved.


### PR DESCRIPTION
See GH-3295 for further details.
