### PR TITLE
HyperV provider resume. GH-3336

### DIFF
--- a/plugins/providers/hyperv/action.rb
+++ b/plugins/providers/hyperv/action.rb
@@ -67,8 +67,8 @@ module VagrantPlugins
         Vagrant::Action::Builder.new.tap do |b|
           b.use HandleBox
           b.use ConfigValidate
-          b.use Call, IsState, :not_created do |env, b2|
-            if env1[:result]
+          b.use Call, IsState, :not_created do |env, b1|
+            if env[:result]
               b1.use Message, I18n.t("vagrant_hyperv.message_not_created")
               next
             end


### PR DESCRIPTION
Fix for vagrant resume command for HyperV provider. Fixed the variable
name in action builder block.
