### PR TITLE
Fix documents when using private_network with dhcp

### DIFF
--- a/website/docs/source/v2/networking/private_network.html.md
+++ b/website/docs/source/v2/networking/private_network.html.md
@@ -34,7 +34,7 @@ via DHCP.
 
 ```ruby
 Vagrant.configure("2") do |config|
-  config.vm.network "private_network", type: "dhcp"
+  config.vm.network "private_network", type: :dhcp
 end
 ```
 


### PR DESCRIPTION
I wrote in my Vagrantfile following [the documents](https://docs.vagrantup.com/v2/networking/private_network.html) as follows  :

``` ruby
  config.vm.provider "virtualbox" do |vb, override|
    override.vm.network "private_network", type: "dhcp"
  end
```
# :smile::smile::smile: Expected  :smile::smile::smile:

``` bash
$ vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: VirtualBox VM is already running.
$ # No problem
```
# :hankey::hankey::hankey: Actual :hankey::hankey::hankey:

``` bash
$ vagrant up
There are errors in the configuration of this machine. Please fix
the following errors and try again:

vm:
* An IP is required for a private network.
$ echo $?
1
```

:scream: :broken_heart:

Next, I correct my Vagrantfile as follows:

``` ruby
  config.vm.provider "virtualbox" do |vb, override|
    override.vm.network "private_network", type: :dchp
  end
```

Then, 

``` bash
$ vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: VirtualBox VM is already running.
$ # No problem
```

:v::v::v:
# :question: :question: :question: Why should I fix it as this patch :question: :question: :question:

See below:

at https://github.com/mitchellh/vagrant/blob/v1.5.1/plugins/providers/virtualbox/action/network.rb#L279 :

``` ruby
if options[:type] == :dhcp
```

at https://github.com/mitchellh/vagrant/blob/v1.5.1/plugins/providers/virtualbox/action/network.rb#L251 :

``` ruby
          options[:ip] = "172.28.128.1" if options[:type] == :dhcp && !options[:ip]
```
