### PR TITLE
Fix for HyperV provider fails when recreating shares on Vagrant reload #...

### DIFF
--- a/plugins/synced_folders/smb/scripts/set_share.ps1
+++ b/plugins/synced_folders/smb/scripts/set_share.ps1
@@ -8,15 +8,8 @@ Param(
 
 $ErrorAction = "Stop"
 
-# See all available shares and check alert user for existing/conflicting
-# share names.
-$path_regexp = [System.Text.RegularExpressions.Regex]::Escape($path)
-$name_regexp = [System.Text.RegularExpressions.Regex]::Escape($share_name)
-$reg = "(?m)$name_regexp\s+$path_regexp\s"
-$existing_share = $($(net share) -join "`n") -Match $reg
-if ($existing_share) {
-    # Always clear the existing share name and create a new one
-    net share $share_name /delete /y
+if (net share | Select-String $share_name) {
+  net share $share_name /delete /y
 }
 
 # The names of the user are language dependent!


### PR DESCRIPTION
...3353

Mitchell, I am not sure what the purpose the powershell hyper-V guys had with the regexs, but they were not working in properly detecting existing smb shares and recreating them. I changed the expression for something simpler that seems to work.
