### PR TITLE
Fixed unquoted ssh with rsync bug

### DIFF
--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -76,7 +76,7 @@ module VagrantPlugins
         command = [
           "rsync",
           args,
-          "-e", rsh,
+          "-e",'"', rsh,'"',
           excludes.map { |e| ["--exclude", e] },
           hostpath,
           "#{username}@#{host}:#{guestpath}",


### PR DESCRIPTION
In the previous version the string was built as

rsync --verbose --archive --delete -z -e ssh -p 2222 -o StrictHostKeyChecking=no -i '/path/to/private_key' --exclude .vagrant/ --exclude {...} /path/to/local/ vagrant@127.0.0.1:/home/vagrant/www

However to connect properly the ssh-part  needs to be quoted, i.e.

rsync --verbose --archive --delete -z -e "ssh -p 2222 -o StrictHostKeyChecking=no -i '/path/to/private_key'" --exclude .vagrant/ --exclude {...} /path/to/local/ vagrant@127.0.0.1:/home/vagrant/www
