### PR TITLE
handle exception when removing a non existing box version

### DIFF
--- a/lib/vagrant/action/builtin/box_remove.rb
+++ b/lib/vagrant/action/builtin/box_remove.rb
@@ -65,6 +65,14 @@ module Vagrant
           box = env[:box_collection].find(
             box_name, box_provider, box_version)
 
+          if box == nil
+            raise Errors::BoxRemoveVersionNotFound,
+              name: box_name,
+              provider: box_provider.to_s,
+              version: box_version,
+              versions: all_versions.join(", ")
+          end
+
           env[:ui].info(I18n.t("vagrant.commands.box.removing",
                               :name => box.name,
                               :provider => box.provider))

--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -196,6 +196,10 @@ module Vagrant
       error_key(:box_remove_provider_not_found)
     end
 
+    class BoxRemoveVersionNotFound < VagrantError
+      error_key(:box_remove_version_not_found)
+    end
+
     class BoxRemoveMultiProvider < VagrantError
       error_key(:box_remove_multi_provider)
     end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -433,6 +433,13 @@ en:
         the provider specified. Please double-check and try again.
 
         The providers for this are: %{providers}
+      box_remove_version_not_found: |-
+        You requested to remove the box '%{name}' with provider
+        '%{provider}' in version '%{version}'. The box '%{name}'
+        exists but not in the specified version '%{version}'.
+        Please double-check and try again.
+
+        The available versions for this box are: %{versions}
       box_server_not_set: |-
         A URL to a Vagrant Cloud server is not set, so boxes cannot
         be added with a shorthand ("mitchellh/precise64") format.


### PR DESCRIPTION
When trying to remove a not existing version of an existing box an
exception is thrown. The exception should be handled and some message
(box version 0.1.2 not available) should be printed.

With this patch the exception is handled correctly by using a newly
introduced exception BoxRemoveVersionNotFound.

Example output:

You requested to remove the box 'berendt/alpine-2.7.5-amd64' with provider
'virtualbox' in version '0.0.2'. The box 'berendt/alpine-2.7.5-amd64'
exists but not in the specified version '0.0.2'.
Please double-check and try again.

The available versions for this box are: 0.1.0

Fixes issue #3344
