### PR TITLE
add missing translation en.vagrant.commands.status.stopping

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1192,6 +1192,8 @@ en:
           that vagrant would be able to control the VM again.
         poweroff: |-
           The VM is powered off. To restart the VM, simply run `vagrant up`
+        stopping: |-
+          The VM is stopping.
         running: |-
           The VM is running. To stop this VM, you can run `vagrant halt` to
           shut it down forcefully, or you can run `vagrant suspend` to simply


### PR DESCRIPTION
VirtualBox got into a limbo mode, as a result, running `vagrant status` reported:

```
$ vagrant status                                                                                                                              *[feature/remove-legacy-api]
Current machine states:

default                   stopping (virtualbox)

translation missing: en.vagrant.commands.status.stopping
```

To satisfy my lack of creativity, please suggest a better text. Much obliged :)
