### PR TITLE
Implicit box_version should not keep you from using a direct URL.

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -119,7 +119,7 @@ module Vagrant
             raise Errors::BoxAddNameRequired
           end
 
-          if env[:box_version]
+          unless env[:box_version] == '>= 0'
             raise Errors::BoxAddDirectVersion
           end
 


### PR DESCRIPTION
The issue is that when you create a Vagrant file with an explicit URL it grabs the default box_version and assumes that you've implied constraints when you haven't.

An example Vagrantfile that causes this issue is in the [coreos vagrant example](https://github.com/coreos/coreos-vagrant/blob/master/Vagrantfile).

This is what you get if you attempt to run it:

```
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'coreos-alpha' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
You specified a box version constraint with a direct box file
path. Box version constraints only work with boxes from Vagrant
Cloud or a custom box host. Please remove the version constraint
and try again.
```

I haven't really given a version, so it shouldn't constraint me from grabbing the box from the URL.

This fixes this. The assumption is that if you want the "latest version", you should be able to grab the URL.
