### PR TITLE
synced_folders/rsync: enable override of default chmod flag

### DIFF
--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -72,9 +72,14 @@ module VagrantPlugins
         args = Array(opts[:args]) if opts[:args]
         args ||= ["--verbose", "--archive", "--delete", "-z"]
 
-        # On Windows, we have to set the chmod flag to avoid permission issues
-        if Vagrant::Util::Platform.windows?
+        # On Windows, we have to set a default chmod flag to avoid permission issues
+        if Vagrant::Util::Platform.windows? && !args.any? { |arg| arg.start_with?("--chmod=") }
+          #Ensures that all non-masked bits get enabled
           args << "--chmod=ugo=rwX"
+          
+          #Remove the -p option if --archive is enabled (--archive equals -rlptgoD)
+          #otherwise new files will not have the destination-default permissions
+          args << "--no-perms" if (args.include? "--archive") || (args.include? "-a")
         end
 
         # Build up the actual command to execute


### PR DESCRIPTION
The default `--chmod` flag on rsync can be overridden on Windows now. 

If no custom `--chmod` flag is specified and `--archive` is used, the `--no-perms` flag is added to the arguments, because `--archive` automatically adds the `--perms` flag which in turn would ignore the `umask` on the guest.

Quote from `man rsync`:

> To give new files the destination-default permissions (while leaving existing files unchanged), make sure that the --perms option is off and use --chmod=ugo=rwX (which ensures that all non-masked bits get enabled).  

I think, this new default behavior is feasible for most Windows users. Do you agree?
