### PR TITLE
Fixed typo in smb errors on error_key call

### DIFF
--- a/plugins/synced_folders/smb/errors.rb
+++ b/plugins/synced_folders/smb/errors.rb
@@ -19,7 +19,7 @@ module VagrantPlugins
       end
 
       class PowershellVersion < SMBError
-        error_Key(:powershell_version)
+        error_key(:powershell_version)
       end
 
       class WindowsHostRequired < SMBError


### PR DESCRIPTION
This will prevent a relevant error being returned (instead giving one about error_Key not being found)
