### PR TITLE
Encapsulate path for smb powershell script

### DIFF
--- a/plugins/synced_folders/smb/synced_folder.rb
+++ b/plugins/synced_folders/smb/synced_folder.rb
@@ -66,7 +66,7 @@ module VagrantPlugins
             "#{machine.id}-#{id.gsub("/", "-")}")
 
           args = []
-          args << "-path" << hostpath.gsub("/", "\\")
+          args << "-path" << "\"#{hostpath.gsub("/", "\\")}\""
           args << "-share_name" << data[:smb_id]
           #args << "-host_share_username" << @creds[:username]
 


### PR DESCRIPTION
Windows allows parens, spaces and other special chars in directory and file names. Sometimes you don't have a choice (weird IT policies, bureaucracy, drugs etc.) and end up with a bunch of this crap in your paths.

In this case, currently it will fail at the point it calls the set_share.ps1 script, I considered extending the gsub to cover other characters but there are quite a lot that are allowed and would cause this problem so I think the easiest solution with the broadest coverage is to simply encapsulate it.
