### PR TITLE
Add box before 'vagrant up' in "Getting Started"

### DIFF
--- a/website/docs/source/v2/getting-started/index.html.md
+++ b/website/docs/source/v2/getting-started/index.html.md
@@ -34,6 +34,7 @@ Vagrant: Up and Running
 ## Up and Running
 
 ```
+$ vagrant box add hashicorp/precise32 http://files.vagrantup.com/precise32.box
 $ vagrant init hashicorp/precise32
 $ vagrant up
 ```


### PR DESCRIPTION
Migrating https://github.com/hashicorp/vagrant-docs-old/issues/11

Hi @mitchellh , just a suggestion, but shouldn't users have to add the "hashicorp/precise32" box before trying to `vagrant up` as listed in the [Getting Started](http://docs.vagrantup.com/v2/getting-started/index.html) page?

I'd suggest this:

```
$ vagrant init hashicorp/precise32
$ vagrant up
```

Be changed to this: 

```
$ vagrant box add hashicorp/precise32 http://files.vagrantup.com/precise32.box
$ vagrant init hashicorp/precise32
$ vagrant up
```
