### PR TITLE
Error with empty shell provisioners

### DIFF
--- a/plugins/provisioners/shell/config.rb
+++ b/plugins/provisioners/shell/config.rb
@@ -53,7 +53,7 @@ module VagrantPlugins
                               :path => expanded_path)
           else
             data = expanded_path.read(16)
-            if !data.valid_encoding?
+            if data != nil && !data.valid_encoding?
               errors << I18n.t(
                 "vagrant.provisioners.shell.invalid_encoding",
                 actual: data.encoding.to_s,


### PR DESCRIPTION
Specifying an empty file as a shell provisioner throws an error.

This can be tested with a minimal Vagrantfile:

``` ruby
# -*- mode: ruby -*-
# vi: set ft=ruby :

VAGRANTFILE_API_VERSION = "2"

Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
  config.vm.box = "hashicorp/precise32"

  config.vm.provision :shell, :path => 'bootstrap.sh'
end
```

(You will also need an empty `bootstrap.sh` in the same folder.)

The error message is:

```
Bringing machine 'default' up with 'virtualbox' provider...
/opt/vagrant/embedded/gems/gems/vagrant-1.5.1/plugins/provisioners/shell/config.rb:56:in `validate': undefined method `valid_encoding?' for nil:NilClass (NoMethodError)
    from /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/plugins/kernel_v2/config/vm.rb:614:in `block in validate'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/plugins/kernel_v2/config/vm.rb:606:in `each'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/plugins/kernel_v2/config/vm.rb:606:in `validate'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/lib/vagrant/config/v2/root.rb:68:in `block in validate'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/lib/vagrant/config/v2/root.rb:64:in `each'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/lib/vagrant/config/v2/root.rb:64:in `validate'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/lib/vagrant/action/builtin/config_validate.rb:15:in `call'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/lib/vagrant/action/warden.rb:34:in `call'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/lib/vagrant/action/builtin/call.rb:57:in `call'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/lib/vagrant/action/warden.rb:34:in `call'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/plugins/providers/virtualbox/action/check_virtualbox.rb:17:in `call'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/lib/vagrant/action/warden.rb:34:in `call'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/lib/vagrant/action/builder.rb:116:in `call'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/lib/vagrant/action/runner.rb:69:in `block in run'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/lib/vagrant/util/busy.rb:19:in `busy'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/lib/vagrant/action/runner.rb:69:in `run'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/lib/vagrant/machine.rb:157:in `action'
    from /opt/vagrant/embedded/gems/gems/vagrant-1.5.1/lib/vagrant/batch_action.rb:72:in `block (2 levels) in run'
```

While this is not fatal behavior, it is still confusing to the user.

This pull request fixes this by skipping the encoding test for empty files.
