### PR TITLE
Decouple inventory_path and inventory generation

### DIFF
--- a/plugins/provisioners/ansible/config.rb
+++ b/plugins/provisioners/ansible/config.rb
@@ -14,6 +14,7 @@ module VagrantPlugins
       attr_accessor :start_at_task
       attr_accessor :groups
       attr_accessor :host_key_checking
+      attr_accessor :generate_inventory
 
       # Joker attribute, used to pass unsupported arguments to ansible-playbook anyway
       attr_accessor :raw_arguments
@@ -36,6 +37,7 @@ module VagrantPlugins
         @host_key_checking = "false"
         @raw_arguments     = UNSET_VALUE
         @raw_ssh_args      = UNSET_VALUE
+        @generate_inventory= UNSET_VALUE
       end
 
       def finalize!
@@ -54,6 +56,9 @@ module VagrantPlugins
         @host_key_checking = nil if @host_key_checking == UNSET_VALUE
         @raw_arguments     = nil if @raw_arguments == UNSET_VALUE
         @raw_ssh_args      = nil if @raw_ssh_args == UNSET_VALUE
+
+        # backwards compatible inventory file generation logic
+        @generate_inventory= (not @inventory_path) if @generate_inventory == UNSET_VALUE
       end
 
       def validate(machine)

--- a/plugins/provisioners/ansible/provisioner.rb
+++ b/plugins/provisioners/ansible/provisioner.rb
@@ -89,12 +89,17 @@ module VagrantPlugins
       # Auto-generate "safe" inventory file based on Vagrantfile,
       # unless inventory_path is explicitly provided
       def setup_inventory_file
-        return config.inventory_path if config.inventory_path
+        return config.inventory_path if config.inventory_path and not config.generate_inventory
 
         # Managed machines
         inventory_machines = {}
 
-        generated_inventory_dir = @machine.env.local_data_path.join(File.join(%w(provisioners ansible inventory)))
+        if config.inventory_path
+          generated_inventory_dir = Pathname.new(File.expand_path(config.inventory_path, @machine.env.cwd))
+        else
+          generated_inventory_dir = @machine.env.local_data_path.join(File.join(%w(provisioners ansible inventory)))
+        end
+
         FileUtils.mkdir_p(generated_inventory_dir) unless File.directory?(generated_inventory_dir)
         generated_inventory_file = generated_inventory_dir.join('vagrant_ansible_inventory')
 
@@ -150,7 +155,11 @@ module VagrantPlugins
           end
         end
 
-        return generated_inventory_file.to_s
+        if config.inventory_path
+          return generated_inventory_dir.to_s
+        else
+          return generated_inventory_file.to_s
+        end
       end
 
       def get_extra_vars_argument


### PR DESCRIPTION
Supports the use case where data from outside of Vagrant (hosts and vars) are desired in addition to the inventory file that vagrant generates.

Previously, if the `inventory_path` was set, the vagrant inventory file would not be generated. This introduces the `generate_inventory` flag to decouple the `inventory_path` from the inventory generation process, allowing user inventories to be merged with the vagrant generated inventory.

If the `generate_inventory` is set to `true` and an `inventory_path` is set and is a directory, the generated inventory file will be placed in that directory and that directory will be passed to ansible.

If the `generate_inventory` flag is not set, previous behavior is maintained, eg. the inventory will not be generated if `inventory_path` is set.

TODO: Update Docs to reflect new functionality

CC: @gildegoma
