### PR TITLE
provisioners/ansible: refer to directory that contains the generated inventory file

### DIFF
--- a/plugins/provisioners/ansible/provisioner.rb
+++ b/plugins/provisioners/ansible/provisioner.rb
@@ -150,7 +150,7 @@ module VagrantPlugins
           end
         end
 
-        return generated_inventory_file.to_s
+        return generated_inventory_dir.to_s
       end
 
       def get_extra_vars_argument


### PR DESCRIPTION
By referring to the directory that contains the generated inventory file,
users can easily provide more settings with additional files stored in
the same directory.

Related issues and comments:
- https://github.com/mitchellh/vagrant/pull/2991#issuecomment-35978587
- #3004
- #3434

/cc: @retr0h, @zeroem 
