### PR TITLE
sort versions and print them as listing

### DIFF
--- a/lib/vagrant/action/builtin/box_remove.rb
+++ b/lib/vagrant/action/builtin/box_remove.rb
@@ -58,14 +58,14 @@ module Vagrant
               raise Errors::BoxRemoveMultiVersion,
                 name: box_name,
                 provider: box_provider.to_s,
-                versions: all_versions.join(", ")
+                versions: all_versions.sort.map! { |k| " * #{k}" }.join("\n")
             end
           elsif !all_versions.include?(box_version)
             raise Errors::BoxRemoveVersionNotFound,
               name: box_name,
               provider: box_provider.to_s,
               version: box_version,
-              versions: all_versions.join(", ")
+              versions: all_versions.sort.map! { |k| " * #{k}" }.join("\n")
           end
 
           box = env[:box_collection].find(


### PR DESCRIPTION
before this patch:

```
$ vagrant box remove --box-version 0.2.9 berendt/ubuntu-14.04-amd64
You requested to remove the box 'berendt/ubuntu-14.04-amd64' version '0.2.9' with
provider 'virtualbox', but that specific version of the box is
not install. Please double-check and try again. The available versions
for this box are:

0.2.11, 0.2.10
```

after this patch:

```
You requested to remove the box 'berendt/ubuntu-14.04-amd64' version '0.2.9' with
provider 'virtualbox', but that specific version of the box is
not install. Please double-check and try again. The available versions
for this box are:

 * 0.2.10
 * 0.2.11
```
