### PR TITLE
Make it so the rsync synced folder type follows symlinks on the host machine

### DIFF
--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -70,7 +70,7 @@ module VagrantPlugins
         # Get the command-line arguments
         args = nil
         args = Array(opts[:args]) if opts[:args]
-        args ||= ["--verbose", "--archive", "--delete", "-z"]
+        args ||= ["--verbose", "--archive", "--delete", "--copy-dirlinks", "-z"]
 
         # On Windows, we have to set a default chmod flag to avoid permission issues
         if Vagrant::Util::Platform.windows? && !args.any? { |arg| arg.start_with?("--chmod=") }

--- a/website/docs/source/v2/synced-folders/rsync.html.md
+++ b/website/docs/source/v2/synced-folders/rsync.html.md
@@ -40,7 +40,7 @@ it will tell you.
 The rsync synced folder type accepts the following options:
 
 * `rsync__args` (array of strings) - A list of arguments to supply
-  to `rsync`. By default this is `["--verbose", "--archive", "--delete", "-z"]`.
+  to `rsync`. By default this is `["--verbose", "--archive", "--delete", "--copy-dirlinks", "-z"]`.
 
 * `rsync__auto` (boolean) - If false, then `rsync-auto` will not
   watch and automatically sync this folder. By default, this is true.


### PR DESCRIPTION
per issue #3444.
