### PR TITLE
When there are multiple versions of a box are available it should be che...

### DIFF
--- a/plugins/commands/box/command/update.rb
+++ b/plugins/commands/box/command/update.rb
@@ -69,7 +69,7 @@ module VagrantPlugins
           end
 
           to_update = [
-            [name, provider, boxes[name][provider].last],
+            [name, provider, boxes[name][provider].sort.last],
           ]
 
           to_update.each do |n, p, v|


### PR DESCRIPTION
...cked if an update is available for the highest version.

Example:

There are version 0.2.10 and 0.2.11 available. The latest update is version 0.2.12.

```
berendt/ubuntu-14.04-amd64          (virtualbox, 0.2.10)
berendt/ubuntu-14.04-amd64          (virtualbox, 0.2.11)
```

Without this patch it will be checked if a higher version than 0.2.10 is available.

```
Checking for updates to 'berendt/ubuntu-14.04-amd64'
Version constraints: > 0.2.10
Provider: virtualbox
Updating 'berendt/ubuntu-14.04-amd64' with provider 'virtualbox' from version
'0.2.10' to '0.2.12'...
Loading metadata for box 'https://vagrantcloud.com/berendt/ubuntu-14.04-amd64'
Adding box 'berendt/ubuntu-14.04-amd64' (v0.2.12) for provider: virtualbox
Downloading: https://vagrantcloud.com/berendt/ubuntu-14.04-amd64/version/23/provider/virtualbox.box
Successfully added box 'berendt/ubuntu-14.04-amd64' (v0.2.12) for 'virtualbox'!
```

with this patch it will be checked if a higher version than 0.2.11 is available (the expected behaviour).

```
Checking for updates to 'berendt/ubuntu-14.04-amd64'
Version constraints: > 0.2.11
Provider: virtualbox
Updating 'berendt/ubuntu-14.04-amd64' with provider 'virtualbox' from version
'0.2.11' to '0.2.12'...
Loading metadata for box 'https://vagrantcloud.com/berendt/ubuntu-14.04-amd64'
Adding box 'berendt/ubuntu-14.04-amd64' (v0.2.12) for provider: virtualbox
Downloading: https://vagrantcloud.com/berendt/ubuntu-14.04-amd64/version/23/provider/virtualbox.box
Successfully added box 'berendt/ubuntu-14.04-amd64' (v0.2.12) for 'virtualbox'!
```
