### PR TITLE
`vagrant box update` should print the used version

### DIFF
--- a/plugins/commands/box/command/update.rb
+++ b/plugins/commands/box/command/update.rb
@@ -95,7 +95,7 @@ module VagrantPlugins
 
         def box_update(box, version, ui)
           ui.output(I18n.t("vagrant.box_update_checking", name: box.name))
-          ui.detail("Version constraints: #{version}")
+          ui.detail("Version constraints: #{box.version}")
           ui.detail("Provider: #{box.provider}")
 
           update = box.has_update?(version)


### PR DESCRIPTION
Example without this patch:

$ vagrant box update
==> default: Checking for updates to 'berendt/opensuse-13.1-x86_64'
    default: Version constraints:
    default: Provider: virtualbox
==> default: Box 'berendt/opensuse-13.1-x86_64' (v0.2.0) is running the latest version.

Example with this patch:

$ vagrant box update
==> default: Checking for updates to 'berendt/opensuse-13.1-x86_64'
    default: Version constraints: 0.2.0
    default: Provider: virtualbox
==> default: Box 'berendt/opensuse-13.1-x86_64' (v0.2.0) is running the latest version.
