### PR TITLE
added missing newline in `box remove version listing`

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -462,9 +462,10 @@ en:
         You requested to remove the box '%{name}' with provider
         '%{provider}'. This box has multiple versions. You must
         explicitly specify which version you want to remove with
-        the `--box-version` flag.
+        the `--box-version` flag. The available versions for this
+        box are:
 
-        Versions: %{versions}
+        %{versions}
       box_remove_not_found: |-
         The box you requested to be removed could not be found. No
         boxes named '%{name}' could be found.


### PR DESCRIPTION
The output of Errors::BoxRemoveMultiVersion is now like
the output of Errors::BoxRemoveVersionNotFound. I think
that's expected.

example output without this patch:

```
$ vagrant box remove berendt/ubuntu-14.04-amd64
You requested to remove the box 'berendt/ubuntu-14.04-amd64' with provider
'virtualbox'. This box has multiple versions. You must
explicitly specify which version you want to remove with
the `--box-version` flag.

Versions:  * 0.2.11
 * 0.2.12
 * 0.2.14
```

example output with this patch:

```
$ vagrant box remove berendt/ubuntu-14.04-amd64
You requested to remove the box 'berendt/ubuntu-14.04-amd64' with provider
'virtualbox'. This box has multiple versions. You must
explicitly specify which version you want to remove with
the `--box-version` flag. The available versions for this
box are:

 * 0.2.11
 * 0.2.12
 * 0.2.14
```
