### PR TITLE
changed rsync and rsync-auto to be primary commands

### DIFF
--- a/plugins/synced_folders/rsync/plugin.rb
+++ b/plugins/synced_folders/rsync/plugin.rb
@@ -9,12 +9,12 @@ module VagrantPlugins
       The Rsync synced folder plugin will sync folders via rsync.
       EOF
 
-      command("rsync", primary: false) do
+      command("rsync", primary: true) do
         require_relative "command/rsync"
         Command::Rsync
       end
 
-      command("rsync-auto", primary: false) do
+      command("rsync-auto", primary: true) do
         require_relative "command/rsync_auto"
         Command::RsyncAuto
       end


### PR DESCRIPTION
At the moment rsync and rsync-auto are not listed in the list of common commands.

example list of common commands with this patch:

```
[...]
     reload       restarts vagrant machine, loads new Vagrantfile configuration
     resume       resume a suspended vagrant machine
     rsync        syncs rsync synced folders to remote machine
     rsync-auto   syncs rsync synced folders automatically when files change
     share        share your Vagrant environment with anyone in the world
[...]
```
