### PR TITLE
Fixes not enough time for docker restart before continuing on to next provisioning step

### DIFF
--- a/plugins/provisioners/docker/cap/debian/docker_configure_auto_start.rb
+++ b/plugins/provisioners/docker/cap/debian/docker_configure_auto_start.rb
@@ -9,6 +9,10 @@ module VagrantPlugins
                 comm.sudo("echo 'DOCKER_OPTS=\"-r=true ${DOCKER_OPTS}\"' >> /etc/default/docker")
                 comm.sudo("stop docker")
                 comm.sudo("start docker")
+                [0, 1, 2, 4].each do |delay|
+                  sleep delay
+                  break if comm.test('test -f /var/run/docker.pid')
+                end
               end
             end
           end


### PR DESCRIPTION
Hi @mitchellh,

I'm getting an issue where docker doesn't have enough time to start before continuing on to the start service step:

``` sh
➜  vagrant up
Bringing machine 'default' up with 'virtualbox' provider...
==> default: Importing base box 'ubuntu'...
  1 # -*- mode: ruby -*-
==> default: Matching MAC address for NAT networking...
==> default: Setting the name of the VM: harmony_default_1397580811827_63596
==> default: Clearing any previously set network interfaces...
==> default: Preparing network interfaces based on configuration...
    default: Adapter 1: nat
    default: Adapter 2: hostonly
==> default: Forwarding ports...
    default: 22 => 2222 (adapter 1)
==> default: Booting VM...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 127.0.0.1:2222
    default: SSH username: vagrant
    default: SSH auth method: private key
    default: Warning: Connection timeout. Retrying...
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
==> default: Configuring and enabling network interfaces...
==> default: Exporting NFS shared folders...
==> default: Preparing to edit /etc/exports. Administrator privileges will be required...
==> default: Mounting NFS shared folders...
==> default: Mounting shared folders...
    default: /vagrant => /Users/kruppel/Projects/zendesk/harmony
==> default: Running provisioner: docker...
    default: Installing Docker (latest) onto machine...
    default: Configuring Docker to autostart containers...
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

service docker start

Stdout from the command:



Stderr from the command:

stdin: is not a tty
start: Job is already running: docker
```

This is my proposed fix. What do you think?
