### PR TITLE
guests/linux: rsync chown if either user or group incorrect [GH-3485]

### DIFF
--- a/plugins/guests/linux/cap/rsync.rb
+++ b/plugins/guests/linux/cap/rsync.rb
@@ -18,7 +18,7 @@ module VagrantPlugins
 
         def self.rsync_post(machine, opts)
           machine.communicate.tap do |comm|
-            comm.sudo("find '#{opts[:guestpath]}' ! -user #{opts[:owner]} -or ! -group #{opts[:group]} -print0 | " +
+            comm.sudo("find '#{opts[:guestpath]}' '(' ! -user #{opts[:owner]} -or ! -group #{opts[:group]} ')' -print0 | " +
               "xargs -0 -r chown -v #{opts[:owner]}:#{opts[:group]}")
           end
         end


### PR DESCRIPTION
Fixes #3485.
