### PR TITLE
Force overwrite of salt configs and keys.

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -90,7 +90,7 @@ module VagrantPlugins
         end
 
         if configure
-          options = "%s -c %s" % [options, config_dir]
+          options = "%s -F -c %s" % [options, config_dir]
         end
 
         if @config.seed_master && @config.install_master


### PR DESCRIPTION
This will tell the salt-bootstrap script to overwrite the master/minion
configs and/or keys each time provision is called. #3524 #3176

Not sure if this is the desired solution. This would change the default behavior to always overwrite the configs and keys. If the current behavior (which is to never overwrite the config and keys) is the desired default behavior, then users can set `salt.bootstrap_options = "-F"` in the `Vagrantfile` to overwrite configs and keys on each `vagrant provision`.
