### PR TITLE
Fix vbox install path detection on Windows

### DIFF
--- a/plugins/providers/virtualbox/driver/base.rb
+++ b/plugins/providers/virtualbox/driver/base.rb
@@ -43,7 +43,7 @@ module VagrantPlugins
 
                 # If the executable exists, then set it as the main path
                 # and break out
-                vboxmanage = "#{path}VBoxManage.exe"
+                vboxmanage = "#{single}VBoxManage.exe"
                 if File.file?(vboxmanage)
                   @vboxmanage_path = Vagrant::Util::Platform.cygwin_windows_path(vboxmanage)
                   break


### PR DESCRIPTION
Basically: vagrant 1.5.4 failed to detect VBoxManage command on Windows 8.
So I tried to help it with VBOX_INSTALL_PATH, which however has been broken by 359ea23069bb58b503fe1923e0e885499a5d946b.
