### PR TITLE
core: return {} if cached synced folders file missing [GH-3550]

### DIFF
--- a/lib/vagrant/action/builtin/mixin_synced_folders.rb
+++ b/lib/vagrant/action/builtin/mixin_synced_folders.rb
@@ -214,7 +214,10 @@ module Vagrant
             end
           end
         rescue Errno::ENOENT
-          return nil
+          # If the file doesn't exist, we probably just have a machine created
+          # by a version of Vagrant that didn't cache shared folders. Report no
+          # shared folders to be safe.
+          return {}
         end
       end
     end

--- a/test/unit/vagrant/action/builtin/mixin_synced_folders_test.rb
+++ b/test/unit/vagrant/action/builtin/mixin_synced_folders_test.rb
@@ -136,9 +136,9 @@ describe Vagrant::Action::Builtin::MixinSyncedFolders do
       expect(result[:nfs]["root"][:foo]).to eql("bar")
     end
 
-    it "returns nil if cached read with no cache" do
+    it "returns {} if cached read with no cache" do
       result = subject.synced_folders(machine, cached: true)
-      expect(result).to be_nil
+      expect(result).to eql({})
     end
 
     it "should be able to save and retrieve cached versions" do


### PR DESCRIPTION
A missing synced folders cache indicates an empty cache, not a failure that
should be handled by the caller. The cache file is missing from data dirs
created by an earlier version of Vagrant.

See #3550.
