### PR TITLE
command/rsync-auto: properly exit on interrupt

### DIFF
--- a/plugins/synced_folders/rsync/command/rsync_auto.rb
+++ b/plugins/synced_folders/rsync/command/rsync_auto.rb
@@ -114,7 +114,7 @@ module VagrantPlugins
           callback = lambda do
             # This needs to execute in another thread because Thread
             # synchronization can't happen in a trap context.
-            Thread.new { queue << true }.join
+            Thread.new { queue << true }
           end
 
           # Run the listener in a busy block so that we can cleanly


### PR DESCRIPTION
Currently, interrupting 'vagrant rsync-auto' once it's waiting for
filesystem events has no effect. Appears to be a deadlock related to
signal handlers in Ruby 2.0 [0](https://bugs.ruby-lang.org/issues/7917).

Remove call to `thread.join` in signal handler. The handler doesn't
need to wait for `true` to be added to the queue; it just needs to
launch the thread.

To reproduce: 
1. Launch `vagrant rsync-auto`.
2. Wait for Vagrant to print "Watching: <paths>"
3. Press Ctrl+C repeatedly. Note that nothing happens.

OS X 10.9.2, Ruby 2.0.0p353
