### PR TITLE
Add SSH proxy_command functionality to rsync

### DIFF
--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -56,8 +56,10 @@ module VagrantPlugins
         # Connection information
         username = ssh_info[:username]
         host     = ssh_info[:host]
+        proxy_command = "-o ProxyCommand='#{ssh_info[:proxy_command]}' " if ssh_info[:proxy_command]
         rsh = [
           "ssh -p #{ssh_info[:port]} " +
+          proxy_command +
           "-o StrictHostKeyChecking=no " +
           "-o UserKnownHostsFile=/dev/null",
           ssh_info[:private_key_path].map { |p| "-i '#{p}'" },


### PR DESCRIPTION
Brings SSH proxy_command to rsync.  Tested with vagrant-libvirt plugin... can now properly rsync to machine on remote server.
