### PR TITLE
Correct bootstrap args

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -106,6 +106,7 @@ module VagrantPlugins
 
         if configure && !install
           options = "%s -C" % options
+        end
 
         if @config.install_master
           options = "%s -M" % options


### PR DESCRIPTION
 The various `install` args should always be passed to salt-bootstrap.

Even when preforming config only, the install flags (i.e. -M, -S, -N),
are used by the bootstrap to determine which configs to copy.
