### PR TITLE
Document the change to use a directory for .vagrant in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1246,6 +1246,10 @@ BACKWARDS INCOMPATIBILITIES:
     format, but this is _opt-in_. Old Vagrantfile format continues to be supported,
     as promised. To use the new features that will be introduced throughout
     the 1.x series, you'll have to upgrade at some point.
+  - The .vagrant file is no longer supported and has been replaced by
+    a .vagrant directory. Running vagrant will automatically upgrade
+    to the new style directory format, after which old versions of
+    Vagrant will not be able to see or control your VM.
 
 FEATURES:
 


### PR DESCRIPTION
Prior to 1.1.0 .vagrant was a file, and once you run Vagrant 1.1+ on a
project, Vagrant 1.0.x will stop working.  This change happened at
approximately commit 4e649cc98792c192c1589a0bd86e8433e90f60cd.

Addresses https://github.com/mitchellh/vagrant/issues/3558
