### PR TITLE
add dependency on Ruby >= 2.0.0

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |s|
   s.summary       = "Build and distribute virtualized development environments."
   s.description   = "Vagrant is a tool for building and distributing virtualized development environments."
 
+  s.required_ruby_version     = ">= 2.0.0"
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant"
 


### PR DESCRIPTION
Vagrant requires Ruby 2, e.g. for `**` keyword arguments.

N.B. I haven't been able to fully test this myself yet, so please sanity check before merging.
