### PR TITLE
backport GH-3277 fix for missing interpolation to older drivers

### DIFF
--- a/plugins/providers/virtualbox/driver/version_4_0.rb
+++ b/plugins/providers/virtualbox/driver/version_4_0.rb
@@ -470,7 +470,9 @@ module VagrantPlugins
           end
 
           # If we reached this point then it didn't work out.
-          raise Vagrant::Errors::VBoxManageError, :command => command.inspect
+          raise Vagrant::Errors::VBoxManageError,
+            command: command.inspect,
+            stderr: r.stderr
         end
 
         def suspend

--- a/plugins/providers/virtualbox/driver/version_4_1.rb
+++ b/plugins/providers/virtualbox/driver/version_4_1.rb
@@ -480,7 +480,9 @@ module VagrantPlugins
           end
 
           # If we reached this point then it didn't work out.
-          raise Vagrant::Errors::VBoxManageError, :command => command.inspect
+          raise Vagrant::Errors::VBoxManageError,
+            command: command.inspect,
+            stderr: r.stderr
         end
 
         def suspend

--- a/plugins/providers/virtualbox/driver/version_4_2.rb
+++ b/plugins/providers/virtualbox/driver/version_4_2.rb
@@ -504,7 +504,9 @@ module VagrantPlugins
           end
 
           # If we reached this point then it didn't work out.
-          raise Vagrant::Errors::VBoxManageError, :command => command.inspect
+          raise Vagrant::Errors::VBoxManageError,
+            command: command.inspect,
+            stderr: r.stderr
         end
 
         def suspend


### PR DESCRIPTION
The original fix for the "missing interpolation argument :stderr" bug
was in d4b3f226, but it only addressed the driver for VirtualBox 4.3:

  https://github.com/mitchellh/vagrant/issues/3277

This backports the fix to the drivers for VirtualBox 4.0, 4.1, and 4.2.
