### PR TITLE
add support for bundler >= 1.6.x

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -35,7 +35,14 @@ module Vagrant
 
       # Set the Bundler UI to be a silent UI. We have to add the
       # `silence` method to it because Bundler UI doesn't have it.
-      ::Bundler.ui = ::Bundler::UI.new
+      ::Bundler.ui =
+        if ::Bundler::UI.const_defined? :Silent
+          # bundler >= 1.6.0
+          ::Bundler::UI::Silent.new
+        else
+          # bundler < 1.6.0
+          ::Bundler::UI.new
+        end
       if !::Bundler.ui.respond_to?(:silence)
         ui = ::Bundler.ui
         def ui.silence(*args)

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
   s.rubyforge_project         = "vagrant"
 
-  s.add_dependency "bundler", "~> 1.5.2"
+  s.add_dependency "bundler", ">= 1.5.2", "< 1.7.0"
   s.add_dependency "childprocess", "~> 0.5.0"
   s.add_dependency "erubis", "~> 2.7.0"
   s.add_dependency "i18n", "~> 0.6.0"


### PR DESCRIPTION
bundler changed their API for Bundler::UI in 1.6.0 via this commit:
- https://github.com/bundler/bundler/commit/5e38e2d7

This caused various issues, e.g.
- https://github.com/mitchellh/vagrant/issues/3451
- https://github.com/test-kitchen/test-kitchen/issues/401

which will hopefully be resolved by teaching vagrant to cope with both API versions.

**N.B. I was not able to test this against any bundler `~> 1.5.2` yet!  Please test that before merging.  It seems to work for me with 1.6.2 so far, though I have not done anything other than a basic `vagrant up`.**
