### PR TITLE
Elevated winrm shell provisioner

### DIFF
--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -141,8 +141,6 @@ module VagrantPlugins
           ensure
             download_path.delete if download_path.file?
           end
-
-          download_path.delete
         elsif config.path
           # Just yield the path to that file...
           root_path = @machine.env.root_path


### PR DESCRIPTION
Defaults to running the WinRM shell provisioner elevated via a scheduled task - like the Chef provisioner. This makes it possible, for example, to install .NET via the shell provisioner.

Fixed remote shell scripts for all platforms. The with_script_file method was deleting the temporary script file on the host twice.
