### PR TITLE
fixed typos found by topy in all Markdown files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1696,7 +1696,7 @@ Note: 0.8.3 and 0.8.4 was yanked due to RubyGems encoding issue.
  - Checking guest addition versions now ignores OSE. [GH-438]
  - Chef solo from a remote URL fixed. [GH-431]
  - Arch linux support: host only networks and changing the host name. [GH-439] [GH-448]
- - Chef solo `roles_path` and `data_bags_path` can only be be single paths. [GH-446]
+ - Chef solo `roles_path` and `data_bags_path` can only be single paths. [GH-446]
  - Fix `virtualbox_not_detected` error message to require 4.1.x. [GH-458]
  - Add shortname (`hostname -s`) for hostname setting on RHEL systems. [GH-456]
  - `vagrant ssh -c` output no longer has a prefix and respects newlines

--- a/website/docs/source/v2/cli/machine-readable.html.md
+++ b/website/docs/source/v2/cli/machine-readable.html.md
@@ -60,7 +60,7 @@ Each component is explained below:
 * **type** is the type of machine-readable message being outputted. There are
   a set of standard types which are covered later.
 
-* **data** is zero or more comma-seperated values associated with the prior
+* **data** is zero or more comma-separated values associated with the prior
   type. The exact amount and meaning of this data is type-dependent, so you
   must read the documentation associated with the type to understand fully.
 
@@ -109,7 +109,7 @@ with the machine-readable output.
 <tr>
 <td>error-exit</td>
 <td>
-	An error occured that caused Vagrant to exit. This contains that
+	An error occurred that caused Vagrant to exit. This contains that
 	error. Contains two data elements: type of error, error message.
 </td>
 </tr>
@@ -118,7 +118,7 @@ with the machine-readable output.
 <td>provider-name</td>
 <td>
 	The provider name of the target machine.
-	<span class="label">targetted</span>
+	<span class="label">targeted</span>
 </td>
 </tr>
 
@@ -126,7 +126,7 @@ with the machine-readable output.
 <td>state</td>
 <td>
 	The state ID of the target machine.
-	<span class="label">targetted</span>
+	<span class="label">targeted</span>
 </td>
 </tr>
 
@@ -135,7 +135,7 @@ with the machine-readable output.
 <td>
 	Human-readable description of the state of the machine. This is the
 	long version, and may be a paragraph or longer.
-	<span class="label">targetted</span>
+	<span class="label">targeted</span>
 </td>
 </tr>
 
@@ -144,7 +144,7 @@ with the machine-readable output.
 <td>
 	Human-readable description of the state of the machine. This is the
 	short version, limited to at most a sentence.
-	<span class="label">targetted</span>
+	<span class="label">targeted</span>
 </td>
 </tr>
 

--- a/website/docs/source/v2/cli/share.html.md
+++ b/website/docs/source/v2/cli/share.html.md
@@ -38,7 +38,7 @@ is available below.
   when SSH sharing is enabled.
 
 * `--ssh-port PORT` - The port of the SSH server running in the Vagrant
-  enviroment. By default, Vagrant will attempt to find this for you.
+  environment. By default, Vagrant will attempt to find this for you.
 
 * `--ssh-once` - Allows SSH access only once. After the first attempt to
   connect via SSH to the Vagrant environment, the generated keypair is

--- a/website/docs/source/v2/multi-machine/index.html.md
+++ b/website/docs/source/v2/multi-machine/index.html.md
@@ -87,7 +87,7 @@ slashes, it assumes you're using a regular expression.
 
 ## Communication Between Machines
 
-In order to faciliate communication within machines in a multi-machine setup,
+In order to facilitate communication within machines in a multi-machine setup,
 the various [networking](/v2/networking/index.html) options should be used.
 In particular, the [private network](/v2/networking/private_network.html) can
 be used to make a private network between multiple machines and the host.

--- a/website/docs/source/v2/networking/forwarded_ports.html.md
+++ b/website/docs/source/v2/networking/forwarded_ports.html.md
@@ -26,7 +26,7 @@ Vagrant.configure("2") do |config|
 end
 ```
 
-This will allow acessing port 80 on the guest via port 8080 on the host.
+This will allow accessing port 80 on the guest via port 8080 on the host.
 
 ## Options Reference
 

--- a/website/docs/source/v2/providers/configuration.html.md
+++ b/website/docs/source/v2/providers/configuration.html.md
@@ -60,7 +60,7 @@ Providers can also override non-provider specific configuration, such
 as `config.vm.box` and any other Vagrant configuration. This is done by
 specifying a second argument to `config.vm.provider`. This argument is
 just like the normal `config`, so set any settings you want, and they will
-be overriden only for that provider.
+be overridden only for that provider.
 
 Example:
 

--- a/website/docs/source/v2/provisioning/cfengine.html.md
+++ b/website/docs/source/v2/provisioning/cfengine.html.md
@@ -110,7 +110,7 @@ has been bootstrapped.
 ## Full Alphabetical List of Configuration Options
 
 - `am_policy_hub` (boolean, default `false`) determines whether the VM will be
-  configured as a CFEngine policy hub (automaticaly bootstrapped to
+  configured as a CFEngine policy hub (automatically bootstrapped to
   its own IP address). You can combine it with `policy_server_address`
   if the VM has multiple network interfaces and you want to bootstrap
   to a specific one.

--- a/website/docs/source/v2/provisioning/puppet_agent.html.md
+++ b/website/docs/source/v2/provisioning/puppet_agent.html.md
@@ -83,7 +83,7 @@ end
 ## Additional Options
 
 Puppet supports a lot of command-line flags. Basically any setting can
-be overriden on the command line. To give you the most power and flexibility
+be overridden on the command line. To give you the most power and flexibility
 possible with Puppet, Vagrant allows you to specify custom command line
 flags to use:
 

--- a/website/docs/source/v2/provisioning/puppet_apply.html.md
+++ b/website/docs/source/v2/provisioning/puppet_apply.html.md
@@ -178,7 +178,7 @@ guest.
 ## Additional Options
 
 Puppet supports a lot of command-line flags. Basically any setting can
-be overriden on the command line. To give you the most power and flexibility
+be overridden on the command line. To give you the most power and flexibility
 possible with Puppet, Vagrant allows you to specify custom command line
 flags to use:
 

--- a/website/www/source/about.html.markdown
+++ b/website/www/source/about.html.markdown
@@ -10,8 +10,8 @@ page_title: "About Vagrant"
 
 Vagrant is a tool for building complete development environments. With an easy-to-use workflow and focus on automation, Vagrant lowers development environment setup time, increases development/production parity, and makes the "works on my machine" excuse a relic of the past.
 
-Vagrant was started in January 2010 by [Mitchell Hashimoto](http://twitter.com/mitchellh). For almost three years, Vagrant was a side-project for Mitchell, a project that he worked on in his free hours after his full time job. During this time, Vagrant grew to be trusted and used by a range of individuals to entire development teams in large companies.
+Vagrant was started in January 2010 by [Mitchell Hashimoto](http://twitter.com/mitchellh). For almost three years, Vagrant was a side-project for Mitchell, a project that he worked on in his free hours after his full-time job. During this time, Vagrant grew to be trusted and used by a range of individuals to entire development teams in large companies.
 
-In November 2012, [HashiCorp](http://www.hashicorp.com) was formed by Mitchell to back the development of Vagrant full time. HashiCorp builds commercial additions and provides professional support and training for Vagrant.
+In November 2012, [HashiCorp](http://www.hashicorp.com) was formed by Mitchell to back the development of Vagrant full-time. HashiCorp builds commercial additions and provides professional support and training for Vagrant.
 
 Vagrant remains and always will be a liberally licensed open source project. Each release of Vagrant is the work of hundreds of individuals' contributions to the [open source project](http://github.com/mitchellh/vagrant).

--- a/website/www/source/blog/2014-02-19-feature-preview-vagrant-1-5-boxes-2-0.html.markdown
+++ b/website/www/source/blog/2014-02-19-feature-preview-vagrant-1-5-boxes-2-0.html.markdown
@@ -33,7 +33,7 @@ READMORE
 
 The box system that is in place in Vagrant 1.4 and earlier has been
 mostly untouched since the first release of Vagrant. While the format
-of boxes and commands were modified slightly for Vagrant 1.1 to accomodate
+of boxes and commands were modified slightly for Vagrant 1.1 to accommodate
 multiple providers, the general use has not changed at all in over four years.
 
 During this time, we've learned a lot about how people use Vagrant and

--- a/website/www/source/blog/2014-02-24-feature-preview-vagrant-1-5-share.html.markdown
+++ b/website/www/source/blog/2014-02-24-feature-preview-vagrant-1-5-share.html.markdown
@@ -74,7 +74,7 @@ $ vagrant share
 
 Once the share is created, a relatively obscure URL is outputted. This URL
 will route directly to your Vagrant environment; it doesn't matter if you
-or accessing party is behing a firewall or NAT.
+or accessing party is behind a firewall or NAT.
 
 Currently, HTTP access is restricted through obscure URLs. We'll be adding
 more ACLs and audit logs for this in the future.


### PR DESCRIPTION
Topy is available at https://github.com/intgr/topy.
