### PR TITLE
Removed unused Solaris and SmartOS halt config properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ BACKWARDS INCOMPATIBILITIES:
   - providers/virtualbox: Shared folders backed by VirtualBox are now
       "transient". They will be removed if you reboot outside of Vagrant.
       Always use `vagrant reload`.
+  - `config.smartos.halt_timeout`, `config.smartos.halt_check_interval`,
+      `config.solaris.halt_timeout`, `config.solaris.halt_check_interval`,
+      `config.solaris11.halt_timeout`, `config.solaris11.halt_check_interval`
+      were unused by Vagrant, so they have been removed.
 
 FEATURES:
 

--- a/plugins/guests/smartos/config.rb
+++ b/plugins/guests/smartos/config.rb
@@ -1,15 +1,11 @@
 module VagrantPlugins
   module GuestSmartos
     class Config < Vagrant.plugin("2", :config)
-      attr_accessor :halt_timeout
-      attr_accessor :halt_check_interval
       # This sets the command to use to execute items as a superuser. sudo is default
       attr_accessor :suexec_cmd
       attr_accessor :device
 
       def initialize
-        @halt_timeout = 30
-        @halt_check_interval = 1
         @suexec_cmd = 'pfexec'
         @device = "e1000g"
       end

--- a/plugins/guests/solaris/config.rb
+++ b/plugins/guests/solaris/config.rb
@@ -1,15 +1,11 @@
 module VagrantPlugins
   module GuestSolaris
     class Config < Vagrant.plugin("2", :config)
-      attr_accessor :halt_timeout
-      attr_accessor :halt_check_interval
       # This sets the command to use to execute items as a superuser. sudo is default
       attr_accessor :suexec_cmd
       attr_accessor :device
 
       def initialize
-        @halt_timeout = 30
-        @halt_check_interval = 1
         @suexec_cmd = 'sudo'
         @device = "e1000g"
       end

--- a/plugins/guests/solaris11/config.rb
+++ b/plugins/guests/solaris11/config.rb
@@ -5,15 +5,11 @@
 module VagrantPlugins
   module GuestSolaris11
     class Config < Vagrant.plugin("2", :config)
-      attr_accessor :halt_timeout
-      attr_accessor :halt_check_interval
       # This sets the command to use to execute items as a superuser. sudo is default
       attr_accessor :suexec_cmd
       attr_accessor :device
 
       def initialize
-        @halt_timeout = 30
-        @halt_check_interval = 1
         @suexec_cmd = 'sudo'
         @device = "net"
       end


### PR DESCRIPTION
These config properties were removed or replaced by graceful_halt_timeout in a prior release of Vagrant.

I don't have a Solaris box so I couldn't try this out, but there are no usages of these config properties inside Vagrant itself.
