### PR TITLE
Updated website documentation for graceful_halt_timeout

### DIFF
--- a/website/docs/source/v2/vagrantfile/machine_settings.html.md
+++ b/website/docs/source/v2/vagrantfile/machine_settings.html.md
@@ -87,7 +87,7 @@ constraints.
 
 `config.vm.graceful_halt_timeout` - The time in seconds that Vagrant will
 wait for the machine to gracefully halt when `vagrant halt` is called.
-Defaults to 300 seconds.
+Defaults to 60 seconds.
 
 <hr>
 


### PR DESCRIPTION
The default value in the code is actually [60 seconds](https://github.com/mitchellh/vagrant/blob/master/plugins/kernel_v2/config/vm.rb#L327), so now the docs match that.
