### PR TITLE
Removed unused halt timeout and check interval settings.

### DIFF
--- a/plugins/guests/windows/config.rb
+++ b/plugins/guests/windows/config.rb
@@ -1,29 +1,21 @@
 module VagrantPlugins
   module GuestWindows
     class Config < Vagrant.plugin("2", :config)
-      attr_accessor :halt_timeout
-      attr_accessor :halt_check_interval
       attr_accessor :set_work_network
 
       def initialize
-        @halt_timeout        = UNSET_VALUE
-        @halt_check_interval = UNSET_VALUE
-        @set_work_network    = UNSET_VALUE
+        @set_work_network = UNSET_VALUE
       end
 
       def validate(machine)
         errors = []
 
-        errors << "windows.halt_timeout cannot be nil." if @halt_timeout.nil?
-        errors << "windows.halt_check_interval cannot be nil." if @halt_check_interval.nil?
         errors << "windows.set_work_network cannot be nil." if @set_work_network.nil?
 
         { "Windows Guest" => errors }
       end
 
       def finalize!
-        @halt_timeout = 30        if @halt_timeout == UNSET_VALUE
-        @halt_check_interval = 1  if @halt_check_interval == UNSET_VALUE
         @set_work_network = false if @set_work_network == UNSET_VALUE
       end
     end

--- a/test/unit/plugins/guests/windows/config_test.rb
+++ b/test/unit/plugins/guests/windows/config_test.rb
@@ -15,14 +15,11 @@ describe VagrantPlugins::GuestWindows::Config do
 
   describe "default values" do
     before { subject.finalize! }
-    
-    its("halt_timeout")        { should == 30 }
-    its("halt_check_interval") { should == 1 }
-    its("set_work_network")    { should == false }
+    its("set_work_network") { should == false }
   end
 
   describe "attributes" do
-    [:halt_timeout, :halt_check_interval, :set_work_network].each do |attribute|
+    [:set_work_network].each do |attribute|
       it "should not default #{attribute} if overridden" do
         subject.send("#{attribute}=".to_sym, 10)
         subject.finalize!


### PR DESCRIPTION
Removed Windows guest settings which are not used anywhere.
