### PR TITLE
Display deprecation warning for unused halt config properties

### DIFF
--- a/plugins/guests/smartos/config.rb
+++ b/plugins/guests/smartos/config.rb
@@ -8,10 +8,19 @@ module VagrantPlugins
       attr_accessor :device
 
       def initialize
-        @halt_timeout = 30
-        @halt_check_interval = 1
+        @halt_timeout = UNSET_VALUE
+        @halt_check_interval = UNSET_VALUE
         @suexec_cmd = 'pfexec'
         @device = "e1000g"
+      end
+
+      def finalize!
+        if @halt_timeout != UNSET_VALUE
+          puts "smartos.halt_timeout is deprecated and will be removed in Vagrant 1.7"
+        end
+        if @halt_check_interval != UNSET_VALUE
+          puts "smartos.halt_check_interval is deprecated and will be removed in Vagrant 1.7"
+        end
       end
     end
   end

--- a/plugins/guests/solaris/config.rb
+++ b/plugins/guests/solaris/config.rb
@@ -8,10 +8,19 @@ module VagrantPlugins
       attr_accessor :device
 
       def initialize
-        @halt_timeout = 30
-        @halt_check_interval = 1
+        @halt_timeout = UNSET_VALUE
+        @halt_check_interval = UNSET_VALUE
         @suexec_cmd = 'sudo'
         @device = "e1000g"
+      end
+
+      def finalize!
+        if @halt_timeout != UNSET_VALUE
+          puts "solaris.halt_timeout is deprecated and will be removed in Vagrant 1.7"
+        end
+        if @halt_check_interval != UNSET_VALUE
+          puts "solaris.halt_check_interval is deprecated and will be removed in Vagrant 1.7"
+        end
       end
     end
   end

--- a/plugins/guests/solaris11/config.rb
+++ b/plugins/guests/solaris11/config.rb
@@ -12,10 +12,19 @@ module VagrantPlugins
       attr_accessor :device
 
       def initialize
-        @halt_timeout = 30
-        @halt_check_interval = 1
+        @halt_timeout = UNSET_VALUE
+        @halt_check_interval = UNSET_VALUE
         @suexec_cmd = 'sudo'
         @device = "net"
+      end
+
+      def finalize!
+        if @halt_timeout != UNSET_VALUE
+          puts "solaris11.halt_timeout is deprecated and will be removed in Vagrant 1.7"
+        end
+        if @halt_check_interval != UNSET_VALUE
+          puts "solaris11.halt_check_interval is deprecated and will be removed in Vagrant 1.7"
+        end
       end
     end
   end


### PR DESCRIPTION
halt_timeout and halt_check_interval will be removed in the next version of Vagrant, 1.7.
