### PR TITLE
Add colorization and log_level support to salt provisioner.

### DIFF
--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -19,6 +19,8 @@ module VagrantPlugins
       attr_accessor :verbose
       attr_accessor :seed_master
       attr_reader   :pillar_data
+      attr_accessor :colorize
+      attr_accessor :log_level
 
       ## bootstrap options
       attr_accessor :temp_config_dir
@@ -43,6 +45,8 @@ module VagrantPlugins
         @verbose = UNSET_VALUE
         @seed_master = UNSET_VALUE
         @pillar_data = UNSET_VALUE
+        @colorize = UNSET_VALUE
+        @log_level = UNSET_VALUE
         @temp_config_dir = UNSET_VALUE
         @install_type = UNSET_VALUE
         @install_args = UNSET_VALUE
@@ -66,6 +70,8 @@ module VagrantPlugins
         @verbose            = nil if @verbose == UNSET_VALUE
         @seed_master        = nil if @seed_master == UNSET_VALUE
         @pillar_data        = {}  if @pillar_data == UNSET_VALUE
+        @colorize           = nil if @colorize == UNSET_VALUE
+        @log_level          = nil if @log_level == UNSET_VALUE
         @temp_config_dir    = nil if @temp_config_dir == UNSET_VALUE
         @install_type       = nil if @install_type == UNSET_VALUE
         @install_args       = nil if @install_args == UNSET_VALUE

--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -141,6 +141,21 @@ module VagrantPlugins
         " pillar='#{@config.pillar_data.to_json}'" if !@config.pillar_data.empty?
       end
 
+      # Get colorization option string to pass with the salt command
+      def get_colorize
+        @config.colorize ? " --force-color" : " --no-color"
+      end
+
+      # Get log output level option string to pass with the salt command
+      def get_loglevel
+        log_levels = ["all", "garbage", "trace", "debug", "info", "warning", "error", "quiet"]
+        if log_levels.include? @config.log_level
+          " --log-level=#{@config.log_level}"
+        else
+          " --log-level=debug"
+        end
+      end
+
       # Copy master and minion configs to VM
       def upload_configs
         if @config.minion_config
@@ -250,14 +265,14 @@ module VagrantPlugins
           @machine.env.ui.info "Calling state.highstate... (this may take a while)"
           if @config.install_master
             @machine.communicate.sudo("salt '*' saltutil.sync_all")
-            @machine.communicate.sudo("salt '*' state.highstate --verbose#{get_pillar}") do |type, data|
+            @machine.communicate.sudo("salt '*' state.highstate --verbose#{get_loglevel}#{get_colorize}#{get_pillar}") do |type, data|
               if @config.verbose
                 @machine.env.ui.info(data)
               end
             end
           else
             @machine.communicate.sudo("salt-call saltutil.sync_all")
-            @machine.communicate.sudo("salt-call state.highstate -l debug#{get_pillar}") do |type, data|
+            @machine.communicate.sudo("salt-call state.highstate #{get_loglevel}#{get_colorize}#{get_pillar}") do |type, data|
               if @config.verbose
                 @machine.env.ui.info(data)
               end

--- a/website/docs/source/v2/provisioning/salt.html.md
+++ b/website/docs/source/v2/provisioning/salt.html.md
@@ -100,6 +100,15 @@ vagrant up. Can be applied to any machine.
 * `run_overstate` - (boolean) Executes `state.over` on 
 vagrant up. Can be applied to the master only.
 
+## Output Control
+
+These may be used to control the output of state execution:
+
+* `colorize` - (boolean) Should output be colorized? Defaults to `nil`.
+
+* `log_level` - (One of `all`, `garbage`, `trace`, `debug`, `info`, `warning`,
+  `error`, `quiet`) How verbose should the output be? Defaults to `debug`.
+
 
 ## Pillar Data
 


### PR DESCRIPTION
This commit adds two new options to the salt provisioner:
- `colorize`: controls color output. Defaults to no-color (present behavior).
- `log_level`: controls log level. Defaults to `debug` (present behavior).

Docs included!

This resolves #2314
