### PR TITLE
fix chef version checking

### DIFF
--- a/templates/provisioners/chef_solo/solo.erb
+++ b/templates/provisioners/chef_solo/solo.erb
@@ -1,5 +1,3 @@
-require 'chef/version_constraint'
-
 <% if node_name %>
 node_name "<%= node_name %>"
 <% end %>


### PR DESCRIPTION
the version checking here uses a function which is intended only
for chef cookbook versions, which must be x.y or x.y.z.  when fed
a legal chef prerelease version the prior code throws an exception:

```
[2014-05-01T22:08:01+00:00] FATAL: Configuration error Chef::Exceptions::InvalidCookbookVersion: '11.14.0.alpha.1' does not match 'x.y.z' or 'x.y'
[2014-05-01T22:08:01+00:00] FATAL:   /tmp/vagrant-chef-2/solo.rb:6:in `from_string'
[2014-05-01T22:08:01+00:00] FATAL: Aborting due to error in '/tmp/vagrant-chef-2/solo.rb'
```

since we only need to compare the major and minor version numbers a
simple #to_f sufficies for this test.

alternative, we could use Gem::Version here, but i didn't really see
the need to...
