### PR TITLE
Update net-ssh to 2.9.0

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_dependency "i18n", "~> 0.6.0"
   s.add_dependency "listen", "~> 2.7.1"
   s.add_dependency "log4r", "~> 1.1.9", "< 1.1.11"
-  s.add_dependency "net-ssh", ">= 2.6.6", "< 2.8.0"
+  s.add_dependency "net-ssh", ">= 2.9.0"
   s.add_dependency "net-scp", "~> 1.1.0"
   s.add_dependency "rb-kqueue", "~> 0.2.0"
   s.add_dependency "wdm", "~> 0.1.0"


### PR DESCRIPTION
This fixes issues when using recent ssh ciphers like Ed25519.
See https://github.com/net-ssh/net-ssh/pull/160
