### PR TITLE
split off virtualbox networking into separate page

### DIFF
--- a/website/docs/source/layouts/layout.erb
+++ b/website/docs/source/layouts/layout.erb
@@ -237,6 +237,7 @@
 									<li<%= sidebar_current("virtualbox-usage") %>><a href="/v2/virtualbox/usage.html">Usage</a></li>
 									<li<%= sidebar_current("virtualbox-boxes") %>><a href="/v2/virtualbox/boxes.html">Creating a Base Box</a></li>
 									<li<%= sidebar_current("virtualbox-configuration") %>><a href="/v2/virtualbox/configuration.html">Configuration</a></li>
+									<li<%= sidebar_current("virtualbox-networking") %>><a href="/v2/virtualbox/networking.html">Networking</a></li>
 									<li<%= sidebar_current("virtualbox-issues") %>><a href="/v2/virtualbox/common-issues.html">Common Issues</a></li>
 								</ul>
 								<% end %>

--- a/website/docs/source/v2/networking/private_network.html.md
+++ b/website/docs/source/v2/networking/private_network.html.md
@@ -74,32 +74,3 @@ Vagrant.configure("2") do |config|
     auto_config: false
 end
 ```
-
-## VirtualBox Internal Network
-
-The VirtualBox provider supports using the private network as a
-VirtualBox [internal network](https://www.virtualbox.org/manual/ch06.html#network_internal).
-By default, private networks are host-only networks, because those are the
-easiest to work with. However, internal networks can be enabled as well.
-
-To specify a private network as an internal network for VirtualBox
-use the `virtualbox__intnet` option with the network. The `virtualbox__`
-(double underscore) prefix tells Vagrant that this option is only for the
-VirtualBox provider.
-
-```ruby
-Vagrant.configure("2") do |config|
-  config.vm.network "private_network", ip: "192.168.50.4",
-    virtualbox__intnet: true
-end
-```
-
-Additionally, if you want to specify that the VirtualBox provider join
-a specific internal network, specify the name of the internal network:
-
-```ruby
-Vagrant.configure("2") do |config|
-  config.vm.network "private_network", ip: "192.168.50.4",
-    virtualbox__intnet: "mynetwork"
-end
-```

--- a/website/docs/source/v2/virtualbox/networking.html.md
+++ b/website/docs/source/v2/virtualbox/networking.html.md
@@ -1,0 +1,35 @@
+---
+page_title: "Networking - VirtualBox Provider"
+sidebar_current: "virtualbox-networking"
+---
+
+# Networking
+
+## VirtualBox Internal Network
+
+The VirtualBox provider supports using the private network as a
+VirtualBox [internal network](https://www.virtualbox.org/manual/ch06.html#network_internal).
+By default, private networks are host-only networks, because those are the
+easiest to work with. However, internal networks can be enabled as well.
+
+To specify a private network as an internal network for VirtualBox
+use the `virtualbox__intnet` option with the network. The `virtualbox__`
+(double underscore) prefix tells Vagrant that this option is only for the
+VirtualBox provider.
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.network "private_network", ip: "192.168.50.4",
+    virtualbox__intnet: true
+end
+```
+
+Additionally, if you want to specify that the VirtualBox provider join
+a specific internal network, specify the name of the internal network:
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.network "private_network", ip: "192.168.50.4",
+    virtualbox__intnet: "mynetwork"
+end
+```


### PR DESCRIPTION
v2/networking/index.html.md encourages the reader to seek
provider-specific information under the documentation for the provider,
so for consistency, any virtualbox-specific networking info should be
placed there, not in the general networking section.
