### PR TITLE
Box format doc improvements

### DIFF
--- a/website/docs/source/v2/boxes/format.html.md
+++ b/website/docs/source/v2/boxes/format.html.md
@@ -104,7 +104,8 @@ It is a JSON document, structured in the following way:
 As you can see, the JSON document can describe multiple versions of a box,
 multiple providers, and can add/remove providers in different versions.
 
-This JSON file can be passed directly to `vagrant box add` from the local
-filesystem using a file path or via a URL, and Vagrant
-will install the proper version of the box. If multiple providers are
-available, Vagrant will ask what provider you want to use.
+This JSON file can be passed directly to `vagrant box add` from the
+local filesystem using a file path or via a URL, and Vagrant will
+install the proper version of the box. In this case, the value for the
+`url` key in the JSON can also be a file path. If multiple providers
+are available, Vagrant will ask what provider you want to use.


### PR DESCRIPTION
These changes address most of the issues described in #3613.

However it's still unclear why use of the box catalog metadata JSON document is "highly recommended" given that:
- No explanation is given about how the catalog metadata is used if you create it as a local file.
- No explanation is given about how the catalog metadata could (or even should) be hosted online.
- If you create a box via vagrant cloud, it will be created automatically anyway.
