### PR TITLE
tell the user when we are checksumming a downloaded box

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -329,7 +329,7 @@ module Vagrant
 
             if opts[:checksum] && opts[:checksum_type]
               validate_checksum(
-                opts[:checksum_type], opts[:checksum], box_url)
+                opts[:checksum_type], opts[:checksum], box_url, env)
             end
 
             # Add the box!
@@ -486,7 +486,7 @@ module Vagrant
           match.last.chomp == "application/json"
         end
 
-        def validate_checksum(checksum_type, checksum, path)
+        def validate_checksum(checksum_type, checksum, path, env)
           checksum_klass = case checksum_type.to_sym
           when :md5
             Digest::MD5
@@ -499,6 +499,7 @@ module Vagrant
               type: env[:box_checksum_type].to_s
           end
 
+          env[:ui].detail(I18n.t("vagrant.actions.box.add.checksumming"))
           @logger.info("Validating checksum with #{checksum_klass}")
           @logger.info("Expected checksum: #{checksum}")
 


### PR DESCRIPTION
There was already a locale string:

```
Calculating and comparing box checksum...
```

but it wasn't being used.  This meant that the UI appeared to hang for
no obvious reason after box download completed, and this could be for
quite a long time for big boxes.  Now the user gets informed as soon as
checksumming begins, and the final `vagrant box add` output looks like
this:

```
==> box: Loading metadata for box 'mybox.json'
    box: URL: file:///home/adam/path/to/mybox/catalog.json
==> box: Adding box 'mycorp/mybox' (v0.0.1) for provider: virtualbox
    box: Downloading: mybox.box
    box: Calculating and comparing box checksum...
==> box: Successfully added box 'mycorp/mybox' (v0.0.1) for 'virtualbox'!
```
