### PR TITLE
Don't wrap the SMB password in single quotes.

### DIFF
--- a/plugins/guests/linux/cap/mount_smb_shared_folder.rb
+++ b/plugins/guests/linux/cap/mount_smb_shared_folder.rb
@@ -30,7 +30,7 @@ module VagrantPlugins
           options[:mount_options] ||= []
           options[:mount_options] << "sec=ntlm"
           options[:mount_options] << "username=#{options[:smb_username]}"
-          options[:mount_options] << "pass='#{smb_password}'"
+          options[:mount_options] << "pass=#{smb_password}"
 
           # First mount command uses getent to get the group
           mount_options = "-o uid=#{mount_uid},gid=#{mount_gid}"


### PR DESCRIPTION
This fixes issue #3503. From the [Shellwords docs](http://www.ruby-doc.org/stdlib-1.9.3/libdoc/shellwords/rdoc/Shellwords.html#method-c-shellescape):

> Note that a resulted string should be used unquoted and is not intended for use in double quotes nor in single quotes.

The issue is that running the password through `Shellwords.shellescape` will add a backslash before the exclamation mark, and by wrapping it in quotes I guess it's interpreted as part of the password;

``` shell
mount -t cifs -o uid=`id -u vagrant`,gid=`id -g vagrant`,sec=ntlm,username=jyggen,pass='password\!' //192.168.50.172/7c916d949ecf5067741bd8c8a4a83f6c /var/www
```

Removing the quotes around the password fixes the issue and share is mounted successfully.

``` shell
mount -t cifs -o uid=`id -u vagrant`,gid=`getent group vagrant | cut -d: -f3`,sec=ntlm,username=jyggen,pass=password\! //192.168.50.172/7c916d949ecf5067741bd8c8a4a83f6c /var/www
```
