### PR TITLE
Add Linux Mint detection

### DIFF
--- a/plugins/guests/mint/guest.rb
+++ b/plugins/guests/mint/guest.rb
@@ -1,0 +1,13 @@
+require "vagrant"
+
+require Vagrant.source_root.join("plugins/guests/ubuntu/guest")
+
+module VagrantPlugins
+  module GuestMint
+    class Guest < VagrantPlugins::GuestUbuntu::Guest
+      def detect?(machine)
+        machine.communicate.test("cat /etc/issue | grep 'Linux Mint'")
+      end
+    end
+  end
+end

--- a/plugins/guests/mint/plugin.rb
+++ b/plugins/guests/mint/plugin.rb
@@ -1,0 +1,15 @@
+require "vagrant"
+
+module VagrantPlugins
+  module GuestMint
+    class Plugin < Vagrant.plugin("2")
+      name "Mint guest"
+      description "Mint guest support."
+
+      guest("mint", "ubuntu") do
+        require File.expand_path("../guest", __FILE__)
+        Guest
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Linux Mint is a popular distribution based on Ubuntu
- When creating a VM based on Linux Mint, it cannot detect
  that it is based on Ubuntu and it is detected as just linux
  and configure_networks fails
- https://github.com/mitchellh/vagrant/issues/3647
