### PR TITLE
Fix Docker error reporting bug

### DIFF
--- a/plugins/providers/docker/executor/local.rb
+++ b/plugins/providers/docker/executor/local.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
 
           if result.exit_code != 0 && !interrupted
             raise Errors::ExecuteError,
-              command: command.inspect,
+              command: cmd.inspect,
               stderr: result.stderr,
               stdout: result.stdout
           end


### PR DESCRIPTION
There's no "command" variable; it should be "cmd". This bug causes it to print an unhelpful exception if the Docker command fails.
