### PR TITLE
public_send vs send when merging configs

### DIFF
--- a/lib/vagrant/config/v2/loader.rb
+++ b/lib/vagrant/config/v2/loader.rb
@@ -55,10 +55,10 @@ module Vagrant
           # merge every key. This avoids issues with the same reference
           # being part of the config.
           old_state["config_map"].each do |k, _|
-            old.send(k)
+            old.public_send(k)
           end
           new_state["config_map"].each do |k, _|
-            new.send(k)
+            new.public_send(k)
           end
 
           # The config map for the new object is the old one merged with the


### PR DESCRIPTION
This fixes the problem when config keys collide with Kernel/Object
methods (private). An example is `exec` which is used in vagrant-exec
plugin.

Compare:

``` ruby
> old.send :exec
ArgumentError: wrong number of arguments (0 for 1+)
> old.public_send :exec
=> #<Vagrant::Config::V2::DummyConfig:0x007fe212cc05c8>
```

P.S. You might suggest me to rename method from `exec`, but `public_send` is still safer to use
