### PR TITLE
fix subprocess external encode issue. 

### DIFF
--- a/lib/vagrant/util/io.rb
+++ b/lib/vagrant/util/io.rb
@@ -29,7 +29,7 @@ module Vagrant
               break if !results || results[0].empty?
 
               # Read!
-              data << io.readpartial(READ_CHUNK_SIZE)
+              data << io.readpartial(READ_CHUNK_SIZE).encode("UTF-8", Encoding.default_external)
             else
               # Do a simple non-blocking read on the IO object
               data << io.read_nonblock(READ_CHUNK_SIZE)

--- a/lib/vagrant/util/subprocess.rb
+++ b/lib/vagrant/util/subprocess.rb
@@ -25,6 +25,7 @@ module Vagrant
       def initialize(*command)
         @options = command.last.is_a?(Hash) ? command.pop : {}
         @command = command.dup
+        @command.each { |s| s.encode!(Encoding.default_external) }
         @command[0] = Which.which(@command[0]) if !File.file?(@command[0])
         if !@command[0]
           raise Errors::CommandUnavailableWindows, file: command[0] if Platform.windows?


### PR DESCRIPTION
fix vagrant up failed if interface name include non ASCII character
https://github.com/mitchellh/vagrant/issues/3706

in io.rb
 subprocess resuts convert external encoding to utf-8

in subprocess.rb
 command line argument convert utf-8 to  external encoding
