### PR TITLE
remove `-v` flag from post-rsync `chmod`

### DIFF
--- a/plugins/guests/openbsd/cap/rsync.rb
+++ b/plugins/guests/openbsd/cap/rsync.rb
@@ -26,7 +26,7 @@ module VagrantPlugins
         def self.rsync_post(machine, opts)
           machine.communicate.sudo(
             "find '#{opts[:guestpath]}' '(' ! -user #{opts[:owner]} -or ! -group #{opts[:group]} ')' -print0 | " +
-            "xargs -0 -r chown -v #{opts[:owner]}:#{opts[:group]}")
+            "xargs -0 -r chown #{opts[:owner]}:#{opts[:group]}")
         end
       end
     end


### PR DESCRIPTION
OpenBSD `chmod` does not support the `-v` flag, which causes
`vagrant up` to fail if an rsync `synced_folder` is in use.
