### PR TITLE
Speed up nokogiri installation during Travis runs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,7 @@ before_install:
   - sudo apt-get install -qq -y bsdtar
 rvm:
   - 2.0.0
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 script: rake test:unit


### PR DESCRIPTION
Version 1.6 of Nokogiri builds its own copy of libxml2 during installation.
Setting `NOKOGIRI_USE_SYSTEM_LIBRARIES=true` skips this step and shaves about a
minute off of Travis runs.
