### PR TITLE
fix windows guest with puppet and a facter block

### DIFF
--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -140,7 +140,7 @@ module VagrantPlugins
 
             # If we're on Windows, we need to use the PowerShell style
             if windows?
-              facts.map! { |v| "$env:#{v}" }
+              facts.map! { |v| "$env:#{v};" }
             end
 
             facter = "#{facts.join(" ")} "


### PR DESCRIPTION
Powershell doesn't understand the unix-style ENV=thing command syntax, the old vagrant-windows plugin monkey patched the provisioner to put semicolons between statements to set the variables before running puppet - this fixes the issue inside a windows? block leaving the normal non-windows code path working - therefore works for me on both unix and windows provisions with a facter block in place
