### PR TITLE
RSync folder synchonization on Windows isn't compatible with MSYS-port of RSync

### DIFF
--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -39,8 +39,12 @@ module VagrantPlugins
         hostpath  = Vagrant::Util::Platform.fs_real_path(hostpath).to_s
 
         if Vagrant::Util::Platform.windows?
-          # rsync for Windows expects cygwin style paths, always.
+          # Cygwin's rsync expects cygwin style paths in form of '/cygdrive/c/path/to/file'
           hostpath = Vagrant::Util::Platform.cygwin_path(hostpath)
+          if !Vagrant::Util::Platform.cygwin?
+            # MSYS' rsync expects paths in form of '/c/path/to/file'
+            hostpath = hostpath.sub(%r{^/cygdrive}, '')
+          end
         end
 
         # Make sure the host path ends with a "/" to avoid creating


### PR DESCRIPTION
If MSYS port of RSync tool is used on Windows for folder synchronization, it fails with error

```
rsync: change_dir "/cygdrive/c/Users/michael.kuzmin/Projects/vagrant" failed: Bad file number (9)
```

This is because MSYS expects file paths in form of `/c/Users/michael.kuzmin/Projects/vagrant`, without leading `/cygdrive` part.

The pull request adds additional check for this case.

Also it would be great if you reopen https://github.com/mitchellh/vagrant/issues/3236 and bundle rsync and openssh right in Vagrant installer.
That would significantly simplify Vagrant adoption by developers in our company.
