### PR TITLE
providers/docker: Fix SSH access to container when no Host VM is in use

### DIFF
--- a/plugins/providers/docker/provider.rb
+++ b/plugins/providers/docker/provider.rb
@@ -136,7 +136,10 @@ module VagrantPlugins
         # here and we let Vagrant core deal with it ;)
         return nil if !ip
 
-        { host: ip }
+        {
+          host: ip,
+          port: @machine.config.ssh.guest_port
+        }
       end
 
       def state


### PR DESCRIPTION
This should fix GH-3799. I've tested it on an Ubuntu 14.04 host with Docker 0.11.1 using the native driver.

Although it works with @FooBarWidget's Vagrantfile, it takes a while for vagrant to be able to SSH into the container (~32s). I dunno why that happens but I hope it has nothing to do with Vagrant :smiley: 

```
$ cat Vagrantfile 

Vagrant.configure("2") do |config|
  config.vm.provider :docker do |d, override|
    d.image   = "phusion/baseimage:0.9.9"
    d.name    = "vagrant-docker-test"
    d.cmd     = ["/sbin/my_init", "--enable-insecure-key"]
    d.has_ssh = true
  end

  config.ssh.username = "root"
  config.ssh.private_key_path = "insecure_key"
end
```

```
$ time be vagrant up --provider=docker

Bringing machine 'default' up with 'docker' provider...
==> default: Creating the container...
    default:   Name: vagrant-docker-test
    default:  Image: phusion/baseimage:0.9.9
    default:    Cmd: /sbin/my_init --enable-insecure-key
    default: Volume: /home/fabio/projects/oss/vagrant/example:/vagrant
    default:   Port: 2222:22
    default:  
    default: Container created: da40f38c38de4a6b
==> default: Starting container...
==> default: Waiting for machine to boot. This may take a few minutes...
    default: SSH address: 172.17.0.4:22
    default: SSH username: root
    default: SSH auth method: private key
    default: Warning: Connection timeout. Retrying...
    default: Warning: Connection timeout. Retrying...
==> default: Machine booted and ready!

real    0m32.962s
user    0m1.858s
sys 0m0.313s
```

```
$ be vagrant ssh -c 'echo Hello Docker'

Hello Docker
Connection to 172.17.0.4 closed.
```
