### PR TITLE
Windows Guest: cannot assign static IP addresses in private_network when running vagrant on windows host

### DIFF
--- a/plugins/guests/windows/cap/configure_networks.rb
+++ b/plugins/guests/windows/cap/configure_networks.rb
@@ -57,7 +57,7 @@ module VagrantPlugins
               provider: machine.provider_name.to_s
           end
 
-          driver_mac_address = machine.provider.capability(:nic_mac_addresses)
+          driver_mac_address = machine.provider.capability(:nic_mac_addresses).invert
           @@logger.debug("mac addresses: #{driver_mac_address.inspect}")
 
           vm_interface_map = {}


### PR DESCRIPTION
For windows hosts in version <=1.6.2, the hash returned by machine.provider.capability(:nic_mac_addresses) follows the form { 1 => mac_address1, 2 => mac_address2, ... }.

The code in VagrantPlugins::GuestWindows::Cap::ConfigureNetworks::create_vm_interface expects the hash to be keyed by the mac addresses.   Because of this, create_vm_interfaces cannot find the interfaces to set the static IP's
