### PR TITLE
added capath option to curl Downloader

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -398,6 +398,7 @@ module Vagrant
 
           downloader_options = {}
           downloader_options[:ca_cert] = env[:box_download_ca_cert]
+          downloader_options[:ca_path] = env[:box_download_ca_path]
           downloader_options[:continue] = true
           downloader_options[:insecure] = env[:box_download_insecure]
           downloader_options[:client_cert] = env[:box_client_cert]

--- a/lib/vagrant/action/builtin/handle_box.rb
+++ b/lib/vagrant/action/builtin/handle_box.rb
@@ -61,6 +61,7 @@ module Vagrant
 
           # Determine the set of formats that this box can be in
           box_download_ca_cert = machine.config.vm.box_download_ca_cert
+          box_download_ca_path = machine.config.vm.box_download_ca_path
           box_download_client_cert = machine.config.vm.box_download_client_cert
           box_download_insecure = machine.config.vm.box_download_insecure
           box_formats = machine.provider_options[:box_format] ||
@@ -82,6 +83,7 @@ module Vagrant
               box_version: machine.config.vm.box_version,
               box_client_cert: box_download_client_cert,
               box_download_ca_cert: box_download_ca_cert,
+              box_download_ca_path: box_download_ca_path,
               box_download_insecure: box_download_insecure,
             }))
           rescue Errors::BoxAlreadyExists

--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -43,6 +43,7 @@ module Vagrant
         # Get the various optional values
         @auth        = options[:auth]
         @ca_cert     = options[:ca_cert]
+        @ca_path     = options[:ca_path]
         @continue    = options[:continue]
         @headers     = options[:headers]
         @insecure    = options[:insecure]
@@ -195,6 +196,7 @@ module Vagrant
         ]
 
         options += ["--cacert", @ca_cert] if @ca_cert
+        options += ["--capath", @ca_path] if @ca_path
         options += ["--continue-at", "-"] if @continue
         options << "--insecure" if @insecure
         options << "--cert" << @client_cert if @client_cert

--- a/plugins/commands/box/command/add.rb
+++ b/plugins/commands/box/command/add.rb
@@ -29,6 +29,10 @@ module VagrantPlugins
               options[:ca_cert] = c
             end
 
+            o.on("--capath DIR", String, "CA certificate directory for SSL download") do |c|
+              options[:ca_path] = c
+            end
+
             o.on("--cert FILE", String,
                  "A client SSL cert, if needed") do |c|
               options[:client_cert] = c
@@ -84,6 +88,7 @@ module VagrantPlugins
             box_clean: options[:clean],
             box_force: options[:force],
             box_download_ca_cert: options[:ca_cert],
+            box_download_ca_path: options[:ca_path],
             box_download_client_cert: options[:client_cert],
             box_download_insecure: options[:insecure],
             ui: Vagrant::UI::Prefixed.new(@env.ui, "box"),

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -21,6 +21,7 @@ module VagrantPlugins
       attr_accessor :box_url
       attr_accessor :box_version
       attr_accessor :box_download_ca_cert
+      attr_accessor :box_download_ca_path
       attr_accessor :box_download_checksum
       attr_accessor :box_download_checksum_type
       attr_accessor :box_download_client_cert
@@ -39,6 +40,7 @@ module VagrantPlugins
         @box                          = UNSET_VALUE
         @box_check_update             = UNSET_VALUE
         @box_download_ca_cert         = UNSET_VALUE
+        @box_download_ca_path         = UNSET_VALUE
         @box_download_checksum        = UNSET_VALUE
         @box_download_checksum_type   = UNSET_VALUE
         @box_download_client_cert     = UNSET_VALUE
@@ -323,6 +325,7 @@ module VagrantPlugins
         @box = nil if @box == UNSET_VALUE
         @box_check_update = true if @box_check_update == UNSET_VALUE
         @box_download_ca_cert = nil if @box_download_ca_cert == UNSET_VALUE
+        @box_download_ca_path = nil if @box_download_ca_path == UNSET_VALUE
         @box_download_checksum = nil if @box_download_checksum == UNSET_VALUE
         @box_download_checksum_type = nil if @box_download_checksum_type == UNSET_VALUE
         @box_download_client_cert = nil if @box_download_client_cert == UNSET_VALUE
@@ -515,6 +518,16 @@ module VagrantPlugins
             errors << I18n.t(
               "vagrant.config.vm.box_download_ca_cert_not_found",
               path: box_download_ca_cert)
+          end
+        end
+
+        if box_download_ca_path
+          path = Pathname.new(box_download_ca_path).
+            expand_path(machine.env.root_path)
+          if !path.directory?
+            errors << I18n.t(
+              "vagrant.config.vm.box_download_ca_path_not_found",
+              path: box_download_ca_path)
           end
         end
 

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1216,6 +1216,8 @@ en:
           Invalid box version constraints: %{version}
         box_download_ca_cert_not_found: |-
           "box_download_ca_cert" file not found: %{path}
+        box_download_ca_path_not_found: |-
+          "box_download_ca_path" directory not found: %{path}
         box_download_checksum_blank: |-
           Checksum type specified but "box_download_checksum" is blank
         box_download_checksum_notblank: |-

--- a/website/docs/source/v2/cli/box.html.md
+++ b/website/docs/source/v2/cli/box.html.md
@@ -51,6 +51,9 @@ after the initial download.
 * `--cacert CERTFILE` - The certificate for the CA used to verify the peer.
   This should be used if the remote end doesn't use a standard root CA.
 
+* `--capath CERTDIR` - The certificate directoryt for the CA used to verify the peer.
+  This should be used if the remote end doesn't use a standard root CA.
+
 * `--cert CERTFILE` - A client certificate to use when downloading the box, if
   necessary.
 


### PR DESCRIPTION
Hi

In my company, we use some repositories which are signed by a private CA. The cert of the CA is installed on every server in /etc/ssl/certs, rather than added to a bundle.

I think it may be valuable to have an option which permit to use such a certs dir for the CA, when adding a box. Currently, only the cacert option could be passed to the Downloader component, my patch adds the support to the --capath option of curl.

Hope you will merge it.

Regards,
