### PR TITLE
CoreOS vagrant's configuration code look for interface names starting with 'enp0', but in my case when deploying CoreOS image to libvirt environment interfaces had names 'ens4v1', 'ens5v2'

### DIFF
--- a/plugins/guests/coreos/cap/configure_networks.rb
+++ b/plugins/guests/coreos/cap/configure_networks.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
 
             # Read network interface names
             interfaces = []
-            comm.sudo("ifconfig | grep enp0 | cut -f1 -d:") do |_, result|
+            comm.sudo("ifconfig | grep 'enp0\\|ens' | cut -f1 -d:") do |_, result|
               interfaces = result.split("\n")
             end
 


### PR DESCRIPTION
CoreOS vagrant's configuration code look for interface names starting with 'enp0', but in my case when deploying CoreOS image to libvirt environment interfaces had names 'ens4v1', 'ens5v2'

This patch should fix it, but it might be part of a bigger issue and having these two patterns might not cover all possible configurations.
