### PR TITLE
Added conditional for temporary interfaces

### DIFF
--- a/plugins/guests/solaris11/cap/configure_networks.rb
+++ b/plugins/guests/solaris11/cap/configure_networks.rb
@@ -22,7 +22,9 @@ module VagrantPlugins
               machine.communicate.execute("#{su_cmd} ipadm create-addr -T static -a #{network[:ip]}/#{cidr} #{device}/v4")
             elsif network[:type].to_sym == :dhcp
               #machine.communicate.execute("#{ifconfig_cmd} dhcp start")
-              machine.communicate.execute("#{su_cmd} ipadm create-addr -T addrconf #{device}/v4")
+              if machine.communicate.test("ipadm show-if -o all | grep #{device} | tr -s ' ' | cut -d ' ' -f 6  | grep '4\|6'")
+                machine.communicate.execute("#{su_cmd} ipadm create-addr -T addrconf #{device}/v4")
+              end
             end
           end
         end


### PR DESCRIPTION
This should fix #3793.

Here's Oracle's take: http://docs.oracle.com/cd/E23824_01/html/821-1458/gljtt.html. :neckbeard: :zzz: 

Solaris 11 doesn't like ipadm commands aimed at temporary interfaces, so I wrapped it in a conditional that tests for permanent interfaces. I can't find a context in Solaris+VBox where you would get a permanent interface, so permanent interface dudes beware. The first interface isn't even marked permanent from my stock Solaris install. In any case, this will keep that dhcp command from firing on temporary interfaces, causing Vagrant to freak out and bomb.

Turns out if you assign a mac to the adapter with:
`config.vm.network :public_network, :adapter => 2, :mac => "deadbeef9999"`
and DHCP is working on the bridged network, Solaris 11 is ok with this, and you should get assigned an address. 

For static addresses, the command on L22 will also blow up on non-permanent interfaces. In Solaris, they want you to destroy and rebuild into a permanent interface. :no_good: The docs don't help at all with that, but here we are.
