### PR TITLE
drop `-r` flag from `xargs` on OS X

### DIFF
--- a/plugins/guests/darwin/cap/rsync.rb
+++ b/plugins/guests/darwin/cap/rsync.rb
@@ -23,7 +23,7 @@ module VagrantPlugins
 
           machine.communicate.sudo(
             "find '#{opts[:guestpath]}' '(' ! -user #{opts[:owner]} -or ! -group #{opts[:group]} ')' -print0 | " +
-            "xargs -0 -r chown #{opts[:owner]}:#{opts[:group]}")
+            "xargs -0 chown #{opts[:owner]}:#{opts[:group]}")
         end
       end
     end


### PR DESCRIPTION
OS X's `xargs` does not support the `-r` flag (which means "do not
execute the command even once if there are no arguments"), but
behaves by default as if it was specified.

You can verify this yourself with this test:

```
$ touch zero-length-file
$ xargs echo <zero-length-file
```

If `echo` is executed, you will see a blank line.  If it is not
executed (i.e. `-r` is specified or the behavior is implied) then
you will see no blank line.
