### PR TITLE
provisioners/puppet: run in elevated mode on Win guests

### DIFF
--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -159,7 +159,7 @@ module VagrantPlugins
             "vagrant.provisioners.puppet.running_puppet",
             manifest: config.manifest_file))
 
-          @machine.communicate.sudo(command, good_exit: [0,2]) do |type, data|
+          @machine.communicate.sudo(command, elevated: true, good_exit: [0,2]) do |type, data|
             if !data.chomp.empty?
               @machine.ui.info(data.chomp)
             end


### PR DESCRIPTION
I think that `puppet apply` should behave like `chef-solo` when dealing with Windows guests.

Currently puppet commands are run directly through WinRM, and because of WinRM security model, issues similar to the following one could happen:

https://tickets.opscode.com/browse/COOK-1172
