### PR TITLE
Fixed issue 3918

### DIFF
--- a/plugins/communicators/winrm/scripts/elevated_shell.ps1.erb
+++ b/plugins/communicators/winrm/scripts/elevated_shell.ps1.erb
@@ -1,4 +1,4 @@
-$command = "<%= options[:command] %>"
+$command = "<%= options[:command] %>" + '; exit $LASTEXITCODE'
 $user = '<%= options[:username] %>'
 $password = '<%= options[:password] %>'
 


### PR DESCRIPTION
Fixes issue #3918

Running Windows guest commands through a scheduled task were not returning the correct exit codes, they were only returning 1 or 0. This has negative consequences especially for Puppet which can return an exit code of 2 for partial success.

Since we're running an executable from inside a powershell encoded command we need to ensure we explicitly propagate the exit code to the original caller just like a regular PowerShell script - in this case cmd /c which in return is called from a scheduled task.
