### PR TITLE
Update the Vagrantfiles included in website

### DIFF
--- a/website/docs/Vagrantfile
+++ b/website/docs/Vagrantfile
@@ -17,7 +17,7 @@ bundle
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "precise64"
+  config.vm.box = "hashicorp/precise64"
   config.vm.network "private_network", ip: "33.33.33.10"
   config.vm.provision "shell", inline: $script, privileged: false
   config.vm.synced_folder ".", "/vagrant", type: "rsync"

--- a/website/www/Vagrantfile
+++ b/website/www/Vagrantfile
@@ -17,7 +17,7 @@ bundle
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "precise64"
+  config.vm.box = "hashicorp/precise64"
   config.vm.network "private_network", ip: "33.33.33.10"
   config.vm.provision "shell", inline: $script, privileged: false
   config.vm.synced_folder ".", "/vagrant", type: "rsync"


### PR DESCRIPTION
When trying to build/use the Vagrantfiles in the `website` folders, I got errors on `vagrant up`. 

This modifies the `config.vm.box` to be `hashicorp/precise64`, so that Vagrant downloads the box if I don't have it already and named `precisese64` (which I didn't). 
