### PR TITLE
Backtick-escape the facter env command in powershell. Fixes issue 3958

### DIFF
--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -140,7 +140,7 @@ module VagrantPlugins
 
             # If we're on Windows, we need to use the PowerShell style
             if windows?
-              facts.map! { |v| "$env:#{v};" }
+              facts.map! { |v| "`$env:#{v};" }
             end
 
             facter = "#{facts.join(" ")} "


### PR DESCRIPTION
When a puppet.facter block is defined on windows, the puppet apply is succeeding but the ps1 task vagrant runs returns 1.

I think this is because the env value is not being quoted, ie:

works:
cmd /c powershell.exe `$env:FACTER_environment='.'.; puppet apply

fails:
PS C:\tmp> cmd /c powershell.exe "$env:FACTER_environment='.'; puppet apply"
The term '.=.' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:6

```
.='.' <<<< ; puppet apply
    CategoryInfo : ObjectNotFound: (.=.:String) [], CommandNotFoundException
    FullyQualifiedErrorId : CommandNotFoundException
```

If i backtick-escape the $env, it works.
