### PR TITLE
fixed writing rdp file on windows host

### DIFF
--- a/plugins/hosts/windows/cap/rdp.rb
+++ b/plugins/hosts/windows/cap/rdp.rb
@@ -21,12 +21,12 @@ module VagrantPlugins
             "vagrant-rdp-#{Time.now.to_i}-#{rand(10000)}.rdp")
           config_path.open("w+") do |f|
             opts.each do |k, v|
-              config.puts("#{k}:#{v}")
+              f.puts("#{k}:#{v}")
             end
           end
 
           # Build up the args to mstsc
-          args = [config.path]
+          args = [config_path.to_s]
           if rdp_info[:extra_args]
             args = rdp_info[:extra_args] + args
           end


### PR DESCRIPTION
The last change of #3875 doesn't work on windows host calling `vagrant rdp boxname`

```
C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.6.3/plugins/hosts/windows/cap/rdp.rb:24:in `block (2 levels) in rdp_client': private method `puts' called for nil:NilClass (NoMethodError)
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-1.6.3/plugins/hosts/windows/cap/rdp.rb:23:in `each'
```

So I fixed it for me with the following changes.

But instead of writing more and more temporary files I suggest writing the rdp file into .vagrant/machines/boxname/rdp.rdp to use the same file name for each box and stored in the local vagrant directory tree. Should I create a PR for that?
