### PR TITLE
Fixed issue 3987

### DIFF
--- a/plugins/guests/windows/cap/change_host_name.rb
+++ b/plugins/guests/windows/cap/change_host_name.rb
@@ -2,11 +2,24 @@ module VagrantPlugins
   module GuestWindows
     module Cap
       module ChangeHostName
+
         def self.change_host_name(machine, name)
-          # On windows, renaming a computer seems to require a reboot
-          machine.communicate.execute(
-            "wmic computersystem where name=\"%COMPUTERNAME%\" call rename name=\"#{name}\"",
-            shell: :cmd)
+          change_host_name_and_wait(machine, name, machine.config.vm.graceful_halt_timeout)
+        end
+
+        def self.change_host_name_and_wait(machine, name, sleep_timeout)
+          # If the configured name matches the current name, then bail
+          return if machine.communicate.test("if ($env:ComputerName -eq '#{name}') { exit 0 } exit 1")
+
+          # Rename and then reboot in one step
+          exit_code = machine.communicate.execute(
+            "netdom renamecomputer \"$Env:COMPUTERNAME\" /NewName:#{name} /Force /Reboot:0",
+            error_check: false)
+
+          raise Errors::RenameComputerFailed if exit_code != 0
+
+          # Don't continue until the machine has shutdown and rebooted
+          sleep(sleep_timeout)
         end
       end
     end

--- a/plugins/guests/windows/errors.rb
+++ b/plugins/guests/windows/errors.rb
@@ -13,6 +13,10 @@ module VagrantPlugins
       class NetworkWinRMRequired < WindowsError
         error_key(:network_winrm_required)
       end
+
+      class RenameComputerFailed < WindowsError
+        error_key(:rename_computer_failed)
+      end
     end
   end
 end

--- a/templates/locales/guest_windows.yml
+++ b/templates/locales/guest_windows.yml
@@ -1,5 +1,5 @@
 en:
-  vagrant_winrm:
+  vagrant_windows:
     errors:
       cant_read_mac_addresses: |-
         The provider being used to start Windows ('%{provider}')
@@ -18,3 +18,10 @@ en:
         Note that the Windows guest must be configured to accept insecure
         WinRM connections, and the WinRM port must be forwarded properly from
         the guest machine. This is not always done by default.
+      rename_computer_failed: |-
+        Renaming the Windows guest failed. Most often this is because you've
+        specified a FQDN instead of just a host name.
+
+        Ensure the new guest name is properly formatted. Standard names may
+        contain letters (a-z, A-Z), numbers (0-9), and hypens (-), but no
+        spaces or periods (.). The name may not consist entirely of digits.


### PR DESCRIPTION
Fixed issue #3987 

Reboot the Windows guest after renaming the computer so changes take affect immediately before attempting to provision the box.
- Changed rename from wmic to netdom since netdom seems to work correctly in Windows 2008R2 and newer OSs.
- Fixed Windows guest error translations, the wrong namespace was specified in the yaml file.

This potentially won't work on older OSs like Windows7, but I haven't confirmed. At least for the majority of users this is an improvement.
