### PR TITLE
Unable to use puppet.working_directory on Windows

### DIFF
--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -149,7 +149,7 @@ module VagrantPlugins
           command = "#{facter}puppet apply #{options}"
           if config.working_directory
             if windows?
-              command = "cd #{config.working_directory}; if ($?) \{ #{command} \}"
+              command = "cd #{config.working_directory}; if (`$?) \{ #{command} \}"
             else
               command = "cd #{config.working_directory} && #{command}"
             end


### PR DESCRIPTION
Fix escaping of powershell variable.

As this is nested in a powershell variable `$command`, it must be escaped
otherwise it is evaluated when the variable is created, giving an error that
`The term 'True' is not recognized as the name of a cmdlet, function,
script`. This prevented using a `puppet.working_directory` on Windows.
