### PR TITLE
correction install nfs client on RHEL

### DIFF
--- a/plugins/guests/redhat/cap/nfs_client.rb
+++ b/plugins/guests/redhat/cap/nfs_client.rb
@@ -5,6 +5,8 @@ module VagrantPlugins
         def self.nfs_client_install(machine)
           machine.communicate.tap do |comm|
             comm.sudo("yum -y install nfs-utils nfs-utils-lib")
+            comm.sudo("chkconfig rpcbind on")
+            comm.sudo("service rpcbind start")
           end
         end
       end


### PR DESCRIPTION
On Centos/Redhat just install nfs-utils is not enought. We need to start
rpcbind, else we have this error :

mount.nfs: rpc.statd is not running but is required for remote locking.
mount.nfs: Either use '-o nolock' to keep locks local, or start statd.
mount.nfs: an incorrect mount option was specified
