### PR TITLE
Improved box checksum verification performance

### DIFF
--- a/lib/vagrant/util/file_checksum.rb
+++ b/lib/vagrant/util/file_checksum.rb
@@ -8,7 +8,7 @@ class DigestClass
 end
 
 class FileChecksum
-  BUFFER_SIZE = 16328
+  BUFFER_SIZE = 1024 * 8
 
   # Initializes an object to calculate the checksum of a file. The given
   # ``digest_klass`` should implement the ``DigestClass`` interface. Note
@@ -25,11 +25,12 @@ class FileChecksum
   # @return [String]
   def checksum
     digest = @digest_klass.new
+    buf = ''
 
     File.open(@path, "rb") do |f|
       while !f.eof
         begin
-          buf = f.readpartial(BUFFER_SIZE)
+          f.readpartial(BUFFER_SIZE, buf)
           digest.update(buf)
         rescue EOFError
           # Although we check for EOF earlier, this seems to happen


### PR DESCRIPTION
When adding large boxes verifying the checksum took noticably longer than expected because the Ruby GC was needlessly working overtime. With this PR the amount of total RAM consumed by the Ruby process was halved. MD5 checksum validation of a 10GB box was cut from 42 seconds to 18 seconds.
## GC stats - existing code

{:count=>2616, :heap_used=>447, :heap_length=>802, :heap_increment=>355, :heap_live_num=>92545, :heap_free_num=>89447, :heap_final_num=>0, :total_allocated_object=>2071688, :total_freed_object=>1979143}
## GC stats - new code

{:count=>31, :heap_used=>447, :heap_length=>802, :heap_increment=>355, :heap_live_num=>92395, :heap_free_num=>89443, :heap_final_num=>1, :total_allocated_object=>810035, :total_freed_object=>717640}
