### PR TITLE
VirtualBox driver should replace only last occurence of suggested VM name

### DIFF
--- a/plugins/providers/virtualbox/driver/version_4_2.rb
+++ b/plugins/providers/virtualbox/driver/version_4_2.rb
@@ -180,12 +180,12 @@ module VagrantPlugins
           disk_params = Array.new
           disks = output.scan(/(\d+): Hard disk image: source image=.+, target path=(.+),/)
           disks.each do |unit_num, path|
-             disk_params << "--vsys"
-              disk_params << "0"  #Derive vsys num .. do we support OVF's with multiple machines?
-              disk_params << "--unit"
-              disk_params << unit_num
-              disk_params << "--disk"
-              disk_params << path.sub("/#{suggested_name}/", "/#{specified_name}/")
+            disk_params << "--vsys"
+            disk_params << "0"  #Derive vsys num .. do we support OVF's with multiple machines?
+            disk_params << "--unit"
+            disk_params << unit_num
+            disk_params << "--disk"
+            disk_params << path.reverse.sub("/#{suggested_name}/".reverse, "/#{specified_name}/".reverse).reverse # Replace only last occurence
           end
 
           execute("import", ovf , *name_params, *disk_params) do |type, data|

--- a/plugins/providers/virtualbox/driver/version_4_3.rb
+++ b/plugins/providers/virtualbox/driver/version_4_3.rb
@@ -188,12 +188,12 @@ module VagrantPlugins
           disk_params = []
           disks = output.scan(/(\d+): Hard disk image: source image=.+, target path=(.+),/)
           disks.each do |unit_num, path|
-             disk_params << "--vsys"
-             disk_params << "0"
-             disk_params << "--unit"
-             disk_params << unit_num
-             disk_params << "--disk"
-             disk_params << path.sub("/#{suggested_name}/", "/#{specified_name}/")
+            disk_params << "--vsys"
+            disk_params << "0"
+            disk_params << "--unit"
+            disk_params << unit_num
+            disk_params << "--disk"
+            disk_params << path.reverse.sub("/#{suggested_name}/".reverse, "/#{specified_name}/".reverse).reverse # Replace only last occurence
           end
 
           execute("import", ovf , *name_params, *disk_params) do |type, data|


### PR DESCRIPTION
When suggested VM name is present also in the path, the bug encountered:

<pre>
INFO subprocess: Starting process: ["/usr/bin/VBoxManage", "import", "/media/arch/srs-vagrant/.vagrant.d/boxes/debian740_provisioned/virtualbox/box.ovf", "--vsys", "0", "--vmname", "srs-vagrant_1403592072958_54939", "--vsys", "0", "--unit", "10", "--disk", "/media/arch/<b>srs-vagrant_1403592072958_54939/vbox/srs-vagrant</b>/box-disk1.vmdk"]
</pre>


But should be

<pre>
INFO subprocess: Starting process: ["/usr/bin/VBoxManage", "import", "/media/arch/srs-vagrant/.vagrant.d/boxes/debian740_provisioned/virtualbox/box.ovf", "--vsys", "0", "--vmname", "srs-vagrant_1403600101329_78183", "--vsys", "0", "--unit", "10", "--disk", "/media/arch/<b>srs-vagrant/vbox/srs-vagrant_1403600101329_78183</b>/box-disk1.vmdk"]
</pre>


Also indentation of code was fixed (code style).
