### PR TITLE
Better WinRM command failure messaging

### DIFF
--- a/plugins/communicators/winrm/errors.rb
+++ b/plugins/communicators/winrm/errors.rb
@@ -18,6 +18,10 @@ module VagrantPlugins
         error_key(:invalid_shell)
       end
 
+      class WinRMBadExitStatus < WinRMError
+        error_key(:winrm_bad_exit_status)
+      end
+
       class WinRMNotReady < WinRMError
         error_key(:winrm_not_ready)
       end

--- a/templates/locales/comm_winrm.yml
+++ b/templates/locales/comm_winrm.yml
@@ -8,6 +8,19 @@ en:
         Password: %{password}
         Endpoint: %{endpoint}
         Message: %{message}
+      winrm_bad_exit_status: |-
+        The following WinRM command responded with a non-zero exit status.
+        Vagrant assumes that this means the command failed!
+
+        %{command}
+
+        Stdout from the command:
+
+        %{stdout}
+
+        Stderr from the command:
+
+        %{stderr}
       execution_error: |-
         An error occurred executing a remote WinRM command.
 

--- a/test/unit/plugins/communicators/winrm/communicator_test.rb
+++ b/test/unit/plugins/communicators/winrm/communicator_test.rb
@@ -61,9 +61,10 @@ describe VagrantPlugins::CommunicatorWinRM::Communicator do
     end
 
     it "raises error when error_check is true and exit code is non-zero" do
-      expect(shell).to receive(:powershell).with(kind_of(String)).and_return({ exitcode: 1 })
+      expect(shell).to receive(:powershell).with(kind_of(String)).and_return(
+        { exitcode: 1, data: [{ stdout: '', stderr: '' }] })
       expect { subject.execute("dir") }.to raise_error(
-        VagrantPlugins::CommunicatorWinRM::Errors::ExecutionError)
+        VagrantPlugins::CommunicatorWinRM::Errors::WinRMBadExitStatus)
     end
 
     it "does not raise error when error_check is false and exit code is non-zero" do


### PR DESCRIPTION
Non-zero exit command failures should include the stdout and stderr in the error message just like the SSH communicator. A new WinRMBadExitStatus class was added to include stdout and stderr that differs from the generic ExecutionError that can occur when WinRM returns a 500 status code. Getting the output is helpful during development.

Its now possible to specify only an error_class and have that use the correct error_key by default. Previously only specifying an error_class would display the wrong message if the caller didn't also override the error_key option. I think the SSH communicator also has this issue since it always provides a default error_key option.
