### PR TITLE
First attempt at trying to fix issue 2476

### DIFF
--- a/plugins/provisioners/chef/provisioner/chef_client.rb
+++ b/plugins/provisioners/chef/provisioner/chef_client.rb
@@ -104,14 +104,18 @@ module VagrantPlugins
             "vagrant.provisioners.chef.deleting_from_server",
             deletable: deletable, name: node_name))
 
-          command = ["knife", deletable, "delete", "--yes", node_name]
-          r = Vagrant::Util::Subprocess.execute(*command)
-          if r.exit_code != 0
-            @machine.ui.error(I18n.t(
-              "vagrant.chef_client_cleanup_failed",
-              deletable: deletable,
-              stdout: r.stdout,
-              stderr: r.stderr))
+          # Knife is not part of the current Vagrant bundle, so it needs to run
+          # in the context of the system.
+          Bundler.with_clean_env do
+            command = ["knife", deletable, "delete", "--yes", node_name]
+            r = Vagrant::Util::Subprocess.execute(*command)
+            if r.exit_code != 0
+              @machine.ui.error(I18n.t(
+                "vagrant.chef_client_cleanup_failed",
+                deletable: deletable,
+                stdout: r.stdout,
+                stderr: r.stderr))
+            end
           end
         end
       end


### PR DESCRIPTION
One possible solution to #2476, although likely incomplete.

This addresses the error "chef is not part of the bundle" when the chef-client provisioner attempts to delete the node or client from the Chef Server. While this fixes the specific issue on my system, its likely that it does not account for all system configurations like RVM.

The Bundler.with_clean_env should probably be moved internally to Subprocess.execute, but that's a riskier change and I'd like to get some feedback before even attempting that size of change.
