### PR TITLE
Clarify docs for rsync ownership

### DIFF
--- a/website/docs/source/v2/synced-folders/rsync.html.md
+++ b/website/docs/source/v2/synced-folders/rsync.html.md
@@ -49,7 +49,9 @@ The rsync synced folder type accepts the following options:
   [`owner` and `group`](/v2/synced-folders/basic_usage.html)
   options for the synced folder are ignored and Vagrant won't execute
   a recursive `chown`. This defaults to true. This option exists because
-  the `chown` causes issues for some development environments.
+  the `chown` causes issues for some development environments. Note that
+  any `rsync__args` options for ownership **will be overridden** by
+  `rsync__chown`.
 
 * `rsync__exclude` (string or array of strings) - A list of files or directories
   to exclude from the sync. The values can be any acceptable rsync exclude


### PR DESCRIPTION
I've only ever reached the rsync docs from Google, which I imagine is pretty common. It's not clear that the options for rsync shared folders also include global options applicable to any shared folder. Specifically, it's very confusing when customizing the rsync command, and not having ownership match what the args are setting.

This PR adds a link up to the basic usage docs (which should jump out a little more), as well as indicates that 'owner' and 'group' supersede any rsync options.
