### PR TITLE
Fix value for manifest_file

### DIFF
--- a/templates/commands/init/Vagrantfile.erb
+++ b/templates/commands/init/Vagrantfile.erb
@@ -85,7 +85,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   #
   # config.vm.provision "puppet" do |puppet|
   #   puppet.manifests_path = "manifests"
-  #   puppet.manifest_file  = "site.pp"
+  #   puppet.manifest_file  = "default.pp"
   # end
 
   # Enable provisioning with chef solo, specifying a cookbooks path, roles


### PR DESCRIPTION
This value should match the default, mentioned at the Vagrant Documentation. Otherwise, new users could be confused.
