### PR TITLE
Arch Linux nfs service files changed

### DIFF
--- a/plugins/hosts/arch/cap/nfs.rb
+++ b/plugins/hosts/arch/cap/nfs.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class NFS
         def self.nfs_check_command(env)
           if systemd?
-            return "/usr/sbin/systemctl status nfsd"
+            return "/usr/sbin/systemctl status nfs-server"
           else
             return "/etc/rc.d/nfs-server status"
           end
@@ -12,7 +12,7 @@ module VagrantPlugins
 
         def self.nfs_start_command(env)
           if systemd?
-            return "/usr/sbin/systemctl start nfsd rpc-idmapd rpc-mountd rpcbind"
+            return "/usr/sbin/systemctl start nfs-server nfs-idmapd nfs-mountd rpcbind"
           else
             return "sh -c 'for s in {rpcbind,nfs-common,nfs-server}; do /etc/rc.d/$s start; done'"
           end


### PR DESCRIPTION
The systemd service files changed in archlinux:

nfsd.service       -> nfs-server.service
rpc-idmapd.service -> nfs-idmapd.service
rpc-mountd.service -> nfs-mountd.service

Signed-off-by: BlackEagle ike.devolder@gmail.com
