### PR TITLE
Fix spelling of Chef Solo, Chef Client, and Chef Server in website docs

### DIFF
--- a/website/docs/source/v2/provisioning/chef_client.html.md
+++ b/website/docs/source/v2/provisioning/chef_client.html.md
@@ -7,7 +7,7 @@ sidebar_current: "provisioning-chefclient"
 
 **Provisioner name: `chef_client`**
 
-The chef client provisioner allows you to provision the guest using
+The Chef Client provisioner allows you to provision the guest using
 [Chef](http://www.opscode.com/chef/), specifically by connecting
 to an existing Chef Server and registering the Vagrant machine as a
 node within your infrastructure.
@@ -26,9 +26,9 @@ provisioner.
 
 ## Authenticating
 
-The minimum required to use provision using Chef client is to provide
-a URL to the Chef sever as well as the path to the validation key so
-that the node can register with the Chef server:
+The minimum required to use provision using Chef Client is to provide
+a URL to the Chef Server as well as the path to the validation key so
+that the node can register with the Chef Server:
 
 ```ruby
 Vagrant.configure("2") do |config|
@@ -39,13 +39,13 @@ Vagrant.configure("2") do |config|
 end
 ```
 
-The node will register with the Chef server specified, download the
+The node will register with the Chef Server specified, download the
 proper run list for that node, and provision.
 
 ## Specifying a Run List
 
-Normally, the Chef server is responsible for specifying the run list
-for the node. However, you can override what the Chef server sends
+Normally, the Chef Server is responsible for specifying the run list
+for the node. However, you can override what the Chef Server sends
 down by manually specifying a run list:
 
 ```ruby
@@ -81,7 +81,7 @@ end
 ## Other Configuration Options
 
 There are a few more configuration options available. These generally don't
-need to be modified but are available if your Chef server requires customization
+need to be modified but are available if your Chef Server requires customization
 of these variables:
 
 * `client_key_path`
@@ -90,8 +90,8 @@ of these variables:
 
 ## Cleanup
 
-When you provision your Vagrant virtual machine with Chef server, it creates a
-new Chef "node" entry and Chef "client" entry on the Chef server, using the
+When you provision your Vagrant virtual machine with Chef Server, it creates a
+new Chef "node" entry and Chef "client" entry on the Chef Server, using the
 hostname of the machine. After you tear down your guest machine, Vagrant can be
 configured to do it automatically with the following settings:
 
@@ -101,7 +101,7 @@ chef.delete_client = true
 ```
 
 If you don't specify it or set it to `false`, you must explicitly delete these
-entries from the Chef server before you provision a new one with Chef server.
+entries from the Chef Server before you provision a new one with Chef Server.
 For example, using Chef's built-in `knife` tool:
 
 ```
@@ -110,7 +110,7 @@ $ knife client delete precise64
 ```
 
 If you fail to do so, you'll get the following error when Vagrant
-tries to provision the machine with Chef client:
+tries to provision the machine with Chef Client:
 
 ```
 HTTP Request Returned 409 Conflict: Client already exists.

--- a/website/docs/source/v2/provisioning/chef_common.html.md
+++ b/website/docs/source/v2/provisioning/chef_common.html.md
@@ -48,7 +48,7 @@ provisioners.
 * `log_level` (string) - The log level for Chef output. This defaults to
   "info".
 
-* `node_name` (string) - The node name for the Chef client. By default this
+* `node_name` (string) - The node name for the Chef Client. By default this
   will be your hostname.
 
 * `provisioning_path` (string) - The path on the remote machine where Vagrant

--- a/website/docs/source/v2/provisioning/chef_solo.html.md
+++ b/website/docs/source/v2/provisioning/chef_solo.html.md
@@ -7,11 +7,11 @@ sidebar_current: "provisioning-chefsolo"
 
 **Provisioner name: `chef_solo`**
 
-The chef solo provisioner allows you to provision the guest using
+The Chef Solo provisioner allows you to provision the guest using
 [Chef](http://www.opscode.com/chef/), specifically with
 [Chef Solo](http://docs.opscode.com/chef_solo.html).
 
-Chef solo is ideal for people who are already experienced with Chef,
+Chef Solo is ideal for people who are already experienced with Chef,
 already have Chef cookbooks, or are looking to learn Chef. Specifically,
 this documentation page will not go into how to use Chef or how to write
 Chef cookbooks, since Chef is a complete system that is beyond the scope
@@ -28,13 +28,13 @@ of a single page of documentation.
 
 ## Options
 
-This section lists the complete set of available options for the Chef solo
+This section lists the complete set of available options for the Chef Solo
 provisioner. More detailed examples of how to use the provisioner are
 available below this section.
 
 Note that only the Chef-solo specific options are shown below. There is
 also a large set of [common options](/v2/provisioning/chef_common.html)
-that are available with both the Chef solo and Chef client provisioners.
+that are available with both the Chef Solo and Chef client provisioners.
 
 * `cookbooks_path` (string or array) - A list of paths to where cookbooks
   are stored. By default this is "cookbooks", expecting a cookbooks folder
@@ -158,7 +158,7 @@ end
 ## Custom JSON Data
 
 Additional configuration data for Chef attributes can be passed in
-to Chef solo. This is done by setting the `json` property with a Ruby
+to Chef Solo. This is done by setting the `json` property with a Ruby
 hash (dictionary-like object), which is converted to JSON and passed
 in to Chef:
 


### PR DESCRIPTION
@sethvargo FYI - Updated Vagrant website docs to use 'Chef Server', 'Chef Client', and 'Chef Solo'.
