### PR TITLE
Changed order of nfs exports parameters for FreeBSD

### DIFF
--- a/templates/nfs/exports_freebsd.erb
+++ b/templates/nfs/exports_freebsd.erb
@@ -1,5 +1,5 @@
 # VAGRANT-BEGIN: <%= user %> <%= uuid %>
 <% folders.each do |dirs, opts| %>
-<%= dirs.map { |d| "\"#{d}\"" }.join(" ") %> <%= ips.join(" ") %> <%=opts[:bsd__compiled_nfs_options] %>
+<%= dirs.map { |d| "#{d}" }.join(" ") %> <%=opts[:bsd__compiled_nfs_options] %> <%= ips.join(" ") %>
 <% end %>
 # VAGRANT-END: <%= user %> <%= uuid %>


### PR DESCRIPTION
The order of parameters in /etc/exports for FreeBSD 10 is different than the current template.  I had to swap the nfs_options with the ips and remove the quotes from the directorys exported or I would get "permission denied" in the guest (which is also FreeBSD 10)
