### PR TITLE
Put encrypted data bag secret in default location

### DIFF
--- a/plugins/provisioners/chef/provisioner/base.rb
+++ b/plugins/provisioners/chef/provisioner/base.rb
@@ -142,7 +142,7 @@ module VagrantPlugins
 
         def guest_encrypted_data_bag_secret_key_path
           if @config.encrypted_data_bag_secret_key_path
-            File.join(@config.provisioning_path, "encrypted_data_bag_secret_key")
+            File.join(@config.provisioning_path, "encrypted_data_bag_secret")
           end
         end
 


### PR DESCRIPTION
Following the chef [doc](http://docs.opscode.com/chef/essentials_data_bags.html) the default expected location for the secret is `/etc/chef/encrypted_data_bag_secret`.
