### PR TITLE
Fix #4039 - Puppet provisioner should support targeting a directory

### DIFF
--- a/plugins/provisioners/puppet/config/puppet.rb
+++ b/plugins/provisioners/puppet/config/puppet.rb
@@ -105,7 +105,8 @@ module VagrantPlugins
                                path: expanded_path.to_s)
             else
               expanded_manifest_file = expanded_path.join(manifest_file)
-              if !expanded_manifest_file.file?
+              if !expanded_manifest_file.file? and
+	         !expanded_manifest_file.directory?
                 errors << I18n.t("vagrant.provisioners.puppet.manifest_missing",
                                  manifest: expanded_manifest_file.to_s)
               end


### PR DESCRIPTION
Puppet is dropping support for the import statement. It is superseded
by the ability to use a directory in place of a site manifest file.

Since the puppet provisioner relies on `puppet apply` to do the work,
it is sufficient to allow a directory to be specified as the manifest
file, because puppet apply will use all manifest files found in said
directory.
