### PR TITLE
hosts/arch: Fix NFS service name [GH-4176]

### DIFF
--- a/plugins/hosts/arch/cap/nfs.rb
+++ b/plugins/hosts/arch/cap/nfs.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class NFS
         def self.nfs_check_command(env)
           if systemd?
-            return "/usr/sbin/systemctl status nfsd"
+            return "/usr/sbin/systemctl status nfs-server"
           else
             return "/etc/rc.d/nfs-server status"
           end
@@ -12,9 +12,9 @@ module VagrantPlugins
 
         def self.nfs_start_command(env)
           if systemd?
-            return "/usr/sbin/systemctl start nfsd rpc-idmapd rpc-mountd rpcbind"
+            return "/usr/sbin/systemctl start nfs-server"
           else
-            return "sh -c 'for s in {rpcbind,nfs-common,nfs-server}; do /etc/rc.d/$s start; done'"
+            return "/etc/rc.d/nfs-server start"
           end
         end
 


### PR DESCRIPTION
Only the `nfs-server.service` needs to be started now to bring up NFS on Arch. [See here](https://bbs.archlinux.org/viewtopic.php?id=183444)
