### PR TITLE
Enterprise Linux 7 Dynamic network cards fix (ref #4171)

### DIFF
--- a/plugins/guests/enterprise7/guest.rb
+++ b/plugins/guests/enterprise7/guest.rb
@@ -1,0 +1,11 @@
+module VagrantPlugins
+  module GuestEnterpriseLinux7
+
+      class Guest < Vagrant.plugin('2', :guest)
+        def detect?(machine)
+          machine.communicate.test('grep "\(CentOS\|Red Hat Enterprise\) Linux release 7" /etc/redhat-release')
+        end
+      end
+
+  end
+end

--- a/plugins/guests/enterprise7/plugin.rb
+++ b/plugins/guests/enterprise7/plugin.rb
@@ -1,0 +1,22 @@
+require 'vagrant'
+
+module VagrantPlugins
+  module GuestEnterpriseLinux7
+
+    class Plugin < Vagrant.plugin("2")
+      name "Enterprise Linux 7 Guest"
+      description "Enterprise Linux 7 guest support."
+
+      guest("el7", "redhat") do
+        require File.expand_path("../guest", __FILE__)
+        Guest
+      end
+
+      guest_capability("el7","configure_networks") do
+        require File.expand_path("../../fedora/cap/configure_networks", __FILE__)
+        ::VagrantPlugins::GuestFedora::Cap::ConfigureNetworks
+      end
+
+    end
+  end
+end


### PR DESCRIPTION
Uses fedora's network configuration for RedHat and CentOS 7.

Possibly fixes #4171 but I doubt this is the 'cleanest' way. Pointers
welcome.
