### PR TITLE
accept vhd as well as vhdx file types on hyper-v

### DIFF
--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -27,15 +27,17 @@ module VagrantPlugins
             end
           end
 
-          vhdx_path = nil
+          image_path = nil
+          image_ext = nil
           hd_dir.each_child do |f|
-            if f.extname.downcase == ".vhdx"
-              vhdx_path = f
+            if %w{.vhd .vhdx}.include?(f.extname.downcase)
+              image_path = f
+              image_ext = f.extname.downcase
               break
             end
           end
 
-          if !config_path || !vhdx_path
+          if !config_path || !image_path
             raise Errors::BoxInvalid
           end
 
@@ -64,16 +66,16 @@ module VagrantPlugins
           end
 
           env[:ui].detail("Cloning virtual hard drive...")
-          source_path = vhdx_path.to_s
-          dest_path   = env[:machine].data_dir.join("disk.vhdx").to_s
+          source_path = image_path.to_s
+          dest_path   = env[:machine].data_dir.join("disk.#{image_ext}").to_s
           FileUtils.cp(source_path, dest_path)
-          vhdx_path = dest_path
+          image_path = dest_path
 
           # We have to normalize the paths to be Windows paths since
           # we're executing PowerShell.
           options = {
             vm_xml_config:  config_path.to_s.gsub("/", "\\"),
-            vhdx_path:      vhdx_path.to_s.gsub("/", "\\")
+            image_path:      image_path.to_s.gsub("/", "\\")
           }
           options[:switchname] = switch if switch
 

--- a/plugins/providers/hyperv/scripts/import_vm.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm.ps1
@@ -2,7 +2,7 @@ Param(
     [Parameter(Mandatory=$true)]
     [string]$vm_xml_config,
     [Parameter(Mandatory=$true)]
-    [string]$vhdx_path,
+    [string]$image_path,
 
     [string]$switchname=$null
 )
@@ -119,7 +119,7 @@ foreach ($controller in $controllers) {
 
         $addDriveParam = @{
             ControllerNumber = $rx.Match($controller.node.name).value
-            Path = $vhdx_path
+            Path = $image_path
         }
 
         if ($drive.pool_id."#text") {


### PR DESCRIPTION
This allows both .vhd and .vhdx as supportable file extensions for hyper-v. Although vhdx is the more modern and possibly preferred extension. Microsoft still ships evaluation windows VHDs in using the older .vhd format. So supporting this format means vagrant boxes can be made from these VHDs without having to migrate them.
