### PR TITLE
Fix NFS server starting/stopping and status check

### DIFF
--- a/plugins/hosts/arch/cap/nfs.rb
+++ b/plugins/hosts/arch/cap/nfs.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class NFS
         def self.nfs_check_command(env)
           if systemd?
-            return "/usr/sbin/systemctl status nfsd"
+            return "/usr/sbin/systemctl status nfs-server.service"
           else
             return "/etc/rc.d/nfs-server status"
           end
@@ -12,7 +12,7 @@ module VagrantPlugins
 
         def self.nfs_start_command(env)
           if systemd?
-            return "/usr/sbin/systemctl start nfsd rpc-idmapd rpc-mountd rpcbind"
+            return "/usr/sbin/systemctl start nfs-server.service"
           else
             return "sh -c 'for s in {rpcbind,nfs-common,nfs-server}; do /etc/rc.d/$s start; done'"
           end


### PR DESCRIPTION
According to https://wiki.archlinux.org/index.php/NFS#Starting_the_server (and verified on my ArchLinux workstation)

The way vagrat currently interacts with NFS via systemd is there for a reason, I believe, however, I didn't find one -- so probably another check should be there.
