### PR TITLE
Fix 'vagrant up' command in Docker docs

### DIFF
--- a/website/docs/source/v2/docker/basics.html.md
+++ b/website/docs/source/v2/docker/basics.html.md
@@ -52,7 +52,7 @@ end
 </pre>
 
 The above configuration will look for a `Dockerfile` in the same
-directory as the Vagrantfile. When `vagrant up` is run, Vagrant
+directory as the Vagrantfile. When `vagrant up --provider=docker` is run, Vagrant
 automatically builds that Dockerfile and starts a container
 based on that Dockerfile.
 


### PR DESCRIPTION
Without the `--provider=docker` argument, running `vagrant up` causes an error:

```
There are errors in the configuration of this machine. Please fix
the following errors and try again:

vm:
 * A box must be specified.
```
