### PR TITLE
Fix #3860 by making sure post-up command never returns an error code

### DIFF
--- a/templates/guests/debian/network_dhcp.erb
+++ b/templates/guests/debian/network_dhcp.erb
@@ -3,7 +3,7 @@
 auto eth<%= options[:interface] %>
 iface eth<%= options[:interface] %> inet dhcp
 <% if !options[:use_dhcp_assigned_default_route] %>
-    post-up route del default dev $IFACE
+    post-up route del default dev $IFACE || true
 <% else %>
     # We need to disable eth0, see GH-2648
     post-up route del default dev eth0


### PR DESCRIPTION
I suspect the post-up command could just be removed, but this is the more conservative option. If deleting the default route for an interface fails, it's unlikely to start working after some number of seconds. (Issue #3860)
