### PR TITLE
Add config.vm.box_server_url setting

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -53,7 +53,7 @@ module Vagrant
             next if url[i] !~ /^[^\/]+\/[^\/]+$/
 
             if !File.file?(url[i])
-              server   = Vagrant.server_url
+              server = Vagrant.server_url env[:box_server_url]
               raise Errors::BoxServerNotSet if !server
 
               expanded = true

--- a/lib/vagrant/shared_helpers.rb
+++ b/lib/vagrant/shared_helpers.rb
@@ -60,9 +60,9 @@ module Vagrant
   # Returns the URL prefix to the server.
   #
   # @return [String]
-  def self.server_url
+  def self.server_url(config_server_url=nil)
     result = ENV["VAGRANT_SERVER_URL"]
-    result = nil if result == ""
+    result = config_server_url if result == "" or result == nil
     result || DEFAULT_SERVER_URL
   end
 

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -19,6 +19,7 @@ module VagrantPlugins
       attr_accessor :box
       attr_accessor :box_check_update
       attr_accessor :box_url
+      attr_accessor :box_server_url
       attr_accessor :box_version
       attr_accessor :box_download_ca_cert
       attr_accessor :box_download_ca_path

--- a/test/unit/vagrant/shared_helpers_test.rb
+++ b/test/unit/vagrant/shared_helpers_test.rb
@@ -71,6 +71,18 @@ describe Vagrant do
         expect(subject.server_url).to eq("foo")
       end
     end
+
+    it "is the VAGRANT_SERVER_URL value if the server url is configured" do
+      with_temp_env("VAGRANT_SERVER_URL" => "foo") do
+        expect(subject.server_url('bar')).to eq("foo")
+      end
+    end
+
+    it "is the configured server url if VAGRANT_SERVER_URL is not set" do
+      with_temp_env("VAGRANT_SERVER_URL" => nil) do
+        expect(subject.server_url("bar")).to eq("bar")
+      end
+    end
   end
 
   describe "#user_data_path" do


### PR DESCRIPTION
This commits adds a new config setting `config.vm.box_server_url` to set the URL of a local VagrantCloud instance in the Vagrantfile. If the environment variable `VAGRANT_SERVER_URL` is set, it will still be preferred.
