### PR TITLE
[salt] added new configuration parameter : minion_fail_on_error

### DIFF
--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -20,6 +20,7 @@ module VagrantPlugins
       attr_accessor :seed_master
       attr_reader   :pillar_data
       attr_accessor :colorize
+      attr_accessor :minion_fail_on_error
       attr_accessor :log_level
 
       ## bootstrap options
@@ -46,6 +47,7 @@ module VagrantPlugins
         @seed_master = UNSET_VALUE
         @pillar_data = UNSET_VALUE
         @colorize = UNSET_VALUE
+        @minion_fail_on_error = UNSET_VALUE
         @log_level = UNSET_VALUE
         @temp_config_dir = UNSET_VALUE
         @install_type = UNSET_VALUE
@@ -57,28 +59,29 @@ module VagrantPlugins
       end
 
       def finalize!
-        @minion_config      = nil if @minion_config == UNSET_VALUE
-        @minion_key         = nil if @minion_key == UNSET_VALUE
-        @minion_pub         = nil if @minion_pub == UNSET_VALUE
-        @master_config      = nil if @master_config == UNSET_VALUE
-        @master_key         = nil if @master_key == UNSET_VALUE
-        @master_pub         = nil if @master_pub == UNSET_VALUE
-        @run_highstate      = nil if @run_highstate == UNSET_VALUE
-        @run_overstate      = nil if @run_overstate == UNSET_VALUE
-        @always_install     = nil if @always_install == UNSET_VALUE
-        @bootstrap_script   = nil if @bootstrap_script == UNSET_VALUE
-        @verbose            = nil if @verbose == UNSET_VALUE
-        @seed_master        = nil if @seed_master == UNSET_VALUE
-        @pillar_data        = {}  if @pillar_data == UNSET_VALUE
-        @colorize           = nil if @colorize == UNSET_VALUE
-        @log_level          = nil if @log_level == UNSET_VALUE
-        @temp_config_dir    = nil if @temp_config_dir == UNSET_VALUE
-        @install_type       = nil if @install_type == UNSET_VALUE
-        @install_args       = nil if @install_args == UNSET_VALUE
-        @install_master     = nil if @install_master == UNSET_VALUE
-        @install_syndic     = nil if @install_syndic == UNSET_VALUE
-        @no_minion          = nil if @no_minion == UNSET_VALUE
-        @bootstrap_options  = nil if @bootstrap_options == UNSET_VALUE
+        @minion_config          = nil if @minion_config == UNSET_VALUE
+        @minion_key             = nil if @minion_key == UNSET_VALUE
+        @minion_pub             = nil if @minion_pub == UNSET_VALUE
+        @master_config          = nil if @master_config == UNSET_VALUE
+        @master_key             = nil if @master_key == UNSET_VALUE
+        @master_pub             = nil if @master_pub == UNSET_VALUE
+        @run_highstate          = nil if @run_highstate == UNSET_VALUE
+        @run_overstate          = nil if @run_overstate == UNSET_VALUE
+        @always_install         = nil if @always_install == UNSET_VALUE
+        @bootstrap_script       = nil if @bootstrap_script == UNSET_VALUE
+        @verbose                = nil if @verbose == UNSET_VALUE
+        @seed_master            = nil if @seed_master == UNSET_VALUE
+        @pillar_data            = {}  if @pillar_data == UNSET_VALUE
+        @colorize               = nil if @colorize == UNSET_VALUE
+        @minion_fail_on_error   = nil if @minion_fail_on_error == UNSET_VALUE
+        @log_level              = nil if @log_level == UNSET_VALUE
+        @temp_config_dir        = nil if @temp_config_dir == UNSET_VALUE
+        @install_type           = nil if @install_type == UNSET_VALUE
+        @install_args           = nil if @install_args == UNSET_VALUE
+        @install_master         = nil if @install_master == UNSET_VALUE
+        @install_syndic         = nil if @install_syndic == UNSET_VALUE
+        @no_minion              = nil if @no_minion == UNSET_VALUE
+        @bootstrap_options      = nil if @bootstrap_options == UNSET_VALUE
 
       end
 

--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -170,6 +170,11 @@ module VagrantPlugins
         end
       end
 
+      # Get retcode-passthrough option string to pass with the salt-call command
+      def get_retcodepassthrough
+        @config.minion_fail_on_error ? " --retcode-passthrough" : " "
+      end
+
       # Copy master and minion configs to VM
       def upload_configs
         if @config.minion_config
@@ -235,7 +240,7 @@ module VagrantPlugins
           else
             bootstrap_destination = File.join(config_dir, "bootstrap_salt.sh")
           end
- 
+
           @machine.communicate.sudo("rm -f %s" % bootstrap_destination)
           @machine.communicate.upload(bootstrap_path.to_s, bootstrap_destination)
           @machine.communicate.sudo("chmod +x %s" % bootstrap_destination)
@@ -266,7 +271,7 @@ module VagrantPlugins
           if !bootstrap
             raise Salt::Errors::SaltError, :bootstrap_failed
           end
-           
+
           if configure and !install
             @machine.env.ui.info "Salt successfully configured!"
           elsif configure and install
@@ -278,7 +283,7 @@ module VagrantPlugins
           @machine.env.ui.info "Salt did not need installing or configuring."
         end
       end
-      
+
       def call_overstate
         if @config.run_overstate
           if @config.install_master
@@ -318,7 +323,7 @@ module VagrantPlugins
               end
             else
               @machine.communicate.sudo("salt-call saltutil.sync_all")
-              @machine.communicate.sudo("salt-call state.highstate #{get_loglevel}#{get_colorize}#{get_pillar}") do |type, data|
+              @machine.communicate.sudo("salt-call state.highstate #{get_loglevel}#{get_colorize}#{get_pillar}#{get_retcodepassthrough}") do |type, data|
                 if @config.verbose
                   @machine.env.ui.info(data)
                 end

--- a/website/docs/source/v2/provisioning/salt.html.md
+++ b/website/docs/source/v2/provisioning/salt.html.md
@@ -56,7 +56,7 @@ on this machine. Not supported on Windows.
 `false`. Not supported on Windows.
 
 * `install_type`  (stable | git | daily | testing) - Whether to install from a
-distribution's stable package manager, git tree-ish, daily ppa, or testing repository. 
+distribution's stable package manager, git tree-ish, daily ppa, or testing repository.
 Not supported on Windows.
 
 * `install_args` (develop) - When performing a git install,
@@ -71,6 +71,9 @@ These only make sense when `no_minion` is `false`.
 
 * `minion_config`    (string, default: "salt/minion") - Path to
 a custom salt minion config file.
+
+* `minion_fail_on_error` - (boolean, default: `false`) If `true`, Vagrant will
+return an error code if Salt provisionning has failed
 
 * `minion_key`  (string) - Path to your minion key
 


### PR DESCRIPTION
If `true`, Vagrant will return an error code if Salt provisionning has failed

This is related to https://github.com/mitchellh/vagrant/issues/4304
