### PR TITLE
Fixes 4309: Error when provisioning Windows host using Puppet

### DIFF
--- a/plugins/communicators/winrm/communicator.rb
+++ b/plugins/communicators/winrm/communicator.rb
@@ -125,7 +125,7 @@ module VagrantPlugins
         script = Vagrant::Util::TemplateRenderer.render(path, options: {
           username: shell.username,
           password: shell.password,
-          command: command,
+          command: command.gsub("\"", "`\""),
         })
         guest_script_path = "c:/tmp/vagrant-elevated-shell.ps1"
         file = Tempfile.new(["vagrant-elevated-shell", "ps1"])


### PR DESCRIPTION
When the winrm communicator executes a command in an elevated shell,
this patch causes it to escape double quotes.

This is necessary as the first line in the file that it produces and
then executes it puts the command into a variable called command that
is delimited by double quotes.

While this is probably a best practice that should be implemented, it solves a real world problem of using Puppet to provision a Windows box and having facts that are either arrays or hashes as their string representation contains double quotes.
