### PR TITLE
fix double dot in the drive file name for hyperv

### DIFF
--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -67,7 +67,7 @@ module VagrantPlugins
 
           env[:ui].detail("Cloning virtual hard drive...")
           source_path = image_path.to_s
-          dest_path   = env[:machine].data_dir.join("disk.#{image_ext}").to_s
+          dest_path   = env[:machine].data_dir.join("disk#{image_ext}").to_s
           FileUtils.cp(source_path, dest_path)
           image_path = dest_path
 

--- a/test/unit/plugins/providers/hyperv/action/import_test.rb
+++ b/test/unit/plugins/providers/hyperv/action/import_test.rb
@@ -1,35 +1,56 @@
 require_relative "../../../../base"
 
 describe VagrantPlugins::HyperV::Action::Import do
-  let(:iso_env) do
-    env = isolated_environment
-    env.vagrantfile("")
-    env.create_vagrant_env
-  end
-  let(:machine) do
-    iso_env.machine(iso_env.machine_names[0], :dummy).tap do |m|
-      m.provider.stub(driver: driver)
-    end
-  end
+  include_context "unit"
+
+  let(:box) { double("box")}
+  let(:box_collection) { double("box_collection")}
+  let(:powershell) { double("powershell") }
+  let(:machine) {double("machine")}
+  let(:env) {{ 
+    machine: machine,
+    ui: Vagrant::UI::Silent.new
+  }}
   let(:app)    { lambda { |*args| }}
-  
+  let(:driver) {double("driver")}
+  let(:provider) { double("provider")}
+  let(:box_dir) { isolated_environment.box3('default', '1.0',  :hyperv) }
+  let(:image_drive) { box_dir.join("Virtual Hard Disks") }
   before do
-    box_dir = iso_env.box2(:dummy, "hyperv")
     vm_dir = box_dir.join("Virtual Machines")
-    @hd_dir = box_dir.join("Virtual Hard Disks")
     vm_dir.mkpath
-    @hd_dir.mkpath
+    image_drive.mkpath
     vm_dir.join("vm.xml").open("w")
+    @import_path = "bad val"
+    allow(driver).to receive(:import){ |arg| @import_path = arg[:image_path]}
+    allow(Vagrant::Util::Platform).to receive(:windows?).and_return(true)
+    allow(Vagrant::Util::Platform).to receive(:windows_admin?).and_return(true)
+    stub_const("Vagrant::Util::PowerShell", powershell)
+    powershell.stub(available?: true)
+    machine.stub(box: box)
+    box.stub(directory: box_dir)
+    provider.stub(driver: driver)
+    machine.stub(provider: provider)
+    machine.stub(:id=)
+    driver.stub(execute: [{:name => 'switch'}])
+    machine.stub(data_dir: Pathname("/data_dir"))
+    FileUtils.stub(:cp)
   end
   
-  subject { described_class.new(app, iso_env) }
+  subject { described_class.new(app, env) }
 
+  it "parses the vhdx file" do
+    image_drive.join("disk.vhdx").open("w")
+    
+    subject.call(env)
 
-  it "parses the vhd file" do
-    @hd_dir.join("disk.vhdx").open("w")
-
-    subject.call(iso_env)
-
-    expect(File).to exist(machine.data_dir.join('disk.vhdx'))
+    expect(@import_path).to eq("\\data_dir\\disk.vhdx")
   end
+  it "parses the vhd file" do
+    image_drive.join("disk.vhd").open("w")
+    
+    subject.call(env)
+
+    expect(@import_path).to eq("\\data_dir\\disk.vhd")
+  end  
 end


### PR DESCRIPTION
This fixes an issue in my previous pull request #4208 found by @ziyan and adds unit tests to cover the scenarios.
