### PR TITLE
fixes import for hyper-v generation 2 VMs

### DIFF
--- a/plugins/providers/hyperv/scripts/import_vm.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm.ps1
@@ -15,6 +15,7 @@ $Dir = Split-Path $script:MyInvocation.MyCommand.Path
 
 $vm_name = $vmconfig.configuration.properties.name.'#text'
 $processors = $vmconfig.configuration.settings.processors.count.'#text'
+$generation = [int]($vmconfig.configuration.properties.subtype.'#text')+1
 
 function GetUniqueName($name) {
     Get-VM | ForEach-Object -Process {
@@ -61,6 +62,7 @@ Switch ((Select-Xml -xml $vmconfig -XPath "//boot").node.device0."#text") {
 
 $vm_params = @{
     Name = $vm_name
+    Generation = $generation
     NoVHD = $True
     MemoryStartupBytes = $MemoryStartupBytes
     SwitchName = $switchname


### PR DESCRIPTION
Currently, packaging a Hyper-V Generation 2 VM and running `Vagrant UP` will result in a VM being created that cannot boot into the OS and the `vagrant up` command will throw since it cannot discover the guest IP.

This simply finds the `subtype` of the vm in the vm config which is the zero based generation and adds the `Generation` parameter to the `New-VM` cmdlet passing the one-based value.

This can be tested using:

```
vagrant box add mwrock/Windows8.1-amd64 --provider hyperv
```
