### PR TITLE
Option to enable symlinks for docker mounted volumes

### DIFF
--- a/plugins/providers/docker/action/host_machine_sync_folders.rb
+++ b/plugins/providers/docker/action/host_machine_sync_folders.rb
@@ -123,9 +123,11 @@ module VagrantPlugins
                 data[:virtualbox__transient] = true
 
                 # mount folder with symlink support
-                env[:machine].provider.host_vm.provider.driver.execute_command(
-                  ["setextradata", env[:machine].provider.host_vm.id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/#{data[:id]}", "1"]
-                )
+                if env[:machine].provider_config.symlink_volumes
+                  host_machine.provider.driver.execute_command(
+                    ["setextradata", host_machine.id, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/#{data[:id]}", "1"]
+                  )
+                end
 
                 new_config.synced_folder(
                   data[:hostpath],

--- a/plugins/providers/docker/config.rb
+++ b/plugins/providers/docker/config.rb
@@ -38,6 +38,11 @@ module VagrantPlugins
       #
       # @return [Boolean]
       attr_accessor :force_host_vm
+      
+      # When enabled, all volumes mounted to a docker container will have symlink support enabled.
+      #
+      # @return [Boolean]
+      attr_accessor :symlink_volumes
 
       # True if the Docker container exposes SSH access. If this is true,
       # then Vagrant can do a bunch more things like setting the hostname,


### PR DESCRIPTION
Example of how this is configured:

```
Vagrant.configure("2") do |config|
    config.vm.define "app" do |v|
        v.vm.provider "docker" do |d|
            d.symlink_volumes = true
        end
    end
end
```
