### PR TITLE
Fix synced folders when running docker-run after vagrant up

### DIFF
--- a/plugins/providers/docker/action.rb
+++ b/plugins/providers/docker/action.rb
@@ -222,11 +222,11 @@ module VagrantPlugins
                     post: true
                 end
               end
-            end
 
-            b2.use Call, IsState, :not_created do |env2, b3|
-              if !env2[:result]
-                b3.use EnvSet, host_machine_sync_folders: false
+              b2.use Call, IsState, :not_created do |env2, b3|
+                if !env2[:result]
+                  b3.use EnvSet, host_machine_sync_folders: false
+                end
               end
             end
 

--- a/plugins/providers/docker/action/host_machine_sync_folders.rb
+++ b/plugins/providers/docker/action/host_machine_sync_folders.rb
@@ -63,13 +63,15 @@ module VagrantPlugins
           proxy_ui.opts[:prefix_spaces] = true
           proxy_ui.opts[:target] = env[:machine].name.to_s
 
+          mounted = host_machine.provider.driver.read_shared_folders
+
           # Read the existing folders that are setup
           existing_folders = synced_folders(host_machine, cached: true)
           existing_ids = {}
           if existing_folders
             existing_folders.each do |impl, fs|
               fs.each do |_name, data|
-                if data[:docker_sfid] && (data[:docker_host_sfid] == host_sfid || data[:docker_host_id] == host_machine.id)
+                if data[:docker_sfid] && (data[:docker_host_sfid] == host_sfid || data[:docker_host_id] == host_machine.id) && mounted.include?(data[:id])
                   existing_ids[data[:docker_sfid]] = data
                 end
               end

--- a/plugins/providers/virtualbox/driver/base.rb
+++ b/plugins/providers/virtualbox/driver/base.rb
@@ -186,6 +186,12 @@ module VagrantPlugins
         def read_guest_additions_version
         end
 
+        # Returns a list of folders currently mounted on the virtual machine
+        #
+        # @return [Array<String>]
+        def read_shared_folders
+        end
+
         # Returns the value of a guest property on the current VM.
         #
         # @param  [String] property the name of the guest property to read

--- a/plugins/providers/virtualbox/driver/meta.rb
+++ b/plugins/providers/virtualbox/driver/meta.rb
@@ -101,6 +101,7 @@ module VagrantPlugins
           :read_machine_folder,
           :read_network_interfaces,
           :read_state,
+          :read_shared_folders,
           :read_used_ports,
           :read_vms,
           :resume,

--- a/plugins/providers/virtualbox/driver/version_4_0.rb
+++ b/plugins/providers/virtualbox/driver/version_4_0.rb
@@ -268,6 +268,20 @@ module VagrantPlugins
           return nil
         end
 
+        def read_shared_folders
+          info = execute("showvminfo", @uuid, "--machinereadable", retryable: true).split("SharedFolderNameMachineMapping1")[1]
+
+          folders = []
+
+          info.split("\n").each do |line|
+            if name = line[/^SharedFolderNameTransientMapping[0-9]="(.+?)"$/, 1]
+              folders << name
+            end
+          end
+
+          return folders
+        end
+
         def read_guest_ip(adapter_number)
           read_guest_property("/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP")
         end

--- a/plugins/providers/virtualbox/driver/version_4_1.rb
+++ b/plugins/providers/virtualbox/driver/version_4_1.rb
@@ -260,6 +260,20 @@ module VagrantPlugins
           end
         end
 
+        def read_shared_folders
+          info = execute("showvminfo", @uuid, "--machinereadable", retryable: true).split("SharedFolderNameMachineMapping1")[1]
+
+          folders = []
+
+          info.split("\n").each do |line|
+            if name = line[/^SharedFolderNameTransientMapping[0-9]="(.+?)"$/, 1]
+              folders << name
+            end
+          end
+
+          return folders
+        end
+
         def read_guest_additions_version
           output = execute("guestproperty", "get", @uuid, "/VirtualBox/GuestAdd/Version",
                            retryable: true)

--- a/plugins/providers/virtualbox/driver/version_4_2.rb
+++ b/plugins/providers/virtualbox/driver/version_4_2.rb
@@ -283,6 +283,20 @@ module VagrantPlugins
           end
         end
 
+        def read_shared_folders
+          info = execute("showvminfo", @uuid, "--machinereadable", retryable: true).split("SharedFolderNameMachineMapping1")[1]
+
+          folders = []
+
+          info.split("\n").each do |line|
+            if name = line[/^SharedFolderNameTransientMapping[0-9]="(.+?)"$/, 1]
+              folders << name
+            end
+          end
+
+          return folders
+        end
+
         def read_guest_additions_version
           output = execute("guestproperty", "get", @uuid, "/VirtualBox/GuestAdd/Version",
                            retryable: true)

--- a/plugins/providers/virtualbox/driver/version_4_3.rb
+++ b/plugins/providers/virtualbox/driver/version_4_3.rb
@@ -292,6 +292,20 @@ module VagrantPlugins
           end
         end
 
+        def read_shared_folders
+          info = execute("showvminfo", @uuid, "--machinereadable", retryable: true).split("SharedFolderNameMachineMapping1")[1]
+
+          folders = []
+
+          info.split("\n").each do |line|
+            if name = line[/^SharedFolderNameTransientMapping[0-9]="(.+?)"$/, 1]
+              folders << name
+            end
+          end
+
+          return folders
+        end
+
         def read_guest_additions_version
           output = execute("guestproperty", "get", @uuid, "/VirtualBox/GuestAdd/Version",
                            retryable: true)


### PR DESCRIPTION
I believe this fixes the problem in #3873, not sure why the host_sfid is used (appears to randomly generate), instead I would think we should check if that same mount path was already used in the host VM, and if so, reuse it (instead of trying to remount a new path, which doesn't work because it isn't being mounted on the host VM).
