### PR TITLE
Clean docker containers when calling vagrant docker-run

### DIFF
--- a/plugins/providers/docker/action/create.rb
+++ b/plugins/providers/docker/action/create.rb
@@ -29,6 +29,9 @@ module VagrantPlugins
             # Allocate a pty if it was requested
             params[:pty] = true if env[:run_pty]
 
+            # Remove container after execution
+            params[:rm] = true if env[:run_rm]
+
             # We link to our original container
             # TODO
           end

--- a/plugins/providers/docker/command/run.rb
+++ b/plugins/providers/docker/command/run.rb
@@ -10,6 +10,7 @@ module VagrantPlugins
           options = {}
           options[:detach] = false
           options[:pty] = false
+          options[:rm] = true
 
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant docker-run [command...]"
@@ -23,6 +24,10 @@ module VagrantPlugins
 
             o.on("-t", "--[no-]tty", "Allocate a pty") do |t|
               options[:pty] = t
+            end
+
+            o.on("-r,", "--[no-]rm", "Remove container after execution") do |r|
+              options[:rm] = r
             end
           end
 
@@ -56,6 +61,7 @@ module VagrantPlugins
               run_command: command,
               run_detach: options[:detach],
               run_pty: options[:pty],
+              run_rm: options[:rm]
             )
           end
 

--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -49,6 +49,7 @@ module VagrantPlugins
         run_cmd += %W(--privileged) if params[:privileged]
         run_cmd += %W(-h #{params[:hostname]}) if params[:hostname]
         run_cmd << "-i" << "-t" if params[:pty]
+        run_cmd << "--rm=true" if params[:rm]
         run_cmd += params[:extra_args] if params[:extra_args]
         run_cmd += [image, cmd]
 


### PR DESCRIPTION
Fix for #4296. I implemented this to remove by default, which can be bypassed by calling it with the --no-rm flag. Implementation could easily change to not do by default, but given that keeping it around is usually for debugging (my perspective at least), it is good to usually remove it.

```
vagrant docker-run --no-rm myapp -- bash
```
