### PR TITLE
Selecting for duration of timeout can cause hang

### DIFF
--- a/lib/vagrant/util/subprocess.rb
+++ b/lib/vagrant/util/subprocess.rb
@@ -128,7 +128,7 @@ module Vagrant
         @logger.debug("Selecting on IO")
         while true
           writers = notify_stdin ? [process.io.stdin] : []
-          results = ::IO.select([stdout, stderr], writers, nil, timeout || 0.1)
+          results = ::IO.select([stdout, stderr], writers, nil, 0.1)
           results ||= []
           readers = results[0]
           writers = results[1]


### PR DESCRIPTION
When specifying a timeout, the subprocess used to select for timeout seconds on the stdout, stderr pipes.

This creates a race condition and can cause the `Subprocess#execute` to hang for the full timeout interval if the process has already exited and no more output is send to the pipes.

This race is happening with a higher probability if the subprocess is generating a lot of output.
