### PR TITLE
Fix #4034 by adding an option to set pty to false forcibly.

### DIFF
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -169,6 +169,7 @@ module VagrantPlugins
           command:     command,
           shell:       nil,
           sudo:        false,
+          without_pty: false,
         }.merge(opts || {})
 
         opts[:good_exit] = Array(opts[:good_exit])
@@ -180,6 +181,7 @@ module VagrantPlugins
           shell_opts = {
             sudo: opts[:sudo],
             shell: opts[:shell],
+            without_pty: opts[:without_pty],
           }
 
           shell_execute(connection, command, **shell_opts) do |type, data|
@@ -405,7 +407,8 @@ module VagrantPlugins
       def shell_execute(connection, command, **opts)
         opts = {
           sudo: false,
-          shell: nil
+          shell: nil,
+          without_pty: false,
         }.merge(opts)
 
         sudo  = opts[:sudo]
@@ -423,7 +426,7 @@ module VagrantPlugins
 
         # Open the channel so we can execute or command
         channel = connection.open_channel do |ch|
-          if @machine.config.ssh.pty
+          if @machine.config.ssh.pty && !opts[:without_pty]
             ch.request_pty do |ch2, success|
               if success
                 @logger.debug("pty obtained for connection")

--- a/plugins/guests/linux/cap/shell_expand_guest_path.rb
+++ b/plugins/guests/linux/cap/shell_expand_guest_path.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class ShellExpandGuestPath
         def self.shell_expand_guest_path(machine, path)
           real_path = nil
-          machine.communicate.execute("echo; printf #{path}") do |type, data|
+          machine.communicate.execute("echo; printf #{path}", without_pty: true) do |type, data|
             if type == :stdout
               real_path ||= ""
               real_path += data


### PR DESCRIPTION
Fix for #4034. Multiple synced_folder using NFS is correctly working with `config.ssh.pty` is false. But `config.ssh.pty` is true, mount on same point in later version of Vagrant.
Therefore I added the option, and I implemented pty regardless of setting to assume pty false forcibly in `shell_expand_guest_path` of Linux.
