### PR TITLE
fix should_upload_file, write to stdout before exit 1

### DIFF
--- a/plugins/communicators/winrm/file_manager.rb
+++ b/plugins/communicators/winrm/file_manager.rb
@@ -131,6 +131,7 @@ module VagrantPlugins
               exit 0
             }
           }
+          Write-Host "should upload file $dest_file_path"
           exit 1
         EOH
         @shell.powershell(cmd)[:exitcode] == 1


### PR DESCRIPTION
@sneal: I repeatedly come to this solution to fix the upload problem in the WinRM communicator. The error described in #4054 occurs very often with Windows 2008 R2 and Windows 7 guests, probably without the latest Windows updates.

In previous versions of vagrant these boxes could be provisioned just fine.

After a debugging session I found that writing a message to stdout seems to do the trick.

Without the patch my test showed errors like this:

```
$ vagrant up
Bringing machine 'default' up with 'vmware_fusion' provider...
==> default: Cloning VMware VM: 'windows_7_ultimate'. This can take some time...
==> default: Verifying vmnet devices are healthy...
==> default: Preparing network adapters...
==> default: Starting the VMware VM...
==> default: Waiting for machine to boot. This may take a few minutes...
==> default: Machine booted and ready!
==> default: Forwarding ports...
    default: -- 3389 => 3389
    default: -- 5985 => 55985
==> default: Configuring network adapters within the VM...
==> default: Configuring secondary network adapters through VMware 
==> default: on Windows is not yet supported. You will need to manually
==> default: configure the network adapter.
==> default: Enabling and configuring shared folders...
    default: -- /Users/stefan/code/tst: /vagrant
==> default: Running provisioner: shell...
    default: Running: c:\tmp\vagrant-shell.ps1
==> default: The argument 'c:\tmp\vagrant-shell.ps1' to the -File parameter does not exist. Provide the path to an existing '.ps1' file as an argument to the -File parameter.
~/code/tst
$ vagrant provision
==> default: Running provisioner: shell...
    default: Running: c:\tmp\vagrant-shell.ps1
==> default: The argument 'c:\tmp\vagrant-shell.ps1' to the -File parameter does not exist. Provide the path to an existing '.ps1' file as an argument to the -File parameter.
~/code/tst
$ vagrant provision
==> default: Running provisioner: shell...
    default: Running: c:\tmp\vagrant-shell.ps1
==> default: The argument 'c:\tmp\vagrant-shell.ps1' to the -File parameter does not exist. Provide the path to an existing '.ps1' file as an argument to the -File parameter.
```

Running `vagrant up` and more `vagrant provision` commands just showed the error.

After adding the `Write-Host` command inside the `should_upload_file?` function before the `exit 1` removed all tese errors and a clean run with `vagrant destroy -f` and `vagrant up` were successful from now on.

I have tested this patch with Vagrant 1.6.3 + only this new code line as well as the latest 1.6.4.dev from master branch (with the rename reboot enhancement). In both cases I had the provisioning problems without it and solved it with this additional code line.
