### PR TITLE
Update Windows Salt provisioner version

### DIFF
--- a/plugins/provisioners/salt/bootstrap-salt.ps1
+++ b/plugins/provisioners/salt/bootstrap-salt.ps1
@@ -1,5 +1,5 @@
 # Salt version to install
-$version = '2014.1.4'
+$version = '2014.1.10'
 
 # Create C:\tmp\ - if Vagrant doesn't upload keys and/or config it might not exist
 New-Item C:\tmp\ -ItemType directory | out-null


### PR DESCRIPTION
Update the salt minion version used when provisioning windows. Salt is moving pretty fast and the newer versions fix a lot of issues.
