### PR TITLE
Handle errors that do not set an exit code

### DIFF
--- a/plugins/communicators/winrm/shell.rb
+++ b/plugins/communicators/winrm/shell.rb
@@ -54,7 +54,7 @@ module VagrantPlugins
       def powershell(command, &block)
         # ensure an exit code
         command << "\r\n"
-        command << "if ($LASTEXITCODE) { exit $LASTEXITCODE } else { exit 0 }"
+        command << "if ($?) { exit 0 } else { if($LASTEXITCODE) { exit $LASTEXITCODE } else { exit 1 } }"
         execute_shell(command, :powershell, &block)
       end
 


### PR DESCRIPTION
Most powershell commands do not natively return an exit code on failure. In fact, most often an exit code is only returned by command line exeutables. For example:

```
C:>blahbidyblooblahblou
```

or

```
mkdir zzz:\badDir
```

will both fail (unless you have a `zzz:\` drive). Powershell provides `$?` which returns a boolean value indicating success or failure of the last command. This will also return $False if the last comman does return a non 0 exit code. So this change checks the output of `$?` and if there is no `$lastexitcode` then it exits 1.
