### PR TITLE
`sudo vagrant up` fails due to `SSHKeyBadOwner`

### DIFF
--- a/lib/vagrant/util/ssh.rb
+++ b/lib/vagrant/util/ssh.rb
@@ -33,7 +33,7 @@ module Vagrant
         LOGGER.debug("Checking key permissions: #{key_path}")
         stat = key_path.stat
 
-        if !stat.owned?
+        if !(stat.owned? || (Process.uid == 0))
           # The SSH key must be owned by ourselves
           raise Errors::SSHKeyBadOwner, key_path: key_path
         end


### PR DESCRIPTION
Allows using `sudo vagrant up` without `chown`ing the insecure private key
