### PR TITLE
Fixed missing sentinel after running provision

### DIFF
--- a/lib/vagrant/action/builtin/provision.rb
+++ b/lib/vagrant/action/builtin/provision.rb
@@ -27,49 +27,52 @@ module Vagrant
           config_enabled = env[:provision_enabled] if env.has_key?(:provision_enabled)
 
           # Check if we already provisioned, and if so, disable the rest
-          sentinel_enabled = true
+          sentinel_enable_provision = true
 
           ignore_sentinel = true
           if env.has_key?(:provision_ignore_sentinel)
             ignore_sentinel = env[:provision_ignore_sentinel]
           end
 
-          sentinel_path   = nil
-          update_sentinel = false
+          sentinel_path = env[:machine].data_dir.join("action_provision")
           if !ignore_sentinel
             @logger.info("Checking provisioner sentinel if we should run...")
-            sentinel_path = env[:machine].data_dir.join("action_provision")
-            if sentinel_path.file?
-              # The sentinel file is in the format of "version:data" so that
-              # we can remain backwards compatible with previous sentinels.
-              # Versions so far:
-              #
-              #   Vagrant < 1.5.0: A timestamp. The weakness here was that
-              #     if it wasn't cleaned up, it would incorrectly not provision
-              #     new machines.
-              #
-              #   Vagrant >= 1.5.0: "1.5:ID", where ID is the machine ID.
-              #     We compare both so we know whether it is a new machine.
-              #
-              contents = sentinel_path.read.chomp
-              parts    = contents.split(":", 2)
+          end
+          if sentinel_path.file?
+            # The sentinel file is in the format of "version:data" so that
+            # we can remain backwards compatible with previous sentinels.
+            # Versions so far:
+            #
+            #   Vagrant < 1.5.0: A timestamp. The weakness here was that
+            #     if it wasn't cleaned up, it would incorrectly not provision
+            #     new machines.
+            #
+            #   Vagrant >= 1.5.0: "1.5:ID", where ID is the machine ID.
+            #     We compare both so we know whether it is a new machine.
+            #
+            contents = sentinel_path.read.chomp
+            parts    = contents.split(":", 2)
 
-              if parts.length == 1
+            if parts.length == 1
+              if !ignore_sentinel
                 @logger.info("Old-style sentinel found! Not provisioning.")
-                sentinel_enabled = false
-                update_sentinel = true
-              elsif parts[0] == "1.5" && parts[1] == env[:machine].id.to_s
-                @logger.info("Sentinel found! Not provisioning.")
-                sentinel_enabled = false
-              else
-                @logger.info("Sentinel found with another machine ID. Removing.")
-                sentinel_path.unlink
+                sentinel_enable_provision = false
               end
+              @logger.info("Updating provisioning sentinel to new format")
+              write_sentinel(env)
+            elsif parts[0] == "1.5" && parts[1] == env[:machine].id.to_s
+              if !ignore_sentinel
+                @logger.info("Sentinel found! Not provisioning.")
+                sentinel_enable_provision = false
+              end
+            else
+              @logger.info("Provisioner sentinel found with another machine ID. Removing.")
+              sentinel_path.unlink
             end
           end
 
           # Store the value so that other actions can use it
-          env[:provision_enabled] = sentinel_enabled if !env.has_key?(:provision_enabled)
+          env[:provision_enabled] = sentinel_enable_provision if !env.has_key?(:provision_enabled)
 
           # Ask the provisioners to modify the configuration if needed
           provisioner_instances(env).each do |p, _|
@@ -79,16 +82,6 @@ module Vagrant
           # Continue, we need the VM to be booted.
           @app.call(env)
 
-          # Write the sentinel if we have to
-          if sentinel_path
-            if update_sentinel || !sentinel_path.file?
-              @logger.info("Writing provisioning sentinel so we don't provision again")
-              sentinel_path.open("w") do |f|
-                f.write("1.5:#{env[:machine].id}")
-              end
-            end
-          end
-
           # If we're configured to not provision, notify the user and stop
           if !config_enabled
             env[:ui].info(I18n.t("vagrant.actions.vm.provision.disabled_by_config"))
@@ -97,7 +90,7 @@ module Vagrant
 
           # If we're not provisioning because of the sentinel, tell the user
           # but continue trying for the "always" provisioners
-          if !sentinel_enabled
+          if !sentinel_enable_provision
             env[:ui].info(I18n.t("vagrant.actions.vm.provision.disabled_by_sentinel"))
           end
 
@@ -108,7 +101,7 @@ module Vagrant
               !env[:provision_types].include?(type_name)
 
             # Don't run if sentinel is around and we're not always running
-            next if !sentinel_enabled && options[:run] != :always
+            next if !sentinel_enable_provision && options[:run] != :always
 
             env[:ui].info(I18n.t(
               "vagrant.actions.vm.provision.beginning",
@@ -120,6 +113,19 @@ module Vagrant
               provisioner_name: type_name,
             ))
           end
+
+          # Write the sentinel if it does not already exist
+          if !sentinel_path.file?
+            @logger.info("Writing provisioning sentinel so we don't provision again")
+            write_sentinel(env)
+          end
+        end
+
+        def write_sentinel(env)
+            sentinel_path = env[:machine].data_dir.join("action_provision")
+            sentinel_path.open("w") do |f|
+              f.write("1.5:#{env[:machine].id}")
+            end
         end
 
         # This is pulled out into a seperate method so that users can


### PR DESCRIPTION
This fixes a bug I discovered where "vagrant provision" would never create the sentinel file resulting in provisioners running again on the next "vagrant up".

Steps to reproduce.
1. Start with no VM
2. vagrant up --no-provision
3. vagrant provision
   - Provisioners are run but no sentinel file is created
4. vagrant up
   - Provisioners are run again because the sentinel file does not exist. This time the sentinel file is created so subsequent up commands do not run provisioners as expected.

I've also made the following improvements to the code.
- Always upgrade sentinel format if pre 1.5 format sentinel is found
- Moved writing of Sentinel file to after provisioning is completed
