### PR TITLE
Use -f argument to rm to force-remove files.

### DIFF
--- a/plugins/guests/darwin/cap/mount_vmware_shared_folder.rb
+++ b/plugins/guests/darwin/cap/mount_vmware_shared_folder.rb
@@ -12,7 +12,7 @@ module VagrantPlugins
           machine.communicate.tap do |comm|
             # clear prior symlink
             if comm.test("test -L \"#{guestpath}\"", sudo: true)
-              comm.sudo("rm \"#{guestpath}\"")
+              comm.sudo("rm -f \"#{guestpath}\"")
             end
 
             # clear prior directory if exists

--- a/plugins/guests/debian/cap/configure_networks.rb
+++ b/plugins/guests/debian/cap/configure_networks.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
             # from the interface file.
             comm.sudo("sed -e '/^#VAGRANT-BEGIN/,/^#VAGRANT-END/ d' /etc/network/interfaces > /tmp/vagrant-network-interfaces")
             comm.sudo("su -c 'cat /tmp/vagrant-network-interfaces > /etc/network/interfaces'")
-            comm.sudo("rm /tmp/vagrant-network-interfaces")
+            comm.sudo("rm -f /tmp/vagrant-network-interfaces")
 
             # Accumulate the configurations to add to the interfaces file as
             # well as what interfaces we're actually configuring since we use that
@@ -48,7 +48,7 @@ module VagrantPlugins
             end
 
             comm.sudo("cat /tmp/vagrant-network-entry >> /etc/network/interfaces")
-            comm.sudo("rm /tmp/vagrant-network-entry")
+            comm.sudo("rm -f /tmp/vagrant-network-entry")
 
             # Bring back up each network interface, reconfigured
             interfaces.each do |interface|

--- a/plugins/guests/esxi/cap/mount_nfs_folder.rb
+++ b/plugins/guests/esxi/cap/mount_nfs_folder.rb
@@ -20,7 +20,7 @@ module VagrantPlugins
 
               # symlink vmfs volume to :guestpath
               if comm.test("test -L '#{guestpath}'")
-                comm.execute("rm '#{guestpath}'")
+                comm.execute("rm -f '#{guestpath}'")
               end
               if comm.test("test -d '#{guestpath}'")
                 comm.execute("rmdir '#{guestpath}'")

--- a/plugins/guests/fedora/cap/configure_networks.rb
+++ b/plugins/guests/fedora/cap/configure_networks.rb
@@ -64,7 +64,7 @@ module VagrantPlugins
             machine.communicate.sudo("touch #{network_scripts_dir}/ifcfg-#{interface}")
             machine.communicate.sudo("sed -e '/^#VAGRANT-BEGIN/,/^#VAGRANT-END/ d' #{network_scripts_dir}/ifcfg-#{interface} > /tmp/vagrant-ifcfg-#{interface}")
             machine.communicate.sudo("cat /tmp/vagrant-ifcfg-#{interface} > #{network_scripts_dir}/ifcfg-#{interface}")
-            machine.communicate.sudo("rm /tmp/vagrant-ifcfg-#{interface}")
+            machine.communicate.sudo("rm -f /tmp/vagrant-ifcfg-#{interface}")
 
             # Render and upload the network entry file to a deterministic
             # temporary location.
@@ -89,7 +89,7 @@ module VagrantPlugins
               machine.communicate.sudo("/sbin/ifup #{interface}")
             end
 
-            machine.communicate.sudo("rm /tmp/vagrant-network-entry_#{interface}")
+            machine.communicate.sudo("rm -f /tmp/vagrant-network-entry_#{interface}")
           end
         end
       end

--- a/plugins/guests/freebsd/cap/configure_networks.rb
+++ b/plugins/guests/freebsd/cap/configure_networks.rb
@@ -37,7 +37,7 @@ module VagrantPlugins
 
             machine.communicate.upload(temp.path, "/tmp/vagrant-network-entry")
             machine.communicate.sudo("su -m root -c 'cat /tmp/vagrant-network-entry >> /etc/rc.conf'", {shell: "sh"})
-            machine.communicate.sudo("rm /tmp/vagrant-network-entry", {shell: "sh"})
+            machine.communicate.sudo("rm -f /tmp/vagrant-network-entry", {shell: "sh"})
 
             if network[:type].to_sym == :static
               machine.communicate.sudo("ifconfig #{ifname} inet #{network[:ip]} netmask #{network[:netmask]}", {shell: "sh"})

--- a/plugins/guests/gentoo/cap/configure_networks.rb
+++ b/plugins/guests/gentoo/cap/configure_networks.rb
@@ -13,7 +13,7 @@ module VagrantPlugins
             # Remove any previous host only network additions to the interface file
             comm.sudo("sed -e '/^#VAGRANT-BEGIN/,/^#VAGRANT-END/ d' /etc/conf.d/net > /tmp/vagrant-network-interfaces")
             comm.sudo("cat /tmp/vagrant-network-interfaces > /etc/conf.d/net")
-            comm.sudo("rm /tmp/vagrant-network-interfaces")
+            comm.sudo("rm -f /tmp/vagrant-network-interfaces")
 
             # Configure each network interface
             networks.each do |network|
@@ -32,7 +32,7 @@ module VagrantPlugins
               comm.sudo("ln -fs /etc/init.d/net.lo /etc/init.d/net.eth#{network[:interface]}")
               comm.sudo("/etc/init.d/net.eth#{network[:interface]} stop 2> /dev/null")
               comm.sudo("cat /tmp/vagrant-network-entry >> /etc/conf.d/net")
-              comm.sudo("rm /tmp/vagrant-network-entry")
+              comm.sudo("rm -f /tmp/vagrant-network-entry")
               comm.sudo("/etc/init.d/net.eth#{network[:interface]} start")
             end
           end

--- a/plugins/guests/netbsd/cap/configure_networks.rb
+++ b/plugins/guests/netbsd/cap/configure_networks.rb
@@ -28,7 +28,7 @@ module VagrantPlugins
             # upload it and append it to the new rc.conf file
             machine.communicate.upload(temp.path, "/tmp/vagrant-network-entry")
             machine.communicate.sudo("cat /tmp/vagrant-network-entry >> #{newrcconf}")
-            machine.communicate.sudo("rm /tmp/vagrant-network-entry")
+            machine.communicate.sudo("rm -f /tmp/vagrant-network-entry")
 
             ifname = "wm#{network[:interface]}"
             # remove old configuration

--- a/plugins/guests/suse/cap/configure_networks.rb
+++ b/plugins/guests/suse/cap/configure_networks.rb
@@ -26,7 +26,7 @@ module VagrantPlugins
             machine.communicate.sudo("touch #{network_scripts_dir}/ifcfg-eth#{network[:interface]}")
             machine.communicate.sudo("sed -e '/^#VAGRANT-BEGIN/,/^#VAGRANT-END/ d' #{network_scripts_dir}/ifcfg-eth#{network[:interface]} > /tmp/vagrant-ifcfg-eth#{network[:interface]}")
             machine.communicate.sudo("cat /tmp/vagrant-ifcfg-eth#{network[:interface]} > #{network_scripts_dir}/ifcfg-eth#{network[:interface]}")
-            machine.communicate.sudo("rm /tmp/vagrant-ifcfg-eth#{network[:interface]}")
+            machine.communicate.sudo("rm -f /tmp/vagrant-ifcfg-eth#{network[:interface]}")
 
             # Render and upload the network entry file to a deterministic
             # temporary location.
@@ -51,7 +51,7 @@ module VagrantPlugins
               machine.communicate.sudo("/sbin/ifup eth#{interface} 2> /dev/null")
             end
 
-            machine.communicate.sudo("rm /tmp/vagrant-network-entry_#{interface}")
+            machine.communicate.sudo("rm -f /tmp/vagrant-network-entry_#{interface}")
           end
         end
       end

--- a/plugins/providers/docker/communicator.rb
+++ b/plugins/providers/docker/communicator.rb
@@ -93,7 +93,7 @@ module VagrantPlugins
           block.call(type, data)
         end
 
-        @host_vm.communicate.execute("rm #{remote_temp}", error_check: false)
+        @host_vm.communicate.execute("rm -f #{remote_temp}", error_check: false)
 
         return result
       end
@@ -118,7 +118,7 @@ module VagrantPlugins
           "#{container_ssh_command} 'cat >#{to}' <#{to_temp}")
 
         # Remove the temporary file
-        @host_vm.communicate.execute("rm #{to_temp}", error_check: false)
+        @host_vm.communicate.execute("rm -f #{to_temp}", error_check: false)
       end
 
       #-------------------------------------------------------------------

--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -103,7 +103,7 @@ module VagrantPlugins
 
       def rm(cid)
         if created?(cid)
-          execute('docker', 'rm', '-v', cid)
+          execute('docker', 'rm', '-f', '-v', cid)
         end
       end
 

--- a/test/unit/plugins/providers/docker/driver_test.rb
+++ b/test/unit/plugins/providers/docker/driver_test.rb
@@ -159,7 +159,7 @@ describe VagrantPlugins::DockerProvider::Driver do
       before { subject.stub(created?: true) }
 
       it 'removes the container' do
-        subject.should_receive(:execute).with('docker', 'rm', '-v', cid)
+        subject.should_receive(:execute).with('docker', 'rm', '-f', '-v', cid)
         subject.rm(cid)
       end
     end
@@ -168,7 +168,7 @@ describe VagrantPlugins::DockerProvider::Driver do
       before { subject.stub(created?: false) }
 
       it 'does not attempt to remove the container' do
-        subject.should_not_receive(:execute).with('docker', 'rm', '-v', cid)
+        subject.should_not_receive(:execute).with('docker', 'rm', '-f', '-v', cid)
         subject.rm(cid)
       end
     end


### PR DESCRIPTION
When using pty=true, removing files using sudo may request confirmation,
which will hang the connection.

Similarly, sometimes assumptions about file existence may be wrong and
in those cases it seems better to continue on as long as the file does
not exist, so -f makes sense there, too.
