### PR TITLE
Ensure rsync_post has find permissions on smartos

### DIFF
--- a/plugins/guests/smartos/cap/rsync.rb
+++ b/plugins/guests/smartos/cap/rsync.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
         end
 
         def self.rsync_post(machine, opts)
-          machine.communicate.execute("find '#{opts[:guestpath]}' '(' ! -user #{opts[:owner]} -or ! -group #{opts[:group]} ')' -print0 | " +
+          machine.communicate.execute("#{machine.config.smartos.suexec_cmd} find '#{opts[:guestpath]}' '(' ! -user #{opts[:owner]} -or ! -group #{opts[:group]} ')' -print0 | " +
               "#{machine.config.smartos.suexec_cmd} xargs -0 chown #{opts[:owner]}:#{opts[:group]}")
         end
       end

--- a/test/unit/plugins/guests/smartos/cap/rsync_test.rb
+++ b/test/unit/plugins/guests/smartos/cap/rsync_test.rb
@@ -40,7 +40,7 @@ describe "VagrantPlugins::VagrantPlugins::Cap::Rsync" do
 
   describe ".rsync_post" do
     it 'chowns incorrectly owned files in sync dir' do
-      communicator.expect_command("find '/sync_dir' '(' ! -user somebody -or ! -group somegroup ')' -print0 | pfexec xargs -0 chown somebody:somegroup")
+      communicator.expect_command("pfexec find '/sync_dir' '(' ! -user somebody -or ! -group somegroup ')' -print0 | pfexec xargs -0 chown somebody:somegroup")
       plugin.rsync_post(machine, guestpath: '/sync_dir', owner: 'somebody', group: 'somegroup')
     end
   end


### PR DESCRIPTION
I didn't run into problems in my initial tests, but as I've been playing around with synced folders in local zones in a custom plugin this turns out to be an issue. Find needs permission to read the files that were just written out by root, in any case.
