### PR TITLE
Remove erroneous yum upgrade.

### DIFF
--- a/plugins/provisioners/docker/cap/redhat/docker_install.rb
+++ b/plugins/provisioners/docker/cap/redhat/docker_install.rb
@@ -29,7 +29,6 @@ module VagrantPlugins
               if ! comm.test("rpm -qa | grep epel-release")
                 comm.sudo("rpm -ivh http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm")
               end
-              comm.sudo("yum -y upgrade")
               comm.sudo("yum -y install docker-io")
             end
           end


### PR DESCRIPTION
This upgrade shouldn't be part of the docker setup process. If an
upgrade is needed, it should be done independently of the docker setup.
Do it to your base image, or if needed, as a shell provisioner step.
