### PR TITLE
Fix NFS when DHCP settings use a custom IP range

### DIFF
--- a/plugins/providers/virtualbox/action/prepare_nfs_settings.rb
+++ b/plugins/providers/virtualbox/action/prepare_nfs_settings.rb
@@ -67,7 +67,7 @@ module VagrantPlugins
         def read_static_machine_ips
           ips = []
           @machine.config.vm.networks.each do |type, options|
-            if type == :private_network && options[:ip].is_a?(String)
+            if type == :private_network && options[:type] == :static && options[:ip].is_a?(String)
               ips << options[:ip]
             end
           end


### PR DESCRIPTION
Only use the static IP if it is indeed a static IP. Otherwise assume
it's DHCP and get the IP that way.

Fixes #4433 
