### PR TITLE
Fix wrong command to set hostname on RHEL7.

### DIFF
--- a/plugins/guests/redhat/cap/change_host_name.rb
+++ b/plugins/guests/redhat/cap/change_host_name.rb
@@ -12,7 +12,7 @@ module VagrantPlugins
         end
 
         def self.change_host_name_rhel7(machine, name)
-          machine.communicate.sudo("homenamectl set-hostname #{name}")
+          machine.communicate.sudo("hostnamectl set-hostname #{name}")
         end
 
         attr_reader :machine, :new_hostname


### PR DESCRIPTION
The command to set hostnames on EL7 is "hostnamectl", not "homenamectl".
