### PR TITLE
add guard for provisioning script in getting-started

### DIFF
--- a/website/docs/source/v2/getting-started/provisioning.html.md
+++ b/website/docs/source/v2/getting-started/provisioning.html.md
@@ -26,8 +26,10 @@ and save it as `bootstrap.sh` in the same directory as your Vagrantfile:
 
 apt-get update
 apt-get install -y apache2
-rm -rf /var/www
-ln -fs /vagrant /var/www
+if ! [ -L /var/www ]; then
+  rm -rf /var/www
+  ln -fs /vagrant /var/www
+fi
 ```
 
 Next, we configure Vagrant to run this shell script when setting up


### PR DESCRIPTION
If user experimenting while learning through getting started, and run as suggested `vagrant reload --provision` but more than one time, it'll remove all work that user did.
