### PR TITLE
Fix for issue #4452 : undefined stdout in communicator.rb

### DIFF
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -570,7 +570,7 @@ module VagrantPlugins
             raise Vagrant::Errors::SSHInvalidShell.new
           end
 
-          data = stdout[/.*#{PTY_DELIM_START}(.*?)#{PTY_DELIM_END}/m, 1]
+          data = pty_stdout[/.*#{PTY_DELIM_START}(.*?)#{PTY_DELIM_END}/m, 1]
           @logger.debug("PTY stdout parsed: #{data}")
           yield :stdout, data if block_given?
         end


### PR DESCRIPTION
Fixes #4452.
The stdout variable was changed during commit
https://github.com/mitchellh/vagrant/commit/138aa5aad375ac0c076a0e0a3493
e25906ce0434 . This commit just corrects this omission.
