### PR TITLE
Fixes #4450, add another expand_path ../ to get back to the guests directory

### DIFF
--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -23,7 +23,7 @@ module VagrantPlugins
         def self.configure_networks_rhel7(machine, networks)
           # This is kind of jank but the configure networks is the same
           # as Fedora at this point.
-          require File.expand_path("../../fedora/cap/configure_networks", __FILE__)
+          require File.expand_path("../../../fedora/cap/configure_networks", __FILE__)
           ::VagrantPlugins::GuestFedora::Cap::ConfigureNetworks.
             configure_networks(machine, networks)
         end


### PR DESCRIPTION
When installing from master after #4438 fix was in, I get the following error, which this PR fixes:

```
vagrant up test7
Bringing machine 'test7' up with 'virtualbox' provider...
==> test7: Importing base box 'opscode-centos-7.0'...
==> test7: Matching MAC address for NAT networking...
==> test7: Setting the name of the VM: test7
==> test7: Clearing any previously set network interfaces...
==> test7: Preparing network interfaces based on configuration...
    test7: Adapter 1: nat
    test7: Adapter 2: hostonly
==> test7: Forwarding ports...
    test7: 22 => 2222 (adapter 1)
==> test7: Running 'pre-boot' VM customizations...
==> test7: Booting VM...
==> test7: Waiting for machine to boot. This may take a few minutes...
    test7: SSH address: 127.0.0.1:2222
    test7: SSH username: vagrant
    test7: SSH auth method: private key
    test7: Warning: Connection timeout. Retrying...
==> test7: Machine booted and ready!
==> test7: Checking for guest additions in VM...
==> test7: Setting hostname...
==> test7: Configuring and enabling network interfaces...
==> test7: Forcing shutdown of VM...
==> test7: Destroying VM and associated drives...
/path/to/gems/vagrant-1.6.4/plugins/guests/redhat/cap/configure_networks.rb:26:in `require': cannot load such file -- /path/to/gems/vagrant-1.6.4/plugins/guests/redhat/fedora/cap/configure_networks (LoadError)
  from /path/to/gems/vagrant-1.6.4/plugins/guests/redhat/cap/configure_networks.rb:26:in `configure_networks_rhel7'
  from /path/to/gems/vagrant-1.6.4/plugins/guests/redhat/cap/configure_networks.rb:17:in `configure_networks'
```
