### PR TITLE
Explain the most common choice when choosing which network to bridge to

### DIFF
--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -197,7 +197,7 @@ module VagrantPlugins
               # The choice that the user has chosen as the bridging interface
               choice = nil
               while !valid.include?(choice)
-                choice = @env[:ui].ask("What interface should the network bridge to? ")
+                choice = @env[:ui].ask I18n.t("vagrant.actions.vm.bridged_networking.interface_selection")
                 choice = choice.to_i
               end
 

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1450,6 +1450,8 @@ en:
           specific_not_found: |-
             Specific bridge '%{bridge}' not found. You may be asked to specify
             which network to bridge to.
+          interface_selection: |-
+            What interface should the network bridge to? (Usually the internet-connected interface)
         check_box:
           not_found: |-
             Box '%{name}' was not found. Fetching box from specified URL for


### PR DESCRIPTION
I recently brought up a vagrant VM which uses `public_network` as `config.vm.network`. I was then presented with this question: 

```
==> default: Available bridged network interfaces:
1) en0: Wi-Fi (AirPort)
2) en1: Thunderbolt 1
3) en2: Thunderbolt 2
4) bridge0
5) p2p0
    default: What interface should the network bridge to?
```

I had no idea, honestly. And then I Googled what to select, and the answers were pretty much unanimous:

https://github.com/mitchellh/vagrant/issues/1226#issuecomment-12929493
https://github.com/mitchellh/vagrant/issues/886#issuecomment-45163341
https://www.newmediadenver.com/blog/public-network-vagrant-vm

You select the one which is connected to the internet. I thought a good idea would be to add this piece of knowledge to the question above, so it would now look like this:

```
==> default: Available bridged network interfaces:
1) en0: Wi-Fi (AirPort)
2) en1: Thunderbolt 1
3) en2: Thunderbolt 2
4) bridge0
5) p2p0
    default: What interface should the network bridge to? (Usually the internet-connected interface)
```

Tried to keep it as short as possible.
