### PR TITLE
change_host_name.rb for TinyCore Linux

### DIFF
--- a/plugins/guests/tinycore/cap/change_host_name.rb
+++ b/plugins/guests/tinycore/cap/change_host_name.rb
@@ -1,0 +1,14 @@
+module VagrantPlugins
+  module GuestTinyCore
+    module Cap
+      class ChangeHostName
+        def self.change_host_name(machine, name)
+          if !machine.communicate.test("hostname | grep '^#{name}$'")
+            machine.communicate.sudo("sh -c 'echo \"#{name}\" > /etc/hostname'")
+            machine.communicate.sudo("/usr/bin/sethostname #{name}")
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello,

Most TinyCore based vagrant boxes (at least boot2docker) run in memory and do no persist. I'm mentioning this, because if you were to restart a persistent vanilla TinyCore box, `/opt/bootsync.sh` runs after boot and has its own `/usr/bin/sethostname box` statement, in which case we might need to make changes to the script. Btw, boot2docker's `/opt/bootsync.sh` calls `/etc/rc.d/hostname` script for this. Playing with these files would probably be messy and unacceptable.

However, if the `change_host_name` method is run every time after the box is up (am I right about this?), I don't believe we need to override any of the hostname scripts, making this pull request LookingGTM.

(I want to try https://github.com/phinze/landrush plugin for docker containers, which uses hostname value from `config.vm.hostname`, setting which warns about missing change_host_name cap.)

PS: I'm new to vagrant
