### PR TITLE
Shared folder `sync` hook

### DIFF
--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -122,6 +122,8 @@ module VagrantPlugins
             "vagrant.rsync_folder_excludes", excludes: excludes.inspect))
         end
 
+        machine.env.hook(:sync_pre)
+
         # If we have tasks to do before rsyncing, do those.
         if machine.guest.capability?(:rsync_pre)
           machine.guest.capability(:rsync_pre, opts)
@@ -140,6 +142,8 @@ module VagrantPlugins
         if machine.guest.capability?(:rsync_post)
           machine.guest.capability(:rsync_post, opts)
         end
+
+        machine.env.hook(:sync_post)
       end
     end
   end

--- a/test/unit/plugins/synced_folders/rsync/helper_test.rb
+++ b/test/unit/plugins/synced_folders/rsync/helper_test.rb
@@ -138,6 +138,14 @@ describe VagrantPlugins::SyncedFolderRSync::RsyncHelper do
       subject.rsync_single(machine, ssh_info, opts)
     end
 
+    it "runs the `sync_pre` and `sync_post` hooks" do
+      expect(machine.env).to receive(:hook).with(:sync_pre).ordered
+      expect(Vagrant::Util::Subprocess).to receive(:execute).ordered.and_return(result)
+      expect(machine.env).to receive(:hook).with(:sync_post).ordered
+
+      subject.rsync_single(machine, ssh_info, opts)
+    end
+
     it "executes the rsync_pre capability first if it exists" do
       expect(guest).to receive(:capability?).with(:rsync_pre).and_return(true)
       expect(guest).to receive(:capability).with(:rsync_pre, opts).ordered


### PR DESCRIPTION
In gh-4394, I proposed a general `sync` action hook that would be triggered
whenever folder synchronization occurred. I've been able to implement the hook
for the `rsync` mechanism, but I'm not sure how to proceed with the `nfs` and
`smb` mechanism.

Ideally, I would want to implement this at some higher level (instead of
extending each mechanism explicitly). Based on my current understanding,
though, it looks like Vagrant isn't generally aware of when sycnhronization
occurs. The more that I look at the code for `nfs`, the more I think that
Vagrant may not be aware of synchronization for that mechansim at all. If this
is the case, then the proposed `sync` hook (triggered regardless of
synchronization mechanism) will not be possible.

@mitchellh Would you mind giving me some advice on where to go from here?
