### PR TITLE
Fix NFSClient plugin for Redhat / Centos 7 guests

### DIFF
--- a/plugins/guests/redhat/cap/nfs_client.rb
+++ b/plugins/guests/redhat/cap/nfs_client.rb
@@ -5,7 +5,12 @@ module VagrantPlugins
         def self.nfs_client_install(machine)
           machine.communicate.tap do |comm|
             comm.sudo("yum -y install nfs-utils nfs-utils-lib")
-            comm.sudo("/etc/init.d/rpcbind restart; /etc/init.d/nfs restart")
+            case machine.guest.capability("flavor")
+            when :rhel_7
+              comm.sudo("/bin/systemctl restart rpcbind nfs")
+            else
+              comm.sudo("/etc/init.d/rpcbind restart; /etc/init.d/nfs restart")
+            end
           end
         end
       end


### PR DESCRIPTION
Fixes #4476.

All unit tests pass. Created new Centos 7 box and verified NFS client was installed without error. The NFS mount itself was also immediately available.
