### PR TITLE
hosts/windows: Don't mount all drives into the RDP session

### DIFF
--- a/plugins/hosts/windows/cap/rdp.rb
+++ b/plugins/hosts/windows/cap/rdp.rb
@@ -10,7 +10,6 @@ module VagrantPlugins
         def self.rdp_client(env, rdp_info)
           config = nil
           opts   = {
-            "drivestoredirect:s"       => "*",
             "full address:s"           => "#{rdp_info[:host]}:#{rdp_info[:port]}",
             "prompt for credentials:i" => "1",
             "username:s"               => rdp_info[:username],


### PR DESCRIPTION
This setting mounts all available drives (C:\ and mapped network
drives) into the RDP session. This shouldn't be the default.
