### PR TITLE
Set ComputerName and LocalHostName on darwin guests

### DIFF
--- a/plugins/guests/darwin/cap/change_host_name.rb
+++ b/plugins/guests/darwin/cap/change_host_name.rb
@@ -4,7 +4,9 @@ module VagrantPlugins
       class ChangeHostName
         def self.change_host_name(machine, name)
           if !machine.communicate.test("hostname -f | grep '^#{name}$' || hostname -s | grep '^#{name}$'")
+            machine.communicate.sudo("scutil --set ComputerName #{name}")
             machine.communicate.sudo("scutil --set HostName #{name}")
+            machine.communicate.sudo("scutil --set LocalHostName #{name}")
             machine.communicate.sudo("hostname #{name}")
           end
         end


### PR DESCRIPTION
This sets the bonjour host name for darwin guests to the same value
as config.vm.hostname. It also sets the user-friendly name for the
system.
