### PR TITLE
A more reliable way to detect Ubuntu via lsb_release

### DIFF
--- a/plugins/guests/ubuntu/guest.rb
+++ b/plugins/guests/ubuntu/guest.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
   module GuestUbuntu
     class Guest < Vagrant.plugin("2", :guest)
       def detect?(machine)
-        machine.communicate.test("cat /etc/issue | grep 'Ubuntu'")
+        machine.communicate.test("[ -x /usr/bin/lsb_release ] && /usr/bin/lsb_release -i 2>/dev/null | grep Ubuntu")
       end
     end
   end


### PR DESCRIPTION
The default `/etc/issue` might have been changed by the administrator and not contain the string 'Ubuntu' anymore. The tool `lsb_release` is the recommended tool from the Linux Standards Base (LSB) project.
