### PR TITLE
providers/docker: allow multiple links to same backend (different aliases)

### DIFF
--- a/plugins/providers/docker/action/create.rb
+++ b/plugins/providers/docker/action/create.rb
@@ -96,10 +96,10 @@ module VagrantPlugins
           image = @env[:create_image]
           image ||= @provider_config.image
 
-          links = {}
+          links = []
           @provider_config._links.each do |link|
             parts = link.split(":", 2)
-            links[parts[0]] = parts[1]
+            links << parts
           end
 
           {

--- a/test/unit/plugins/providers/docker/driver_test.rb
+++ b/test/unit/plugins/providers/docker/driver_test.rb
@@ -17,7 +17,7 @@ describe VagrantPlugins::DockerProvider::Driver do
       ports:      '8080:80',
       volumes:    '/host/path:guest/path',
       detach:     true,
-      links:      {janis: 'joplin'},
+      links:      [[:janis, 'joplin'], [:janis, 'janis']],
       env:        {key: 'value'},
       name:       cid,
       hostname:   'jimi-hendrix',
@@ -43,7 +43,9 @@ describe VagrantPlugins::DockerProvider::Driver do
     end
 
     it 'links containers' do
-      expect(cmd_executed).to match(/--link #{params[:links].to_a.flatten.join(':')} .+ #{Regexp.escape params[:image]}/)
+      params[:links].each do |link|
+        expect(cmd_executed).to match(/--link #{link.join(':')} .+ #{Regexp.escape params[:image]}/)
+      end
     end
 
     it 'sets environmental variables' do


### PR DESCRIPTION
# The issue

The docker provider silently discards `docker run --link` definitions when the backend is linked multiple times under different aliases, eg. `docker run --link backend:alias1 --link backend:alias2`.

This is an uncommon case, but I have a container that expects the `ALIAS1_*` and `ALIAS2_*` environment variables to be present, and will not boot the container if they are not.

That container runs just fine if I assemble the `docker run` command line by hand, but it won't if I use a `Vagrantfile`: the container seems to boot, but if I look carefully only the last defined alias to the backend is actually created.
## How to reproduce

Create a `Vagrantfile` with the following content:

```
# Force the provider so we don't have to type in --provider=docker all the time
ENV['VAGRANT_DEFAULT_PROVIDER'] = 'docker'

Vagrant.configure("2") do |config|
  config.vm.provider :docker do |docker|
    docker.image     = 'phusion/baseimage:0.9.13'
    docker.cmd       = %w[/sbin/my_init --enable-insecure-key]
    # backend links
    docker.link( "backend:b1" )
    docker.link( "backend:b2" )
  end
  # workaround https://github.com/mitchellh/vagrant/issues/3799
  config.ssh.username = 'root'
  config.ssh.private_key_path = 'insecure-phusion-key'
  config.ssh.port = '22'
end
```

To be able to ssh into the container, download and save the following key into the same directory as the above `Vagrantfile`:

``` ssh
$ wget -O insecure-phusion-key https://github.com/phusion/baseimage-docker/raw/master/image/insecure_key
```

Then:

```
$ docker run -d --name backend busybox:ubuntu-14.04 top # cheapest running container possible
$ vagrant up
```

The output from `vagrant up` looks like this:

``` sh
Bringing machine 'default' up with 'docker' provider...
==> default: Creating the container...
    default:   Name: vagrant-docker-link-bug_default_1412005293
    default:  Image: phusion/baseimage:0.9.13
    default:    Cmd: /sbin/my_init --enable-insecure-key
    default: Volume: /home/julien/RubymineProjects/vagrant-docker-link-bug:/vagrant
    default:   Link: backend:b2
    default:  
    default: Container created: e1289e9e178b51cb
==> default: Starting container...
```

Notice that there is a line for `Link: backend:b2` but no line for `Link: backend:b1`.

Sshing into the container we can see that no link environment variables for `B1` is present either:

``` sh
$ vagrant ssh -c env | grep ^B
B2_NAME=/vagrant-docker-link-bug_default_1412008835/b2
```
# Proposed fix

This PR fixes the issue by storing the links passed to `docker run` in an Array of [backend, alias] pairs rather than a Hash[backend: alias] which won't allow for multiple aliases to the same backend.

After applying fix, the above ssh command would look like:

``` sh
$ vagrant ssh -c env | grep ^B
B2_NAME=/vagrant-docker-link-bug_default_1412010763/b2
B1_NAME=/vagrant-docker-link-bug_default_1412010763/b1
```
