### PR TITLE
config.vm.box_server_url setting is ignored

### DIFF
--- a/lib/vagrant/action/builtin/handle_box.rb
+++ b/lib/vagrant/action/builtin/handle_box.rb
@@ -79,6 +79,7 @@ module Vagrant
             env[:action_runner].run(Vagrant::Action.action_box_add, env.merge({
               box_name: machine.config.vm.box,
               box_url: machine.config.vm.box_url || machine.config.vm.box,
+              box_server_url: machine.config.vm.box_server_url,
               box_provider: box_formats,
               box_version: machine.config.vm.box_version,
               box_client_cert: box_download_client_cert,


### PR DESCRIPTION
https://github.com/mitchellh/vagrant/pull/4282 introduced new setting to set alternate vagrant cloud server URLs, but it doesn't work actually: the value is ignored, and `env[:box_server_url]` in [box_add.rb](https://github.com/mitchellh/vagrant/blob/master/lib/vagrant/action/builtin/box_add.rb#L56) is always empty.

This PR helps to process the value correctly.
