### PR TITLE
Use HTTPS to download docker's gpg key.

### DIFF
--- a/plugins/provisioners/docker/cap/debian/docker_install.rb
+++ b/plugins/provisioners/docker/cap/debian/docker_install.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
               end
               comm.sudo("apt-get update -y")
               comm.sudo("apt-get install -y --force-yes -q curl")
-              comm.sudo("curl http://get.docker.io/gpg | apt-key add -")
+              comm.sudo("curl https://get.docker.io/gpg | apt-key add -")
               comm.sudo("echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list")
               comm.sudo("apt-get update")
               comm.sudo("echo lxc lxc/directory string /var/lib/lxc | debconf-set-selections")


### PR DESCRIPTION
Vagrant if failing while trying to add docker gpg.

```
  default: Installing Docker (latest) onto machine...
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

curl http://get.docker.io/gpg | apt-key add -

Stdout from the command:



Stderr from the command:

stdin: is not a tty
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   184  100   184    0     0     71      0  0:00:02  0:00:02 --:--:-- 18400
gpg: no valid OpenPGP data found.
```

```
$ curl http://get.docker.io/gpg
<html>
<head><title>301 Moved Permanently</title></head>
<body bgcolor="white">
<center><h1>301 Moved Permanently</h1></center>
<hr><center>nginx/1.6.2</center>
</body>
</html>
```

Update: The reason for this error is because they are forcing SSL on the URL.
Fixed #4569
