### PR TITLE
Fixed #4569 by adding redirect support

### DIFF
--- a/plugins/provisioners/docker/cap/debian/docker_install.rb
+++ b/plugins/provisioners/docker/cap/debian/docker_install.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
               end
               comm.sudo("apt-get update -y")
               comm.sudo("apt-get install -y --force-yes -q curl")
-              comm.sudo("curl http://get.docker.io/gpg | apt-key add -")
+              comm.sudo("curl -sSL http://get.docker.io/gpg | apt-key add -")
               comm.sudo("echo deb http://get.docker.io/ubuntu docker main > /etc/apt/sources.list.d/docker.list")
               comm.sudo("apt-get update")
               comm.sudo("echo lxc lxc/directory string /var/lib/lxc | debconf-set-selections")


### PR DESCRIPTION
Installer now mimics behavior set forth in shell scrip at http://get.docker.com
