### PR TITLE
Check whether Salt bootstrap script exists before deleting it. GH-4614

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -236,7 +236,9 @@ module VagrantPlugins
             bootstrap_destination = File.join(config_dir, "bootstrap_salt.sh")
           end
 
-          @machine.communicate.sudo("rm -f %s" % bootstrap_destination)
+          if @machine.communicate.test("test -f %s" % bootstrap_destination)
+            @machine.communicate.sudo("rm -f %s" % bootstrap_destination)
+          end
           @machine.communicate.upload(bootstrap_path.to_s, bootstrap_destination)
           @machine.communicate.sudo("chmod +x %s" % bootstrap_destination)
           if @machine.config.vm.communicator == :winrm


### PR DESCRIPTION
A small fix for preventing Salt provisioning errors via WinRM when trying to delete a missing file.

Tested to make sure it doesn't break Linux minions provisioning via SSH.

Issue #4614
