### PR TITLE
Solving #2905 - Restarting Solaris 11 boxes with static ip addresses

### DIFF
--- a/plugins/guests/solaris11/cap/configure_networks.rb
+++ b/plugins/guests/solaris11/cap/configure_networks.rb
@@ -19,8 +19,8 @@ module VagrantPlugins
               #machine.communicate.execute("#{ifconfig_cmd} up")
               #machine.communicate.execute("#{su_cmd} sh -c \"echo '#{network[:ip]}' > /etc/hostname.#{device}\"")
               # ipadm create-addr -T static -a local=172.16.10.15/24 net2/v4
-              if machine.communicate.test("ipadm | grep net1/v4")
-                machine.communicate.execute("#{su_cmd} ipadm delete-addr net1/v4")
+              if machine.communicate.test("ipadm | grep #{device}/v4")
+                machine.communicate.execute("#{su_cmd} ipadm delete-addr #{device}/v4")
               end
               machine.communicate.execute("#{su_cmd} ipadm create-addr -T static -a #{network[:ip]}/#{cidr} #{device}/v4")
             elsif network[:type].to_sym == :dhcp


### PR DESCRIPTION
Adding condition for the ipadm command on static ip addresses.
This will enable restarting solaris 11 vagrant boxes with static ip addresses.
The problem was reported in #2905. The fix in #3793 did only solve the problem for dhcp, not for static ip addresses.
