### PR TITLE
Force compatible Bundler version in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: ruby
 before_install:
   - sudo apt-get update -qq
   - sudo apt-get install -qq -y bsdtar
+  - rvm @global do gem uninstall bundler --all --executables
+  - gem uninstall bundler --all --executables
+  - gem install bundler --version '< 1.7.0'
 rvm:
   - 2.0.0
 env:


### PR DESCRIPTION
Uninstall all other Bunlder versions and install one that fulfills our requirements (`< 1.7.0`).

Refs: #4617 #3587
