### PR TITLE
Allow SSH LogLevel to be overridden in Vagrant.Util.SSH.exec

### DIFF
--- a/lib/vagrant/util/ssh.rb
+++ b/lib/vagrant/util/ssh.rb
@@ -102,12 +102,14 @@ module Vagrant
         options[:username] = ssh_info[:username]
         options[:private_key_path] = ssh_info[:private_key_path]
 
+        log_level = ssh_info[:log_level] || "FATAL"
+
         # Command line options
         command_options = [
           "-p", options[:port].to_s,
           "-o", "Compression=yes",
           "-o", "DSAAuthentication=yes",
-          "-o", "LogLevel=FATAL",
+          "-o", "LogLevel=#{log_level}",
           "-o", "StrictHostKeyChecking=no",
           "-o", "UserKnownHostsFile=/dev/null"]
 


### PR DESCRIPTION
Fix #4637

In `SSH.exec` from [ssh.rb](https://github.com/julienvey/vagrant/blob/58b1bc317f9fa237a05e3024a54e1fb823523394/lib/vagrant/util/ssh.rb#L66) the LogLevel is set to "FATAL" by default

This class can be used in many actions, such as [ssh_run.rb](https://github.com/julienvey/vagrant/blob/58b1bc317f9fa237a05e3024a54e1fb823523394/lib/vagrant/action/builtin/ssh_run.rb) or [ssh_exec.rb](https://github.com/julienvey/vagrant/blob/58b1bc317f9fa237a05e3024a54e1fb823523394/lib/vagrant/action/builtin/ssh_run.rb) but can also be called from custom providers actions.

There are some cases where the SSH command will fail silently, for instance in a network unreachable error. 

I suggest to keep the LogLevel default value to `FATAL` but to allow custom providers or other plugins to override this option. Doing this, it will not change vagrant default behaviour, but will allow plugins to adjust the LogLevel at their will and provide more meaningful information when necessary.
