### PR TITLE
Fix #4658. Bad NFS exports file on OS X & BSD hosts.

### DIFF
--- a/plugins/providers/virtualbox/driver/version_4_0.rb
+++ b/plugins/providers/virtualbox/driver/version_4_0.rb
@@ -269,7 +269,12 @@ module VagrantPlugins
         end
 
         def read_guest_ip(adapter_number)
-          read_guest_property("/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP")
+          ip = read_guest_property("/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP")
+          if !valid_ip_address?(ip)
+            raise Vagrant::Errors::VirtualBoxGuestPropertyNotFound, guest_property: "/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP"
+          end
+
+          return ip
         end
 
         def read_guest_property(property)
@@ -497,6 +502,16 @@ module VagrantPlugins
                 raise
               end
             end
+          end
+        end
+
+        def valid_ip_address?(ip)
+          # Filter out invalid IP addresses
+          # GH-4658 VirtualBox can report an IP address of 0.0.0.0 for FreeBSD guests.
+          if ip == "0.0.0.0"
+            return false
+          else
+            return true
           end
         end
 

--- a/plugins/providers/virtualbox/driver/version_4_1.rb
+++ b/plugins/providers/virtualbox/driver/version_4_1.rb
@@ -274,7 +274,12 @@ module VagrantPlugins
         end
 
         def read_guest_ip(adapter_number)
-          read_guest_property("/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP")
+          ip = read_guest_property("/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP")
+          if !valid_ip_address?(ip)
+            raise Vagrant::Errors::VirtualBoxGuestPropertyNotFound, guest_property: "/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP"
+          end
+
+          return ip
         end
 
         def read_guest_property(property)
@@ -507,6 +512,16 @@ module VagrantPlugins
                 raise
               end
             end
+          end
+        end
+
+        def valid_ip_address?(ip)
+          # Filter out invalid IP addresses
+          # GH-4658 VirtualBox can report an IP address of 0.0.0.0 for FreeBSD guests.
+          if ip == "0.0.0.0"
+            return false
+          else
+            return true
           end
         end
 

--- a/plugins/providers/virtualbox/driver/version_4_2.rb
+++ b/plugins/providers/virtualbox/driver/version_4_2.rb
@@ -305,7 +305,12 @@ module VagrantPlugins
         end
 
         def read_guest_ip(adapter_number)
-          read_guest_property("/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP")
+          ip = read_guest_property("/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP")
+          if !valid_ip_address?(ip)
+            raise Vagrant::Errors::VirtualBoxGuestPropertyNotFound, guest_property: "/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP"
+          end
+
+          return ip
         end
 
         def read_guest_property(property)
@@ -538,6 +543,16 @@ module VagrantPlugins
                 raise
               end
             end
+          end
+        end
+
+        def valid_ip_address?(ip)
+          # Filter out invalid IP addresses
+          # GH-4658 VirtualBox can report an IP address of 0.0.0.0 for FreeBSD guests.
+          if ip == "0.0.0.0"
+            return false
+          else
+            return true
           end
         end
 

--- a/plugins/providers/virtualbox/driver/version_4_3.rb
+++ b/plugins/providers/virtualbox/driver/version_4_3.rb
@@ -314,7 +314,12 @@ module VagrantPlugins
         end
 
         def read_guest_ip(adapter_number)
-          read_guest_property("/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP")
+          ip = read_guest_property("/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP")
+          if !valid_ip_address?(ip)
+            raise Vagrant::Errors::VirtualBoxGuestPropertyNotFound, guest_property: "/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP"
+          end
+
+          return ip
         end
 
         def read_guest_property(property)
@@ -547,6 +552,16 @@ module VagrantPlugins
                 raise
               end
             end
+          end
+        end
+
+        def valid_ip_address?(ip)
+          # Filter out invalid IP addresses
+          # GH-4658 VirtualBox can report an IP address of 0.0.0.0 for FreeBSD guests.
+          if ip == "0.0.0.0"
+            return false
+          else
+            return true
           end
         end
 

--- a/test/unit/plugins/providers/virtualbox/support/shared/virtualbox_driver_version_4_x_examples.rb
+++ b/test/unit/plugins/providers/virtualbox/support/shared/virtualbox_driver_version_4_x_examples.rb
@@ -38,5 +38,16 @@ shared_examples "a version 4.x virtualbox driver" do |options|
 
       expect(value).to eq("127.1.2.3")
     end
+
+    it "does not accept 0.0.0.0 as a valid IP address" do
+      key = "/VirtualBox/GuestInfo/Net/1/V4/IP"
+
+      expect(subprocess).to receive(:execute).
+        with("VBoxManage", "guestproperty", "get", uuid, key, an_instance_of(Hash)).
+        and_return(subprocess_result(stdout: "Value: 0.0.0.0"))
+
+      expect { subject.read_guest_ip(1) }.
+        to raise_error Vagrant::Errors::VirtualBoxGuestPropertyNotFound
+    end
   end
 end


### PR DESCRIPTION
For FreeBSD guests, Virtualbox can sometimes report the private network
interface IP address as "0.0.0.0".  This will cause an invalid NFS
exports file to be generated for FreeBSD and OS X hosts.

Fixed by not allowing Virtualbox to report a guest IP address of
"0.0.0.0".
