### PR TITLE
Rename Windows guest without reboot

### DIFF
--- a/plugins/guests/windows/cap/change_host_name.rb
+++ b/plugins/guests/windows/cap/change_host_name.rb
@@ -12,25 +12,24 @@ module VagrantPlugins
           # We cannot use %ComputerName% because it truncates at 15 chars
           return if machine.communicate.test("if ([System.Net.Dns]::GetHostName() -eq '#{name}') { exit 0 } exit 1")
           
-          # Rename and reboot host if rename succeeded
           script = <<-EOH
             try
             {
               $computer = Get-WmiObject -Class Win32_ComputerSystem
               $computer.rename("#{name}")
                  
-              Remove-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters" -name "Hostname" 
-              Remove-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters" -name "NV Hostname" 
+              Remove-ItemProperty -path "HKLM:\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters" -name "Hostname" 
+              Remove-ItemProperty -path "HKLM:\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters" -name "NV Hostname" 
               
               New-PSDrive -name HKU -PSProvider "Registry" -Root "HKEY_USERS"
               
-              Set-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\Computername\Computername" -name "Computername" -value "#{name}"
-              Set-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Control\Computername\ActiveComputername" -name "Computername" -value "#{name}"
-              Set-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters" -name "Hostname" -value "#{name}"
-              Set-ItemProperty -path "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip\Parameters" -name "NV Hostname" -value  "#{name}"
-              Set-ItemProperty -path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -name "AltDefaultDomainName" -value "#{name}"
-              Set-ItemProperty -path "HKLM:\SOFTWARE\Microsoft\Windows NT\CurrentVersion\Winlogon" -name "DefaultDomainName" -value "#{name}"
-              Set-ItemProperty -path "HKCU:\Volatile Environment" -name "LOGONSERVER" -value "#{name}"
+              Set-ItemProperty -path "HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Computername\\Computername" -name "Computername" -value "#{name}"
+              Set-ItemProperty -path "HKLM:\\SYSTEM\\CurrentControlSet\\Control\\Computername\\ActiveComputername" -name "Computername" -value "#{name}"
+              Set-ItemProperty -path "HKLM:\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters" -name "Hostname" -value "#{name}"
+              Set-ItemProperty -path "HKLM:\\SYSTEM\\CurrentControlSet\\Services\\Tcpip\\Parameters" -name "NV Hostname" -value  "#{name}"
+              Set-ItemProperty -path "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon" -name "AltDefaultDomainName" -value "#{name}"
+              Set-ItemProperty -path "HKLM:\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Winlogon" -name "DefaultDomainName" -value "#{name}"
+              Set-ItemProperty -path "HKCU:\\Volatile Environment" -name "LOGONSERVER" -value "#{name}"
               [Environment]::SetEnvironmentVariable("COMPUTERNAME", "#{name}", "User")
               
               exit 0


### PR DESCRIPTION
Adds feature request #4687 

Tested on Windows 7, Windows 8, Windows 8.1
