### PR TITLE
Addresses issue #2163

### DIFF
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -85,8 +85,17 @@ module VagrantPlugins
               raise
             rescue Vagrant::Errors::SSHKeyTypeNotSupported
               raise
+            rescue Vagrant::Errors::SSHKeyBadOwner
+              # TODO: It would be more polite to check for key ownership/permissions before starting the machine
+              # so that this exception would never happen (currently it may happen)
+              raise
+            rescue Vagrant::Errors::SSHKeyBadPermissions
+              # TODO: It would be more polite to check for key ownership/permissions before starting the machine
+              # so that this exception would never happen (currently it may happen)            
+              raise  
             rescue Vagrant::Errors::VagrantError => e
               # Ignore it, SSH is not ready, some other error.
+              message = e.message
             end
 
             # If we have a message to show, then show it. We don't show


### PR DESCRIPTION
In the situation where the SSH key has invalid permissions/owner, the reconnect-loop keeps failing repeatedly yet stays silent about the reasons. A message must be reported from the default exception handler (added). In addition, the situations where the SSH key owner or permissions are wrong must lead to a proper failure (added). Ideally, though, the owner/permissions check must happen before launching the VM, hence this is not a perfect fix.
