### PR TITLE
silence warnings about unescaped '-' in re char class

### DIFF
--- a/plugins/hosts/linux/cap/nfs.rb
+++ b/plugins/hosts/linux/cap/nfs.rb
@@ -71,7 +71,7 @@ module VagrantPlugins
           user = Process.uid
 
           File.read("/etc/exports").lines.each do |line|
-            if id = line[/^# VAGRANT-BEGIN:( #{user})? ([\.\/A-Za-z0-9-_]+?)$/, 2]
+            if id = line[/^# VAGRANT-BEGIN:( #{user})? ([\.\/A-Za-z0-9\-_]+?)$/, 2]
               if valid_ids.include?(id)
                 logger.debug("Valid ID: #{id}")
               else


### PR DESCRIPTION
Eliminate warnings like this:

```
vagrant/plugins/hosts/linux/cap/nfs.rb:74: warning: character class has '-' without escape: /^# VAGRANT-BEGIN:( 1000)? ([\.\/A-Za-z0-9-_]+?)$/
```
