### PR TITLE
Vagrant is using JSON, so it should properly specify this dependency

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "childprocess", "~> 0.5.0"
   s.add_dependency "erubis", "~> 2.7.0"
   s.add_dependency "i18n", "~> 0.6.0"
+  s.add_dependency "json"
   s.add_dependency "listen", "~> 2.7.1"
   s.add_dependency "hashicorp-checkpoint", "~> 0.1.1"
   s.add_dependency "log4r", "~> 1.1.9", "< 1.1.11"


### PR DESCRIPTION
Vagrant is using JSON, so it should properly specify this dependency as it does for Rake and Minitest.

I can understand if you reject this PR, but it would help us on Fedora, where the JSON gem is not treated as default gem.
