### PR TITLE
Explain that older Vagrant plugin licenses may not work with new VMware

### DIFF
--- a/website/www/source/vmware/index.html.erb
+++ b/website/www/source/vmware/index.html.erb
@@ -177,6 +177,9 @@ page_title: "VMware Vagrant Environments"
 							software, which must be purchased separately. If you're buying over 100 licenses, contact <a href="mailto:sales@hashicorp.com">sales@hashicorp.com</a> for volume pricing.
 						</div>
 						<div class="subtext">
+							Previous plugin versions may not support the latest VMware products. Please visit <a href="http://license.hashicorp.com/upgrade/vmware<%= Time.now.year %>">the license upgrade center</a> to check if your license requires an upgrade before you upgrade your VMware products.
+						</div>
+						<div class="subtext">
 							For reseller information, <a href="/vmware/reseller.html">click here</a>.
 						</div>
 					</div>


### PR DESCRIPTION
This is the result of an unhappy customer who raised a very valid point. If you are not on the official Vagrant mailing list, you would be unaware that upgrading VMware would cause your plugin to stop functioning.

While this does not solve the problem of dispersing that information, it helps clarify that plugin version support is for the latest version of the Vagrant plugin and does not extend to previous ones.

/cc @mitchellh 
