### PR TITLE
doc rsync - use sudo rsync for a restricted folder

### DIFF
--- a/website/docs/source/v2/synced-folders/rsync.html.md
+++ b/website/docs/source/v2/synced-folders/rsync.html.md
@@ -62,7 +62,6 @@ The rsync synced folder type accepts the following options:
   pattern. By default, the ".vagrant/" directory is excluded. We recommend
   excluding revision control directories such as ".git/" as well.
 
-
 ## Example
 
 The following is an example of using RSync to sync a folder:


### PR DESCRIPTION
As rsync is run as vagrant user, this required the destination folder to be writable by vagrant.

This PR add the option to run `sudo rsync` on the guest, in order to let sync to restricted folders

ie bin to /usr/local/bin
