### PR TITLE
You need to press enter to migrate from 1.1 to 1.5

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -243,7 +243,7 @@ en:
       Press ctrl-c now to exit if you want to remove some boxes or free
       up some disk space.
 
-      Press any other key to continue.
+      Press the Enter or Return key to continue.
     version_current: |-
       Installed Version: %{version}
     version_latest: |-


### PR DESCRIPTION
```
$ vagrant version
Vagrant is upgrading some internal state for the latest version.
Please do not quit Vagrant at this time. While upgrading, Vagrant
will need to copy all your boxes, so it will use a considerable
amount of disk space. After it is done upgrading, the temporary disk
space will be freed.

Press ctrl-c now to exit if you want to remove some boxes or free
up some disk space.

Press any other key to continue.
```

I pressed the spacebar. nothing happened.
I pressed lots of other keys, nothing happened.
I pressed enter, something happened.
