### PR TITLE
fix broken tempdir removal

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -80,9 +80,9 @@ module Vagrant
 
     # Removes any temporary files created by init
     def deinit
-      FileUtils.remove_entry_secure(ENV["BUNDLE_APP_CONFIG"]) rescue nil
-      File.unlink(ENV["BUNDLE_CONFIG"]) rescue nil
-      File.unlink(ENV["GEMFILE"]) rescue nil
+      %w{ BUNDLE_APP_CONFIG BUNDLE_CONFIG BUNDLE_GEMFILE }.each do |entry|
+        FileUtils.remove_entry_secure(ENV[entry], true)
+      end
     end
 
     # Installs the list of plugins.


### PR DESCRIPTION
Hi,

`File.unlink(...) rescue nil` was silently not actually removing a temporary directory.

I understand why `rescue nil` was used, but when I see it used I always wonder what might silently go wrong. Might there be a better way to do this?

\- Felix
