### PR TITLE
Stop deleting Gemfile in plugin dev environment.

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -1,4 +1,3 @@
-require "fileutils"
 require "monitor"
 require "pathname"
 require "set"
@@ -80,9 +79,9 @@ module Vagrant
 
     # Removes any temporary files created by init
     def deinit
-      %w{ BUNDLE_APP_CONFIG BUNDLE_CONFIG BUNDLE_GEMFILE }.each do |entry|
-        FileUtils.remove_entry_secure(ENV[entry], true)
-      end
+      File.unlink(ENV["BUNDLE_APP_CONFIG"]) rescue nil
+      File.unlink(ENV["BUNDLE_CONFIG"]) rescue nil
+      File.unlink(ENV["GEMFILE"]) rescue nil
     end
 
     # Installs the list of plugins.


### PR DESCRIPTION
The change in pull request #4861 causes `Gemfile` to be deleted whenever a `bundle exec vagrant` command is run, preventing any more `bundle` commands before a `git checkout Gemfile`, making development extremely difficult.

This pull request simply reverts the merge commit 00e388a8977f519f077dda44aff2ddc4c1b9b05a.
