### PR TITLE
New default option of rsync "--copy-links"

### DIFF
--- a/website/docs/source/v2/synced-folders/rsync.html.md
+++ b/website/docs/source/v2/synced-folders/rsync.html.md
@@ -44,7 +44,7 @@ the destination folder.
 The rsync synced folder type accepts the following options:
 
 * `rsync__args` (array of strings) - A list of arguments to supply
-  to `rsync`. By default this is `["--verbose", "--archive", "--delete", "-z"]`.
+  to `rsync`. By default this is `["--verbose", "--archive", "--delete", "-z", "--copy-links"]`.
 
 * `rsync__auto` (boolean) - If false, then `rsync-auto` will not
   watch and automatically sync this folder. By default, this is true.


### PR DESCRIPTION
As can be seen in [rsync/helper.rb](https://github.com/mitchellh/vagrant/blob/efd1d5e11bfc5a72c7a1d1eae294b4751d841544/plugins/synced_folders/rsync/helper.rb#L81) the "--copy-links" option has been added to the defaults.
