### PR TITLE
rsynced folders don't work with Solaris based OS

### DIFF
--- a/plugins/guests/solaris/cap/rsync.rb
+++ b/plugins/guests/solaris/cap/rsync.rb
@@ -17,10 +17,10 @@ module VagrantPlugins
         end
 
         def self.rsync_post(machine, opts)
-          su_cmd = machine.config.solaris.su_cmd
+          suexec_cmd = machine.config.solaris.suexec_cmd
           machine.communicate.execute(
-            "#{su_cmd} find '#{opts[:guestpath]}' '(' ! -user #{opts[:owner]} -or ! -group #{opts[:group]} ')' -print0 | " +
-            "xargs -0 -r chown #{opts[:owner]}:#{opts[:group]}")
+            "#{suexec_cmd} find '#{opts[:guestpath]}' '(' ! -user #{opts[:owner]} -or ! -group #{opts[:group]} ')' -print0 | " +
+            "xargs -0 chown #{opts[:owner]}:#{opts[:group]}")
         end
       end
     end

--- a/plugins/guests/solaris11/cap/rsync.rb
+++ b/plugins/guests/solaris11/cap/rsync.rb
@@ -17,10 +17,10 @@ module VagrantPlugins
         end
 
         def self.rsync_post(machine, opts)
-          su_cmd = machine.config.solaris11.su_cmd
+          suexec_cmd = machine.config.solaris11.suexec_cmd
           machine.communicate.execute(
-            "#{su_cmd} '#{opts[:guestpath]}' '(' ! -user #{opts[:owner]} -or ! -group #{opts[:group]} ')' -print0 | " +
-              "xargs -0 -r chown #{opts[:owner]}:#{opts[:group]}")
+            "#{suexec_cmd} '#{opts[:guestpath]}' '(' ! -user #{opts[:owner]} -or ! -group #{opts[:group]} ')' -print0 | " +
+              "xargs -0 chown #{opts[:owner]}:#{opts[:group]}")
         end
       end
     end


### PR DESCRIPTION
Hi,
testing OmniOS (r151010j) under VMware, the tools don't fully work since they cause the OS to panic on shutdown. As a temporary workaround we tried to enable rsync based folders in vagrant, but that doesn't to work either. On vagrant up:

``` shell
/opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/plugin/v2/config.rb:73:in `method_missing': undefined method `su_cmd' for #<VagrantPlugins::GuestSolaris::Config:0x000000014a78c8> (NoMethodError)
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/plugins/guests/solaris/cap/rsync.rb:20:in `rsync_post'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/capability_host.rb:111:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/capability_host.rb:111:in `capability'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/guest.rb:43:in `capability'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/plugins/synced_folders/rsync/helper.rb:141:in `rsync_single'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/plugins/synced_folders/rsync/synced_folder.rb:48:in `block in enable'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/plugins/synced_folders/rsync/synced_folder.rb:47:in `each'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/plugins/synced_folders/rsync/synced_folder.rb:47:in `enable'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builtin/synced_folders.rb:90:in `block in call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builtin/synced_folders.rb:87:in `each'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builtin/synced_folders.rb:87:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builtin/synced_folder_cleanup.rb:28:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/plugins/synced_folders/nfs/action_cleanup.rb:25:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /home/bamboo/.vagrant.d/gems/gems/vagrant-vmware-workstation-3.1.2/lib/vagrant-vmware-workstation/action_farm.rb:992:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builtin/provision.rb:80:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builder.rb:116:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `block in run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/util/busy.rb:19:in `busy'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builtin/call.rb:53:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /home/bamboo/.vagrant.d/gems/gems/vagrant-vmware-workstation-3.1.2/lib/vagrant-vmware-workstation/action_farm.rb:71:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /home/bamboo/.vagrant.d/gems/gems/vagrant-vmware-workstation-3.1.2/lib/vagrant-vmware-workstation/action_farm.rb:1022:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builder.rb:116:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `block in run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/util/busy.rb:19:in `busy'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builtin/call.rb:53:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builtin/box_check_outdated.rb:36:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /home/bamboo/.vagrant.d/gems/gems/vagrant-vmware-workstation-3.1.2/lib/vagrant-vmware-workstation/action_farm.rb:1236:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /home/bamboo/.vagrant.d/gems/gems/vagrant-vmware-workstation-3.1.2/lib/vagrant-vmware-workstation/action_farm.rb:273:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /home/bamboo/.vagrant.d/gems/gems/vagrant-vmware-workstation-3.1.2/lib/vagrant-vmware-workstation/action_farm.rb:143:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /home/bamboo/.vagrant.d/gems/gems/vagrant-vmware-workstation-3.1.2/lib/vagrant-vmware-workstation/action_farm.rb:1101:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /home/bamboo/.vagrant.d/gems/gems/vagrant-vmware-workstation-3.1.2/lib/vagrant-vmware-workstation/action_farm.rb:466:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builtin/handle_box.rb:56:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builder.rb:116:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `block in run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/util/busy.rb:19:in `busy'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builtin/call.rb:53:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /home/bamboo/.vagrant.d/gems/gems/vagrant-vmware-workstation-3.1.2/lib/vagrant-vmware-workstation/action_farm.rb:1236:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /home/bamboo/.vagrant.d/gems/gems/vagrant-vmware-workstation-3.1.2/lib/vagrant-vmware-workstation/action_farm.rb:99:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /home/bamboo/.vagrant.d/gems/gems/vagrant-vmware-workstation-3.1.2/lib/vagrant-vmware-workstation/action_farm.rb:273:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builtin/config_validate.rb:25:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /home/bamboo/.vagrant.d/gems/gems/vagrant-vmware-workstation-3.1.2/lib/vagrant-vmware-workstation/action_farm.rb:160:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/warden.rb:34:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/builder.rb:116:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `block in run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/util/busy.rb:19:in `busy'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/action/runner.rb:66:in `run'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/machine.rb:196:in `action_raw'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/machine.rb:173:in `block in action'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/environment.rb:474:in `lock'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/machine.rb:161:in `call'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/machine.rb:161:in `action'
        from /opt/vagrant/embedded/gems/gems/vagrant-1.6.5/lib/vagrant/batch_action.rb:82:in `block (2 levels) in run'
VM must be created before running this command. Run `vagrant up` first.
```

Thanks,
Atha
