### PR TITLE
Escape - in regex

### DIFF
--- a/plugins/hosts/bsd/cap/nfs.rb
+++ b/plugins/hosts/bsd/cap/nfs.rb
@@ -137,7 +137,7 @@ module VagrantPlugins
           user = Process.uid
 
           File.read("/etc/exports").lines.each do |line|
-            if id = line[/^# VAGRANT-BEGIN:( #{user})? ([\.\/A-Za-z0-9-_]+?)$/, 2]
+            if id = line[/^# VAGRANT-BEGIN:( #{user})? ([\.\/A-Za-z0-9\-_]+?)$/, 2]
               if valid_ids.include?(id)
                 logger.debug("Valid ID: #{id}")
               else


### PR DESCRIPTION
I'm getting this when using 1.7.0

```
opt/rubies/2.0.0-p451/lib/ruby/gems/2.0.0/bundler/gems/vagrant-ce037b6ff476/plugins/hosts/bsd/cap/nfs.rb:140: warning: character class has '-' without escape: /^# VAGRANT-BEGIN:( 503)? ([\.\/A-Za-z0-9-_]+?)$/
```
