### PR TITLE
Add back creation of mount point

### DIFF
--- a/plugins/guests/freebsd/cap/mount_nfs_folder.rb
+++ b/plugins/guests/freebsd/cap/mount_nfs_folder.rb
@@ -8,6 +8,8 @@ module VagrantPlugins
               nfs_version_mount_option="-o nfsv#{opts[:nfs_version]}"
             end
 
+            machine.communicate.sudo("mkdir -p #{opts[:guestpath]}", {shell: "sh"})
+
             machine.communicate.sudo(
               "mount -t nfs #{nfs_version_mount_option} " +
               "'#{ip}:#{opts[:hostpath]}' '#{opts[:guestpath]}'", {shell: "sh"})


### PR DESCRIPTION
I think this was accidentally removed in ad4b30dd.  Because it's missing, a FreeBSD guest can no longer have an NFS mount that doesn't previously exist on the box.  Since this runs before provisioning, we can't even fix it via puppet.

It results in this error:

![error](http://i.imgur.com/CABDfXe.png)
