### PR TITLE
Updates documentation to respect Vagrantfile case sensitivity on strict file systems

### DIFF
--- a/website/docs/source/v2/vagrantfile/index.html.md
+++ b/website/docs/source/v2/vagrantfile/index.html.md
@@ -9,7 +9,7 @@ The primary function of the Vagrantfile is to describe the type
 of machine required for a project, and how to configure and
 provision these machines. Vagrantfiles are called Vagrantfiles because
 the actual literal filename for the file is `Vagrantfile` (casing doesn't
-matter).
+matter unless your file system is running in a strict case sensitive mode).
 
 Vagrant is meant to run with one Vagrantfile per project, and the Vagrantfile
 is supposed to be committed to version control. This allows other developers


### PR DESCRIPTION
This is a fix for issue #4907. On strict case sensitive filesystems, the Vagrantfile must follow that exact casing, otherwise Vagrant will fail to launch and will complain no Vagrantfile exists. 

This change adds further accuracy to the documentation to prevent people stumbling into a trap on such file systems. 

cc/ @mitchellh @sethvargo 
