### PR TITLE
Adding link to changelog

### DIFF
--- a/website/www/source/downloads.html.erb
+++ b/website/www/source/downloads.html.erb
@@ -15,7 +15,7 @@ Below are all available downloads for the latest version of Vagrant
 (<%= latest_version %>). Please download the proper package for your
 operating system and architecture. You can find SHA256 checksums
 for packages <a href="https://dl.bintray.com/mitchellh/vagrant/<%= latest_version %>_SHA256SUMS?direct">here</a>, 
-and you can find the version changelog <a href="https://github.com/mitchellh/vagrant/blob/master/CHANGELOG.md">here</a>
+and you can find the version changelog <a href="https://github.com/mitchellh/vagrant/blob/master/CHANGELOG.md">here</a>.
 </p>
 </div>
 


### PR DESCRIPTION
This is a fix for #4488 in order to add an obvious link to the changelog from the main Vagrant website. This change will make it more visible to users on what major features have changed in previous releases. 

cc/ @sethvargo @mitchellh
