### PR TITLE
Named Provisioners only in v1.7.0

### DIFF
--- a/website/docs/source/v2/provisioning/basic_usage.html.md
+++ b/website/docs/source/v2/provisioning/basic_usage.html.md
@@ -45,7 +45,7 @@ it can greatly improve readability. Additionally, some provisioners, like
 the Chef provisioner, have special methods that can be called within that
 block to ease configuration that can't be done with the key/value approach.
 
-Provisioners can also be named. These names are used cosmetically for output
+Provisioners can also be named (since 1.7.0). These names are used cosmetically for output
 as well as overriding provisioner settings (covered further below). An example
 of naming provisioners is shown below:
 


### PR DESCRIPTION
We couldn't figure out why Vagrant would throw an error, turns out this feature is only available in 1.7.0

https://github.com/mitchellh/vagrant/blob/master/CHANGELOG.md#170-december-9-2014
