### PR TITLE
Force opts to be options

### DIFF
--- a/plugins/commands/package/command.rb
+++ b/plugins/commands/package/command.rb
@@ -80,7 +80,7 @@ module VagrantPlugins
           acc
         end
 
-        vm.action(:package, opts)
+        vm.action(:package, **opts)
       end
     end
   end


### PR DESCRIPTION
cb6f3e5 introduced a change to the method airty of machine actions to remove the `extra_env` attribute.
- Fixes #4960
