### PR TITLE
support SMB synced folders on non-Windows hosts

### DIFF
--- a/plugins/synced_folders/smb/errors.rb
+++ b/plugins/synced_folders/smb/errors.rb
@@ -29,6 +29,10 @@ module VagrantPlugins
       class WindowsAdminRequired < SMBError
         error_key(:windows_admin_required)
       end
+
+      class SMBIdRequired < SMBError
+        error_key(:smb_id_required)
+      end
     end
   end
 end

--- a/plugins/synced_folders/smb/plugin.rb
+++ b/plugins/synced_folders/smb/plugin.rb
@@ -8,8 +8,8 @@ module VagrantPlugins
     class Plugin < Vagrant.plugin("2")
       name "SMB synced folders"
       description <<-EOF
-      The SMB synced folders plugin enables you to use SMB folders on
-      Windows and share them to guest machines.
+      The SMB synced folders plugin enables you to use SMB folders and
+      share them to guest machines.
       EOF
 
       synced_folder("smb", 7) do

--- a/plugins/synced_folders/smb/synced_folder.rb
+++ b/plugins/synced_folders/smb/synced_folder.rb
@@ -17,23 +17,20 @@ module VagrantPlugins
       end
 
       def usable?(machine, raise_error=false)
-        if !Vagrant::Util::Platform.windows?
-          raise Errors::WindowsHostRequired if raise_error
-          return false
-        end
-
-        if !Vagrant::Util::Platform.windows_admin?
-          raise Errors::WindowsAdminRequired if raise_error
-          return false
-        end
-
-        psv = Vagrant::Util::PowerShell.version.to_i
-        if psv < 3
-          if raise_error
-            raise Errors::PowershellVersion,
-              version: psv.to_s
+        if Vagrant::Util::Platform.windows?
+          if !Vagrant::Util::Platform.windows_admin?
+            raise Errors::WindowsAdminRequired if raise_error
+            return false
           end
-          return false
+
+          psv = Vagrant::Util::PowerShell.version.to_i
+          if psv < 3
+            if raise_error
+              raise Errors::PowershellVersion,
+                version: psv.to_s
+            end
+            return false
+          end
         end
 
         true
@@ -41,8 +38,6 @@ module VagrantPlugins
 
       def prepare(machine, folders, opts)
         machine.ui.output(I18n.t("vagrant_sf_smb.preparing"))
-
-        script_path = File.expand_path("../scripts/set_share.ps1", __FILE__)
 
         # If we need auth information, then ask the user.
         have_auth = false
@@ -61,23 +56,33 @@ module VagrantPlugins
           @creds[:password] = machine.ui.ask("Password (will be hidden): ", echo: false)
         end
 
-        folders.each do |id, data|
-          hostpath = data[:hostpath]
+        if Vagrant::Util::Platform.windows?
+          script_path = File.expand_path("../scripts/set_share.ps1", __FILE__)
+          folders.each do |id, data|
+            hostpath = data[:hostpath]
 
-          data[:smb_id] ||= Digest::MD5.hexdigest(
-            "#{machine.id}-#{id.gsub("/", "-")}")
+            data[:smb_id] ||= Digest::MD5.hexdigest(
+              "#{machine.id}-#{id.gsub("/", "-")}")
 
-          args = []
-          args << "-path" << "\"#{hostpath.gsub("/", "\\")}\""
-          args << "-share_name" << data[:smb_id]
-          #args << "-host_share_username" << @creds[:username]
+            args = []
+            args << "-path" << "\"#{hostpath.gsub("/", "\\")}\""
+            args << "-share_name" << data[:smb_id]
+            #args << "-host_share_username" << @creds[:username]
 
-          r = Vagrant::Util::PowerShell.execute(script_path, *args)
-          if r.exit_code != 0
-            raise Errors::DefineShareFailed,
-              host: hostpath.to_s,
-              stderr: r.stderr,
-              stdout: r.stdout
+            r = Vagrant::Util::PowerShell.execute(script_path, *args)
+            if r.exit_code != 0
+              raise Errors::DefineShareFailed,
+                host: hostpath.to_s,
+                stderr: r.stderr,
+                stdout: r.stdout
+            end
+          end
+        else
+          folders.each do |id, data|
+			data[:smb_id] = id unless data.key?(:smb_id)
+            if not data[:smb_id]
+              raise Errors::SMBIdRequired, id: id
+            end
           end
         end
       end
@@ -142,15 +147,19 @@ module VagrantPlugins
       protected
 
       def load_host_ips
-        script_path = File.expand_path("../scripts/host_info.ps1", __FILE__)
-        r = Vagrant::Util::PowerShell.execute(script_path)
-        if r.exit_code != 0
-          raise Errors::PowershellError,
-            script: script_path,
-            stderr: r.stderr
-        end
+        if Vagrant::Util::Platform.windows?
+          script_path = File.expand_path("../scripts/host_info.ps1", __FILE__)
+          r = Vagrant::Util::PowerShell.execute(script_path)
+          if r.exit_code != 0
+            raise Errors::PowershellError,
+              script: script_path,
+              stderr: r.stderr
+          end
 
-        JSON.parse(r.stdout)["ip_addresses"]
+          JSON.parse(r.stdout)["ip_addresses"]
+        else
+          []
+        end
       end
     end
   end

--- a/templates/locales/synced_folder_smb.yml
+++ b/templates/locales/synced_folder_smb.yml
@@ -28,7 +28,9 @@ en:
         host.
 
         As another option, you can manually specify an IP for the machine
-        to mount from using the `smb_host` option to the synced folder.
+        to mount from using the `smb_host` option to the synced folder. This
+        is mandatory if the host system is not Windows because the detection
+        of the host IP address is not supported yet on non-Windows hosts.
       powershell_error: |-
         An error occurred while executing a PowerShell script. This error
         is shown below. Please read the error message and see if this is
@@ -48,7 +50,10 @@ en:
         privileges. This is a limitation of Windows, since creating new
         network shares requires admin privileges. Please try again in a
         console with proper permissions or use another synced folder type.
-      windows_host_required: |-
-        SMB shared folders are only available when Vagrant is running
-        on Windows. The guest machine can be running non-Windows. Please use
-        another synced folder type.
+      smb_id_required: |-
+        SMB shared folders require a unique identifier in the 'smb_id'
+        configuration key when the host system is not Windows. The identifier
+        must be equal to the name of the SMB share under which the shared folder
+        is available. Please provide this key for the following shared folder:
+
+        %{id}


### PR DESCRIPTION
The attached patch adds (partial) support for synced folders using SMB when the host machine is not running Windows.

The limitations of the current implementation (compared to the case when the host machine is running Windows) are as follows:
- The IP address of the host machine is not detected automatically, therefore one has to specify `smb_host` explicitly in the `Vagrantfile`
- Since it is quite hard to force a Linux or Mac OS X host to share a specific folder using SMB, it is assumed that the folder that the user wants to mount in the guest machine is _already_ shared by the host, and Vagrant will make no attempts to share it to the guest.
- By default it is assumed that the name of the SMB share on the host is equal to the `id` of the synced folder. If this is not the case, one can use the `smb_id` property of the synced folder in the `Vagrantfile` to specify the name of the SMB share.

We have tested the patch using Scientific Linux and Mac OS X as hosts with a Windows 8.1 guest. All the unit tests pass after applying this patch.
