### PR TITLE
providers/virtualbox: Add 'post-comm' to the list of valid events

### DIFF
--- a/plugins/providers/virtualbox/config.rb
+++ b/plugins/providers/virtualbox/config.rb
@@ -143,7 +143,7 @@ module VagrantPlugins
       def validate(machine)
         errors = _detected_errors
 
-        valid_events = ["pre-import", "pre-boot", "post-boot"]
+        valid_events = ["pre-import", "pre-boot", "post-boot", "post-comm"]
         @customizations.each do |event, _|
           if !valid_events.include?(event)
             errors << I18n.t(


### PR DESCRIPTION
Commit 6a5fee0 is considered as a fix for [GH-3080]

Actually, the new customization event has been added - `post-comm`. But it doesn't work because this event is not passing the validation (`virtualbox/config.rb#validate`). 

So, we just need to add this event to the list of valid events :)
