### PR TITLE
Fix new-style Network Device Naming on CentOS7+VMwarefusion

### DIFF
--- a/plugins/guests/fedora/cap/configure_networks.rb
+++ b/plugins/guests/fedora/cap/configure_networks.rb
@@ -26,7 +26,7 @@ module VagrantPlugins
             end
 
             interface_names = networks.map do |network|
-               "eth#{network[:interface]}"
+               "#{interface_names[network[:interface]]}"
             end
           else
             machine.communicate.sudo("/usr/sbin/biosdevname -d | grep Kernel | cut -f2 -d: | sed -e 's/ //;'") do |_, result|


### PR DESCRIPTION
Support new-style Network Device Naming for ":private_network".

Tested with [box-cutter](https://github.com/box-cutter/centos-vm) for CentOS7+VMwareFusion.
