### PR TITLE
The install path of knife is changed (install check failing)

### DIFF
--- a/plugins/provisioners/chef/cap/linux/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/linux/chef_installed.rb
@@ -6,11 +6,10 @@ module VagrantPlugins
           # Check if Chef is installed at the given version.
           # @return [true, false]
           def self.chef_installed(machine, version)
-            knife = "/opt/chef/bin/knife"
-            command = "test -x #{knife}"
+            command = "which knife"
 
             if version != :latest
-              command << "&& #{knife} --version | grep 'Chef: #{version}'"
+              command << "&& knife --version | grep 'Chef: #{version}'"
             end
 
             machine.communicate.test(command, sudo: true)


### PR DESCRIPTION
At plugins/provisioners/chef/cap/linux/chef_installed.rb,
It supposed the path of knife to 'opt/chef/bin/knife'.
But the real path is /usr/bin/knife on version 11.8.2

```
vagrant@vagrant-ubuntu-trusty-64:/etc$ which knife
/usr/bin/knife
vagrant@vagrant-ubuntu-trusty-64:/etc$ knife --version
Chef: 11.8.2
```

So the check method chef_installed should be changed.

I don't make testcase for this because I don't know how to make a testcase for this case.
I hope someone help it.

Thank you for reading this request.
