### PR TITLE
Docs: Docker doesn't support pub/priv networks

### DIFF
--- a/website/docs/source/v2/docker/basics.html.md
+++ b/website/docs/source/v2/docker/basics.html.md
@@ -65,6 +65,8 @@ and networking options into Docker volumes and forwarded ports.
 You don't have to use the Docker-specific configurations to do this.
 This helps keep your Vagrantfile similar to how it has always looked.
 
+Private and public networks are not currently supported.
+
 ## Host VM
 
 On systems that can't run Linux containers natively, such as Mac OS X


### PR DESCRIPTION
The Docker provider ignores the network identifiers `private_network` and
`public_network`. Document this fact, because it's not immediately obvious.
