### PR TITLE
bash completion doesn't respect VAGRANT_HOME

### DIFF
--- a/contrib/bash/completion.sh
+++ b/contrib/bash/completion.sh
@@ -65,7 +65,7 @@ _vagrant() {
     then
         case "$prev" in
             "init")
-              local box_list=$(find $HOME/.vagrant.d/boxes -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+              local box_list=$(find "${VAGRANT_HOME:-${HOME}/.vagrant.d}/boxes" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
               COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
               return 0
             ;;
@@ -111,7 +111,7 @@ _vagrant() {
       then
         case "$prev" in
             "remove"|"repackage")
-              local box_list=$(find $HOME/.vagrant.d/boxes -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+              local box_list=$(find "${VAGRANT_HOME:-${HOME}/.vagrant.d}/boxes" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
               COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
               return 0
               ;;


### PR DESCRIPTION
When VAGRANT_HOME is set to a different path than $HOME/.vagrant.d, bash
completions regarding box names fails with an error like:

"$ vagrant init <TAB> find: `/home/mert/.vagrant.d/boxes': No such file or directory"

This commit makes completion.sh respect VAGRANT_HOME if it is set. It will continue to use $HOME/.vagrant.d otherwise.
