### PR TITLE
Fix puppet4 autodetect

### DIFF
--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -109,12 +109,12 @@ module VagrantPlugins
           verify_shared_folders(check)
 
           # Verify Puppet is installed and run it
-	  
+
           puppet_bin = "puppet"
           if windows?
-	    puppet_bin = "puppet.bat"
+	          puppet_bin = "puppet.bat"
           end
-	  
+
           @config.binary_path = verify_binary(puppet_bin)
 
           # Upload Hiera configuration if we have it
@@ -176,7 +176,7 @@ module VagrantPlugins
             if machine.communicate.test("sh -c 'command -v #{puppet_bin}'")
               return "/usr/local/bin/"
             end
-            binary = File.join("/opt/puppetlabs/bin", binary)
+            puppet_bin = File.join("/opt/puppetlabs/bin", binary)
             if machine.communicate.test("sh -c 'command -v #{puppet_bin}'")
               return "/opt/puppetlabs/bin/"
             end
@@ -186,9 +186,9 @@ module VagrantPlugins
             @machine.communicate.execute(test_cmd) do |type, data|
               if windows?
                 return data.chomp("\\#{binary}")
-	      else
+	            else
                 return data.chop.chomp("/#{binary}")
-	      end
+	            end
             end
           end
         end

--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -164,7 +164,7 @@ module VagrantPlugins
           if !test_result
             # Just fail if we didnt find it at the user specified path.
             if @config.binary_path
-              raise PuppetError, :not_detected
+              raise PuppetError.new(:not_detected, binary: puppet_bin)
             end
             # Not found but no path was specified, lets try a few default paths
             puppet_bin = File.join("/usr/local/bin/", binary)
@@ -175,7 +175,7 @@ module VagrantPlugins
             if machine.communicate.test("sh -c 'command -v #{puppet_bin}'")
               return "/opt/puppetlabs/bin/"
             end
-            raise PuppetError, :not_detected
+              raise PuppetError.new(:not_detected, binary: puppet_bin)
           else
             # Grab path in form path/puppet, chop off the puppet
             @machine.communicate.execute(test_cmd) do |type, data|


### PR DESCRIPTION
This PR fixes the automatic detection of puppet 4 opensource and Puppet Enterprise 2015.0.2 (which is installed to /usr/local/bin/puppet)

PE 3.8.x should also still be properly autodetected (it's installed to /opt/puppet..)

I temporarily disabled support of puppet.binary_path on Windows which broke with this PR. The winrm provider doesn't seem to like us calling puppet with the full path, when it includes spaces. It's not something that will generally be needed, anyway.

I've tested this with: 
puppet enterprise 2015.2.0 - Linux  (runs off puppet 4 opensource base)
puppet enterprise 3.8.x - Windows
puppet enterprise 3.8.x - Linux
