### PR TITLE
Puppet structured facts toyaml on provisioner

### DIFF
--- a/plugins/provisioners/puppet/config/puppet.rb
+++ b/plugins/provisioners/puppet/config/puppet.rb
@@ -33,7 +33,7 @@ module VagrantPlugins
           @module_path        = UNSET_VALUE
           @options            = []
           @facter             = {}
-          @structured_facts = UNSET_VALUE
+          @structured_facts   = UNSET_VALUE
           @synced_folder_type = UNSET_VALUE
           @temp_dir           = UNSET_VALUE
           @working_directory  = UNSET_VALUE
@@ -54,9 +54,6 @@ module VagrantPlugins
         def merge(other)
           super.tap do |result|
             result.facter  = @facter.merge(other.facter)
-            result.structured_facts  = @facter.merge(other.structured_facts)
-            result.environment_path  = @facter.merge(other.environment_path)
-            result.environment  = @facter.merge(other.environment)
           end
         end
 
@@ -146,7 +143,7 @@ module VagrantPlugins
               if !expanded_environment_file.file? && !expanded_environment_file.directory?
                 errors << I18n.t("vagrant.provisioners.puppet.environment_missing",
                                  environment: environment.to_s,
-                                 environment_path: expanded_path.to_s)
+                                 environmentpath: expanded_path.to_s)
               end
             end
           end

--- a/plugins/provisioners/puppet/config/puppet.rb
+++ b/plugins/provisioners/puppet/config/puppet.rb
@@ -8,6 +8,7 @@ module VagrantPlugins
         attr_accessor :binary_path
 
         attr_accessor :facter
+        attr_accessor :structured_facts
         attr_accessor :hiera_config_path
         attr_accessor :manifest_file
         attr_accessor :manifests_path
@@ -32,6 +33,7 @@ module VagrantPlugins
           @module_path        = UNSET_VALUE
           @options            = []
           @facter             = {}
+          @structured_facts = UNSET_VALUE
           @synced_folder_type = UNSET_VALUE
           @temp_dir           = UNSET_VALUE
           @working_directory  = UNSET_VALUE
@@ -52,6 +54,7 @@ module VagrantPlugins
         def merge(other)
           super.tap do |result|
             result.facter  = @facter.merge(other.facter)
+            result.structured_facts  = @facter.merge(other.structured_facts)
             result.environment_path  = @facter.merge(other.environment_path)
             result.environment  = @facter.merge(other.environment)
           end

--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -129,11 +129,14 @@ module VagrantPlugins
               @facter_config_path = "/ProgramData/PuppetLabs/facter/facts.d/vagrant_facts.yaml"
             end
             t = Tempfile.new("vagrant_facts.yaml")
-            t.write(config.facter)  
+            t.write(config.facter)
             t.close()
-            @machine.communicate.upload(t.path, @facter_config_path)
+            @machine.communicate.tap do |comm|
+              comm.upload(t.path, File.join(@config.temp_dir, "vagrant_facts.yaml"))
+              comm.sudo("cp #{config.temp_dir}/vagrant_facts.yaml #{@facter_config_path}")
+            end
            end
-	  
+
           run_puppet_apply
         end
 

--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -129,7 +129,7 @@ module VagrantPlugins
               @facter_config_path = "/ProgramData/PuppetLabs/facter/facts.d/vagrant_facts.yaml"
             end
             t = Tempfile.new("vagrant_facts.yaml")
-            t.write(config.facter)
+            t.write(config.facter.to_yaml)
             t.close()
             @machine.communicate.tap do |comm|
               comm.upload(t.path, File.join(@config.temp_dir, "vagrant_facts.yaml"))

--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -124,16 +124,16 @@ module VagrantPlugins
           # Build up the structured custom facts if we have any
           # With structured facts on, we assume the config.facter is yaml.
           if config.structured_facts && !config.facter.empty?
-            @facter_config_path = "/etc/facter/facts.d/vagrant_facts.yaml"
+            @facter_config_path = "/etc/puppetlabs/facter/facts.d/vagrant_facts.yaml"
             if windows?
               @facter_config_path = "/ProgramData/PuppetLabs/facter/facts.d/vagrant_facts.yaml"
             end
             t = Tempfile.new("vagrant_facts.yaml")
-	          t.write(config.facter)
+            t.write(config.facter)  
             t.close()
             @machine.communicate.upload(t.path, @facter_config_path)
-	        end
-
+           end
+	  
           run_puppet_apply
         end
 


### PR DESCRIPTION
The rationale here is to make it so existing Vagrantfile configurations remain unchanged after applying the changes at https://github.com/benh57/vagrant/tree/puppet_structuredfacts.

**Ben's change adds support to structured facts on the puppet provisioner, with an added requirement of two minor changes on the Vagrantfile. My contribution removes that requirement, allowing existing Vagrantfile configurations to remain unchanged.**

While benh57's solution worked for me, I had to add a ".to_yaml" to the VagrantFile line that implemented puppet.facter and this would mean existing Vagrant configurations that use Puppet would produce an error if that was not present.

Additionally, without this change, the Vagrant file also needed a "require('yaml')" declaration to make the ".to_yaml" conversion possible.

This is based off of https://github.com/benh57/vagrant/tree/puppet_structuredfacts.
