### PR TITLE
Expanding SMB sharing to be compatible with more than just Windows hosts (#6904)

### DIFF
--- a/plugins/hosts/linux/cap/smb.rb
+++ b/plugins/hosts/linux/cap/smb.rb
@@ -1,0 +1,31 @@
+require "pathname"
+require "log4r"
+
+module VagrantPlugins
+  module HostLinux
+    module Cap
+      class SMB
+        @@logger = Log4r::Logger.new("vagrant::linux_host::capabilities::smb")
+
+        def self.smb_installed(env)
+          !!Vagrant::Util::Which.which("smbd")
+        end
+
+        def self.smb_share(env, folders, machine_id)
+          script_path = "/usr/bin/net usershare add"
+
+          folders.each do |id, data|
+            hostpath = data[:hostpath]
+            @@logger.debug("Pre-hash name: #{machine_id}-#{id.gsub("/", "-")}")
+            data[:smb_id] ||= "#{Digest::MD5.hexdigest(machine_id)}-#{Digest::MD5.hexdigest(id.gsub("/", "-"))}"
+            command = "#{script_path} #{data[:smb_id]} #{hostpath} \"Vagrant Share\" Everyone:F"
+            @@logger.debug("command: " + command)
+            command_result = system(command)
+            @@logger.debug ("command result: #{command_result}")
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/plugins/hosts/linux/plugin.rb
+++ b/plugins/hosts/linux/plugin.rb
@@ -47,6 +47,16 @@ module VagrantPlugins
         require_relative "cap/nfs"
         Cap::NFS
       end
+      
+      host_capability("linux", "smb_installed") do
+        require_relative "cap/smb"
+        Cap::SMB
+      end
+      
+      host_capability("linux", "smb_share") do
+        require_relative "cap/smb"
+        Cap::SMB
+      end
     end
   end
 end

--- a/plugins/hosts/windows/cap/smb.rb
+++ b/plugins/hosts/windows/cap/smb.rb
@@ -1,0 +1,49 @@
+module VagrantPlugins
+  module HostWindows
+    module Cap
+      class SMB
+        @@logger = Log4r::Logger.new("vagrant::windows_host::capabilities::smb")
+        
+        def self.smb_installed(env)
+          if !Vagrant::Util::Platform.windows_admin?
+            raise Errors::WindowsAdminRequired if raise_error
+            return false
+          end
+
+          psv = Vagrant::Util::PowerShell.version.to_i
+          if psv < 3
+            if raise_error
+              raise Errors::PowershellVersion,
+                version: psv.to_s
+            end
+            return false
+          end
+          return true
+        end
+
+        def self.smb_share(env, folders, machine_id)
+          script_path = File.expand_path("../scripts/set_share.ps1", __FILE__)
+
+          folders.each do |id, data|
+            hostpath = data[:hostpath]
+
+            data[:smb_id] ||= Digest::MD5.hexdigest(
+              "#{machine_id}-#{id.gsub("/", "-")}")
+
+            args = []
+            args << "-path" << "\"#{hostpath.gsub("/", "\\")}\""
+            args << "-share_name" << data[:smb_id]
+
+            r = Vagrant::Util::PowerShell.execute(script_path, *args)
+            if r.exit_code != 0
+              raise Errors::DefineShareFailed,
+                host: hostpath.to_s,
+                stderr: r.stderr,
+                stdout: r.stdout
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/hosts/windows/plugin.rb
+++ b/plugins/hosts/windows/plugin.rb
@@ -20,6 +20,16 @@ module VagrantPlugins
         require_relative "cap/rdp"
         Cap::RDP
       end
+      
+      host_capability("windows", "smb_installed") do
+        require_relative "cap/smb"
+        Cap::SMB
+      end
+      
+      host_capability("windows", "smb_share") do
+        require_relative "cap/smb"
+        Cap::SMB
+      end
     end
   end
 end

--- a/plugins/synced_folders/smb/action_cleanup.rb
+++ b/plugins/synced_folders/smb/action_cleanup.rb
@@ -1,0 +1,24 @@
+require "log4r"
+
+module VagrantPlugins
+  module SyncedFolderSMB
+    class ActionCleanup
+      def initialize(app, env)
+        @app    = app
+        @logger = Log4r::Logger.new("vagrant::synced_folders::smb")
+      end
+
+      def call(env)
+        @logger.info("SMB pruning. Removing shares for ID: #{env[:machine].id}")
+        script_list_path =  "/usr/bin/net usershare list"
+        script_delete_path =  "/usr/bin/net usershare delete"
+        share_list = `"#{script_list_path} #{Digest::MD5.hexdigest(env[:machine].id)}"`
+        share_list.each_line{|s|
+          @logger.debug(`"#{script_delete_path} #{s}"`)
+        }
+
+        @app.call(env)
+      end
+    end
+  end
+end

--- a/plugins/synced_folders/smb/errors.rb
+++ b/plugins/synced_folders/smb/errors.rb
@@ -22,8 +22,12 @@ module VagrantPlugins
         error_key(:powershell_version)
       end
 
-      class WindowsHostRequired < SMBError
-        error_key(:windows_host_required)
+      class ScriptError < SMBError
+        error_key(:script_error)
+      end
+
+      class HostCapabilityRequired < SMBError
+        error_key(:host_capability_required)
       end
 
       class WindowsAdminRequired < SMBError

--- a/plugins/synced_folders/smb/plugin.rb
+++ b/plugins/synced_folders/smb/plugin.rb
@@ -9,7 +9,7 @@ module VagrantPlugins
       name "SMB synced folders"
       description <<-EOF
       The SMB synced folders plugin enables you to use SMB folders on
-      Windows and share them to guest machines.
+      compatible hosts and share them to guest machines.
       EOF
 
       synced_folder("smb", 7) do


### PR DESCRIPTION
This only supports the generic Linux host and the pre-existing Windows host, but puts the infrastructure in place so that others with relevant hosts can easily expand on what's been done.
