### PR TITLE
commands/up: don't instantiate machines while installing providers

### DIFF
--- a/plugins/commands/up/command.rb
+++ b/plugins/commands/up/command.rb
@@ -128,9 +128,9 @@ module VagrantPlugins
         # First create a set of all the providers we need to check for.
         # Most likely this will be a set of one.
         providers = Set.new
-        with_target_vms(names) do |machine|
+        with_matching_names(names) do |name|
           # Check if we have this machine in the index
-          entry    = @env.machine_index.get(machine.name.to_s)
+          entry    = @env.machine_index.get(name.to_s)
 
           # Get the provider for this machine. This logic isn't completely
           # straightforward. If we have a forced provider, we always use
@@ -146,7 +146,9 @@ module VagrantPlugins
           p = provider
           p = entry.provider.to_sym if !p && entry
           p = @env.default_provider(
-            machine: machine.name.to_sym, check_usable: false) if !p
+            machine: name, check_usable: false) if !p
+
+          @env.machine_index.release(entry) if entry
 
           # Add it to the set
           providers.add(p)


### PR DESCRIPTION
In `install_providers()`, we previously used `with_target_vms()` to iterate through and regex expand the command line arguments, determine which environment applied to each specified VM, and figure out which provider the core would use for that VM so that we could install it.

`with_target_vms()` has unintentional side-effects, however: it calls `@env.machine()` on each machine it parses from the command line, which causes any machines that don't exist to be created. However, since no provider has been determined yet, these machines are instantiated with the default provider, paying no respect to providers passed to `up` using `--provider`. This means that, if the first provider in the defaults list happens to fail to instantiate, Vagrant reports an error even when the user has explicitly specified a different provider to use.

A possible fix would have been to pass through `--provider` to `with_target_vms()`. However, a cleaner solution is to simply not instantiate any machines while installing providers. A `Machine` object is not required to get the current environment's configuration values, so creating one is unnecessary and inefficient. Instead, this patch splits the argument parsing loop from `with_target_vms()` into a separate function which yields machine names instead of `Machine` objects. Using the new function, `install_providers()` can determine each machine's default provider without creating a `Machine` object and invoking potentially-unrelated providers.

It's not hard to hit this bug during normal usage. The way I discovered it was as follows:
1. Start with a Linux machine with Vagrant installed but not VirtualBox or Docker.
2. Use `vagrant init` to create a Vagrantfile, then realize you can't `up` it because no providers are compatible.
3. Install the DigitalOcean third-party provider because you plan to eventually deploy to the cloud.
4. Install the `libvirt` provider for local testing (make sure you do this after installing DigitalOcean, so that DigitalOcean is earlier in the defaults list).
5. Attempt to start your VM with `vagrant up`.
6. See a DigitalOcean "unauthorized" error and realize that it's choosing the wrong provider.<sup>1</sup>
7. Attempt to start your VM with `vagrant up --provider libvirt`.
8. Observe that the same DigitalOcean error appears, even though you've explicitly specified a provider.

<sup>1</sup>I realize that this is partially the DigitalOcean provider's fault for not being non-defaultable, and I've already submitted a patch to them to fix that. However, one misbehaving provider shouldn't be able to prevent `up` from respecting its command line parameters.
