### PR TITLE
provision only scope=link interfaces. Ignore loopback & co.

### DIFF
--- a/plugins/guests/linux/cap/network_interfaces.rb
+++ b/plugins/guests/linux/cap/network_interfaces.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
         # @return [Array<String>]
         def self.network_interfaces(machine, path = "/sbin/ip")
           s = ""
-          machine.communicate.sudo("#{path} -o -0 addr | grep -v LOOPBACK | awk '{print $2}' | sed 's/://'") do |type, data|
+          machine.communicate.sudo("#{path} -o addr list scope link | awk '{print $2}' | sed 's/://'") do |type, data|
             s << data if type == :stdout
           end
           ifaces = s.split("\n")


### PR DESCRIPTION
If a box comes with docker preinstalled:
- sorted nics are [ "docker0", "enp0s1", "enp0s2", ...]
- the "first" interface becomes "enp0s1" (the NAT one)
- the NAT interface is deconfigured, and the vms become unreachable.

This patch ignores:
- loopback;
- unlinked docker bridges.

Feedback welcome!
