### PR TITLE
Allow alternate ansible debian wheezy repository

### DIFF
--- a/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
@@ -26,7 +26,9 @@ module VagrantPlugins
             def self.ansible_apt_install(machine)
 install_backports_if_wheezy_release = <<INLINE_CRIPT
 CODENAME=`lsb_release -cs`
-if [ x$CODENAME == 'xwheezy' ]; then
+apt-cache show ansible &> /dev/null
+PACKAGERC=$?
+if [ x$CODENAME == 'xwheezy' ] && [ $PACKAGERC != 0 ]; then
   echo 'deb http://http.debian.net/debian wheezy-backports main' > /etc/apt/sources.list.d/wheezy-backports.list
 fi
 INLINE_CRIPT


### PR DESCRIPTION
In case of an alternate debian wheezy repository providing ansible, or even in case of already having backports as a debian apt source, we can simply check the apt cache to find if ansible is an already known package.

(btw, i found "INLINE_CRIPT" a bit weird... Should it not be "INLINE_SCRIPT" ?)
(and why the hell a "x" is prefixed to $CODENAME to compare with "xwheezy" ? Should it not be [ $CODENAME == 'wheezy' ]
