### PR TITLE
add a config option to ignore the box vagrantfile

### DIFF
--- a/lib/vagrant/vagrantfile.rb
+++ b/lib/vagrant/vagrantfile.rb
@@ -163,11 +163,11 @@ module Vagrant
         local_keys = keys.dup
 
         # Load the box Vagrantfile, if there is one
-        if config.vm.box && !config.vm.box_ignore_box_vagrantfile && boxes
+        if config.vm.box && boxes
           box = boxes.find(config.vm.box, box_formats, config.vm.box_version)
           if box
             box_vagrantfile = find_vagrantfile(box.directory)
-            if box_vagrantfile
+            if box_vagrantfile && !config.vm.box_ignore_box_vagrantfile
               box_config_key =
                 "#{boxes.object_id}_#{box.name}_#{box.provider}".to_sym
               @loader.set(box_config_key, box_vagrantfile)

--- a/lib/vagrant/vagrantfile.rb
+++ b/lib/vagrant/vagrantfile.rb
@@ -163,7 +163,7 @@ module Vagrant
         local_keys = keys.dup
 
         # Load the box Vagrantfile, if there is one
-        if config.vm.box && boxes
+        if config.vm.box && !config.vm.box_ignore_box_vagrantfile && boxes
           box = boxes.find(config.vm.box, box_formats, config.vm.box_version)
           if box
             box_vagrantfile = find_vagrantfile(box.directory)

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -21,6 +21,7 @@ module VagrantPlugins
       attr_accessor :base_mac
       attr_accessor :boot_timeout
       attr_accessor :box
+      attr_accessor :box_ignore_box_vagrantfile
       attr_accessor :box_check_update
       attr_accessor :box_url
       attr_accessor :box_server_url
@@ -50,6 +51,7 @@ module VagrantPlugins
         @base_mac                      = UNSET_VALUE
         @boot_timeout                  = UNSET_VALUE
         @box                           = UNSET_VALUE
+        @box_ignore_box_vagrantfile    = UNSET_VALUE
         @box_check_update              = UNSET_VALUE
         @box_download_ca_cert          = UNSET_VALUE
         @box_download_ca_path          = UNSET_VALUE
@@ -376,6 +378,8 @@ module VagrantPlugins
         @base_mac = nil if @base_mac == UNSET_VALUE
         @boot_timeout = 300 if @boot_timeout == UNSET_VALUE
         @box = nil if @box == UNSET_VALUE
+
+        @box_ignore_box_vagrantfile = false if @box_ignore_box_vagrantfile == UNSET_VALUE
 
         if @box_check_update == UNSET_VALUE
           @box_check_update = !present?(ENV["VAGRANT_BOX_UPDATE_CHECK_DISABLE"])


### PR DESCRIPTION
In some case you might get trouble to override the configuration in the vagrant file which packaged in your box, for example the 'privater_network' , 'forwarded_port' etc, you might want an option to stop loading the configuration from the box vagrantfile entirely. 
```
config.vm.box_ignore_box_vagrantfile = true
```
do the trick.