### PR TITLE
Add parallel for destroy

### DIFF
--- a/plugins/commands/destroy/command.rb
+++ b/plugins/commands/destroy/command.rb
@@ -15,6 +15,11 @@ module VagrantPlugins
           o.separator "Options:"
           o.separator ""
 
+          o.on("--[no-]parallel",
+               "Enable or disable parallelism if provider supports it") do |parallel|
+            options[:parallel] = parallel
+          end
+
           o.on("-f", "--force", "Destroy without confirmation.") do |f|
             options[:force] = f
           end
@@ -25,25 +30,66 @@ module VagrantPlugins
         return if !argv
 
         @logger.debug("'Destroy' each target VM...")
-        declined = 0
-        total    = 0
-        with_target_vms(argv, reverse: true) do |vm|
-          action_env = vm.action(
-            :destroy, force_confirm_destroy: options[:force])
 
-          total    += 1
-          declined += 1 if action_env.key?(:force_confirm_destroy_result) &&
-            action_env[:force_confirm_destroy_result] == false
+        # Get the names of the machines we want to bring up
+        names = argv
+        if names.empty?
+          autostart = false
+          @env.vagrantfile.machine_names_and_options.each do |n, o|
+            autostart = true if o.key?(:autostart)
+            o[:autostart] = true if !o.key?(:autostart)
+            names << n.to_s if o[:autostart]
+          end
+
+          # If we have an autostart key but no names, it means that
+          # all machines are autostart: false and we don't start anything.
+          names = nil if autostart && names.empty?
         end
 
-        # Nothing was declined
-        return 0 if declined == 0
+        # Build up the batch job of what we'll do
+        machines = []
+        if names
+          # If we're installing providers, then do that. We don't
+          # parallelize this step because it is likely the same provider
+          # anyways.
+          if options[:install_provider]
+            install_providers(names, provider: options[:provider])
+          end
 
-        # Everything was declined
-        return 1 if declined == total
+          @env.batch(options[:parallel]) do |batch|
+            with_target_vms(names, reverse: true, provider: options[:provider]) do |machine|
+              @env.ui.info(I18n.t(
+                "vagrant.commands.destroy.destroying",
+                name: machine.name,
+                provider: machine.provider_name))
 
-        # Some was declined
-        return 2
+              machines << machine
+
+              batch.action(machine, :destroy, force_confirm_destroy: options[:force])
+            end
+          end
+        end
+
+        if machines.empty?
+          @env.ui.info(I18n.t("vagrant.destroy_no_machines"))
+          return 0
+        end
+
+        # Output the post-up messages that we have, if any
+        machines.each do |m|
+          next if !m.config.vm.post_destroy_message
+          next if m.config.vm.post_destroy_message == ""
+
+          # Add a newline to separate things.
+          @env.ui.info("", prefix: false)
+
+          m.ui.success(I18n.t(
+            "vagrant.post_destroy_message",
+            name: m.name.to_s,
+            message: m.config.vm.post_destroy_message))
+        end
+
+        return 0
       end
     end
   end

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -37,6 +37,7 @@ module VagrantPlugins
       attr_accessor :guest
       attr_accessor :hostname
       attr_accessor :post_up_message
+      attr_accessor :post_destroy_message
       attr_accessor :usable_port_range
       attr_reader :provisioners
 
@@ -66,6 +67,7 @@ module VagrantPlugins
         @guest                         = UNSET_VALUE
         @hostname                      = UNSET_VALUE
         @post_up_message               = UNSET_VALUE
+        @post_destroy_message          = UNSET_VALUE
         @provisioners                  = []
         @usable_port_range             = UNSET_VALUE
 
@@ -397,6 +399,7 @@ module VagrantPlugins
         @hostname = nil if @hostname == UNSET_VALUE
         @hostname = @hostname.to_s if @hostname
         @post_up_message = "" if @post_up_message == UNSET_VALUE
+        @post_destroy_message = "" if @post_destroy_message == UNSET_VALUE
 
         if @usable_port_range == UNSET_VALUE
           @usable_port_range = (2200..2250)

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -204,6 +204,11 @@ en:
       from the creator of the Vagrantfile, and not from Vagrant itself:
 
       %{message}
+    post_destroy_message: |-
+      Machine '%{name}' has a post `vagrant destroy` message. This is a message
+      from the creator of the Vagrantfile, and not from Vagrant itself:
+
+      %{message}      
     provisioner_cleanup: |-
       Running cleanup tasks for '%{name}' provisioner...
     rsync_auto_initial: |-
@@ -261,6 +266,8 @@ en:
       No machines to bring up. This is usually because all machines are
       set to `autostart: false`, which means you have to explicitly specify
       the name of the machine to bring up.
+    destroy_no_machines: |-
+      No machines to destroy.
     upgrading_home_path_v1_5: |-
       Vagrant is upgrading some internal state for the latest version.
       Please do not quit Vagrant at this time. While upgrading, Vagrant
@@ -1812,6 +1819,9 @@ en:
       validate:
         success: |-
           Vagrantfile validated successfully.
+      destroy:
+        destroying: |-
+          Destroying machine '%{name}' up with '%{provider}' provider...          
 
 #-------------------------------------------------------------------------------
 # Translations for Vagrant middleware actions


### PR DESCRIPTION
It can takes ages to decommission an environment if there are slow steps to run when destroying environment e.g. remove machine from AD when its destroyed. Running these steps in parallel will speed this up significantly.

Have followed the approach taken by parallel up.