### PR TITLE
Use a generic login mechanism for the SMB shares.

### DIFF
--- a/plugins/synced_folders/smb/scripts/set_share.ps1
+++ b/plugins/synced_folders/smb/scripts/set_share.ps1
@@ -16,11 +16,11 @@ if (net share | Select-String $share_name) {
 $objSID = New-Object System.Security.Principal.SecurityIdentifier("S-1-1-0")
 $objUser = $objSID.Translate([System.Security.Principal.NTAccount])
 
-$grant = "$objUser,Full"
+$grant = "$objUser`,Full"
 
 if (![string]::IsNullOrEmpty($host_share_username)) {
     $computer_name = $(Get-WmiObject Win32_Computersystem).name
-    $grant         = "$computer_name\$host_share_username,Full"
+    $grant         = "$host_share_username`,Full"
 
     # Here we need to set the proper ACL for this folder. This lets full
     # recursive access to this folder.


### PR DESCRIPTION
This is a patch for the issue #8214 to use the smb share.
It propose a username (this could also be a domain plus username) and asked for the password.
The generated smb share on the host is using this credential to setup the user rights correctly.