### PR TITLE
Fix #8315: Avoid "unexpected token" errors in PowerShell by separating environment variables with semicolons

### DIFF
--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -239,7 +239,14 @@ module VagrantPlugins
               end
             end
 
-            env_vars = env_vars.join(" ")
+            if windows?
+              env_vars = env_vars.join("; ")
+              if !env_vars.empty?
+                env_vars << ";"
+              end
+            else
+              env_vars = env_vars.join(" ")
+            end
           end
 
           command = [


### PR DESCRIPTION
I unfortunately wasn't able to run the unit tests, since the main Vagrantfile wasn't working for me (something about missing argument "-v" while executing gem), so I just modified my live Vagrant installation in order to try out the change. I tried the example from #8315, both with and without the ```puppet.environment_variables = {...}``` part, and it worked fine.