### PR TITLE
Fix #8328: Salt pillar configuration on Windows guests

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -166,7 +166,19 @@ module VagrantPlugins
       ## Actions
       # Get pillar string to pass with the salt command
       def get_pillar
-        " pillar='#{@config.pillar_data.to_json}'" if !@config.pillar_data.empty?
+        if !@config.pillar_data.empty?
+          if @machine.config.vm.communicator == :winrm
+            # ' doesn't have any special behavior on the command prompt,
+            # so '{"x":"y"}' becomes '{x:y}' with literal single quotes.
+            # However, """ will become " , and \\""" will become \" .
+            # Use \\"" instead of \\""" for literal inner-value quotes
+            # to avoid issue with odd number of quotes.
+            # --% disables special PowerShell parsing on the rest of the line.
+            " --% pillar=#{@config.pillar_data.to_json.gsub(/(?<!\\)\"/, '"""').gsub(/\\\"/, %q(\\\\\""))}"
+          else
+            " pillar='#{@config.pillar_data.to_json}'"
+          end
+        end
       end
 
       # Get colorization option string to pass with the salt command

--- a/website/source/docs/provisioning/salt.html.md
+++ b/website/source/docs/provisioning/salt.html.md
@@ -171,6 +171,8 @@ times. The data passed in should only be hashes and lists. Here is an example::
       end
 ```
 
+On Windows guests, this requires PowerShell 3.0 or higher.
+
 ## Preseeding Keys
 
 Preseeding keys is the recommended way to handle provisioning


### PR DESCRIPTION
Given the reproduction setup in #8328 and the below tweaks, here's a test containing a space, single quote, an even number of double quotes (two), and backslash in the pillar:

```
# demo.sls
/demo.txt:
  file.managed:
    - contents: |
        {{ pillar['demo'] }}

# Vagrantfile
    salt.pillar({
      :demo => 'it\'s "really" work\ing'
    })

# Vagrant debug log shows this new call:
C:\salt\salt-call.bat state.highstate --retcode-passthrough  --local --log-level=debug --no-color --% pillar={"""demo""":"""it's \\""really\\"" work\\ing"""}

# demo.txt
it's "really" work\ing
```

Here's a test with an odd number (one) of double quotes:

```
# demo.sls
/demo.txt:
  file.managed:
    - contents: |
        {{ pillar['demo'] }}

# Vagrantfile
    salt.pillar({
      :demo => 'just one "quote'
    })

# Vagrant debug log shows this new call:
C:\salt\salt-call.bat state.highstate --retcode-passthrough  --local --log-level=debug --no-color --% pillar={"""demo""":"""just one \\""quote"""}

# demo.txt
just one "quote
```

And multiple pillar values:

```
# demo.sls
/demo.txt:
  file.managed:
    - contents: |
        {{ pillar['demo'] }}
        {{ pillar['demo2'] }}

# Vagrantfile
    salt.pillar({
      :demo => 'it\'s "really" work\ing',
      :demo2 => 'just one "quote'
    })

# Vagrant debug log shows this new call:
C:\salt\salt-call.bat state.highstate --retcode-passthrough  --local --log-level=debug --no-color --% pillar={"""demo""":"""it's \\""really\\"" work\\ing""","""demo2""":"""just one \\""quote"""}

# demo.txt
it's "really" work\ing
just one "quote
```

This requires PowerShell 3.0 or higher (Windows 7 and up) because of using --% to disable special parsing. I tried to get it working with here-strings for 2.0, but didn't have any luck. I think this is fine because Salt only officially supports Windows 7+ anyway.

The same caveat I ran into with #8316 applies: I wasn't able to run the unit tests due to an issue with the repo's main Vagrantfile. However, I modified my live Vagrant installation in order to test these changes.