### PR TITLE
Clear POSIXLY_CORRECT when using optparse

### DIFF
--- a/lib/vagrant/plugin/v2/command.rb
+++ b/lib/vagrant/plugin/v2/command.rb
@@ -43,6 +43,9 @@ module Vagrant
         # If this method returns `nil`, then you should assume that help
         # was printed and parsing failed.
         def parse_options(opts=nil)
+          # make sure optparse doesn't use POSIXLY_CORRECT parsing
+          ENV["POSIXLY_CORRECT"] = nil
+          
           # Creating a shallow copy of the arguments so the OptionParser
           # doesn't destroy the originals.
           argv = @argv.dup


### PR DESCRIPTION
In case a user (perhaps inadvertently, or for particular reasons) has POSIXLY_CORRECT
set in their environment, make sure to clear it before calling optparse.optparse!() since
we don't really want POSIXLY_CORRECT argument parsing.