### PR TITLE
smb synced folders: auto-elevate

### DIFF
--- a/plugins/synced_folders/smb/scripts/set_share.ps1
+++ b/plugins/synced_folders/smb/scripts/set_share.ps1
@@ -9,7 +9,7 @@ Param(
 $ErrorAction = "Stop"
 
 if (net share | Select-String $share_name) {
-  net share $share_name /delete /y
+    Start-Process -Wait -Verb runAs -FilePath "net" -ArgumentList ("share", "$share_name", "/delete", "/y")
 }
 
 # The names of the user are language dependent!
@@ -35,10 +35,11 @@ if (![string]::IsNullOrEmpty($host_share_username)) {
     #>
 }
 
-$result = net share $share_name=$path /unlimited /GRANT:$grant
-if ($LastExitCode -eq 0) {
+$process = Start-Process -PassThru -Wait -Verb runAs -FilePath "net" -ArgumentList ("share", "$share_name=$path", "/unlimited", "/GRANT:$grant")
+if ($process.ExitCode -eq 0) {
     exit 0
 }
 
-$host.ui.WriteErrorLine("Error: $result")
+$host.ui.WriteErrorLine("Error: net share $share_name=$path /unlimited /GRANT:$grant returned error code $($process.ExitCode)")
+
 exit 1

--- a/plugins/synced_folders/smb/synced_folder.rb
+++ b/plugins/synced_folders/smb/synced_folder.rb
@@ -22,11 +22,6 @@ module VagrantPlugins
           return false
         end
 
-        if !Vagrant::Util::Platform.windows_admin?
-          raise Errors::WindowsAdminRequired if raise_error
-          return false
-        end
-
         psv = Vagrant::Util::PowerShell.version.to_i
         if psv < 3
           if raise_error


### PR DESCRIPTION
This removes the requirement to start `vagrant` as elevated user. Instead, an elevation prompt is shown during `vagrant up`. This elevation prompt is shown twice if the mount already exists (once to remove it, once to make a new one). This is comparable to what happens when network adapters are created and initialized.

The rest of the VM then runs completely as the regular user, which makes it much easier to use tooling that expects this (e.g. IntelliJ expects `vagrant status` to work when run as regular user).

