### PR TITLE
use ubuntu/xenial64 instead of hashicorp/precise64 for tutorial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ IMPROVEMENTS:
   - guests/bsd: Invoke `tee` with explicit path [GH-8740]
   - guests/smartos: Guest updates for host name and nfs capabilities [GH-8695]
   - guests/windows: Add public key capabilities for WinSSH communicator [GH-8761]
+  - providers/virtualbox: Filter machine IPs when preparing NFS settings [GH-8819]
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ IMPROVEMENTS:
   - guests/bsd: Invoke `tee` with explicit path [GH-8740]
   - guests/smartos: Guest updates for host name and nfs capabilities [GH-8695]
   - guests/windows: Add public key capabilities for WinSSH communicator [GH-8761]
+  - hosts/windows: Log command exec encoding failures and use original string on failure [GH-8820]
   - providers/virtualbox: Filter machine IPs when preparing NFS settings [GH-8819]
 
 BUG FIXES:

--- a/README.md
+++ b/README.md
@@ -30,11 +30,11 @@ installed. After this,
 
 To build your first virtual environment:
 
-    vagrant init hashicorp/precise32
+    vagrant init ubuntu/xenial64
     vagrant up
 
 Note: The above `vagrant up` command will also trigger Vagrant to download the
-`precise64` box via the specified URL. Vagrant only does this if it detects that
+`xenial64` box via the specified URL. Vagrant only does this if it detects that
 the box doesn't already exist on your system.
 
 ## Getting Started Guide

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To build your first virtual environment:
     vagrant up
 
 Note: The above `vagrant up` command will also trigger Vagrant to download the
-`precise32` box via the specified URL. Vagrant only does this if it detects that
+`precise64` box via the specified URL. Vagrant only does this if it detects that
 the box doesn't already exist on your system.
 
 ## Getting Started Guide

--- a/lib/vagrant/util/safe_exec.rb
+++ b/lib/vagrant/util/safe_exec.rb
@@ -44,8 +44,19 @@ module Vagrant
               # Re-generate strings to ensure common encoding
               @@logger.debug("Converting command and arguments to common UTF-8 encoding for exec.")
               @@logger.debug("Command: `#{command.inspect}` Args: `#{args.inspect}`")
-              command = "#{command}".force_encoding("UTF-8")
-              args = args.map{|arg| "#{arg}".force_encoding("UTF-8") }
+              begin
+                command = "#{command}".encode("UTF-8")
+              rescue Encoding::UndefinedConversionError => e
+                @@logger.warn("Failed to convert command - #{e.class}: #{e} (`#{command}`)")
+              end
+              args = args.map do |arg|
+                begin
+                  "#{arg}".encode("UTF-8")
+                rescue Encoding::UndefinedConversionError => e
+                  @@logger.warn("Failed to convert command argument - #{e.class}: #{e} (`#{arg}`)")
+                  arg
+                end
+              end
               @@logger.debug("Converted - Command: `#{command.inspect}` Args: `#{args.inspect}`")
             end
             Kernel.exec(command, *args)

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1014,6 +1014,11 @@ en:
 
           vagrant plugin expunge --reinstall
 
+        Or you may want to try updating the installed plugins to their latest
+        versions:
+
+          vagrant plugin update
+
         Error message given during initialization: %{message}
       plugin_load_error: |-
         The plugins failed to load properly. The error message given is

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "~> 11.3.0"
   s.add_development_dependency "rspec", "~> 2.14.0"
   s.add_development_dependency "webmock", "~> 1.20"
-  s.add_development_dependency "fake_ftp", "~> 0.1"
+  s.add_development_dependency "fake_ftp", "~> 0.1.1"
 
   # The following block of code determines the files that should be included
   # in the gem. It does this by reading all the files in the directory where

--- a/website/source/docs/other/environmental-variables.html.md
+++ b/website/source/docs/other/environmental-variables.html.md
@@ -161,6 +161,34 @@ the plugin source error and continue.
 If this is set, Vagrant will not perform any parallel operations (such as
 parallel box provisioning). All operations will be performed in serial.
 
+## `VAGRANT_DETECTED_OS`
+
+This environment variable may be set by the Vagrant launcher to help determine
+the current runtime platform. In general Vagrant will set this value when running
+on a Windows host using a cygwin or msys based shell. If this value is set, the
+Vagrant launcher will not modify it.
+
+## `VAGRANT_DETECTED_ARCH`
+
+This environment variable may be set by the Vagrant launcher to help determine
+the current runtime architecture in use. In general Vagrant will set this value
+when running on a Windows host using a cygwin or msys based shell. The value
+the Vagrant launcher may set in this environment variable will not always match
+the actual architecture of the platform itself. Instead it signifies the detected
+architecture of the environment it is running within. If this value is set, the
+Vagrant launcher will not modify it.
+
+## `VAGRANT_WINPTY_DISABLE`
+
+If this is set, Vagrant will _not_ wrap interactive processes with winpty where
+required.
+
+## `VAGRANT_PREFER_SYSTEM_BIN`
+
+If this is set, Vagrant will prefer using utility executables (like `ssh` and `rsync`)
+from the local system instead of those vendored within the Vagrant installation.
+This currently only applies to Windows systems.
+
 ## `VAGRANT_SKIP_SUBPROCESS_JAILBREAK`
 
 As of Vagrant 1.7.3, Vagrant tries to intelligently detect if it is running in

--- a/website/source/docs/other/wsl.html.md
+++ b/website/source/docs/other/wsl.html.md
@@ -99,6 +99,21 @@ Other useful WSL related environment variables:
 * `VAGRANT_WSL_DISABLE_VAGRANT_HOME` - Do not modify the `VAGRANT_HOME` variable
 * `VAGRANT_WSL_WINDOWS_ACCESS_USER_HOME_PATH` - Custom Windows system home path
 
+If a Vagrant project directory is not within the user's home directory on the
+Windows system, certain actions that include permission checks may fail (like
+`vagrant ssh`). When accessing Vagrant projects outside the WSL Vagrant will
+skip these permission checks when the project path is within the path defined
+in the `VAGRANT_WSL_WINDOWS_ACCESS_USER_HOME_PATH` environment variable. For
+example, if a user wants to run a Vagrant project from the WSL that is located
+at `C:\TestDir\vagrant-project`:
+
+```
+C:\Users\vagrant> cd C:\TestDir\vagrant-project
+C:\TestDir\vagrant-project> bash
+vagrant@vagrant-10:/mnt/c/TestDir/vagrant-project$ export VAGRANT_WSL_WINDOWS_ACCESS_USER_HOME_PATH="/mnt/c/TestDir"
+vagrant@vagrant-10:/mnt/c/TestDir/vagrant-project$ vagrant ssh
+```
+
 ## Using Docker
 
 The docker daemon cannot be run inside the Windows Subsystem for Linux. However,

--- a/website/source/intro/vs/docker.html.md
+++ b/website/source/intro/vs/docker.html.md
@@ -19,7 +19,7 @@ don't have a containerization system built-in, and Docker uses a virtual machine
 with Linux installed to provide that.
 
 Currently, Docker lacks support for certain operating systems (such as
-Windows and BSD). If your target deployment is one of these operating systems,
+BSD). If your target deployment is one of these operating systems,
 Docker will not provide the same production parity as a tool like Vagrant.
 Vagrant will allow you to run a Windows development environment on Mac or Linux,
 as well.


### PR DESCRIPTION
I started with the tutorial today and this could trip up new users. Since precise's repos aren't up anymore its impossible to install updates from ubuntu or do much in the way of a normal ubuntu machine. 

I imagine using the current it would be helpful for most users.

This project looks really cool so far!