### PR TITLE
nfs_udp is false by default if using NFS v4

### DIFF
--- a/plugins/synced_folders/nfs/synced_folder.rb
+++ b/plugins/synced_folders/nfs/synced_folder.rb
@@ -127,9 +127,10 @@ module VagrantPlugins
       def prepare_folder(machine, opts)
         opts[:map_uid] = prepare_permission(machine, :uid, opts)
         opts[:map_gid] = prepare_permission(machine, :gid, opts)
-        opts[:nfs_udp] = true if !opts.key?(:nfs_udp)
         opts[:nfs_version] ||= 3
-
+        if !opts.key?(:nfs_udp)
+          opts[:nfs_udp] = !opts[:nfs_version].to_s.start_with?('4')
+        end
 
         if opts[:nfs_version].to_s.start_with?('4') && opts[:nfs_udp]
           machine.ui.info I18n.t("vagrant.actions.vm.nfs.v4_with_udp_warning")


### PR DESCRIPTION
This fixes the warning

==> default: WARNING: Invalid NFS settings detected!
==> default: 
==> default: Detected UDP enabled with NFSv4. NFSv4 does not support UDP.
==> default: If folder mount fails disable UDP using the following option:
==> default: 
==> default:   nfs_udp: false

When synced folder is configured as

config.vm.synced_folder "/home", "/home", type: "nfs", nfs_version: 4

(without explicit nfs_udp: false)