### PR TITLE
Ensure Hyper-V cmdlets are fully qualified

### DIFF
--- a/plugins/providers/hyperv/scripts/check_hyperv.ps1
+++ b/plugins/providers/hyperv/scripts/check_hyperv.ps1
@@ -2,7 +2,7 @@
 $Dir = Split-Path $script:MyInvocation.MyCommand.Path
 . ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
 
-$check = $(-Not (-Not (Get-Command "Get-VMSwitch" -errorAction SilentlyContinue)))
+$check = $(-Not (-Not (Get-Command "Hyper-V\Get-VMSwitch" -errorAction SilentlyContinue)))
 $result = @{
     result = $check
 }

--- a/plugins/providers/hyperv/scripts/clone_vhd.ps1
+++ b/plugins/providers/hyperv/scripts/clone_vhd.ps1
@@ -6,4 +6,4 @@ Param(
     [string]$Destination
 )
 
-New-VHD -Path $Destination -ParentPath $Source -ErrorAction Stop
+Hyper-V\New-VHD -Path $Destination -ParentPath $Source -ErrorAction Stop

--- a/plugins/providers/hyperv/scripts/create_snapshot.ps1
+++ b/plugins/providers/hyperv/scripts/create_snapshot.ps1
@@ -4,5 +4,5 @@ Param(
     [string]$SnapName
 )
 
-$VM = Get-VM -Id $VmId -ErrorAction "Stop"
-Checkpoint-VM $VM -SnapshotName $SnapName 
+$VM = Hyper-V\Get-VM -Id $VmId -ErrorAction "Stop"
+Hyper-V\Checkpoint-VM $VM -SnapshotName $SnapName 

--- a/plugins/providers/hyperv/scripts/delete_snapshot.ps1
+++ b/plugins/providers/hyperv/scripts/delete_snapshot.ps1
@@ -4,5 +4,5 @@ Param(
     [string]$SnapName
 )
 
-$VM = Get-VM -Id $VmId -ErrorAction "Stop"
-Remove-VMSnapshot $VM -Name $SnapName 
+$VM = Hyper-V\Get-VM -Id $VmId -ErrorAction "Stop"
+Hyper-V\Remove-VMSnapshot $VM -Name $SnapName 

--- a/plugins/providers/hyperv/scripts/delete_vm.ps1
+++ b/plugins/providers/hyperv/scripts/delete_vm.ps1
@@ -3,5 +3,5 @@ Param(
     [string]$VmId
 )
 
-$VM = Get-VM -Id $VmId -ErrorAction "Stop"
-Remove-VM $VM -Force
+$VM = Hyper-V\Get-VM -Id $VmId -ErrorAction "Stop"
+Hyper-V\Remove-VM $VM -Force

--- a/plugins/providers/hyperv/scripts/export_vm.ps1
+++ b/plugins/providers/hyperv/scripts/export_vm.ps1
@@ -5,8 +5,8 @@ Param(
     [string]$Path
 )
 
-$vm = Get-VM -Id $VmId -ErrorAction "Stop"
-$vm | Export-VM -Path $Path
+$vm = Hyper-V\Get-VM -Id $VmId -ErrorAction "Stop"
+$vm | Hyper-V\Export-VM -Path $Path
 
 # Prepare directory structure for box import
 $name = $vm.Name

--- a/plugins/providers/hyperv/scripts/file_sync.ps1
+++ b/plugins/providers/hyperv/scripts/file_sync.ps1
@@ -45,7 +45,7 @@ function Sync-Remote-Machine($machine, $remove_files, $copy_files, $host_path, $
       $from = $host_path + $item
       $to = $guest_path + $item
       # Copy VM can also take a VM object
-      Copy-VMFile  -VM $machine -SourcePath $from -DestinationPath $to -CreateFullPath -FileSource Host -Force
+      Hyper-V\Copy-VMFile  -VM $machine -SourcePath $from -DestinationPath $to -CreateFullPath -FileSource Host -Force
     }
 }
 
@@ -67,7 +67,7 @@ function Get-Empty-folders-From-Source($host_path) {
 
 $delimiter = " || "
 
-$machine = Get-VM -Id $vm_id
+$machine = Hyper-V\Get-VM -Id $vm_id
 
 # FIXME: PowerShell guys please fix this.
 # The below script checks for all VMIntegrationService which are not enabled
@@ -75,7 +75,7 @@ $machine = Get-VM -Id $vm_id
 # When when all the services are enabled this throws an error.
 # Enable VMIntegrationService to true
 try {
-  Get-VM -Id $vm_id | Get-VMIntegrationService -Name "Guest Service Interface" | Enable-VMIntegrationService -Passthru
+  Hyper-V\Get-VM -Id $vm_id | Hyper-V\Get-VMIntegrationService -Name "Guest Service Interface" | Hyper-V\Enable-VMIntegrationService -Passthru
   }
   catch { }
 

--- a/plugins/providers/hyperv/scripts/get_network_config.ps1
+++ b/plugins/providers/hyperv/scripts/get_network_config.ps1
@@ -7,8 +7,8 @@ Param(
 $Dir = Split-Path $script:MyInvocation.MyCommand.Path
 . ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
 
-$vm = Get-VM -Id $VmId -ErrorAction "Stop"
-$networks = Get-VMNetworkAdapter -VM $vm
+$vm = Hyper-V\Get-VM -Id $VmId -ErrorAction "Stop"
+$networks = Hyper-V\Get-VMNetworkAdapter -VM $vm
 foreach ($network in $networks) {
   if ($network.IpAddresses.Length -gt 0) {
     foreach ($ip_address in $network.IpAddresses) {

--- a/plugins/providers/hyperv/scripts/get_network_mac.ps1
+++ b/plugins/providers/hyperv/scripts/get_network_mac.ps1
@@ -8,8 +8,8 @@ $Dir = Split-Path $script:MyInvocation.MyCommand.Path
 . ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
 
 $ip_address = ""
-$vm = Get-VM -Id $VmId -ErrorAction "Stop"
-$networks = Get-VMNetworkAdapter -VM $vm
+$vm = Hyper-V\Get-VM -Id $VmId -ErrorAction "Stop"
+$networks = Hyper-V\Get-VMNetworkAdapter -VM $vm
 foreach ($network in $networks) {
   if ($network.MacAddress -gt 0) {
     $mac_address = $network.MacAddress

--- a/plugins/providers/hyperv/scripts/get_switches.ps1
+++ b/plugins/providers/hyperv/scripts/get_switches.ps1
@@ -7,6 +7,6 @@
 $Dir = Split-Path $script:MyInvocation.MyCommand.Path
 . ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
 
-$Switches = @(Get-VMSwitch `
+$Switches = @(Hyper-V\Get-VMSwitch `
     | Select-Object Name,SwitchType,NetAdapterInterfaceDescription)
 Write-Output-Message $(ConvertTo-JSON $Switches)

--- a/plugins/providers/hyperv/scripts/get_vm_status.ps1
+++ b/plugins/providers/hyperv/scripts/get_vm_status.ps1
@@ -28,7 +28,7 @@ if($HyperVVersion -lt ([version]'10.0')) {
   $ExceptionType = [Microsoft.HyperV.PowerShell.VirtualizationException]
 }
 try {
-    $VM = Get-VM -Id $VmId -ErrorAction "Stop"
+    $VM = Hyper-V\Get-VM -Id $VmId -ErrorAction "Stop"
     $State = $VM.state
     $Status = $VM.status
 } catch [Exception] {

--- a/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
@@ -30,7 +30,7 @@ $VmProperties = @{
     VirtualMachinePath = $data_path
 }
 
-$vmConfig = (Compare-VM -Copy -GenerateNewID @VmProperties)
+$vmConfig = (Hyper-V\Compare-VM -Copy -GenerateNewID @VmProperties)
 
 $generation = $vmConfig.VM.Generation
 
@@ -43,13 +43,13 @@ if (!$vmname) {
 
 if (!$cpus) {
     # Get the processorcount of the VM
-    $processors = (Get-VMProcessor -VM $vmConfig.VM).Count
+    $processors = (Hyper-V\Get-VMProcessor -VM $vmConfig.VM).Count
 }else {
     $processors = $cpus
 }
 
 function GetUniqueName($name) {
-    Get-VM | ForEach-Object -Process {
+    Hyper-V\Get-VM | ForEach-Object -Process {
         if ($name -eq $_.Name) {
             $name =  $name + "_1"
         }
@@ -63,7 +63,7 @@ do {
 } while ($vm_name -ne $name)
 
 if (!$memory) {
-    $configMemory = Get-VMMemory -VM $vmConfig.VM
+    $configMemory = Hyper-V\Get-VMMemory -VM $vmConfig.VM
     $dynamicmemory = $configMemory.DynamicMemoryEnabled
 
     $MemoryMaximumBytes = ($configMemory.Maximum)
@@ -84,46 +84,46 @@ if (!$memory) {
 }
 
 if (!$switchname) {
-    $switchname = (Get-VMNetworkAdapter -VM $vmConfig.VM).SwitchName
+    $switchname = (Hyper-V\Get-VMNetworkAdapter -VM $vmConfig.VM).SwitchName
 }
 
 # Enable nested virtualization if configured
 if ($enable_virtualization_extensions -eq "True") {
-    Set-VMProcessor -VM $vmConfig.VM -ExposeVirtualizationExtensions $true
+    Hyper-V\Set-VMProcessor -VM $vmConfig.VM -ExposeVirtualizationExtensions $true
 }
 
-$vmNetworkAdapter = Get-VMNetworkAdapter -VM $vmConfig.VM
-Connect-VMNetworkAdapter -VMNetworkAdapter $vmNetworkAdapter -SwitchName $switchname
-Set-VM -VM $vmConfig.VM -NewVMName $vm_name
-Set-VM -VM $vmConfig.VM -ErrorAction "Stop"
-Set-VM -VM $vmConfig.VM -ProcessorCount $processors
+$vmNetworkAdapter = Hyper-V\Get-VMNetworkAdapter -VM $vmConfig.VM
+Hyper-V\Connect-VMNetworkAdapter -VMNetworkAdapter $vmNetworkAdapter -SwitchName $switchname
+Hyper-V\Set-VM -VM $vmConfig.VM -NewVMName $vm_name
+Hyper-V\Set-VM -VM $vmConfig.VM -ErrorAction "Stop"
+Hyper-V\Set-VM -VM $vmConfig.VM -ProcessorCount $processors
 
 if ($dynamicmemory) {
-    Set-VM -VM $vmConfig.VM -DynamicMemory
-    Set-VM -VM $vmConfig.VM -MemoryMinimumBytes $MemoryMinimumBytes -MemoryMaximumBytes $MemoryMaximumBytes -MemoryStartupBytes $MemoryStartupBytes
+    Hyper-V\Set-VM -VM $vmConfig.VM -DynamicMemory
+    Hyper-V\Set-VM -VM $vmConfig.VM -MemoryMinimumBytes $MemoryMinimumBytes -MemoryMaximumBytes $MemoryMaximumBytes -MemoryStartupBytes $MemoryStartupBytes
 } else {
-    Set-VM -VM $vmConfig.VM -StaticMemory
-    Set-VM -VM $vmConfig.VM -MemoryStartupBytes $MemoryStartupBytes
+    Hyper-V\Set-VM -VM $vmConfig.VM -StaticMemory
+    Hyper-V\Set-VM -VM $vmConfig.VM -MemoryStartupBytes $MemoryStartupBytes
 }
 
 if ($notes) {
-    Set-VM -VM $vmConfig.VM -Notes $notes
+    Hyper-V\Set-VM -VM $vmConfig.VM -Notes $notes
 }
 
 if ($auto_start_action) {
-    Set-VM -VM $vmConfig.VM -AutomaticStartAction $auto_start_action
+    Hyper-V\Set-VM -VM $vmConfig.VM -AutomaticStartAction $auto_start_action
 }
 
 if ($auto_stop_action) {
-    Set-VM -VM $vmConfig.VM -AutomaticStopAction $auto_stop_action
+    Hyper-V\Set-VM -VM $vmConfig.VM -AutomaticStopAction $auto_stop_action
 }
 
 # Only set EFI secure boot for Gen 2 machines, not gen 1
 if ($generation -ne 1) {
-    Set-VMFirmware -VM $vmConfig.VM -EnableSecureBoot (Get-VMFirmware -VM $vmConfig.VM).SecureBoot
+    Hyper-V\Set-VMFirmware -VM $vmConfig.VM -EnableSecureBoot (Hyper-V\Get-VMFirmware -VM $vmConfig.VM).SecureBoot
 }
 
-$report = Compare-VM -CompatibilityReport $vmConfig
+$report = Hyper-V\Compare-VM -CompatibilityReport $vmConfig
 
 # Stop if there are incompatibilities
 if($report.Incompatibilities.Length -gt 0){
@@ -133,9 +133,9 @@ if($report.Incompatibilities.Length -gt 0){
 
 if($differencing_disk){
     # Get all controller on the VM, first scsi, then IDE if it is a Gen 1 device
-    $controllers = Get-VMScsiController -VM $vmConfig.VM
+    $controllers = Hyper-V\Get-VMScsiController -VM $vmConfig.VM
     if($generation -eq 1){
-        $controllers = @($controllers) + @(Get-VMIdeController -VM $vmConfig.VM)
+        $controllers = @($controllers) + @(Hyper-V\Get-VMIdeController -VM $vmConfig.VM)
     }
 
     foreach($controller in $controllers){
@@ -143,17 +143,17 @@ if($differencing_disk){
             if([System.IO.Path]::GetFileName($drive.Path) -eq [System.IO.Path]::GetFileName($source_path)){
                 # Remove the old disk and replace it with a differencing version
                 $path = $drive.Path
-                Remove-VMHardDiskDrive $drive
-                New-VHD -Path $dest_path -ParentPath $source_path -ErrorAction Stop
-                Add-VMHardDiskDrive -VM $vmConfig.VM -Path $dest_path
+                Hyper-V\Remove-VMHardDiskDrive $drive
+                Hyper-V\New-VHD -Path $dest_path -ParentPath $source_path -ErrorAction Stop
+                Hyper-V\Add-VMHardDiskDrive -VM $vmConfig.VM -Path $dest_path
             }
         }
     }
 }
 
-Import-VM -CompatibilityReport $vmConfig
+Hyper-V\Import-VM -CompatibilityReport $vmConfig
 
-$vm_id = (Get-VM $vm_name).id.guid
+$vm_id = (Hyper-V\Get-VM $vm_name).id.guid
 $resultHash = @{
     name = $vm_name
     id = $vm_id

--- a/plugins/providers/hyperv/scripts/import_vm_xml.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm_xml.ps1
@@ -37,7 +37,7 @@ if (!$cpus) {
 }
 
 function GetUniqueName($name) {
-    Get-VM | ForEach-Object -Process {
+    Hyper-V\Get-VM | ForEach-Object -Process {
         if ($name -eq $_.Name) {
             $name =  $name + "_1"
         }
@@ -118,13 +118,13 @@ $vm_params = @{
 }
 
 # Generation parameter was added in ps v4
-if((get-command New-VM).Parameters.Keys.Contains("generation")) {
+if((get-command Hyper-V\New-VM).Parameters.Keys.Contains("generation")) {
     $vm_params.Generation = $generation
 }
 
 # Create the VM using the values in the hash map
 
-$vm = New-VM @vm_params
+$vm = Hyper-V\New-VM @vm_params
 
 $notes = (Select-Xml -xml $vmconfig -XPath "//notes").node.'#text'
 
@@ -156,7 +156,7 @@ if ($auto_stop_action) {
 }
 
 # Set the values on the VM
-$vm | Set-VM @more_vm_params -Passthru
+$vm | Hyper-V\Set-VM @more_vm_params -Passthru
 
 # Add drives to the virtual machine
 $controllers = Select-Xml -xml $vmconfig -xpath "//*[starts-with(name(.),'controller')]"
@@ -165,15 +165,15 @@ $controllers = Select-Xml -xml $vmconfig -xpath "//*[starts-with(name(.),'contro
 if ($generation -ne 1) {
     # Set EFI secure boot
     if ($secure_boot_enabled -eq "True") {
-        Set-VMFirmware -VM $vm -EnableSecureBoot On
+        Hyper-V\Set-VMFirmware -VM $vm -EnableSecureBoot On
     }  else {
-        Set-VMFirmware -VM $vm -EnableSecureBoot Off
+        Hyper-V\Set-VMFirmware -VM $vm -EnableSecureBoot Off
     }
 }
 
 # Enable nested virtualization if configured
 if ($enable_virtualization_extensions -eq "True") {
-    Set-VMProcessor -VM $vm -ExposeVirtualizationExtensions $true
+    Hyper-V\Set-VMProcessor -VM $vm -ExposeVirtualizationExtensions $true
 }
 
 # A regular expression pattern to pull the number from controllers
@@ -206,12 +206,12 @@ foreach ($controller in $controllers) {
 
         if ($drivetype -eq 'VHD') {
             $addDriveParam.add("ControllerType",$ControllerType)
-            $vm | Add-VMHardDiskDrive @AddDriveparam
+            $vm | Hyper-V\Add-VMHardDiskDrive @AddDriveparam
         }
     }
 }
 
-$vm_id = (Get-VM $vm_name).id.guid
+$vm_id = (Hyper-V\Get-VM $vm_name).id.guid
 $resultHash = @{
     name = $vm_name
     id = $vm_id

--- a/plugins/providers/hyperv/scripts/list_snapshots.ps1
+++ b/plugins/providers/hyperv/scripts/list_snapshots.ps1
@@ -3,8 +3,8 @@ Param(
     [string]$VmId
 )
 
-$VM = Get-VM -Id $VmId -ErrorAction "Stop"
-$Snapshots = @(Get-VMSnapshot $VM | Select-Object Name)
+$VM = Hyper-V\Get-VM -Id $VmId -ErrorAction "Stop"
+$Snapshots = @(Hyper-V\Get-VMSnapshot $VM | Select-Object Name)
 $result = ConvertTo-json $Snapshots
 
 Write-Host "===Begin-Output==="

--- a/plugins/providers/hyperv/scripts/restore_snapshot.ps1
+++ b/plugins/providers/hyperv/scripts/restore_snapshot.ps1
@@ -4,5 +4,5 @@ Param(
     [string]$SnapName
 )
 
-$VM = Get-VM -Id $VmId -ErrorAction "Stop"
-Restore-VMSnapshot $VM -Name $SnapName -Confirm:$false
+$VM = Hyper-V\Get-VM -Id $VmId -ErrorAction "Stop"
+Hyper-V\Restore-VMSnapshot $VM -Name $SnapName -Confirm:$false

--- a/plugins/providers/hyperv/scripts/resume_vm.ps1
+++ b/plugins/providers/hyperv/scripts/resume_vm.ps1
@@ -3,5 +3,5 @@ Param(
     [string]$VmId
 )
 
-$VM = Get-VM -Id $VmId -ErrorAction "Stop"
-Resume-VM $VM
+$VM = Hyper-V\Get-VM -Id $VmId -ErrorAction "Stop"
+Hyper-V\Resume-VM $VM

--- a/plugins/providers/hyperv/scripts/set_network_mac.ps1
+++ b/plugins/providers/hyperv/scripts/set_network_mac.ps1
@@ -10,8 +10,8 @@ $modules += $presentDir + "\utils\write_messages.ps1"
 forEach ($module in $modules) { . $module }
 
 try {
-  $vm = Get-VM -Id $VmId -ErrorAction "stop"
-  Set-VMNetworkAdapter $vm -StaticMacAddress $Mac -ErrorAction "stop"
+  $vm = Hyper-V\Get-VM -Id $VmId -ErrorAction "stop"
+  Hyper-V\Set-VMNetworkAdapter $vm -StaticMacAddress $Mac -ErrorAction "stop"
 }
 catch {
   Write-Error-Message "Failed to set VM's MAC address $_"

--- a/plugins/providers/hyperv/scripts/set_network_vlan.ps1
+++ b/plugins/providers/hyperv/scripts/set_network_vlan.ps1
@@ -10,8 +10,8 @@ $modules += $presentDir + "\utils\write_messages.ps1"
 forEach ($module in $modules) { . $module }
 
 try {
-  $vm = Get-VM -Id $VmId -ErrorAction "stop"
-  Set-VMNetworkAdapterVlan $vm -Access -Vlanid $VlanId
+  $vm = Hyper-V\Get-VM -Id $VmId -ErrorAction "stop"
+  Hyper-V\Set-VMNetworkAdapterVlan $vm -Access -Vlanid $VlanId
 }
 catch {
   Write-Error-Message "Failed to set VM's Vlan ID $_"

--- a/plugins/providers/hyperv/scripts/set_vm_integration_services.ps1
+++ b/plugins/providers/hyperv/scripts/set_vm_integration_services.ps1
@@ -12,7 +12,7 @@ param (
 $Dir = Split-Path $script:MyInvocation.MyCommand.Path
 . ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
 
-$vm = Get-VM -Id $VmId -ErrorAction "stop"
+$vm = Hyper-V\Get-VM -Id $VmId -ErrorAction "stop"
 
 # Set the service based on value
 function VmSetService
@@ -21,10 +21,10 @@ function VmSetService
 
     if ($Value -ne $null){
         if($Value -eq "true"){
-            Enable-VMIntegrationService -VM $Vm -Name $Name
+            Hyper-V\Enable-VMIntegrationService -VM $Vm -Name $Name
         }
         if($Value -eq "false"){
-            Disable-VMIntegrationService -VM $Vm -Name $Name
+            Hyper-V\Disable-VMIntegrationService -VM $Vm -Name $Name
         }
     }
 }

--- a/plugins/providers/hyperv/scripts/start_vm.ps1
+++ b/plugins/providers/hyperv/scripts/start_vm.ps1
@@ -9,8 +9,8 @@ $modules += $presentDir + "\utils\write_messages.ps1"
 forEach ($module in $modules) { . $module }
 
 try {
-  $vm = Get-VM -Id $VmId -ErrorAction "stop"
-  Start-VM $vm -ErrorAction "stop"
+  $vm = Hyper-V\Get-VM -Id $VmId -ErrorAction "stop"
+  Hyper-V\Start-VM $vm -ErrorAction "stop"
   $state = $vm.state
   $status = $vm.status
   $name = $vm.name

--- a/plugins/providers/hyperv/scripts/stop_vm.ps1
+++ b/plugins/providers/hyperv/scripts/stop_vm.ps1
@@ -4,5 +4,5 @@ Param(
 )
 
 # Shuts down virtual machine regardless of any unsaved application data
-$VM = Get-VM -Id $VmId -ErrorAction "Stop"
-Stop-VM $VM -Force
+$VM = Hyper-V\Get-VM -Id $VmId -ErrorAction "Stop"
+Hyper-V\Stop-VM $VM -Force

--- a/plugins/providers/hyperv/scripts/suspend_vm.ps1
+++ b/plugins/providers/hyperv/scripts/suspend_vm.ps1
@@ -3,5 +3,5 @@ Param(
     [string]$VmId
 )
 
-$VM = Get-VM -Id $VmId -ErrorAction "Stop"
-Suspend-VM $VM
+$VM = Hyper-V\Get-VM -Id $VmId -ErrorAction "Stop"
+Hyper-V\Suspend-VM $VM


### PR DESCRIPTION
+ This disambuguates calls to the Hyper-V functions for the Hyper-V provider.
The ambiguity of some commands - such as `Get-VM` - causes the Hyper-V provider
to fail on systems where VMware PowerCLI is installed. This change ensures that
all calls to Hyper-V specific cmdlets or functions are prepended by `Hyper-V\`.
This ensures the correct cmdlet calls are being made.
+ Resolves  #8862.