### PR TITLE
Handle calling reboot detection during an existing shutdown

### DIFF
--- a/plugins/guests/windows/scripts/reboot_detect.ps1
+++ b/plugins/guests/windows/scripts/reboot_detect.ps1
@@ -32,6 +32,11 @@ if (ShuttingDown) {
     exit 2
   }
 
+  if ($LASTEXITCODE -eq 1115) {
+    # A system shutdown is in progress
+    exit 2
+  }
+
   # Remove the pending reboot we just created above
   if ($LASTEXITCODE -eq 0) {
     . shutdown.exe -a


### PR DESCRIPTION
If shutdown is called during an existing shutdown then exception code 1115 is throw.