### PR TITLE
Handle chef provisioner reboot request

### DIFF
--- a/plugins/guests/windows/scripts/reboot_detect.ps1
+++ b/plugins/guests/windows/scripts/reboot_detect.ps1
@@ -32,6 +32,11 @@ if (ShuttingDown) {
     exit 2
   }
 
+  if ($LASTEXITCODE -eq 1115) {
+    # A system shutdown is in progress
+    exit 2
+  }
+
   # Remove the pending reboot we just created above
   if ($LASTEXITCODE -eq 0) {
     . shutdown.exe -a

--- a/plugins/provisioners/chef/provisioner/chef_solo.rb
+++ b/plugins/provisioners/chef/provisioner/chef_solo.rb
@@ -176,36 +176,43 @@ module VagrantPlugins
             @machine.ui.warn(I18n.t("vagrant.chef_run_list_empty"))
           end
 
-          if @machine.guest.capability?(:wait_for_reboot)
-            @machine.guest.capability(:wait_for_reboot)
-          end
-
           command = CommandBuilder.command(:solo, @config,
             windows: windows?,
             colored: @machine.env.ui.color?,
             legacy_mode: @config.legacy_mode,
           )
 
+          still_active = 259 #provisioner has asked chef to reboot
+          
           @config.attempts.times do |attempt|
-            if attempt == 0
-              @machine.ui.info I18n.t("vagrant.provisioners.chef.running_solo")
-            else
-              @machine.ui.info I18n.t("vagrant.provisioners.chef.running_solo_again")
+            exit_status = 0
+            while exit_status == 0 || exit_status == still_active 
+              if @machine.guest.capability?(:wait_for_reboot)
+                @machine.guest.capability(:wait_for_reboot)
+              elsif attempt > 0
+                sleep 10
+                @machine.communicate.wait_for_ready(@machine.config.vm.boot_timeout)
+              end
+              if attempt == 0
+                @machine.ui.info I18n.t("vagrant.provisioners.chef.running_solo")
+              else
+                @machine.ui.info I18n.t("vagrant.provisioners.chef.running_solo_again")
+              end
+
+              opts = { error_check: false, elevated: true }
+              exit_status = @machine.communicate.sudo(command, opts) do |type, data|
+                # Output the data with the proper color based on the stream.
+                color = type == :stdout ? :green : :red
+
+                data = data.chomp
+                next if data.empty?
+
+                @machine.ui.info(data, color: color)
+              end
+
+              # There is no need to run Chef again if it converges
+              return if exit_status == 0
             end
-
-            opts = { error_check: false, elevated: true }
-            exit_status = @machine.communicate.sudo(command, opts) do |type, data|
-              # Output the data with the proper color based on the stream.
-              color = type == :stdout ? :green : :red
-
-              data = data.chomp
-              next if data.empty?
-
-              @machine.ui.info(data, color: color)
-            end
-
-            # There is no need to run Chef again if it converges
-            return if exit_status == 0
           end
 
           # If we reached this point then Chef never converged! Error.

--- a/plugins/provisioners/chef/provisioner/chef_zero.rb
+++ b/plugins/provisioners/chef/provisioner/chef_zero.rb
@@ -56,36 +56,43 @@ module VagrantPlugins
             @machine.ui.warn(I18n.t("vagrant.chef_run_list_empty"))
           end
 
-          if @machine.guest.capability?(:wait_for_reboot)
-            @machine.guest.capability(:wait_for_reboot)
-          end
-
           command = CommandBuilder.command(:client, @config,
             windows:    windows?,
             colored:    @machine.env.ui.color?,
             local_mode: true,
           )
 
+          still_active = 259 #provisioner has asked chef to reboot 
+          
           @config.attempts.times do |attempt|
-            if attempt == 0
-              @machine.ui.info I18n.t("vagrant.provisioners.chef.running_zero")
-            else
-              @machine.ui.info I18n.t("vagrant.provisioners.chef.running_zero_again")
+            exit_status = 0
+            while exit_status == 0 || exit_status == still_active 
+              if @machine.guest.capability?(:wait_for_reboot)
+                @machine.guest.capability(:wait_for_reboot)
+              elsif attempt > 0
+                sleep 10
+                @machine.communicate.wait_for_ready(@machine.config.vm.boot_timeout)
+              end
+              if attempt == 0
+                @machine.ui.info I18n.t("vagrant.provisioners.chef.running_zero")
+              else
+                @machine.ui.info I18n.t("vagrant.provisioners.chef.running_zero_again")
+              end
+
+              opts = { error_check: false, elevated: true }
+              exit_status = @machine.communicate.sudo(command, opts) do |type, data|
+                # Output the data with the proper color based on the stream.
+                color = type == :stdout ? :green : :red
+
+                data = data.chomp
+                next if data.empty?
+
+                @machine.ui.info(data, color: color)
+              end
+
+              # There is no need to run Chef again if it converges
+              return if exit_status == 0
             end
-
-            opts = { error_check: false, elevated: true }
-            exit_status = @machine.communicate.sudo(command, opts) do |type, data|
-              # Output the data with the proper color based on the stream.
-              color = type == :stdout ? :green : :red
-
-              data = data.chomp
-              next if data.empty?
-
-              @machine.ui.info(data, color: color)
-            end
-
-            # There is no need to run Chef again if it converges
-            return if exit_status == 0
           end
 
           # If we reached this point then Chef never converged! Error.


### PR DESCRIPTION
Handle Chef provisioner requests to reboot. A request to reboot is not a convergence failure, so don't treat it like a convergence failure.

Wait for the machine to reboot before trying to continue the provisioning.
