### PR TITLE
Add IPv6 network template for OpenBSD machines

### DIFF
--- a/templates/guests/openbsd/network_static6.erb
+++ b/templates/guests/openbsd/network_static6.erb
@@ -1,0 +1,1 @@
+inet6  <%= options[:ip] %> <%= options[:netmask] %> NONE


### PR DESCRIPTION
The template for ipv6 was missing so far, which resulted in an error when trying to use IPv6 for a machine.