### PR TITLE
fix for issue #8608/Windows hosts

### DIFF
--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -48,7 +48,7 @@ module VagrantPlugins
         run_cmd += ports.map { |p| ['-p', p.to_s] }
         run_cmd += volumes.map { |v|
           v = v.to_s
-          if v.include?(":") && (Vagrant::Util::Platform.windows? || Vagrant::Util::Platform.wsl?)
+          if v.include?(":") && @executor.windows?
             host, guest = v.split(":", 2)
             host = Vagrant::Util::Platform.windows_path(host)
             # NOTE: Docker does not support UNC style paths (which also

--- a/plugins/providers/docker/executor/local.rb
+++ b/plugins/providers/docker/executor/local.rb
@@ -29,6 +29,10 @@ module VagrantPlugins
 
           result.stdout
         end
+
+        def windows?
+          ::Vagrant::Util::Platform.windows? || ::Vagrant::Util::Platform.wsl?
+        end
       end
     end
   end

--- a/plugins/providers/docker/executor/vagrant.rb
+++ b/plugins/providers/docker/executor/vagrant.rb
@@ -65,6 +65,10 @@ module VagrantPlugins
           stdout.chomp
         end
 
+        def windows?
+          false
+        end
+
         protected
 
         def ssh_run(cmd)


### PR DESCRIPTION
Fixes issue #8608. The existing `windows?` expression applies only when it's a local
machine. When it's a VM, it's always set to `false`.