### PR TITLE
provisioners/shell: Use ui.detail for displaying output

### DIFF
--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -43,7 +43,7 @@ module VagrantPlugins
           options = {}
           options[:color] = color if !config.keep_color
 
-          @machine.ui.info(data.chomp, options)
+          @machine.ui.detail(data.chomp, options)
         end
       end
 


### PR DESCRIPTION
Output format of ui.info method (bold text) makes reading long script outputs really heavy on the eyes. ui.detail is a better match for this type of output.