### PR TITLE
provisioners/salt: Fixes timeout issue in salt bootstrapping for windows

### DIFF
--- a/plugins/provisioners/salt/bootstrap-salt.ps1
+++ b/plugins/provisioners/salt/bootstrap-salt.ps1
@@ -53,7 +53,27 @@ Write-Host "Downloading Salt minion installer Salt-Minion-$version-$arch-Setup.e
 $webclient = New-Object System.Net.WebClient
 $url = "https://repo.saltstack.com/windows/Salt-Minion-$version-$arch-Setup.exe"
 $file = "C:\tmp\salt.exe"
-$webclient.DownloadFile($url, $file)
+
+[int]$retries = 0
+Do {
+ try {
+    $retries++
+    $ErrorActionPreference='Stop'
+    $webclient.DownloadFile($url, $file)
+ } catch [Exception] {
+    if($retries -eq 3) {
+        $_
+        $_.GetType()
+        $_.Exception
+        $_.Exception.StackTrace
+        Write-Host
+        exit 1
+    }
+    Write-Warning "Retrying download in 2 seconds. Retry # $retries"
+    Start-Sleep -s 2
+    }
+}
+Until($retries -eq 3)
 
 
 # Install minion silently

--- a/plugins/provisioners/salt/bootstrap-salt.ps1
+++ b/plugins/provisioners/salt/bootstrap-salt.ps1
@@ -60,8 +60,9 @@ Do {
     $retries++
     $ErrorActionPreference='Stop'
     $webclient.DownloadFile($url, $file)
+    break
  } catch [Exception] {
-    if($retries -eq 3) {
+    if($retries -eq 5) {
         $_
         $_.GetType()
         $_.Exception
@@ -73,7 +74,7 @@ Do {
     Start-Sleep -s 2
     }
 }
-Until($retries -eq 3)
+Until($retries -eq 5)
 
 
 # Install minion silently

--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -300,7 +300,7 @@ module VagrantPlugins
           @machine.communicate.upload(bootstrap_path.to_s, bootstrap_destination)
           @machine.communicate.sudo("chmod +x %s" % bootstrap_destination)
           if @machine.config.vm.communicator == :winrm
-            bootstrap = @machine.communicate.sudo("powershell.exe -executionpolicy bypass -file %s %s" % [bootstrap_destination, options]) do |type, data|
+            bootstrap = @machine.communicate.sudo("powershell.exe -NonInteractive -NoProfile -executionpolicy bypass -file %s %s" % [bootstrap_destination, options]) do |type, data|
               if data[0] == "\n"
                 # Remove any leading newline but not whitespace. If we wanted to
                 # remove newlines and whitespace we would have used data.lstrip


### PR DESCRIPTION
Fixes #8991.

1. When remote executing scripts one should always call powershell with
1a. "-NonInteractive", in order to prevent interactive prompts from leading to an endless waiting time for the script to return
1b. "-NoProfile", in order to prevent the loading of unknown custom profiles before execution of the script which could have unintended side effects
2. During my tests I constantly ran into 408 timeouts when downloading the salt binaries. I've prevented that by adding a simple retry mechanism and an error exit in case of multiple failures. Without this change the bootstrap script never returned (and neither did vagrant up)