### PR TITLE
Allow synced folders to contain spaces in the guest path

### DIFF
--- a/plugins/providers/virtualbox/synced_folder.rb
+++ b/plugins/providers/virtualbox/synced_folder.rb
@@ -85,7 +85,7 @@ module VagrantPlugins
       end
 
       def os_friendly_id(id)
-        id.gsub(/[\/\\]/,'_').sub(/^_/, '')
+        id.gsub(/[\s\/\\]/,'_').sub(/^_/, '')
       end
 
       # share_folders sets up the shared folder definitions on the

--- a/test/unit/plugins/providers/virtualbox/synced_folder_test.rb
+++ b/test/unit/plugins/providers/virtualbox/synced_folder_test.rb
@@ -44,4 +44,30 @@ describe VagrantPlugins::ProviderVirtualBox::SyncedFolder do
 
     it "should share the folders"
   end
+
+  describe "os_friendly_id" do
+    it "should not replace normal chars" do
+      expect(subject.send(:os_friendly_id, 'perfectly_valid0_name')).to eq('perfectly_valid0_name')
+    end
+
+    it "should replace spaces" do
+      expect(subject.send(:os_friendly_id, 'Program Files')).to eq('Program_Files')
+    end
+
+    it "should replace leading underscore" do
+      expect(subject.send(:os_friendly_id, '_vagrant')).to eq('vagrant')
+    end
+
+    it "should replace slash" do
+      expect(subject.send(:os_friendly_id, 'va/grant')).to eq('va_grant')
+    end
+
+    it "should replace leading underscore and slash" do
+      expect(subject.send(:os_friendly_id, '/vagrant')).to eq('vagrant')
+    end
+
+    it "should replace backslash" do
+      expect(subject.send(:os_friendly_id, 'foo\\bar')).to eq('foo_bar')
+    end
+  end
 end


### PR DESCRIPTION
It should be valid to allow paths with spaces for the synced folder
guest path but since the guest path is used to generate the ID (if one
isn't provided), this will err out in VirtualBox because it doesn't
allow spaces for the --name argument. We should simply convert ' ' to
'_' as we do with other special characters.