### PR TITLE
Add completion for snapshot names for vagrant snapshot restore|delete

### DIFF
--- a/contrib/bash/completion.sh
+++ b/contrib/bash/completion.sh
@@ -140,6 +140,15 @@ _vagrant() {
               ;;
           esac
           ;;
+        "snapshot")
+          case "$prev" in
+            "restore"|"delete")
+              local snapshot_list=$(vagrant snapshot list)
+              COMPREPLY=($(compgen -W "${snapshot_list}" -- ${cur}))
+              return 0
+            ;;
+          esac
+          ;;
         *)
           ;;
       esac


### PR DESCRIPTION
- Note that this does not cover additional options like --no-provision
- It is also a bit slow, as `vagrant snapshot list` is used to gather
  the data