### PR TITLE
Add Errno::EPIPE exception to ssh communicator

### DIFF
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -36,6 +36,7 @@ module VagrantPlugins
         Errno::ECONNRESET,
         Errno::ENETUNREACH,
         Errno::EHOSTUNREACH,
+        Errno::EPIPE,
         Net::SSH::Disconnect,
         Timeout::Error
       ]


### PR DESCRIPTION
This commit adds an additional exception to retry ssh on when bringing
up a machine and attempting to ssh into the guest.

Fixes #8974