### PR TITLE
Include WinSSH Communicator

### DIFF
--- a/plugins/guests/windows/cap/public_key.rb
+++ b/plugins/guests/windows/cap/public_key.rb
@@ -1,5 +1,7 @@
 require "tempfile"
 
+require_relative '../../../communicators/winssh/communicator'
+
 module VagrantPlugins
   module GuestWindows
     module Cap


### PR DESCRIPTION
This commit requires the winssh communicator class wihtin the public_key
capability for Windows. Prior to this commit users could run into a
situation where Vagrant would check if the machine could speak in WinSSH
and fail on an uninitialized constant.

Fixes #8941