### PR TITLE
Attempt fetching salt bootstrap script with wget

### DIFF
--- a/plugins/provisioners/salt/bootstrap-salt.sh
+++ b/plugins/provisioners/salt/bootstrap-salt.sh
@@ -5,6 +5,8 @@ if [ -x /usr/bin/fetch ]; then
     /usr/bin/fetch -o bootstrap-salt.sh https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh
 elif [ -x /usr/bin/curl ]; then
     /usr/bin/curl -L -O https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh
+elif [ -x /usr/bin/wget ]; then
+    /usr/bin/wget -O bootstrap-salt.sh https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh
 else
     python -c 'import urllib; urllib.urlretrieve("https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh", "bootstrap-salt.sh")'
 fi


### PR DESCRIPTION
On Debian installations, `fetch`, `curl` and `python` commands may not exist. Only `wget` is guaranteed as explained in the commit message.

This fixes the following error on minimal Debian images, and possibly other distributions and operating systems.
```
==> default: Running provisioner: salt...
Copying salt minion config to vm.
Checking if salt-minion is installed
salt-minion was not found.
Checking if salt-call is installed
salt-call was not found.
Using Bootstrap Options:  -X -F -c /tmp stable
Bootstrapping Salt... (this may take a while)
stdin: is not a tty

/tmp/bootstrap_salt.sh: 9: /tmp/bootstrap_salt.sh:
python: not found

Salt successfully configured and installed!
run_overstate set to false. Not running state.overstate.
Calling state.highstate... (this may take a while)
stdin: is not a tty

bash: line 4: salt-call: command not found
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

salt-call state.highstate --retcode-passthrough  --local --log-level=warning --force-color

Stdout from the command:



Stderr from the command:

stdin: is not a tty
bash: line 4: salt-call: command not found
$
```
