### PR TITLE
Use environment variable for CURL_CA_BUNDLE

### DIFF
--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -297,8 +297,7 @@ module Vagrant
         # If we're in Vagrant, then we use the packaged CA bundle
         if Vagrant.in_installer?
           subprocess_options[:env] ||= {}
-          subprocess_options[:env]["CURL_CA_BUNDLE"] =
-            File.expand_path("cacert.pem", ENV["VAGRANT_INSTALLER_EMBEDDED_DIR"])
+          subprocess_options[:env]["CURL_CA_BUNDLE"] = ENV["CURL_CA_BUNDLE"]
         end
 
         return [options, subprocess_options]

--- a/test/unit/vagrant/util/downloader_test.rb
+++ b/test/unit/vagrant/util/downloader_test.rb
@@ -210,4 +210,32 @@ describe Vagrant::Util::Downloader do
       expect(subject.head).to eq("foo")
     end
   end
+
+  describe "#options" do
+    describe "CURL_CA_BUNDLE" do
+      let(:ca_bundle){ "CUSTOM_CA_BUNDLE" }
+
+      context "when running within the installer" do
+        before do
+          allow(Vagrant).to receive(:in_installer?).and_return(true)
+          allow(ENV).to receive(:[]).with("CURL_CA_BUNDLE").and_return(ca_bundle)
+        end
+
+        it "should set custom CURL_CA_BUNDLE in subprocess ENV" do
+          _, subprocess_opts = subject.send(:options)
+          expect(subprocess_opts[:env]).not_to be_nil
+          expect(subprocess_opts[:env]["CURL_CA_BUNDLE"]).to eql(ca_bundle)
+        end
+      end
+
+      context "when not running within the installer" do
+        before{ allow(Vagrant).to receive(:installer?).and_return(false) }
+
+        it "should not set custom CURL_CA_BUNDLE in subprocess ENV" do
+          _, subprocess_opts = subject.send(:options)
+          expect(subprocess_opts[:env]).to be_nil
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
When running within the installer, use an environment variable for setting the CURL_CA_BUNDLE instead of generating the path. This allows the launcher to define the path _if_ the user has not already provided a custom bundle to be used.