### PR TITLE
Add app.vagrantup.com to allowed auth hosts

### DIFF
--- a/plugins/commands/login/middleware/add_authentication.rb
+++ b/plugins/commands/login/middleware/add_authentication.rb
@@ -6,8 +6,10 @@ require_relative "../client"
 module VagrantPlugins
   module LoginCommand
     class AddAuthentication
-      VCLOUD = "vagrantcloud.com".freeze
-      ATLAS  = "atlas.hashicorp.com".freeze
+      ALLOWED_AUTHENTICATION_HOSTS = %w[
+        atlas.hashicorp.com
+        vagrantcloud.com
+      ].freeze
 
       def initialize(app, env)
         @app = app
@@ -25,12 +27,8 @@ module VagrantPlugins
             replace = u.host == server_uri.host
 
             if !replace
-              # We need this in here for the transition we made from
-              # Vagrant Cloud to Atlas. This preserves access tokens
-              # appending to both without leaking access tokens to
-              # unsavory URLs.
-              if (u.host == VCLOUD && server_uri.host == ATLAS) ||
-                  (u.host == ATLAS && server_uri.host == VCLOUD)
+              if ALLOWED_AUTHENTICATION_HOSTS.include?(u.host) &&
+                  ALLOWED_AUTHENTICATION_HOSTS.include?(server_uri.host)
                 replace = true
               end
             end

--- a/plugins/commands/login/middleware/add_authentication.rb
+++ b/plugins/commands/login/middleware/add_authentication.rb
@@ -7,6 +7,7 @@ module VagrantPlugins
   module LoginCommand
     class AddAuthentication
       ALLOWED_AUTHENTICATION_HOSTS = %w[
+        app.vagrantup.com
         atlas.hashicorp.com
         vagrantcloud.com
       ].freeze

--- a/test/unit/plugins/commands/login/middleware/add_authentication_test.rb
+++ b/test/unit/plugins/commands/login/middleware/add_authentication_test.rb
@@ -71,13 +71,15 @@ describe VagrantPlugins::LoginCommand::AddAuthentication do
 
       original = [
         "http://google.com/box.box",
+        "http://app.vagrantup.com/foo.box",
         "http://vagrantcloud.com/foo.box",
         "http://vagrantcloud.com/bar.box?arg=true",
       ]
 
       expected = original.dup
       expected[1] = "#{original[1]}?access_token=#{token}"
-      expected[2] = "#{original[2]}&access_token=#{token}"
+      expected[2] = "#{original[2]}?access_token=#{token}"
+      expected[3] = "#{original[3]}&access_token=#{token}"
 
       env[:box_urls] = original.dup
       subject.call(env)


### PR DESCRIPTION
This should allow users setting `VAGRANT_SERVER_URL=https://app.vagrantup.com` to authenticate to private boxes.