### PR TITLE
sketch out minix guest plugin

### DIFF
--- a/plugins/guests/minix/cap/change_host_name.rb
+++ b/plugins/guests/minix/cap/change_host_name.rb
@@ -1,0 +1,15 @@
+module VagrantPlugins
+  module GuestMINIX
+    module Cap
+      class ChangeHostName
+        def self.change_host_name(machine, name)
+          if !machine.communicate.test("hostname -s | grep '^#{name}$'")
+            machine.communicate.sudo(<<CMDS, {shell: "sh"})
+hostname #{name}
+CMDS
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/minix/cap/rsync.rb
+++ b/plugins/guests/minix/cap/rsync.rb
@@ -1,0 +1,21 @@
+require_relative "../../../synced_folders/rsync/default_unix_cap"
+
+module VagrantPlugins
+  module GuestMINIX
+    module Cap
+      class RSync
+        extend VagrantPlugins::SyncedFolderRSync::DefaultUnixCap
+
+        def self.rsync_install(machine)
+          machine.communicate.sudo(
+            'yes | pkgin update && yes | pkgin install rsync'
+          )
+        end
+
+        def self.rsync_command(machine)
+          'su root -c rsync'
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/minix/guest.rb
+++ b/plugins/guests/minix/guest.rb
@@ -1,0 +1,11 @@
+require "vagrant"
+
+module VagrantPlugins
+  module GuestMINIX
+    class Guest < Vagrant.plugin("2", :guest)
+      def detect?(machine)
+        machine.communicate.test("uname -s | grep Minix")
+      end
+    end
+  end
+end

--- a/plugins/guests/minix/plugin.rb
+++ b/plugins/guests/minix/plugin.rb
@@ -1,0 +1,30 @@
+require "vagrant"
+
+module VagrantPlugins
+  module GuestMINIX
+    class Plugin < Vagrant.plugin("2")
+      name "MINIX guest"
+      description "MINIX guest support."
+
+      guest(:minix, :netbsd) do
+        require_relative "guest"
+        Guest
+      end
+
+      guest_capability(:minix, :change_host_name) do
+        require_relative "cap/change_host_name"
+        Cap::ChangeHostName
+      end
+
+      guest_capability(:minix, :rsync_install) do
+        require_relative "cap/rsync"
+        Cap::RSync
+      end
+
+      guest_capability(:minix, :rsync_command) do
+        require_relative "cap/rsync"
+        Cap::RSync
+      end
+    end
+  end
+end


### PR DESCRIPTION
I'd like to add shared folder support to my mcandre/minix box, so it would be cool if Vagrant supported MINIX guests and enabled rsync shared_folder support!

Here's the work in progress box on Vagrant Cloud for testing purposes:

https://app.vagrantup.com/mcandre/boxes/minix

Hopefully someone can figure out how to integrate the development version of Vagrant with this box, for example extending the box to enable a functioning shared folder setup using the rsync guest support in this PR. Unfortunately, I tried both writing this as a local vagrant plugin and as invoking a new Vagrant application built from this branch, but the development setups doesn't work too well on my machine, and the documentation was a bit sparse for how to set these up properly. If someone with more Vagrant knowledge could try out this guest code, that would be awesome!