### PR TITLE
Suggest being able to be a machine name from the file name too.

### DIFF
--- a/lib/vagrant/vagrantfile.rb
+++ b/lib/vagrant/vagrantfile.rb
@@ -42,6 +42,7 @@ module Vagrant
     # @return [Machine]
     def machine(name, provider, boxes, data_path, env)
       # Load the configuration for the machine
+      name = File.basename(name.to_s).delete(File.extname(name.to_s)).to_sym # Become a vmname if name from file path.
       results = machine_config(name, provider, boxes)
       box             = results[:box]
       config          = results[:config]
@@ -111,6 +112,7 @@ module Vagrant
     #   machine. See the main documentation body for more info.
     def machine_config(name, provider, boxes)
       keys = @keys.dup
+      name = File.basename(name.to_s).delete(File.extname(name.to_s)).to_sym # Become a vmname if name from file path.
 
       sub_machine = @config.vm.defined_vms[name]
       if !sub_machine

--- a/lib/vagrant/vagrantfile.rb
+++ b/lib/vagrant/vagrantfile.rb
@@ -42,7 +42,7 @@ module Vagrant
     # @return [Machine]
     def machine(name, provider, boxes, data_path, env)
       # Load the configuration for the machine
-      name = File.basename(name.to_s).delete(File.extname(name.to_s)).to_sym # Become a vmname if name from file path.
+      name = File.basename(name.to_s).sub(File.extname(name.to_s),'').to_sym # Become a vmname if name from file path.
       results = machine_config(name, provider, boxes)
       box             = results[:box]
       config          = results[:config]
@@ -112,7 +112,7 @@ module Vagrant
     #   machine. See the main documentation body for more info.
     def machine_config(name, provider, boxes)
       keys = @keys.dup
-      name = File.basename(name.to_s).delete(File.extname(name.to_s)).to_sym # Become a vmname if name from file path.
+      name = File.basename(name.to_s).sub(File.extname(name.to_s),'').to_sym # Become a vmname if name from file path.
 
       sub_machine = @config.vm.defined_vms[name]
       if !sub_machine

--- a/test/unit/vagrant/vagrantfile_test.rb
+++ b/test/unit/vagrant/vagrantfile_test.rb
@@ -401,4 +401,23 @@ describe Vagrant::Vagrantfile do
       expect(subject.primary_machine_name).to be_nil
     end
   end
+
+  describe "#machine_names_if_filename_and_path" do
+    it "returns the machine name single-VM by the file name" do
+      RSpec.describe [:foo] do
+        before do
+          ARGV.clear
+          ARGV.concat(['playbooks/foo.yaml'])
+          vm_name = File.basename(ARGV[1]).delete(File.extname(ARGV[1]))
+          expect { print 'foo' }.to output(vm_name).to_stdout
+
+          configure do |config|
+            config.vm.define vm_name
+          end
+
+          expect(subject.machine_names).to eq([:foo])
+        end
+      end
+    end
+  end
 end

--- a/test/unit/vagrant/vagrantfile_test.rb
+++ b/test/unit/vagrant/vagrantfile_test.rb
@@ -408,7 +408,7 @@ describe Vagrant::Vagrantfile do
         before do
           ARGV.clear
           ARGV.concat(['playbooks/foo.yaml'])
-          vm_name = File.basename(ARGV[1]).delete(File.extname(ARGV[1]))
+          vm_name = File.basename(ARGV[1]).sub(File.extname(ARGV[1]),'')
           expect { print 'foo' }.to output(vm_name).to_stdout
 
           configure do |config|


### PR DESCRIPTION
## TL;DR

- I want to be able to easily specify machine name etc. by loose argument.

## Description

- I'm a suggest to increase the degree of freedom so that the name of the machine can be obtained from the file name too.
- For instance, when reusing ansible playbook with one Vagrantfile, it is possible to specify it by tab completion (eg, bash_completion), so I think it will be easier to handle.

* Thing I want to do
     * I want to increase freedom of machine name and other specification by cmd argument
     * I want to make it executable by file specification
     * I want to be able to execute even Path specification
     * If the above is OK, designation becomes possible by tab completion, it will be easier
        - The expectation for higher reusability
* Do not do it.
     * Specify as an environment variable
        - It does not match the current specification of Vagrant, it becomes hard to handle because its method of usage greatly changes with other Vagrantfiles

### Example

#### Before

```
vagrant up foo
```
- playbooks/foo.yml execute.

```
vagrant up foo.yml
vagrant up playbooks/foo.yml
vagrant up playbooks/foo
```
- playbooks/foo.yml not execute.
   - The error is following
 　- `The machine with the name 'foo.yml' was not found configured for this Vagrant environment.`

#### After

- All succeeds.
- This commit is to solve this problem.

#### Details

- To Github comment
   - inb4 tl;dr