### PR TITLE
Fix #8620 by making cifs mount_option "sec=" configurable

### DIFF
--- a/plugins/guests/linux/cap/mount_smb_shared_folder.rb
+++ b/plugins/guests/linux/cap/mount_smb_shared_folder.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
           smb_password = options[:smb_password]
 
           options[:mount_options] ||= []
-          options[:mount_options] << "sec=ntlm"
+          options[:mount_options] << "sec=ntlm" unless options[:mount_options].grep(/^sec=/) || options.fetch(:nosec, false)
           options[:mount_options] << "credentials=/etc/smb_creds_#{name}"
 
           mount_options = "-o uid=#{mount_uid},gid=#{mount_gid}"


### PR DESCRIPTION
Recent Linux kernels require sec=ntlmssp or similar and don't work with sec=ntlm anymore.

This PR makes it easy to override the old behavior while retaining backward compatibility.

If a `sec=...` option is specified in the `mount_options`, then use that, otherwise fall back to the old behavior of hard-coding `sec=ntlm`

Example:
```
config.vm.synced_folder ".", "/vagrant", { mount_options: ["sec=ntlmssp"] } 
```

If a top-level option of 'nosec' is true then do not add the default `sec=ntlm`, allowing the guest's default to be used.
Example:
```
config.vm.synced_folder ".", "/vagrant", { nosec: true } 
```