### PR TITLE
Ansible Provisioner: Fix broken 'ask_sudo_pass' option

### DIFF
--- a/plugins/provisioners/ansible/config/host.rb
+++ b/plugins/provisioners/ansible/config/host.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
         #
         alias :ask_sudo_pass :ask_become_pass
         def ask_sudo_pass=(value)
-          show_deprecation_warning 'ask_sudo_pass', 'ask_become_pass'
+          show_deprecation_info 'ask_sudo_pass', 'ask_become_pass'
           @ask_become_pass = value
         end
 

--- a/test/unit/plugins/provisioners/ansible/config/host_test.rb
+++ b/test/unit/plugins/provisioners/ansible/config/host_test.rb
@@ -78,6 +78,7 @@ describe VagrantPlugins::Ansible::Config::Host, :skip_windows => true do
       allow($stdout).to receive(:puts)
     end
     it_behaves_like "any VagrantConfigProvisioner strict boolean attribute", :ask_sudo_pass, false
+    it_behaves_like "any deprecated option", :ask_sudo_pass, :ask_become_pass, true
   end
   describe "ask_vault_pass option" do
     it_behaves_like "any VagrantConfigProvisioner strict boolean attribute", :ask_vault_pass, false

--- a/test/unit/plugins/provisioners/ansible/config/shared.rb
+++ b/test/unit/plugins/provisioners/ansible/config/shared.rb
@@ -30,6 +30,17 @@ shared_examples_for 'options shared by both Ansible provisioners' do
 
 end
 
+shared_examples_for 'any deprecated option' do |deprecated_option, new_option, option_value|
+  it "shows the deprecation message" do
+    expect($stdout).to receive(:puts).with("DEPRECATION: The '#{deprecated_option}' option for the Ansible provisioner is deprecated.").and_return(nil)
+    expect($stdout).to receive(:puts).with("Please use the '#{new_option}' option instead.").and_return(nil)
+    expect($stdout).to receive(:puts).with("The '#{deprecated_option}' option will be removed in a future release of Vagrant.\n\n").and_return(nil)
+
+    subject.send("#{deprecated_option}=", option_value)
+    subject.finalize!
+  end
+end
+
 shared_examples_for 'an Ansible provisioner' do | path_prefix, ansible_setup |
 
   provisioner_label  = "ansible #{ansible_setup} provisioner"
@@ -158,6 +169,15 @@ shared_examples_for 'an Ansible provisioner' do | path_prefix, ansible_setup |
       allow($stdout).to receive(:puts)
     end
     it_behaves_like "any VagrantConfigProvisioner strict boolean attribute", :sudo, false
+    it_behaves_like "any deprecated option", :sudo, :become, true
+  end
+
+  describe "sudo_user option" do
+    before do
+      # Filter the deprecation notice
+      allow($stdout).to receive(:puts)
+    end
+    it_behaves_like "any deprecated option", :sudo_user, :become_user, "foo"
   end
 
 end


### PR DESCRIPTION
This bug is a regression introduced in Vagrant 2.0.0. It hasn't been caught by unit tests because
Vagrant::Plugin::V2::Config [catches all invalid/bad configuration calls](https://github.com/hashicorp/vagrant/blob/master/lib/vagrant/plugin/v2/config.rb#L70-L83)
and save them for generating error messages later.
The `ask_sudo_pass=(value)` method was therefore not interrupted when calling the undefined `show_deprecation_warning` method and the
`@ask_become_pass` attribute was (surprisingly) correctly set (allowing
the related unit tests to pass).

In order to avoid similar problem to happen again:
* the deprecation message output is now fully verified (e47deb7)
* we now ensure that the provisioner configurations used by the unit tests have no errors (8333090d1d24578bd33f4913f5ae2c0f8b2cf899)

Bug reported by @trombik (https://github.com/hashicorp/vagrant/commit/8834afbd8e6198b49b0a0ad2b3756c139a8d27b7#commitcomment-25424227)

Workaround: use the recommended `ask_become_pass` option instead.

Related Issues:
* GH-1484
* GH-8913