### PR TITLE
Fix #5203 - Add timestamp to log

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -41,6 +41,8 @@ if ENV["VAGRANT_LOG"] && ENV["VAGRANT_LOG"] != ""
     logger = Log4r::Logger.new("vagrant")
     logger.outputters = Log4r::Outputter.stderr
     logger.level = level
+    format = Log4r::PatternFormatter.new(:pattern => "%d [%5l] %m", :date_pattern => "%F %T.%L")
+    Log4r::Outputter.stderr.formatter = format
     logger = nil
   end
 end

--- a/lib/vagrant/ui.rb
+++ b/lib/vagrant/ui.rb
@@ -315,8 +315,9 @@ module Vagrant
 
         prefix = ""
         if !opts.key?(:prefix) || opts[:prefix]
-          prefix = OUTPUT_PREFIX
-          prefix = " " * OUTPUT_PREFIX.length if \
+          now = "#{Time.now.strftime('%F %T.%L')} "
+          prefix = now + OUTPUT_PREFIX
+          prefix = now + " " * OUTPUT_PREFIX.length if \
             type == :detail || type == :ask || opts[:prefix_spaces]
         end
 

--- a/test/unit/plugins/commands/snapshot/command/list_test.rb
+++ b/test/unit/plugins/commands/snapshot/command/list_test.rb
@@ -52,7 +52,7 @@ describe VagrantPlugins::CommandSnapshot::Command::List do
       it "prints a message if the vm does not exist" do
         machine.id = nil
 
-        expect(iso_env.ui).to receive(:info).with("==> default: VM not created. Moving on...", anything)
+        expect(iso_env.ui).to receive(:info).with(/==> default: VM not created. Moving on.../, anything)
           .and_return({})
         expect(machine).to_not receive(:action)
         expect(subject.execute).to eq(0)

--- a/test/unit/vagrant/ui_test.rb
+++ b/test/unit/vagrant/ui_test.rb
@@ -326,7 +326,7 @@ describe Vagrant::UI::Prefixed do
 
     it "prefixes every line" do
       expect(ui).to receive(:detail).with(
-        /    #{prefix}: foo\\n.*    #{prefix}: bar$/, bold: false, target: prefix)
+        /    #{prefix}: foo\n.*    #{prefix}: bar$/, bold: false, target: prefix)
       subject.detail("foo\nbar")
     end
 
@@ -367,7 +367,7 @@ describe Vagrant::UI::Prefixed do
     end
 
     it "prefixes every line" do
-      expect(ui).to receive(:output).with(/==> #{prefix}: foo\\n.*==> #{prefix}: bar$/, anything)
+      expect(ui).to receive(:output).with(/==> #{prefix}: foo\n.*==> #{prefix}: bar$/, anything)
       subject.output("foo\nbar")
     end
 

--- a/test/unit/vagrant/ui_test.rb
+++ b/test/unit/vagrant/ui_test.rb
@@ -313,20 +313,20 @@ describe Vagrant::UI::Prefixed do
 
   describe "#ask" do
     it "does not request bolding" do
-      expect(ui).to receive(:ask).with("    #{prefix}: foo", bold: false, target: prefix)
+      expect(ui).to receive(:ask).with(/    #{prefix}: foo$/, bold: false, target: prefix)
       subject.ask("foo")
     end
   end
 
   describe "#detail" do
     it "prefixes with spaces and the message" do
-      expect(ui).to receive(:safe_puts).with("    #{prefix}: foo", anything)
+      expect(ui).to receive(:safe_puts).with(/    #{prefix}: foo$/, anything)
       subject.detail("foo")
     end
 
     it "prefixes every line" do
       expect(ui).to receive(:detail).with(
-        "    #{prefix}: foo\n    #{prefix}: bar", bold: false, target: prefix)
+        /    #{prefix}: foo\\n.*    #{prefix}: bar$/, bold: false, target: prefix)
       subject.detail("foo\nbar")
     end
 
@@ -357,17 +357,17 @@ describe Vagrant::UI::Prefixed do
 
   describe "#output" do
     it "prefixes with an arrow and the message" do
-      expect(ui).to receive(:output).with("==> #{prefix}: foo", anything)
+      expect(ui).to receive(:output).with(/==> #{prefix}: foo$/, anything)
       subject.output("foo")
     end
 
     it "prefixes with spaces if requested" do
-      expect(ui).to receive(:output).with("    #{prefix}: foo", anything)
+      expect(ui).to receive(:output).with(/    #{prefix}: foo$/, anything)
       subject.output("foo", prefix_spaces: true)
     end
 
     it "prefixes every line" do
-      expect(ui).to receive(:output).with("==> #{prefix}: foo\n==> #{prefix}: bar", anything)
+      expect(ui).to receive(:output).with(/==> #{prefix}: foo\\n.*==> #{prefix}: bar$/, anything)
       subject.output("foo\nbar")
     end
 
@@ -377,18 +377,18 @@ describe Vagrant::UI::Prefixed do
     end
 
     it "requests bolding" do
-      expect(ui).to receive(:output).with("==> #{prefix}: foo", bold: true, target: prefix)
+      expect(ui).to receive(:output).with(/==> #{prefix}: foo$/, bold: true, target: prefix)
       subject.output("foo")
     end
 
     it "does not request bolding if class-level disabled" do
       ui.opts[:bold] = false
-      expect(ui).to receive(:output).with("==> #{prefix}: foo", target: prefix)
+      expect(ui).to receive(:output).with(/==> #{prefix}: foo$/, target: prefix)
       subject.output("foo")
     end
 
     it "prefixes with another prefix if requested" do
-      expect(ui).to receive(:output).with("==> bar: foo", anything)
+      expect(ui).to receive(:output).with(/==> bar: foo$/, anything)
       subject.output("foo", target: "bar")
     end
   end


### PR DESCRIPTION
Example of log:
```
...
2017-11-11 01:49:44.877 ==> default: Clearing any previously set forwarded ports...
2017-11-11 01:49:49.599 ==> default: Clearing any previously set network interfaces...
2017-11-11 01:49:49.823 ==> default: Preparing network interfaces based on configuration...
2017-11-11 01:49:49.825     default: Adapter 1: nat
2017-11-11 01:49:49.988 ==> default: Forwarding ports...
2017-11-11 01:49:50.156     default: 22 (guest) => 2222 (host) (adapter 1)
2017-11-11 01:49:50.649 ==> default: Running 'pre-boot' VM customizations...
2017-11-11 01:49:51.140 ==> default: Booting VM...
...
```

or with VAGRANT_LOG="DEBUG" :
```
2017-11-11 02:01:32.053 [ INFO] Vagrant version: 2.0.1
2017-11-11 02:01:32.054 [ INFO] Ruby version: 2.4.2
2017-11-11 02:01:32.054 [ INFO] RubyGems version: 2.6.13
2017-11-11 02:01:32.061 [ INFO] VAGRANT_COLOR="true"
2017-11-11 02:01:32.061 [ INFO] VAGRANT_EXECUTABLE="C:\\HashiCorp\\Vagrant\\embedded\\gems\\gems\\vagrant-2.0.1\\bin\\vagrant"
2017-11-11 02:01:32.062 [ INFO] VAGRANT_FORCE_COLOR="true"
2017-11-11 02:01:32.062 [ INFO] VAGRANT_INSTALLER_EMBEDDED_DIR="C:\\HashiCorp\\Vagrant\\embedded"
2017-11-11 02:01:32.062 [ INFO] VAGRANT_INSTALLER_ENV="1"
2017-11-11 02:01:32.063 [ INFO] VAGRANT_INSTALLER_VERSION="2"
2017-11-11 02:01:32.063 [ INFO] VAGRANT_LOG="DEBUG"
2017-11-11 02:01:32.064 [ INFO] VAGRANT_OLD_ENV_="ExitCode=00000002"
2017-11-11 02:01:32.064 [ INFO] VAGRANT_OLD_ENV_ALLUSERSPROFILE="C:\\ProgramData"
2017-11-11 02:01:32.064 [ INFO] VAGRANT_OLD_ENV_ANSICON="146x1000 (146x39)"
2017-11-11 02:01:32.064 [ INFO] VAGRANT_OLD_ENV_ANSICON_DEF="F"
...
2017-11-11 02:01:32.687 [ INFO] Plugins:
2017-11-11 02:01:32.688 [ INFO]   - vagrant-mutate = [installed: 1.2.0 constraint: > 0]
2017-11-11 02:01:32.688 [ INFO]   - vagrant-share = [installed: undefined constraint: > 0]
2017-11-11 02:01:32.689 [ INFO]   - vagrant-vbguest = [installed: 0.14.2 constraint: > 0]
2017-11-11 02:01:32.937 [DEBUG] Current generated plugin dependency list: [<Gem::Dependency type=:runtime name="vagrant-mutate" requirements="> 0">, <Gem::Dependency type=:runtime name="vagrant-share" requirements="> 0">, <Gem::Dependency type=:runtime name="vagrant-vbguest" requirements="> 0">]
2017-11-11 02:01:32.938 [DEBUG] Generating new builtin set instance.
2017-11-11 02:01:32.946 [DEBUG] Generating new plugin set instance. Skip gems - []
2017-11-11 02:01:32.974 [DEBUG] Activating solution set: ["vagrant-mutate-1.2.0", "ruby_dep-1.3.1", "erubis-2.7.0", "builder-3.2.3", "gyoku-1.3.1", "nori-2.6.0", "multi_json-1.12.2", "little-plugger-1.1.4", "logging-2.2.2", "rubyntlm-0.6.2", "httpclient-2.8.3", "ffi-1.9.18", "gssapi-1.2.0", "winrm-2.2.3", "rubyzip-1.2.1", "winrm-fs-1.1.0", "winrm-elevated-1.1.0", "wdm-0.1.1", "netrc-0.11.0", "mime-types-data-3.2016.0521", "mime-types-3.1", "unf_ext-0.0.7.4", "unf-0.1.4", "domain_name-0.5.20170404", "http-cookie-1.0.3", "rest-client-2.0.2", "rb-kqueue-0.2.5", "net-ssh-4.1.0", "net-scp-1.2.1", "net-sftp-2.1.2", "log4r-1.1.10", "hashicorp-checkpoint-0.1.4", "rb-inotify-0.9.10", "rb-fsevent-0.10.2", "listen-3.1.5", "i18n-0.8.0", "childprocess-0.6.3", "vagrant-2.0.1", "vagrant-share-1.1.9", "micromachine-2.0.0", "vagrant-vbguest-0.15.0"]
2017-11-11 02:01:32.975 [DEBUG] Activating gem vagrant-mutate-1.2.0
2017-11-11 02:01:32.976 [DEBUG] Activating gem vagrant-share-1.1.9
2017-11-11 02:01:32.976 [DEBUG] Activating gem micromachine-2.0.0
...
2017-11-11 02:01:37.703 ==> default: Checking if box '...' is up to date...
```