### PR TITLE
Update vagrant-spec to include Windows platforms and updated linux boxes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ boxes/*
 /website/.vagrant
 /website/build
 /vagrant-spec.config.rb
+test/vagrant-spec/.vagrant/
 
 # Bundler/Rubygems
 *.gem

--- a/test/vagrant-spec/Vagrantfile.spec
+++ b/test/vagrant-spec/Vagrantfile.spec
@@ -1,15 +1,15 @@
 # Guest boxes to use for vagrant-spec
 GUEST_BOXES = {
-  'spox/ubuntu-16.04' => '0.0.1',
-  'spox/centos-7' => '0.0.1',
+  'hashicorp-vagrant/ubuntu-16.04' => '1.0.0',
+  'hashicorp-vagrant/centos-7.4' => '1.0.0',
   'spox/windows-10' => '0.0.1',
   'spox/osx-10.12' => '0.0.1'
 }
 
 # Host boxes to run vagrant-spec
 HOST_BOXES = {
-  'spox/ubuntu-16.04' => '0.0.1',
-  'spox/centos-7' => '0.0.1',
+  'hashicorp-vagrant/ubuntu-16.04' => '1.0.0',
+  'hashicorp-vagrant/centos-7.4' => '1.0.0',
   'spox/windows-10' => '0.0.1',
   'spox/osx-10.12' => '0.0.1'
 }

--- a/test/vagrant-spec/Vagrantfile.spec
+++ b/test/vagrant-spec/Vagrantfile.spec
@@ -2,7 +2,7 @@
 GUEST_BOXES = {
   'hashicorp-vagrant/ubuntu-16.04' => '1.0.0',
   'hashicorp-vagrant/centos-7.4' => '1.0.0',
-  'spox/windows-10' => '0.0.1',
+  'hashicorp-vagrant/windows-10' => '1.0.0',
   'spox/osx-10.12' => '0.0.1'
 }
 
@@ -10,7 +10,7 @@ GUEST_BOXES = {
 HOST_BOXES = {
   'hashicorp-vagrant/ubuntu-16.04' => '1.0.0',
   'hashicorp-vagrant/centos-7.4' => '1.0.0',
-  'spox/windows-10' => '0.0.1',
+  'hashicorp-vagrant/windows-10' => '1.0.0',
   'spox/osx-10.12' => '0.0.1'
 }
 
@@ -23,6 +23,9 @@ enabled_hosts = ENV["VAGRANT_HOST_BOXES"] ? ENV["VAGRANT_HOST_BOXES"].split(",")
 guest_boxes = Hash[GUEST_BOXES.find_all{|name, version| enabled_guests.include?(name)}.compact]
 host_boxes = Hash[HOST_BOXES.find_all{|name, version| enabled_hosts.include?(name)}.compact]
 
+# Grab vagrantcloud token, if available
+vagrantcloud_token = ENV["VAGRANT_CLOUD_TOKEN"]
+
 # Download copies of the guest boxes for testing if missing
 enabled_providers.each do |provider_name|
   guest_boxes.each do |guest_box, box_version|
@@ -30,7 +33,11 @@ enabled_providers.each do |provider_name|
     box_path = File.join(File.dirname(__FILE__), "./boxes/#{guest_box.sub('/', '_')}.#{provider_name}.#{box_version}.box")
     if !File.exist?(box_path)
       $stderr.puts "Downloading guest box #{guest_box}"
-      result = system("curl -Lf -o #{box_path} \"https://atlas.hashicorp.com/#{box_owner}/boxes/#{box_name}/versions/#{box_version}/providers/#{provider_name}.box\"")
+      cmd = "curl -Lf -o #{box_path} https://app.vagrantup.com/#{box_owner}/boxes/#{box_name}/versions/#{box_version}/providers/#{provider_name}.box"
+      if vagrantcloud_token
+        cmd += "?access_token=#{vagrantcloud_token}"
+      end
+      result = system(cmd)
       if !result
         $stderr.puts
         $stderr.puts "ERROR: Failed to download guest box #{guest_box} for #{provider_name}!"
@@ -50,27 +57,45 @@ Vagrant.configure(2) do |global_config|
         config.vm.box_version = box_version
         config.vm.synced_folder '.', '/vagrant', disable: true
         config.vm.synced_folder '../../', '/vagrant'
-        config.vm.provider :vmware_workstation do |vmware|
-          vmware.vmx["memsize"] = ENV.fetch("VAGRANT_HOST_MEMORY", "2048")
-          vmware.vmx['vhv.enable'] = 'TRUE'
-          vmware.vmx['vhv.allow'] = 'TRUE'
+        [:vmware_workstation, :vmware_fusion].each do |vmware_provider|
+          config.vm.provider vmware_provider do |vmware|
+            vmware.vmx["memsize"] = ENV.fetch("VAGRANT_HOST_MEMORY", "2048")
+            vmware.vmx['vhv.enable'] = 'TRUE'
+            vmware.vmx['vhv.allow'] = 'TRUE'
+          end
         end
-        config.vm.provision :shell, path: "./scripts/#{platform}-setup.#{provider_name}.sh", run: "once"
+        if platform == "windows"
+          config.vm.provision :shell, path: "./scripts/#{platform}-setup.#{provider_name}.ps1", run: "once"
+        else
+          config.vm.provision :shell, path: "./scripts/#{platform}-setup.#{provider_name}.sh", run: "once"
+        end
         guest_boxes.each_with_index do |box_info, idx|
           guest_box, box_version = box_info
           spec_cmd_args = ENV["VAGRANT_SPEC_ARGS"]
           if idx != 0
             spec_cmd_args = "#{spec_cmd_args} --without-component cli/*".strip
           end
-          config.vm.provision(
-            :shell,
-            path: "./scripts/#{platform}-run.#{provider_name}.sh",
-            keep_color: true,
-            env: {
-              "VAGRANT_SPEC_ARGS" => "--no-builtin #{spec_cmd_args}".strip,
-              "VAGRANT_SPEC_BOX" => "/vagrant/test/vagrant-spec/boxes/#{guest_box.sub('/', '_')}.#{provider_name}.#{box_version}.box"
-            }
-          )
+          if platform == "windows"
+            config.vm.provision(
+              :shell,
+              path: "./scripts/#{platform}-run.#{provider_name}.ps1",
+              keep_color: true,
+              env: {
+                "VAGRANT_SPEC_ARGS" => "--no-builtin #{spec_cmd_args}".strip,
+                "VAGRANT_SPEC_BOX" => "c:/vagrant/#{guest_box.sub('/', '_')}.#{provider_name}.#{box_version}.box"
+              }
+            )
+          else
+            config.vm.provision(
+              :shell,
+              path: "./scripts/#{platform}-run.#{provider_name}.sh",
+              keep_color: true,
+              env: {
+                "VAGRANT_SPEC_ARGS" => "--no-builtin #{spec_cmd_args}".strip,
+                "VAGRANT_SPEC_BOX" => "/vagrant/test/vagrant-spec/boxes/#{guest_box.sub('/', '_')}.#{provider_name}.#{box_version}.box"
+              }
+            )
+          end
         end
       end
     end

--- a/test/vagrant-spec/readme.md
+++ b/test/vagrant-spec/readme.md
@@ -1,0 +1,48 @@
+# Running vagrant-spec
+
+## Requirements
+
+- vagrant installed (from source, or from packages)
+- vagrant vmware plugin
+- ![vagrant](https://github.com/hashicorp/vagrant) repo
+- ![vagrant-spec](https://github.com/hashicorp/vagrant-spec) repo
+
+## How to run
+
+First, we need to build vagrant-spec:
+
+```
+cd vagrant-spec
+gem build *.gemspec
+cp vagrant-spec-0.0.1.gem /path/to/vagrant/vagrant-spec.gem
+```
+
+Next, make a decision as to which host and guest boxes will be used to run the tests.
+
+From the root dir of the `vagrant` project, run the following command:
+
+```shell
+VAGRANT_CLOUD_TOKEN=REAL_TOKEN_HERE VAGRANT_HOST_BOXES=hashicorp-vagrant/centos-7.4 VAGRANT_GUEST_BOXES=hashicorp-vagrant/windows-10 VAGRANT_CWD=test/vagrant-spec/ VAGRANT_VAGRANTFILE=Vagrantfile.spec vagrant up
+```
+
+If you are running windows, you must give your host box more memory than the default. That can be done through the environment variable `VAGRANT_HOST_MEMORY`
+
+```shell
+VAGRANT_HOST_MEMORY=10000 VAGRANT_CLOUD_TOKEN=REAL_TOKEN_HERE VAGRANT_HOST_BOXES=hashicorp-vagrant/centos-7.4 VAGRANT_GUEST_BOXES=hashicorp-vagrant/windows-10 VAGRANT_CWD=test/vagrant-spec/ VAGRANT_VAGRANTFILE=Vagrantfile.spec vagrant up
+```
+
+
+## Relevant environment variables:
+
+- VAGRANT_CLOUD_TOKEN
+  + Token to use if fetching a private box (like windows)
+- VAGRANT_HOST_BOXES
+  - Vagrant box to use to host and run tests
+- VAGRANT_GUEST_BOXES
+  - Vagrant box to use to run tests on
+- VAGRANT_CWD
+  - Directory location of vagrant-spec Vagrantfile
+- VAGRANT_VAGRANTFILE
+  - Vagrantfile to use for running vagrant-spec
+- VAGRANT_HOST_MEMORY
+  - Set how much memory your host will use (defaults to 2048)

--- a/test/vagrant-spec/scripts/ubuntu-setup.virtualbox.sh
+++ b/test/vagrant-spec/scripts/ubuntu-setup.virtualbox.sh
@@ -2,6 +2,7 @@
 set -xe
 
 apt-get update -q
+apt-get install -qy linux-headers-$(uname -r)
 apt-get install -qy virtualbox
 
 pushd /vagrant

--- a/test/vagrant-spec/scripts/windows-run.virtualbox.ps1
+++ b/test/vagrant-spec/scripts/windows-run.virtualbox.ps1
@@ -1,0 +1,4 @@
+cd /vagrant
+vagrant plugin install ./vagrant-spec.gem
+
+vagrant vagrant-spec $Env:VAGRANT_SPEC_ARGS /vagrant/test/vagrant-spec/configs/vagrant-spec.config.virtualbox.rb

--- a/test/vagrant-spec/scripts/windows-setup.virtualbox.ps1
+++ b/test/vagrant-spec/scripts/windows-setup.virtualbox.ps1
@@ -1,0 +1,69 @@
+Write-Output "Downloading virtualbox guest additions"
+$vboxadd_url = "http://download.virtualbox.org/virtualbox/5.2.2/VBoxGuestAdditions_5.2.2.iso"
+$vboxadd_output = "C:/Windows/Temp/vboxguestadditions.iso"
+
+(New-Object System.Net.WebClient).DownloadFile($vboxadd_url, $vboxadd_output)
+
+Write-Output "Mounting virtualbox guest additions"
+Mount-DiskImage -ImagePath $vboxadd_output
+
+Write-Output "Installing Virtualbox Guest Additions"
+Write-Output "Checking for Certificates in vBox ISO"
+if(test-path E:\ -Filter *.cer)
+{
+  Get-ChildItem E:\cert -Filter *.cer | ForEach-Object { certutil -addstore -f "TrustedPublisher" $_.FullName }
+}
+Start-Process -FilePath "E:\VBoxWindowsAdditions.exe" -ArgumentList "/S" -Wait
+
+Write-Output "Downloading virtualbox"
+$vbox_url = "http://download.virtualbox.org/virtualbox/5.2.2/VirtualBox-5.2.2-119230-Win.exe"
+$vbox_output = "C:/Windows/Temp/virtualbox.exe"
+
+(New-Object System.Net.WebClient).DownloadFile($vbox_url, $vbox_output)
+
+Write-Output "Installing virtualbox"
+# Extract the contents of the installer
+Start-Process -FilePath $vbox_output `
+    -ArgumentList ('--extract','--silent','--path','C:\Windows\Temp') `
+    -Wait `
+    -NoNewWindow
+
+# Find the installer
+# Determine if this is a 64-bit or 32-bit CPU
+$architecture="x86"
+if ((Get-WmiObject -Class Win32_OperatingSystem).OSArchitecture -eq "64-bit") {
+    $architecture = "amd64"
+}
+
+cd "C:\Windows\Temp"
+
+$matches = Get-ChildItem | Where-Object { $_.Name -match "VirtualBox-.*_$($architecture).msi" }
+if ($matches.Count -ne 1) {
+   Write-Host "Multiple matches for VirtualBox MSI found: $($matches.Count)"
+   exit 1
+}
+$installerPath = Resolve-Path $matches[0]
+
+# Run the installer
+Start-Process -FilePath "$($env:systemroot)\System32\msiexec.exe" `
+    -ArgumentList "/i `"$installerPath`" /qn /norestart /l*v `"$($pwd)\vbox_install.log`"" `
+    -Verb RunAs `
+    -Wait `
+    -WorkingDirectory "$pwd"
+
+cd "C:\vagrant\pkg\dist"
+$vagrant_matches = Get-ChildItem | Where-Object { $_.Name -match "vagrant.*_x86_64.msi" }
+if ($vagrant_matches.Count -ne 1) {
+   Write-Host "Could not find vagrant installer"
+   exit 1
+}
+$vagrant_installerPath = Resolve-Path $vagrant_matches[0]
+
+Write-Output $vagrant_installerPath
+
+Write-Output "Installing vagrant"
+Start-Process -FilePath "$($env:systemroot)\System32\msiexec.exe" `
+    -ArgumentList "/i `"$vagrant_installerPath`" /qn /norestart /l*v `"$($pwd)\vagrant_install.log`"" `
+    -Verb RunAs `
+    -Wait `
+    -WorkingDirectory "$pwd"


### PR DESCRIPTION
This PR updates vagrant-spec to run with windows platforms and updated linux boxes. It also
adds a readme to give more information on how to run the vagrant-spec
suite.

### Todo

- [x] Add setup and run scripts for Windows host
- [x] Properly curl down vagrant boxes from host runner
- [x] Clean up how spec tests select a vagrant package to install on windows