### PR TITLE
dragonflybsd: extend FreeBSD

### DIFF
--- a/plugins/guests/dragonflybsd/plugin.rb
+++ b/plugins/guests/dragonflybsd/plugin.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
       name "DragonFly BSD guest"
       description "DragonFly BSD guest support."
 
-      guest(:dragonflybsd, :bsd) do
+      guest(:dragonflybsd, :freebsd) do
         require_relative "guest"
         Guest
       end


### PR DESCRIPTION
Reuse FreeBSD guest code for installing rsync, etc., as dragonfly- and freebsd are very similar, especially with regard to package management.