### PR TITLE
synced_folders/rsync: Use "staff" as a default group name on Darwin

### DIFF
--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -62,7 +62,7 @@ module VagrantPlugins
 
         # Folder options
         opts[:owner] ||= ssh_info[:username]
-        opts[:group] ||= ssh_info[:username]
+        opts[:group] ||= Vagrant::Util::Platform.darwin? ? "staff" : ssh_info[:username]
 
         # set log level
         log_level = ssh_info[:log_level] || "FATAL"


### PR DESCRIPTION
By default, on macOS (and OS X) boxes for Vagrant don't have "vagrant" group existing. 
We should use "staff" as a default group name while doing `chown`.

This PR fixes the problem with rsync on macOS guests. Reproduction scenario:

```ruby
# Vagrantfile

config.vm.provider "virtualbox" do |_, override|
  override.vm.synced_folder ".", "/vagrant", type: "rsync"
end
```

```
$ vagrant up --provider=virtualbox
<...>
==> default: Machine booted and ready!
==> default: Checking for guest additions in VM...
    default: No guest additions were detected on the base box for this VM! Guest
    default: additions are required for forwarded ports, shared folders, host only
    default: networking, and more. If SSH fails on this machine, please install
    default: the guest additions and repackage the box to continue.
    default:
    default: This is not an error message; everything may continue to work properly,
    default: in which case you may ignore this message.
==> default: Rsyncing folder: /Users/legal/Workspace/vagrant-test-macos/ => /vagrant
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

find /vagrant '!' -type l -a '(' ! -user vagrant -or ! -group vagrant ')' -exec chown vagrant:vagrant '{}' +

Stdout from the command:



Stderr from the command:

find: -group: vagrant: no such group
```