### PR TITLE
website: Fix Vagrant Cloud API examples

### DIFF
--- a/website/source/docs/vagrant-cloud/api.html.md.erb
+++ b/website/source/docs/vagrant-cloud/api.html.md.erb
@@ -13,9 +13,9 @@ sidebar_current: "vagrant-cloud-api"
       $(".examples pre.highlight." + language).show();
     }
 
-    $(document).ready(function() {
-      setExampleLanguage("shell"); }
-    );
+    $(document).on('ready turbolinks:load', function() {
+      setExampleLanguage("shell");
+    });
   </script>
 
   <style>


### PR DESCRIPTION
When using Turbolinks to navigate between docs pages, the document ready event never fired and all language examples were shown. This should fix the issue without needed a refresh/example menu click.