### PR TITLE
Exit 0 if vagrant destroy finds no running vms

### DIFF
--- a/plugins/commands/destroy/command.rb
+++ b/plugins/commands/destroy/command.rb
@@ -60,6 +60,10 @@ module VagrantPlugins
         # Nothing was declined
         return 0 if declined == 0
 
+        # Everything was declined, and all states are `not_created`
+        return 0 if declined == machines.length &&
+                    declined == init_states.values.count(:not_created)
+
         # Everything was declined, state was not changed
         return 1 if declined == machines.length
 

--- a/test/unit/plugins/commands/destroy/command_test.rb
+++ b/test/unit/plugins/commands/destroy/command_test.rb
@@ -51,6 +51,14 @@ describe VagrantPlugins::CommandDestroy::Command do
       expect(subject.execute).to eq(0)
     end
 
+    it "exits 0 if vms are not created" do
+      allow_any_instance_of(Vagrant::BatchAction).to receive(:action) .with(machine, :destroy, anything)
+      allow(machine.state).to receive(:id).and_return(:not_created)
+
+      expect(machine.state).to receive(:id).and_return(:not_created)
+      expect(subject.execute).to eq(0)
+    end
+
     it "exits 1 if a vms destroy was declined" do
       allow_any_instance_of(Vagrant::BatchAction).to receive(:action) .with(machine, :destroy, anything)
 


### PR DESCRIPTION
This commit reverts the behavior of `vagrant destroy` to exit 0 if no
running vms were found when the destroy command is run.

Fixes #9137