### PR TITLE
Print more helpful error message for NameEror exceptions

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -780,6 +780,10 @@ module Vagrant
       error_key(:vagrantfile_load_error)
     end
 
+    class VagrantfileNameError < VagrantError
+      error_key(:vagrantfile_name_error)
+    end
+
     class VagrantfileSyntaxError < VagrantError
       error_key(:vagrantfile_syntax_error)
     end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1374,6 +1374,14 @@ en:
         Path: %{path}
         Line number: %{line}
         Message: %{exception_class}: %{message}
+      vagrantfile_name_error: |-
+        There was an error loading a Vagrantfile. The file being loaded
+        and the error message are shown below. This is usually caused by
+        an invalid or undefined variable.
+
+        Path: %{path}
+        Line number: %{line}
+        Message: %{message}
       vagrantfile_syntax_error: |-
         There is a syntax error in the following Vagrantfile. The syntax error
         message is reproduced below for convenience:

--- a/test/unit/vagrant/config/loader_test.rb
+++ b/test/unit/vagrant/config/loader_test.rb
@@ -87,6 +87,20 @@ describe Vagrant::Config::Loader do
       expect(warnings).to eq([])
       expect(errors).to eq([])
     end
+
+    it "should throw a NameError exception if invalid or undefined variable is used" do
+      vagrantfile = <<-VF
+      Vagrant.configure("2") do |config|
+        config.ssh.port = variable
+      end
+      VF
+
+      instance.set(:foo, temporary_file(vagrantfile))
+
+      expect {
+        instance.load([:foo])
+      }.to raise_error(Vagrant::Errors::VagrantfileNameError, /invalid or undefined variable/)
+    end
   end
 
   describe "finalization" do


### PR DESCRIPTION
This commit adds some additional handling for when Vagrant loads config
files. Instead of showing the basic ruby exception, it prints a more
helpful error message and tries to direct the user to the line number
and file where the exception is occuring.

Fixes #9055

Example:

```
brian@localghost:vagrant-sandbox % vagrant validate
There was an error loading a Vagrantfile. The file being loaded
and the error message are shown below. This is usually caused by
an invalid or undefined variable.

Path: /Users/brian/code/vagrant-sandbox/Vagrantfile
Line number: 14
Message: undefined local variable or method `vagrant'
```