### PR TITLE
Check SMB credentials before using them

### DIFF
--- a/plugins/synced_folders/smb/scripts/check_credentials.ps1
+++ b/plugins/synced_folders/smb/scripts/check_credentials.ps1
@@ -1,0 +1,19 @@
+Param(
+    [Parameter(Mandatory=$true)]
+    [string]$username,
+    [Parameter(Mandatory=$true)]
+    [string]$password
+)
+
+Add-Type -AssemblyName System.DirectoryServices.AccountManagement
+
+$DSContext = New-Object System.DirectoryServices.AccountManagement.PrincipalContext(
+    [System.DirectoryServices.AccountManagement.ContextType]::Machine,
+    $env:COMPUTERNAME
+)
+
+if ( $DSContext.ValidateCredentials( $username, $password ) ) {
+    exit 0
+} else {
+    exit 1
+}

--- a/templates/locales/synced_folder_smb.yml
+++ b/templates/locales/synced_folder_smb.yml
@@ -10,6 +10,8 @@ en:
       You will be asked for the username and password to use for the SMB
       folders shortly. Please use the proper username/password of your
       Windows account.
+    incorrect_credentials: |-
+      Credentials incorrect. Please try again.
 
     errors:
       define_share_failed: |-


### PR DESCRIPTION
Check that the provided username/password are valid before using them to set up SMB shares.

This helps avoid having to reboot the VM just because the user messed up a password.