### PR TITLE
Atomically apply new hostname.if(5)

### DIFF
--- a/plugins/guests/openbsd/cap/configure_networks.rb
+++ b/plugins/guests/openbsd/cap/configure_networks.rb
@@ -36,15 +36,8 @@ module VagrantPlugins
 
             machine.communicate.sudo("mv /tmp/vagrant-network-entry /etc/hostname.#{ifname}")
 
-            # remove old configurations
-            machine.communicate.sudo("sudo ifconfig #{ifname} inet delete", { error_check: false })
-            machine.communicate.sudo("pkill -f 'dhclient: #{ifname}'", { error_check: false })
-
-            if network[:type].to_sym == :static
-              machine.communicate.sudo("ifconfig #{ifname} inet #{network[:ip]} netmask #{network[:netmask]}")
-            elsif network[:type].to_sym == :dhcp
-              machine.communicate.sudo("dhclient #{ifname}")
-            end
+            # apply new configurations
+            machine.communicate.sudo("sh /etc/netstart #{ifname}")
           end
         end
       end


### PR DESCRIPTION
This fixes an issue when the interface being configured is the
interface through which ssh traffic is forwarded.

In a complex scenario, one needs to disable the default interface for
NAT, and use other interface for ssh. In this case, when vagrant run
`ifconfig #{ifname} inet delete`, the second ifconfig that is supposed
to restore interface settings will never be called. This might be a rare
need, but it is also strongly recommended to use `netstart` when
reconfiguring interfaces after updating `hostname.if(5)`.

The issue can be triggered when ssh connection has issues between two
`ifconfig` commands.