### PR TITLE
Provide optional timestamp on log output

### DIFF
--- a/bin/vagrant
+++ b/bin/vagrant
@@ -52,6 +52,19 @@ if argv.include?("--debug")
   ENV["VAGRANT_LOG"] = "debug"
 end
 
+# Enable log timestamps if requested
+if argv.include?("--timestamp")
+  argv.delete("--timestamp")
+  ENV["VAGRANT_LOG_TIMESTAMP"] = "1"
+end
+
+# Convenience flag to enable debug with timestamps
+if argv.include?("--debug-timestamp")
+  argv.delete("--debug-timestamp")
+  ENV["VAGRANT_LOG"] = "debug"
+  ENV["VAGRANT_LOG_TIMESTAMP"] = "1"
+end
+
 # Stdout/stderr should not buffer output
 $stdout.sync = true
 $stderr.sync = true

--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -41,6 +41,12 @@ if ENV["VAGRANT_LOG"] && ENV["VAGRANT_LOG"] != ""
     logger = Log4r::Logger.new("vagrant")
     logger.outputters = Log4r::Outputter.stderr
     logger.level = level
+    if ENV["VAGRANT_LOG_TIMESTAMP"]
+      Log4r::Outputter.stderr.formatter = Log4r::PatternFormatter.new(
+        pattern: "%d [%5l] %m",
+        date_pattern: "%F %T"
+      )
+    end
     logger = nil
   end
 end


### PR DESCRIPTION
Enable log message output to be prefixed with the date and time.
Include CLI flag to optionally enable `--timestamp` and a
convenience flag to enable debug logging with timestamps at
the same time `--debug-timestamp`.