### PR TITLE
Add a clean error message for invalid IP addresses

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -448,6 +448,10 @@ module Vagrant
       error_key(:collides, "vagrant.actions.vm.host_only_network")
     end
 
+    class NetworkAddressInvalid < VagrantError
+      error_key(:network_address_invalid)
+    end
+
     class NetworkDHCPAlreadyAttached < VagrantError
       error_key(:dhcp_already_attached, "vagrant.actions.vm.network")
     end

--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -1,4 +1,5 @@
 require "ipaddr"
+require "resolv"
 require "set"
 
 require "log4r"
@@ -258,7 +259,12 @@ module VagrantPlugins
           # Default IP is in the 20-bit private network block for DHCP based networks
           options[:ip] = "172.28.128.1" if options[:type] == :dhcp && !options[:ip]
 
-          ip = IPAddr.new(options[:ip])
+          begin
+            ip = IPAddr.new(options[:ip])
+          rescue IPAddr::InvalidAddressError => e
+            raise Vagrant::Errors::NetworkAddressInvalid, :ip => options[:ip], :error_msg => e.message
+          end
+
           if ip.ipv4?
             options[:netmask] ||= "255.255.255.0"
 

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -891,6 +891,11 @@ en:
         %{message}
       network_type_not_supported: |-
         The %{type} network type is not supported for this box or guest.
+      network_address_invalid: |-
+        The IP address '%{ip}' is not valid. Please review the error message
+        below to help resolve the issue:
+
+          %{error_msg}
       network_manager_not_installed: |-
         Vagrant was instructed to configure the %{device} network device to
         be managed by NetworkManager. However, the configured guest VM does

--- a/test/unit/plugins/providers/virtualbox/action/network_test.rb
+++ b/test/unit/plugins/providers/virtualbox/action/network_test.rb
@@ -70,6 +70,20 @@ describe VagrantPlugins::ProviderVirtualBox::Action::Network do
     }])
   end
 
+  it "raises the appropriate error when provided with an invalid IP address" do
+    guest = double("guest")
+    machine.config.vm.network 'private_network', { ip: '192.168.33.06' }
+
+    expect{ subject.call(env) }.to raise_error(Vagrant::Errors::NetworkAddressInvalid)
+  end
+
+  it "raises no invalid network error when provided with a valid IP address" do
+    guest = double("guest")
+    machine.config.vm.network 'private_network', { ip: '192.168.33.6' }
+
+    expect{ subject.call(env) }.not_to raise_error(Vagrant::Errors::NetworkAddressInvalid)
+  end
+
   context "with a dhcp private network" do
     let(:bridgedifs)  { [] }
     let(:hostonlyifs) { [] }


### PR DESCRIPTION
This PR addresses issue #9166 by throwing a user-friendly error message whenever an invalid address error is thrown by `IPAddr`. Given the following Vagrantfile:

```ruby
Vagrant.configure(2) do |config|
  config.vm.box = "ubuntu/trusty64"
  config.vm.network "private_network", ip: "192.168.33.06"
end
```

Instead of a stack trace that can be difficult to read for newer developers, the following error will be thrown:

![screenshot 2017-12-14 14 56 30](https://user-images.githubusercontent.com/920019/34016631-e171795c-e0df-11e7-9600-b174f760c5ce.png)