### PR TITLE
recognize solaris alternatives

### DIFF
--- a/plugins/guests/solaris11/guest.rb
+++ b/plugins/guests/solaris11/guest.rb
@@ -8,7 +8,7 @@ module VagrantPlugins
   module GuestSolaris11
     class Guest < Vagrant.plugin("2", :guest)
       def detect?(machine)
-        machine.communicate.test("uname -sr | grep 'SunOS 5.11'")
+        machine.communicate.test("uname -sr | grep 'SunOS.*5\\.11'")
       end
     end
   end


### PR DESCRIPTION
As the Solaris project is dead, recognize that Solaris alternatives like DilOS and SmartOS feature a Solaris compatible kernel and capabilities.