### PR TITLE
Fixed hostonly matching not respecting :name argument

### DIFF
--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -479,6 +479,11 @@ module VagrantPlugins
           @env[:machine].provider.driver.read_host_only_interfaces.each do |interface|
             return interface if config[:name] && config[:name] == interface[:name]
 
+            #if a config name is specified, we should only look for that.
+            if config[:name] != ""
+                next
+            end
+
             if interface[:ip] != ""
               return interface if this_netaddr == \
                 network_address(interface[:ip], interface[:netmask])


### PR DESCRIPTION
This will fix issue #9301 

hostonly_find_matching_network should respect, that if a name is given, it should only base matching on that name, and not the IP etc.