### PR TITLE
Modify the matching pattern of guest os for amazon linux

### DIFF
--- a/plugins/guests/amazon/guest.rb
+++ b/plugins/guests/amazon/guest.rb
@@ -2,7 +2,7 @@ module VagrantPlugins
   module GuestAmazon
     class Guest < Vagrant.plugin("2", :guest)
       def detect?(machine)
-        machine.communicate.test("grep 'Amazon Linux AMI' /etc/os-release")
+        machine.communicate.test("grep 'Amazon Linux' /etc/os-release")
       end
     end
   end


### PR DESCRIPTION
When we use amazon linux 2 virtual box image, we can't detect guest operating system
So, change the matching pattern to search guest operating system for amazon linux

Issue #9306 

Amazon Linux
```
$ cat /etc/os-release
NAME="Amazon Linux AMI"
VERSION="2017.03"
ID="amzn"
ID_LIKE="rhel fedora"
VERSION_ID="2017.03"
PRETTY_NAME="Amazon Linux AMI 2017.03"
ANSI_COLOR="0;33"
CPE_NAME="cpe:/o:amazon:linux:2017.03:ga"
HOME_URL="http://aws.amazon.com/amazon-linux-ami/"
```

Amazon Linux 2 
```
$ cat /etc/os-release
NAME="Amazon Linux"
VERSION="2.0 (2017.12)"
ID="amzn"
ID_LIKE="centos rhel fedora"
VERSION_ID="2.0"
PRETTY_NAME="Amazon Linux 2.0 (2017.12) LTS Release Candidate"
ANSI_COLOR="0;33"
CPE_NAME="cpe:2.3:o:amazon:amazon_linux:2.0"
HOME_URL="https://amazonlinux.com/"
```