### PR TITLE
ifconfig is replaced by ip command suite. So use "ip addr" and failback

### DIFF
--- a/plugins/guests/linux/cap/read_ip_address.rb
+++ b/plugins/guests/linux/cap/read_ip_address.rb
@@ -3,9 +3,17 @@ module VagrantPlugins
     module Cap
       class ReadIPAddress
         def self.read_ip_address(machine)
-          command = "LANG=en ifconfig  | grep 'inet addr:'| grep -v '127.0.0.1' | cut -d: -f2 | awk '{ print $1 }'"
+
+          comm = machine.communicate
+
+          if comm.test("test -f /sbin/ip")
+            command = "LANG=en ip addr  | grep -Po 'inet \\K[\\d.]+' | grep -v 127.0.0.1"
+          else
+            command = "LANG=en ifconfig  | grep 'inet addr:'| grep -v '127.0.0.1' | cut -d: -f2 | awk '{ print $1 }'"
+          end
+
           result  = ""
-          machine.communicate.sudo(command) do |type, data|
+          comm.sudo(command) do |type, data|
             result << data if type == :stdout
           end
 

--- a/plugins/guests/linux/cap/read_ip_address.rb
+++ b/plugins/guests/linux/cap/read_ip_address.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
 
           comm = machine.communicate
 
-          if comm.test("test -f /sbin/ip")
+          if comm.test("which ip")
             command = "LANG=en ip addr  | grep -Po 'inet \\K[\\d.]+' | grep -v 127.0.0.1"
           else
             command = "LANG=en ifconfig  | grep 'inet addr:'| grep -v '127.0.0.1' | cut -d: -f2 | awk '{ print $1 }'"


### PR DESCRIPTION
So use "ip addr" and fallback to ifconfig. This function fails in the Debian stretch images where ifconfig command is not installed