### PR TITLE
Deprecate :paranoid in favor of :verify_host_key

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -438,7 +438,7 @@ module Vagrant
       info[:port] ||= @config.ssh.default.port
       info[:private_key_path] ||= @config.ssh.default.private_key_path
       info[:keys_only] ||= @config.ssh.default.keys_only
-      info[:paranoid] ||= @config.ssh.default.paranoid
+      info[:verify_host_key] ||= @config.ssh.default.verify_host_key
       info[:username] ||= @config.ssh.default.username
       info[:compression] ||= @config.ssh.default.compression
       info[:dsa_authentication] ||= @config.ssh.default.dsa_authentication
@@ -449,7 +449,7 @@ module Vagrant
       info[:host] = @config.ssh.host if @config.ssh.host
       info[:port] = @config.ssh.port if @config.ssh.port
       info[:keys_only] = @config.ssh.keys_only
-      info[:paranoid] = @config.ssh.paranoid
+      info[:verify_host_key] = @config.ssh.verify_host_key
       info[:compression] = @config.ssh.compression
       info[:dsa_authentication] = @config.ssh.dsa_authentication
       info[:username] = @config.ssh.username if @config.ssh.username

--- a/lib/vagrant/util/ssh.rb
+++ b/lib/vagrant/util/ssh.rb
@@ -126,7 +126,7 @@ module Vagrant
         end
 
         # no strict hostkey checking unless paranoid
-        if ! ssh_info[:paranoid]
+        if ! ssh_info[:verify_host_key]
           command_options += [
             "-o", "StrictHostKeyChecking=no",
             "-o", "UserKnownHostsFile=/dev/null"]

--- a/plugins/commands/ssh_config/command.rb
+++ b/plugins/commands/ssh_config/command.rb
@@ -47,7 +47,7 @@ module VagrantPlugins
             ssh_port: ssh_info[:port],
             ssh_user: ssh_info[:username],
             keys_only: ssh_info[:keys_only],
-            paranoid: ssh_info[:paranoid],
+            verify_host_key: ssh_info[:verify_host_key],
             private_key_path: ssh_info[:private_key_path],
             log_level: ssh_info[:log_level],
             forward_agent: ssh_info[:forward_agent],

--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -364,7 +364,7 @@ module VagrantPlugins
           forward_agent:         ssh_info[:forward_agent],
           send_env:              ssh_info[:forward_env],
           keys_only:             ssh_info[:keys_only],
-          paranoid:              ssh_info[:paranoid],
+          verify_host_key:       ssh_info[:verify_host_key],
           password:              ssh_info[:password],
           port:                  ssh_info[:port],
           timeout:               15,

--- a/plugins/kernel_v2/config/ssh_connect.rb
+++ b/plugins/kernel_v2/config/ssh_connect.rb
@@ -9,6 +9,7 @@ module VagrantPlugins
       attr_accessor :insert_key
       attr_accessor :keys_only
       attr_accessor :paranoid
+      attr_accessor :verify_host_key
       attr_accessor :compression
       attr_accessor :dsa_authentication
       attr_accessor :extra_args
@@ -22,6 +23,7 @@ module VagrantPlugins
         @insert_key       = UNSET_VALUE
         @keys_only        = UNSET_VALUE
         @paranoid         = UNSET_VALUE
+        @verify_host_key  = UNSET_VALUE
         @compression      = UNSET_VALUE
         @dsa_authentication = UNSET_VALUE
         @extra_args       = UNSET_VALUE
@@ -36,6 +38,7 @@ module VagrantPlugins
         @insert_key       = true if @insert_key == UNSET_VALUE
         @keys_only        = true if @keys_only == UNSET_VALUE
         @paranoid         = false if @paranoid == UNSET_VALUE
+        @verify_host_key  = false if @verify_host_key == UNSET_VALUE
         @compression      = true if @compression == UNSET_VALUE
         @dsa_authentication = true if @dsa_authentication == UNSET_VALUE
         @extra_args       = nil if @extra_args == UNSET_VALUE
@@ -43,6 +46,11 @@ module VagrantPlugins
         if @private_key_path && !@private_key_path.is_a?(Array)
           @private_key_path = [@private_key_path]
         end
+
+        if @paranoid
+          @verify_host_key = @paranoid
+        end
+
       end
 
       # NOTE: This is _not_ a valid config validation method, since it
@@ -62,6 +70,10 @@ module VagrantPlugins
                 path: raw_path)
             end
           end
+        end
+
+        if @paranoid
+          machine.env.ui.warn(I18n.t("vagrant.config.ssh.paranoid_deprecated"))
         end
 
         errors

--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -101,7 +101,7 @@ module VagrantPlugins
         end
 
         # no strict hostkey checking unless paranoid
-        if ! ssh_info[:paranoid]
+        if ! ssh_info[:verify_host_key]
           rsh += [
             "-o", "StrictHostKeyChecking=no",
             "-o", "UserKnownHostsFile=/dev/null"]

--- a/templates/commands/ssh_config/config.erb
+++ b/templates/commands/ssh_config/config.erb
@@ -2,7 +2,7 @@ Host <%= host_key %>
   HostName <%= ssh_host %>
   User <%= ssh_user %>
   Port <%= ssh_port %>
-<% if ! paranoid -%>
+<% if ! verify_host_key -%>
   UserKnownHostsFile /dev/null
   StrictHostKeyChecking no
 <% end -%>

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1633,6 +1633,9 @@ en:
           Unknown configuration section '%{key}'.
       ssh:
         private_key_missing: "`private_key_path` file must exist: %{path}"
+        paranoid_deprecated: |-
+          The key `paranoid` is deprecated. Please use `verify_host_key`. Supported
+          values are exactly the same, only the name of the option has changed.
       vm:
         bad_version: |-
           Invalid box version constraints: %{version}

--- a/test/unit/plugins/commands/ssh_config/command_test.rb
+++ b/test/unit/plugins/commands/ssh_config/command_test.rb
@@ -23,7 +23,7 @@ describe VagrantPlugins::CommandSSHConfig::Command do
     port:             1234,
     username:         "testuser",
     keys_only:        true,
-    paranoid:         false,
+    verify_host_key:         false,
     private_key_path: ["/home/vagrant/.private/keys.key"],
     forward_agent:    false,
     forward_x11:      false
@@ -124,8 +124,8 @@ Host #{machine.name}
       expect(output).not_to include('IdentitiesOnly')
     end
 
-    it "omits StrictHostKeyChecking and UserKnownHostsFile when paranoid is true" do
-      allow(machine).to receive(:ssh_info) { ssh_info.merge(paranoid: true) }
+    it "omits StrictHostKeyChecking and UserKnownHostsFile when verify_host_key is true" do
+      allow(machine).to receive(:ssh_info) { ssh_info.merge(verify_host_key: true) }
 
       output = ""
       allow(subject).to receive(:safe_puts) do |data|

--- a/test/unit/plugins/communicators/ssh/communicator_test.rb
+++ b/test/unit/plugins/communicators/ssh/communicator_test.rb
@@ -357,7 +357,7 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
           username: nil,
           password: nil,
           keys_only: true,
-          paranoid: false
+          verify_host_key: false
         )
       end
 
@@ -370,10 +370,10 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
         communicator.send(:connect)
       end
 
-      it "has paranoid disabled" do
+      it "has verify_host_key disabled" do
         expect(Net::SSH).to receive(:start).with(
           nil, nil, hash_including(
-            paranoid: false
+            verify_host_key: false
           )
         ).and_return(true)
         communicator.send(:connect)
@@ -412,7 +412,7 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
       end
     end
 
-    context "with keys_only disabled and paranoid enabled" do
+    context "with keys_only disabled and verify_host_key enabled" do
 
       before do
         expect(machine).to receive(:ssh_info).and_return(
@@ -422,7 +422,7 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
           username: nil,
           password: nil,
           keys_only: false,
-          paranoid: true
+          verify_host_key: true
         )
       end
 
@@ -435,10 +435,10 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
         communicator.send(:connect)
       end
 
-      it "has paranoid disabled" do
+      it "has verify_host_key disabled" do
         expect(Net::SSH).to receive(:start).with(
           nil, nil, hash_including(
-            paranoid: true
+            verify_host_key: true
           )
         ).and_return(true)
         communicator.send(:connect)
@@ -455,7 +455,7 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
           username: nil,
           password: nil,
           keys_only: true,
-          paranoid: false
+          verify_host_key: false
         )
       end
 
@@ -479,7 +479,7 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
           username: nil,
           password: nil,
           keys_only: true,
-          paranoid: false
+          verify_host_key: false
         )
       end
 
@@ -512,7 +512,7 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
           username: 'vagrant',
           password: 'vagrant',
           keys_only: true,
-          paranoid: false
+          verify_host_key: false
         )
       end
 
@@ -550,7 +550,7 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
           username: 'vagrant',
           password: 'vagrant',
           keys_only: true,
-          paranoid: false
+          verify_host_key: false
         )
       end
 

--- a/test/unit/plugins/communicators/winssh/communicator_test.rb
+++ b/test/unit/plugins/communicators/winssh/communicator_test.rb
@@ -298,7 +298,7 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
           username: nil,
           password: nil,
           keys_only: true,
-          paranoid: false
+          verify_host_key: false
         )
       end
 
@@ -311,10 +311,10 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
         communicator.send(:connect)
       end
 
-      it "has paranoid disabled" do
+      it "has verify_host_key disabled" do
         expect(Net::SSH).to receive(:start).with(
           nil, nil, hash_including(
-            paranoid: false
+            verify_host_key: false
           )
         ).and_return(true)
         communicator.send(:connect)
@@ -339,7 +339,7 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
       end
     end
 
-    context "with keys_only disabled and paranoid enabled" do
+    context "with keys_only disabled and verify_host_key enabled" do
 
       before do
         expect(machine).to receive(:ssh_info).and_return(
@@ -349,7 +349,7 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
           username: nil,
           password: nil,
           keys_only: false,
-          paranoid: true
+          verify_host_key: true
         )
       end
 
@@ -362,10 +362,10 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
         communicator.send(:connect)
       end
 
-      it "has paranoid disabled" do
+      it "has verify_host_key disabled" do
         expect(Net::SSH).to receive(:start).with(
           nil, nil, hash_including(
-            paranoid: true
+            verify_host_key: true
           )
         ).and_return(true)
         communicator.send(:connect)
@@ -382,7 +382,7 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
           username: nil,
           password: nil,
           keys_only: true,
-          paranoid: false
+          verify_host_key: false
         )
       end
 
@@ -406,7 +406,7 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
           username: nil,
           password: nil,
           keys_only: true,
-          paranoid: false
+          verify_host_key: false
         )
       end
 
@@ -439,7 +439,7 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
           username: 'vagrant',
           password: 'vagrant',
           keys_only: true,
-          paranoid: false
+          verify_host_key: false
         )
       end
 
@@ -477,7 +477,7 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
           username: 'vagrant',
           password: 'vagrant',
           keys_only: true,
-          paranoid: false
+          verify_host_key: false
         )
       end
 

--- a/test/unit/plugins/synced_folders/rsync/helper_test.rb
+++ b/test/unit/plugins/synced_folders/rsync/helper_test.rb
@@ -220,7 +220,7 @@ describe VagrantPlugins::SyncedFolderRSync::RsyncHelper do
     let(:ssh_info) {{
       :private_key_path => ['/path/to/key'],
       :keys_only        => true,
-      :paranoid         => false,
+      :verify_host_key  => false,
     }}
     let(:opts)      {{
       hostpath: "/foo",

--- a/test/unit/vagrant/machine_test.rb
+++ b/test/unit/vagrant/machine_test.rb
@@ -790,8 +790,8 @@ describe Vagrant::Machine do
         it "keys_only should be default" do
           expect(instance.ssh_info[:keys_only]).to be(true)
         end
-        it "paranoid should be default" do
-          expect(instance.ssh_info[:paranoid]).to be(false)
+        it "verify_host_key should be default" do
+          expect(instance.ssh_info[:verify_host_key]).to be(false)
         end
         it "extra_args should be nil" do
           expect(instance.ssh_info[:extra_args]).to be(nil)
@@ -808,9 +808,9 @@ describe Vagrant::Machine do
           instance.config.ssh.keys_only = false
           expect(instance.ssh_info[:keys_only]).to be(false)
         end
-        it "paranoid should be overridden" do
-          instance.config.ssh.paranoid = true
-          expect(instance.ssh_info[:paranoid]).to be(true)
+        it "verify_host_key should be overridden" do
+          instance.config.ssh.verify_host_key = true
+          expect(instance.ssh_info[:verify_host_key]).to be(true)
         end
       end
     end

--- a/test/unit/vagrant/util/ssh_test.rb
+++ b/test/unit/vagrant/util/ssh_test.rb
@@ -89,13 +89,13 @@ describe Vagrant::Util::SSH do
       end
     end
 
-    context "when paranoid is true" do
+    context "when verify_host_key is true" do
       let(:ssh_info) {{
         host: "localhost",
         port: 2222,
         username: "vagrant",
         private_key_path: [temporary_file],
-        paranoid: true
+        verify_host_key: true
       }}
 
       it "does not disable StrictHostKeyChecking or set UserKnownHostsFile" do

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency "listen", "~> 3.1.5"
   s.add_dependency "hashicorp-checkpoint", "~> 0.1.1"
   s.add_dependency "log4r", "~> 1.1.9", "< 1.1.11"
-  s.add_dependency "net-ssh", "~> 4.1.0"
+  s.add_dependency "net-ssh", "~> 4.2.0"
   s.add_dependency "net-sftp", "~> 2.1"
   s.add_dependency "net-scp", "~> 1.2.0"
   s.add_dependency "rb-kqueue", "~> 0.2.0"

--- a/website/source/docs/vagrantfile/ssh_settings.html.md
+++ b/website/source/docs/vagrantfile/ssh_settings.html.md
@@ -67,8 +67,17 @@ any keys stored in ssh-agent). The default value is `true`.
 
 <hr>
 
+`config.ssh.verify_host_key` - Perform strict host-key verification. The default
+value is `false`.
+
+<hr>
+
 `config.ssh.paranoid` - Perform strict host-key verification. The default value
 is `false`.
+
+__Deprecation:__
+The `config.ssh.paranoid` option is deprecated and will be removed in a future release.
+Please use the `config.ssh.verify_host_key` option instead.
 
 <hr>
 


### PR DESCRIPTION
As of `net-ssh` version 4.2.0, the key :paranoid has been deprecated in
favor of using :verify_host_key. This commit updates Vagrants ssh config
to use the new key, and deprecates the use of :paranoid.

Fixes #9062 