### PR TITLE
Notify when host changes on redirect

### DIFF
--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -101,13 +101,6 @@ module Vagrant
             progress_data << data
 
             while true
-              # If we have a full amount of column data (two "\r") then
-              # we report new progress reports. Otherwise, just keep
-              # accumulating.
-              match = progress_regexp.match(progress_data)
-
-              break if !match
-
               # If the download has been redirected and we are no longer downloading
               # from the original host, notify the user that the target host has
               # changed from the source.
@@ -129,9 +122,24 @@ module Vagrant
                 break
               end
 
-              data = match[1].to_s
-              stop = progress_data.index(data) + data.length
-              progress_data.slice!(0, stop)
+              # If we have a full amount of column data (two "\r") then
+              # we report new progress reports. Otherwise, just keep
+              # accumulating.
+              match = nil
+              check_match = true
+
+              while check_match
+                check_match = progress_regexp.match(progress_data)
+                if check_match
+                  data = check_match[1].to_s
+                  stop = progress_data.index(data) + data.length
+                  progress_data.slice!(0, stop)
+
+                  match = check_match
+                end
+              end
+
+              break if !match
 
               # Ignore the first \r and split by whitespace to grab the columns
               columns = data.strip.split(/\s+/)

--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -89,7 +89,7 @@ module Vagrant
           extra_subprocess_opts[:notify] = :stderr
 
           progress_data = ""
-          progress_regexp = /^\r\s*(\d.+)\r$/m
+          progress_regexp = /^\r\s*(\d.+?)\r/m
 
           # Setup the proc that'll receive the real-time data from
           # the downloader.

--- a/test/unit/vagrant/util/downloader_test.rb
+++ b/test/unit/vagrant/util/downloader_test.rb
@@ -23,7 +23,7 @@ describe Vagrant::Util::Downloader do
   describe "#download!" do
     let(:curl_options) {
       ["-q", "--fail", "--location", "--max-redirs", "10",
-       "--user-agent", described_class::USER_AGENT,
+       "--verbose", "--user-agent", described_class::USER_AGENT,
        "--output", destination, source, {}]
     }
 
@@ -195,7 +195,7 @@ describe Vagrant::Util::Downloader do
 
   describe "#head" do
     let(:curl_options) {
-      ["-q", "--fail", "--location", "--max-redirs", "10", "--user-agent", described_class::USER_AGENT, source, {}]
+      ["-q", "--fail", "--location", "--max-redirs", "10", "--verbose", "--user-agent", described_class::USER_AGENT, source, {}]
     }
 
     it "returns the output" do


### PR DESCRIPTION
When the downloader encounters redirects and the final destination is a different host than the original source, display notification to user of the new host.