### PR TITLE
Show all box providers in command outdated

### DIFF
--- a/lib/vagrant/action/builtin/box_check_outdated.rb
+++ b/lib/vagrant/action/builtin/box_check_outdated.rb
@@ -69,6 +69,7 @@ module Vagrant
             env[:ui].warn(I18n.t(
               "vagrant.box_outdated_single",
               name: update[0].name,
+              provider: box.provider,
               current: box.version,
               latest: update[1].version))
           else

--- a/plugins/commands/box/command/outdated.rb
+++ b/plugins/commands/box/command/outdated.rb
@@ -51,15 +51,12 @@ module VagrantPlugins
         def outdated_global(download_options)
           boxes = {}
           @env.boxes.all.reverse.each do |name, version, provider|
-            next if boxes[name]
-            boxes[name] = @env.boxes.find(name, provider, version)
-          end
-
-          boxes.values.each do |box|
+            box = @env.boxes.find(name, provider, version)
             if !box.metadata_url
               @env.ui.output(I18n.t(
                 "vagrant.box_outdated_no_metadata",
-                name: box.name))
+                name: box.name,
+                provider: box.provider))
               next
             end
 
@@ -70,6 +67,7 @@ module VagrantPlugins
               @env.ui.error(I18n.t(
                 "vagrant.box_outdated_metadata_error",
                 name: box.name,
+                provider: box.provider,
                 message: e.extra_data[:message]))
               next
             end
@@ -80,11 +78,13 @@ module VagrantPlugins
               @env.ui.success(I18n.t(
                 "vagrant.box_up_to_date",
                 name: box.name,
+                provider: box.provider,
                 version: box.version))
             else
               @env.ui.warn(I18n.t(
                 "vagrant.box_outdated",
                 name: box.name,
+                provider: box.provider,
                 current: box.version,
                 latest: latest.to_s,))
             end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -36,7 +36,7 @@ en:
     box_loading_metadata: |-
       Loading metadata for box '%{name}'
     box_outdated: |-
-      * '%{name}' is outdated! Current: %{current}. Latest: %{latest}
+      * '%{name}' for '%{provider}' is outdated! Current: %{current}. Latest: %{latest}
     box_outdated_checking_with_refresh: |-
       Checking if box '%{name}' is up to date...
     box_outdated_local: |-
@@ -58,20 +58,20 @@ en:
       Error loading box metadata while attempting to check for
       updates: %{message}
     box_outdated_single: |-
-      A newer version of the box '%{name}' is available! You currently
-      have version '%{current}'. The latest is version '%{latest}'. Run
-      `vagrant box update` to update.
+      A newer version of the box '%{name}' for provider '%{provider}' is
+      available! You currently have version '%{current}'. The latest is version
+      '%{latest}'. Run `vagrant box update` to update.
     box_outdated_metadata_error: |-
-      * '%{name}': Error loading metadata: %{message}
+      * '%{name}' for '%{provider}': Error loading metadata: %{message}
     box_outdated_no_metadata: |-
-      * '%{name}' wasn't added from a catalog, no version information
+      * '%{name}' for '%{provider}' wasn't added from a catalog, no version information
     box_updating: |-
       Updating '%{name}' with provider '%{provider}' from version
       '%{old}' to '%{new}'...
     box_update_checking: |-
       Checking for updates to '%{name}'
     box_up_to_date: |-
-      * '%{name}' (v%{version}) is up to date
+      * '%{name}' for '%{provider}' (v%{version}) is up to date
     box_up_to_date_single: |-
       Box '%{name}' (v%{version}) is running the latest version.
     cfengine_bootstrapping: |-


### PR DESCRIPTION
Prior to this commit, when the `--global` flag was used with the
`vagrant box outdated` command, it would ignore box providers and not
inform the user of all outdated boxes. This commit fixes that by
displaying each box within the users environment, and includes the
provider of the box in the message.

Fixes #9044