### PR TITLE
Change to a temporary directory before downloading script files

### DIFF
--- a/plugins/provisioners/salt/bootstrap-salt.sh
+++ b/plugins/provisioners/salt/bootstrap-salt.sh
@@ -1,5 +1,7 @@
 #!/bin/sh -
 
+cd `mktemp --directory`
+
 # We just download the bootstrap script by default and execute that.
 if [ -x /usr/bin/fetch ]; then
     /usr/bin/fetch -o bootstrap-salt.sh https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh

--- a/plugins/provisioners/salt/bootstrap-salt.sh
+++ b/plugins/provisioners/salt/bootstrap-salt.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -
 
-cd `mktemp --directory`
+cd `mktemp -d`
 
 # We just download the bootstrap script by default and execute that.
 if [ -x /usr/bin/fetch ]; then


### PR DESCRIPTION
Avoids leaving confusing files in the working directory (probably ~vagrant).  Fixes #9350 