### PR TITLE
Allow docker provisioner to run on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ BUG FIXES:
 
   - commands/package: Fix --output path with specified folder [GH-9131]
   - providers/hyper-v: Fix enable virtualization extensions on import [GH-9255]
+  - provisioners/ansible(both): Fix broken 'ask_sudo_pass' option [GH-9173]
 
 ## 2.0.1 (November 2, 2017)
 

--- a/plugins/provisioners/docker/cap/windows/docker_daemon_running.rb
+++ b/plugins/provisioners/docker/cap/windows/docker_daemon_running.rb
@@ -1,0 +1,13 @@
+module VagrantPlugins
+  module DockerProvisioner
+    module Cap
+      module Windows
+        module DockerDaemonRunning
+          def self.docker_daemon_running(machine)
+            machine.communicate.test("tasklist | find \"`\"dockerd`\"\"")
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/provisioners/docker/client.rb
+++ b/plugins/provisioners/docker/client.rb
@@ -127,9 +127,8 @@ module VagrantPlugins
       def create_container(config)
         args = container_run_args(config)
 
-        @machine.communicate.sudo %[
-          rm -f #{config[:cidfile]}
-          docker run #{args}
+        @machine.communicate.sudo %[rm -f #{config[:cidfile]}
+                                    docker run #{args}
         ]
 
         sha  = Digest::SHA1.hexdigest(args)

--- a/plugins/provisioners/docker/client.rb
+++ b/plugins/provisioners/docker/client.rb
@@ -128,8 +128,9 @@ module VagrantPlugins
         args = container_run_args(config)
 
         @machine.communicate.sudo %[rm -f #{config[:cidfile]}
-                                    docker run #{args}
-        ]
+                                  ]
+        @machine.communicate.sudo %[docker run #{args}
+                                  ]
 
         sha  = Digest::SHA1.hexdigest(args)
         container_data_path(config).open("w+") do |f|

--- a/plugins/provisioners/docker/client.rb
+++ b/plugins/provisioners/docker/client.rb
@@ -132,7 +132,6 @@ module VagrantPlugins
           docker run #{args}
         ]
 
-        name = container_name(config)
         sha  = Digest::SHA1.hexdigest(args)
         container_data_path(config).open("w+") do |f|
           f.write(sha)

--- a/plugins/provisioners/docker/plugin.rb
+++ b/plugins/provisioners/docker/plugin.rb
@@ -54,6 +54,11 @@ module VagrantPlugins
         Cap::Linux::DockerDaemonRunning
       end
 
+      guest_capability("windows", "docker_daemon_running") do
+        require_relative "cap/windows/docker_daemon_running"
+        Cap::Windows::DockerDaemonRunning
+      end
+
       provisioner(:docker) do
         require_relative "provisioner"
         Provisioner


### PR DESCRIPTION
fixes #9339 
remove whitespace causing winrm filter from working

fixes #9280 
Check to see if docker is running

also fixes issue when file does not exist on windows and it is attempted to be removed, it no longer causes an error.