### PR TITLE
Introduce flag for SharedFoldersEnableSymlinksCreate

### DIFF
--- a/plugins/providers/virtualbox/driver/version_4_1.rb
+++ b/plugins/providers/virtualbox/driver/version_4_1.rb
@@ -584,8 +584,10 @@ module VagrantPlugins
               folder[:hostpath]]
             args << "--transient" if folder.key?(:transient) && folder[:transient]
 
-            # Enable symlinks on the shared folder
-            execute("setextradata", @uuid, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/#{folder[:name]}", "1")
+            if folder[:SharedFoldersEnableSymlinksCreate]
+              # Enable symlinks on the shared folder
+              execute("setextradata", @uuid, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/#{folder[:name]}", "1")
+            end
 
             # Add the shared folder
             execute("sharedfolder", "add", @uuid, *args)

--- a/plugins/providers/virtualbox/driver/version_4_2.rb
+++ b/plugins/providers/virtualbox/driver/version_4_2.rb
@@ -517,8 +517,10 @@ module VagrantPlugins
               folder[:hostpath]]
             args << "--transient" if folder.key?(:transient) && folder[:transient]
 
-            # Enable symlinks on the shared folder
-            execute("setextradata", @uuid, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/#{folder[:name]}", "1")
+            if folder[:SharedFoldersEnableSymlinksCreate]
+              # Enable symlinks on the shared folder
+              execute("setextradata", @uuid, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/#{folder[:name]}", "1")
+            end
 
             # Add the shared folder
             execute("sharedfolder", "add", @uuid, *args)

--- a/plugins/providers/virtualbox/driver/version_4_3.rb
+++ b/plugins/providers/virtualbox/driver/version_4_3.rb
@@ -639,8 +639,10 @@ module VagrantPlugins
               hostpath]
             args << "--transient" if folder.key?(:transient) && folder[:transient]
 
-            # Enable symlinks on the shared folder
-            execute("setextradata", @uuid, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/#{folder[:name]}", "1")
+            if folder[:SharedFoldersEnableSymlinksCreate]
+              # Enable symlinks on the shared folder
+              execute("setextradata", @uuid, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/#{folder[:name]}", "1")
+            end
 
             # Add the shared folder
             execute("sharedfolder", "add", @uuid, *args)

--- a/plugins/providers/virtualbox/driver/version_5_0.rb
+++ b/plugins/providers/virtualbox/driver/version_5_0.rb
@@ -673,8 +673,10 @@ module VagrantPlugins
               hostpath]
             args << "--transient" if folder.key?(:transient) && folder[:transient]
 
-            # Enable symlinks on the shared folder
-            execute("setextradata", @uuid, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/#{folder[:name]}", "1", retryable: true)
+            if folder[:SharedFoldersEnableSymlinksCreate]
+              # Enable symlinks on the shared folder
+              execute("setextradata", @uuid, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/#{folder[:name]}", "1", retryable: true)
+            end
 
             # Add the shared folder
             execute("sharedfolder", "add", @uuid, *args, retryable: true)

--- a/plugins/providers/virtualbox/synced_folder.rb
+++ b/plugins/providers/virtualbox/synced_folder.rb
@@ -103,12 +103,23 @@ module VagrantPlugins
             hostpath = Vagrant::Util::Platform.cygwin_windows_path(hostpath)
           end
 
+          sharefoldersenablesymlinkscreate = true
+
+          if ENV['VAGRANT_DISABLE_VBOXSYMLINKCREATE']
+            sharefoldersenablesymlinkscreate = false
+          end
+
+          unless data[:SharedFoldersEnableSymlinksCreate].nil?
+            sharefoldersenablesymlinkscreate = data[:SharedFoldersEnableSymlinksCreate]
+          end
+
           # Only setup the shared folders that match our transient level
           if (!!data[:transient]) == transient
             defs << {
               name: os_friendly_id(id),
               hostpath: hostpath.to_s,
               transient: transient,
+              SharedFoldersEnableSymlinksCreate: sharefoldersenablesymlinkscreate
             }
           end
         end

--- a/test/unit/plugins/providers/virtualbox/driver/version_5_0_test.rb
+++ b/test/unit/plugins/providers/virtualbox/driver/version_5_0_test.rb
@@ -1,0 +1,43 @@
+require_relative "../base"
+
+describe VagrantPlugins::ProviderVirtualBox::Driver::Version_5_0 do
+  include_context "virtualbox"
+
+  let(:vbox_version) { "5.0.0" }
+
+  subject { VagrantPlugins::ProviderVirtualBox::Driver::Meta.new(uuid) }
+
+  it_behaves_like "a version 4.x virtualbox driver"
+
+  describe "#shared_folders" do
+    let(:folders) { [{:name=>"folder",
+                     :hostpath=>"/Users/brian/vagrant-folder",
+                     :transient=>false,
+                     :SharedFoldersEnableSymlinksCreate=>true}]}
+
+    let(:folders_disabled) { [{:name=>"folder",
+                     :hostpath=>"/Users/brian/vagrant-folder",
+                     :transient=>false,
+                     :SharedFoldersEnableSymlinksCreate=>false}]}
+
+    it "enables SharedFoldersEnableSymlinksCreate if true" do
+      expect(subprocess).to receive(:execute).
+        with("VBoxManage", "setextradata", anything, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/folder", "1", {:notify=>[:stdout, :stderr]}).
+        and_return(subprocess_result(exit_code: 0))
+
+      expect(subprocess).to receive(:execute).
+        with("VBoxManage", "sharedfolder", "add", anything, "--name", "folder", "--hostpath", "/Users/brian/vagrant-folder", {:notify=>[:stdout, :stderr]}).
+        and_return(subprocess_result(exit_code: 0))
+      subject.share_folders(folders)
+
+    end
+
+    it "disables SharedFoldersEnableSymlinksCreate if false" do
+      expect(subprocess).to receive(:execute).
+        with("VBoxManage", "sharedfolder", "add", anything, "--name", "folder", "--hostpath", "/Users/brian/vagrant-folder", {:notify=>[:stdout, :stderr]}).
+        and_return(subprocess_result(exit_code: 0))
+      subject.share_folders(folders_disabled)
+
+    end
+  end
+end

--- a/website/source/docs/other/environmental-variables.html.md
+++ b/website/source/docs/other/environmental-variables.html.md
@@ -211,3 +211,10 @@ but just a filename.
 This environmental variable is commonly used in scripting environments
 where a single folder may contain multiple Vagrantfiles representing
 different configurations.
+
+## `VAGRANT_DISABLE_VBOXSYMLINKCREATE`
+
+If set, this will disable the ability to create symlinks with all virtualbox
+shared folders. Defaults to true if the option is not set. This can be overriden
+on a per-folder basis within your Vagrantfile config by settings the
+`SharedFoldersEnableSymlinksCreate` option to true.

--- a/website/source/docs/synced-folders/virtualbox.html.md
+++ b/website/source/docs/synced-folders/virtualbox.html.md
@@ -16,6 +16,12 @@ VirtualBox shared folders are the default synced folder type. These synced
 folders use the VirtualBox shared folder system to sync file changes from
 the guest to the host and vice versa.
 
+## Options
+
+* `SharedFoldersEnableSymlinksCreate` (boolean) - If false, will disable the
+ability to create symlinks with the given virtualbox shared folder. Defaults to
+true if the option is not present.
+
 ## Caveats
 
 There is a [VirtualBox bug][sendfile bug] related to `sendfile` which can result


### PR DESCRIPTION
Prior to this commit, the virtualbox synced folder option
`SharedFoldersEnableSymlinksCreate` was always enabled. This commit
introduces a config option and an environment variable which allows
users to configure the option globally or per synced_folder in their
Vagrantfile.