### PR TITLE
Check SMB credentials

### DIFF
--- a/plugins/hosts/windows/cap/smb.rb
+++ b/plugins/hosts/windows/cap/smb.rb
@@ -17,6 +17,16 @@ module VagrantPlugins
           true
         end
 
+        def self.smb_validate_password(env, machine, username, password)
+          script_path = File.expand_path("../../scripts/check_credentials.ps1", __FILE__)
+          args = []
+          args << "-username" << "'#{username.gsub("'", "''")}'"
+          args << "-password" << "'#{password.gsub("'", "''")}'"
+
+          r = Vagrant::Util::PowerShell.execute(script_path, *args)
+          r.exit_code == 0
+        end
+
         def self.smb_cleanup(env, machine, opts)
           script_path = File.expand_path("../../scripts/unset_share.ps1", __FILE__)
 

--- a/plugins/hosts/windows/plugin.rb
+++ b/plugins/hosts/windows/plugin.rb
@@ -46,6 +46,11 @@ module VagrantPlugins
         Cap::SMB
       end
 
+      host_capability("windows", "smb_cleanup") do
+        require_relative "cap/smb"
+        Cap::SMB
+      end
+
       host_capability("windows", "configured_ip_addresses") do
         require_relative "cap/configured_ip_addresses"
         Cap::ConfiguredIPAddresses

--- a/plugins/hosts/windows/scripts/check_credentials.ps1
+++ b/plugins/hosts/windows/scripts/check_credentials.ps1
@@ -1,0 +1,19 @@
+Param(
+    [Parameter(Mandatory=$true)]
+    [string]$username,
+    [Parameter(Mandatory=$true)]
+    [string]$password
+)
+
+Add-Type -AssemblyName System.DirectoryServices.AccountManagement
+
+$DSContext = New-Object System.DirectoryServices.AccountManagement.PrincipalContext(
+    [System.DirectoryServices.AccountManagement.ContextType]::Machine,
+    $env:COMPUTERNAME
+)
+
+if ( $DSContext.ValidateCredentials( $username, $password ) ) {
+    exit 0
+} else {
+    exit 1
+}

--- a/plugins/synced_folders/smb/errors.rb
+++ b/plugins/synced_folders/smb/errors.rb
@@ -26,6 +26,10 @@ module VagrantPlugins
         error_key(:name_error)
       end
 
+      class CredentialsRequestError < SMBError
+        error_key(:credentials_request_error)
+      end
+
       class DefineShareFailed < SMBError
         error_key(:define_share_failed)
       end

--- a/templates/locales/synced_folder_smb.yml
+++ b/templates/locales/synced_folder_smb.yml
@@ -15,6 +15,8 @@ en:
       You will be asked for the username and password to use for the SMB
       folders shortly. Please use the proper username/password of your
       account.
+    incorrect_credentials: |-
+      Credentials incorrect. Please try again.
 
     uac:
       prune_warning: |-

--- a/templates/locales/synced_folder_smb.yml
+++ b/templates/locales/synced_folder_smb.yml
@@ -39,6 +39,9 @@ en:
         Vagrant SMB synced folders require the account password to be stored
         in an NT compatible format. Please update your sharing settings to
         enable a Windows compatible password and try again.
+      credentials_request_error: |-
+        Vagrant failed to receive credential information required for preparing
+        an SMB share.
       define_share_failed: |-
         Exporting an SMB share failed! Details about the failure are shown
         below. Please inspect the error message and correct any problems.


### PR DESCRIPTION
This is an update of #9253 

Since the SMB implementation has been refactored, the original commit was cherry picked in and then modified to extract the functionality into a host capability that can be utilized when available.