### PR TITLE
Support SMB mount option overrides

### DIFF
--- a/test/unit/plugins/guests/linux/cap/mount_smb_shared_folder.rb
+++ b/test/unit/plugins/guests/linux/cap/mount_smb_shared_folder.rb
@@ -104,4 +104,28 @@ describe "VagrantPlugins::GuestLinux::Cap::MountSMBSharedFolder" do
       end
     end
   end
+
+  describe ".merge_mount_options" do
+    let(:base){ ["opt1", "opt2=on", "opt3", "opt4,opt5=off"] }
+    let(:override){ ["opt8", "opt4=on,opt6,opt7=true"] }
+
+    context "with no override" do
+      it "should split options into individual options" do
+        result = cap.merge_mount_options(base, [])
+        expect(result.size).to eq(5)
+      end
+    end
+
+    context "with overrides" do
+      it "should merge all options" do
+        result = cap.merge_mount_options(base, override)
+        expect(result.size).to eq(8)
+      end
+
+      it "should override options defined in base" do
+        result = cap.merge_mount_options(base, override)
+        expect(result).to include("opt4=on")
+      end
+    end
+  end
 end


### PR DESCRIPTION
This also updates the default `sec` mount option from `ntlm` to `ntlmssp`.