### PR TITLE
Allow hiding environment variable values in shell provisioner

### DIFF
--- a/plugins/provisioners/shell/config.rb
+++ b/plugins/provisioners/shell/config.rb
@@ -14,6 +14,7 @@ module VagrantPlugins
       attr_accessor :binary
       attr_accessor :keep_color
       attr_accessor :name
+      attr_accessor :sensitive
       attr_accessor :powershell_args
       attr_accessor :powershell_elevated_interactive
 
@@ -29,6 +30,7 @@ module VagrantPlugins
         @binary                = UNSET_VALUE
         @keep_color            = UNSET_VALUE
         @name                  = UNSET_VALUE
+        @sensitive             = UNSET_VALUE
         @powershell_args       = UNSET_VALUE
         @powershell_elevated_interactive  = UNSET_VALUE
       end
@@ -45,11 +47,18 @@ module VagrantPlugins
         @binary               = false if @binary == UNSET_VALUE
         @keep_color           = false if @keep_color == UNSET_VALUE
         @name                 = nil if @name == UNSET_VALUE
+        @sensitive            = false if @sensitive == UNSET_VALUE
         @powershell_args      = "-ExecutionPolicy Bypass" if @powershell_args == UNSET_VALUE
         @powershell_elevated_interactive = false if @powershell_elevated_interactive == UNSET_VALUE
 
         if @args && args_valid?
           @args = @args.is_a?(Array) ? @args.map { |a| a.to_s } : @args.to_s
+        end
+
+        if @sensitive
+          @env.each do |_, v|
+            Vagrant::Util::CredentialScrubber.sensitive(v)
+          end
         end
       end
 

--- a/test/unit/plugins/provisioners/shell/config_test.rb
+++ b/test/unit/plugins/provisioners/shell/config_test.rb
@@ -127,5 +127,26 @@ describe "VagrantPlugins::Shell::Config" do
 
       expect(subject.args).to eq ["string", '1', '2']
     end
+
+    context "with sensitive option enabled" do
+      it 'marks environment variable values sensitive' do
+        subject.env = {"KEY1" => "VAL1", "KEY2" => "VAL2"}
+        subject.sensitive = true
+
+        expect(Vagrant::Util::CredentialScrubber).to receive(:sensitive).with("VAL1")
+        expect(Vagrant::Util::CredentialScrubber).to receive(:sensitive).with("VAL2")
+        subject.finalize!
+      end
+    end
+
+    context "with sensitive option disabled" do
+      it 'does not mark environment variable values sensitive' do
+        subject.env = {"KEY1" => "VAL1", "KEY2" => "VAL2"}
+        subject.sensitive = false
+
+        expect(Vagrant::Util::CredentialScrubber).not_to receive(:sensitive)
+        subject.finalize!
+      end
+    end
   end
 end

--- a/website/source/docs/provisioning/shell.html.md
+++ b/website/source/docs/provisioning/shell.html.md
@@ -84,7 +84,7 @@ The remainder of the available options are optional:
 * `sha1` (string) - SHA1 checksum used to validate remotely downloaded shell files.
 
 * `sensitive` (boolean) - Marks the Hash values used in the `env` option as sensitive
-  and hides them from output.
+  and hides them from output. By default this is "false".
 
 <a name="inline-scripts"></a>
 ## Inline Scripts

--- a/website/source/docs/provisioning/shell.html.md
+++ b/website/source/docs/provisioning/shell.html.md
@@ -83,6 +83,9 @@ The remainder of the available options are optional:
 
 * `sha1` (string) - SHA1 checksum used to validate remotely downloaded shell files.
 
+* `sensitive` (boolean) - Marks the Hash values used in the `env` option as sensitive
+  and hides them from output.
+
 <a name="inline-scripts"></a>
 ## Inline Scripts
 


### PR DESCRIPTION
Adds the value of environment variables defined in the shell provisioner to the credential scrubber to prevent them from being displayed.