### PR TITLE
More explicit Solaris 11 and inherit SmartOS from Solaris

### DIFF
--- a/plugins/guests/smartos/plugin.rb
+++ b/plugins/guests/smartos/plugin.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
         Config
       end
 
-      guest(:smartos)  do
+      guest(:smartos, :solaris)  do
         require_relative "guest"
         Guest
       end

--- a/plugins/guests/solaris11/guest.rb
+++ b/plugins/guests/solaris11/guest.rb
@@ -8,7 +8,7 @@ module VagrantPlugins
   module GuestSolaris11
     class Guest < Vagrant.plugin("2", :guest)
       def detect?(machine)
-        machine.communicate.test("uname -sr | grep 'SunOS.*5\\.11'")
+        machine.communicate.test("grep 'Solaris 11' /etc/release")
       end
     end
   end


### PR DESCRIPTION
SmartOS is a distribution of illumos which is the successor of OpenSolaris before it was closed down by Oracle. SmartOS as distribution is similar to OmniOS which is already inherit by solaris.

The problem here is that SmartOS and OmniOS are between Solaris 10 and Solaris 11 so the `uname -sr` already return 5.11 also if it's not the same as Oracle Solaris 11. For that reason we need an more explicit check on solaris11 guests, so checking the `/etc/release` file make more sense.