### PR TITLE
Allow which to use original path. Prefer native ssh.

### DIFF
--- a/lib/vagrant/util/ssh.rb
+++ b/lib/vagrant/util/ssh.rb
@@ -72,6 +72,10 @@ module Vagrant
         # If we didn't find an ssh executable, see if we shipped one
         if !ssh_path
           ssh_path = Which.which("ssh")
+          if ssh_path && Platform.windows? && (Platform.cygwin? || Platform.msys?)
+            LOGGER.warn("Failed to locate native SSH executable. Using vendored version.")
+            LOGGER.warn("If display issues are encountered, install the ssh package for your environment.")
+          end
         end
 
         if !ssh_path

--- a/lib/vagrant/util/which.rb
+++ b/lib/vagrant/util/which.rb
@@ -11,8 +11,10 @@ module Vagrant
       #   http://stackoverflow.com/questions/2108727/which-in-ruby-checking-if-program-exists-in-path-from-ruby
       #
       # @param [String] cmd The command to search for in the PATH.
+      # @param [Hash] opts Optional flags
+      #   @option [Boolean] :original_path Search within original path if available
       # @return [String] The full path to the executable or `nil` if not found.
-      def self.which(cmd)
+      def self.which(cmd, **opts)
         exts = nil
 
         if !Platform.windows? || ENV['PATHEXT'].nil?
@@ -29,8 +31,14 @@ module Vagrant
           exts = ENV['PATHEXT'].split(';')
         end
 
+        if opts[:original_path]
+          search_path = ENV.fetch('VAGRANT_OLD_ENV_PATH', ENV['PATH'])
+        else
+          search_path = ENV['PATH']
+        end
+
         SilenceWarnings.silence! do
-          ENV['PATH'].encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '').split(File::PATH_SEPARATOR).each do |path|
+          search_path.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '').split(File::PATH_SEPARATOR).each do |path|
             exts.each do |ext|
               exe = "#{path}#{File::SEPARATOR}#{cmd}#{ext}"
               return exe if File.executable? exe

--- a/test/unit/vagrant/util/which_test.rb
+++ b/test/unit/vagrant/util/which_test.rb
@@ -13,10 +13,8 @@ describe Vagrant::Util::Which do
     file.chmod(mode)
 
     # set the path to the directory where the file is located
-    savepath = ENV['PATH']
-    ENV['PATH'] = dir.to_s
+    allow(ENV).to receive(:[]).with("PATH").and_return(dir.to_s)
     block.call filename + test_extension
-    ENV['PATH'] = savepath
 
     file.unlink
   end
@@ -38,6 +36,15 @@ describe Vagrant::Util::Which do
   it "should return nil for a non-executable file" do
     tester '.txt', '.txt', 0644 do |name|
       expect(described_class.which(name)).to be_nil
+    end
+  end
+
+  context "original_path option" do
+    before{ allow(ENV).to receive(:[]).with("PATH").and_return("") }
+
+    it "should use the original path when instructed" do
+      expect(ENV).to receive(:fetch).with("VAGRANT_OLD_ENV_PATH", any_args).and_return("")
+      described_class.which("file", original_path: true)
     end
   end
 end


### PR DESCRIPTION
Provides support for `Util::Which` to search for executables using the original PATH if Vagrant has configured a modified PATH (running from the launcher). This update also searches the original path first when looking for an ssh executable, falling back to checking within the modified PATH only if no ssh is found. 