### PR TITLE
Add master_json_config & minion_json_config options to salt provisioner

### DIFF
--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -6,9 +6,11 @@ module VagrantPlugins
     class Config < Vagrant.plugin("2", :config)
       ## salty-vagrant options
       attr_accessor :minion_config
+      attr_accessor :minion_json_config
       attr_accessor :minion_key
       attr_accessor :minion_pub
       attr_accessor :master_config
+      attr_accessor :master_json_config
       attr_accessor :master_key
       attr_accessor :master_pub
       attr_accessor :grains_config
@@ -42,9 +44,11 @@ module VagrantPlugins
 
       def initialize
         @minion_config = UNSET_VALUE
+        @minion_json_config = UNSET_VALUE
         @minion_key = UNSET_VALUE
         @minion_pub = UNSET_VALUE
         @master_config = UNSET_VALUE
+        @master_json_config = UNSET_VALUE
         @master_key = UNSET_VALUE
         @master_pub = UNSET_VALUE
         @grains_config = UNSET_VALUE
@@ -100,6 +104,8 @@ module VagrantPlugins
         @master_id          = nil if @master_id == UNSET_VALUE
         @salt_call_args     = nil if @salt_call_args == UNSET_VALUE
         @salt_args          = nil if @salt_args == UNSET_VALUE
+        @minion_json_config = nil if @minion_json_config == UNSET_VALUE
+        @master_json_config = nil if @master_json_config == UNSET_VALUE
 
         # NOTE: Optimistic defaults are set in the provisioner. UNSET_VALUEs
         # are converted there to allow proper detection of unset values.

--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -89,7 +89,7 @@ module VagrantPlugins
       end
 
       def need_configure
-        @config.minion_config or @config.minion_key or @config.master_config or @config.master_key or @config.grains_config or @config.version
+        @config.minion_config or @config.minion_key or @config.master_config or @config.master_key or @config.grains_config or @config.version or @config.minion_json_config or @config.master_json_config
       end
 
       def need_install
@@ -115,6 +115,16 @@ module VagrantPlugins
         # Any extra options passed to bootstrap
         if @config.bootstrap_options
           options = "%s %s" % [options, @config.bootstrap_options]
+        end
+
+        if @config.master_json_config && @machine.config.vm.communicator != :winrm
+          config = @config.master_json_config
+          options = "%s -J '#{config}'" % [options]
+        end
+
+        if @config.minion_json_config && @machine.config.vm.communicator != :winrm
+          config = @config.minion_json_config
+          options = "%s -j '#{config}'" % [options]
         end
 
         if configure && @machine.config.vm.communicator != :winrm

--- a/test/unit/plugins/provisioners/salt/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/salt/provisioner_test.rb
@@ -40,6 +40,8 @@ describe VagrantPlugins::Salt::Provisioner do
         allow(config).to receive(:install_type).and_return('stable')
         allow(config).to receive(:install_args).and_return('develop')
         allow(config).to receive(:verbose).and_return(true)
+        allow(config).to receive(:master_json_config).and_return(true)
+        allow(config).to receive(:minion_json_config).and_return(true)
         allow(machine.config.vm).to receive(:communicator).and_return(:winrm)
         allow(config).to receive(:bootstrap_options).and_return(additional_windows_options)
         result = subject.bootstrap_options(true, true, "C:\\salttmp")

--- a/website/source/docs/provisioning/salt.html.md
+++ b/website/source/docs/provisioning/salt.html.md
@@ -96,6 +96,9 @@ public key
 
 * `masterless`  (boolean) - Calls state.highstate in local mode. Uses `minion_id` and `pillar_data` when provided.
 
+* `minion_json_config` (string) - Valid json for configuring the salt minion
+(`-j` in bootstrap-salt.sh). Not supported on Windows.
+
 * `salt_call_args` (array) - An array of additional command line flag arguments to be passed to the `salt-call` command when provisioning with masterless.
 
 ## Master Options
@@ -110,6 +113,9 @@ These only make sense when `install_master` is `true`. Not supported on Windows 
 
 * `seed_master`  (dictionary) - Upload keys to master, thereby
 pre-seeding it before use. Example: `{minion_name:/path/to/key.pub}`
+
+* `master_json_config` (string) - Valid json for configuring the salt master
+(`-J` in bootstrap-salt.sh). Not supported on Windows.
 
 * `salt_args` (array) - An array of additional command line flag arguments to be passed to the `salt` command when provisioning with masterless.
 


### PR DESCRIPTION
Fixes #9417 

* Allow use of -j/-J bootstrap options for configuring master/minion