### PR TITLE
Update systemd? check for guest inspection

### DIFF
--- a/lib/vagrant/util/guest_inspection.rb
+++ b/lib/vagrant/util/guest_inspection.rb
@@ -12,7 +12,7 @@ module Vagrant
         #
         # @return [Boolean]
         def systemd?(comm)
-          comm.test("systemctl | grep '^-\.mount'")
+          comm.test("ps -o comm= 1 | grep systemd")
         end
 
         # systemd-networkd.service is in use

--- a/test/unit/plugins/guests/debian/cap/configure_networks_test.rb
+++ b/test/unit/plugins/guests/debian/cap/configure_networks_test.rb
@@ -65,7 +65,7 @@ describe "VagrantPlugins::GuestDebian::Cap::ConfigureNetworks" do
     end
 
     before do
-      allow(comm).to receive(:test).with("systemctl | grep '^-.mount'").and_return(false)
+      allow(comm).to receive(:test).with("ps -o comm= 1 | grep systemd").and_return(false)
       allow(comm).to receive(:test).with("sudo systemctl status systemd-networkd.service").and_return(false)
       allow(comm).to receive(:test).with("netplan -h").and_return(false)
     end
@@ -83,7 +83,7 @@ describe "VagrantPlugins::GuestDebian::Cap::ConfigureNetworks" do
 
     context "with systemd" do
       before do
-        expect(comm).to receive(:test).with("systemctl | grep '^-.mount'").and_return(true)
+        expect(comm).to receive(:test).with("ps -o comm= 1 | grep systemd").and_return(true)
         allow(comm).to receive(:test).with("netplan -h").and_return(false)
       end
 


### PR DESCRIPTION
Prior to this commit, the regex matcher used with grep to determine if a
system was using systemd? was failing on systems that did not exactly
match the old regex. This commit updates that communications test to use
a different method of determining if systemd is in use with the ps
command.

Fixes #9428 