### PR TITLE
Updating check for Hyper-V

### DIFF
--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -105,9 +105,9 @@ module Vagrant
           return @_windows_hyperv_enabled if defined?(@_windows_hyperv_enabled)
 
           @_windows_hyperv_enabled = -> {
-            ps_cmd = "$(Get-WindowsOptionalFeature -FeatureName Microsoft-Hyper-V-All -Online).State"
+            ps_cmd = "$(Get-ComputerInfo).HypervisorPresent"
             output = Vagrant::Util::PowerShell.execute_cmd(ps_cmd)
-            return output == 'Enabled'
+            return output == 'True'
           }.call
 
           return @_windows_hyperv_enabled

--- a/test/unit/vagrant/util/platform_test.rb
+++ b/test/unit/vagrant/util/platform_test.rb
@@ -217,14 +217,14 @@ describe Vagrant::Util::Platform do
 
   describe ".windows_hyperv_enabled?" do
     it "should return true if enabled" do
-      allow(Vagrant::Util::PowerShell).to receive(:execute_cmd).and_return('Enabled')
+      allow(Vagrant::Util::PowerShell).to receive(:execute_cmd).and_return('True')
 
       expect(Vagrant::Util::Platform.windows_hyperv_enabled?).to be_truthy
     end
 
     it "should return false if disabled" do
       Vagrant::Util::Platform.reset!
-      allow(Vagrant::Util::PowerShell).to receive(:execute_cmd).and_return('Disabled')
+      allow(Vagrant::Util::PowerShell).to receive(:execute_cmd).and_return('False')
 
       expect(Vagrant::Util::Platform.windows_hyperv_enabled?).to be_falsey
     end


### PR DESCRIPTION
This is an updated check to tell if a hypervisor (including Hyper-V) is running on Windows. Virtualbox uses this check to avoid crashing (See #9258). 

This fix covers a few more corner cases than the previous one in #9456:

* Allow virtualbox to run if Hyper-V is installed, but currently disabled. If you want to switch a machine between using Virtualbox and Hyper-V, you can do it with another boot entry - [Link](https://blogs.msdn.microsoft.com/virtual_pc_guy/2008/04/14/creating-a-no-hypervisor-boot-entry/)
* Works on Windows Server & Windows 10. Windows Server uses `Get-WindowsFeature` to check for install, while `Get-WindowsOptionalFeature` is used on Windows 10 ¯\\_(ツ)_/¯ 
* There are two other features that use the hypervisor, so it's possible to have it loaded but Microsoft-HyperV-All isn't installed: Windows-Defender-ApplicationGuard, and [DeviceGuard](https://docs.microsoft.com/en-us/windows/security/threat-protection/device-guard/deploy-device-guard-enable-virtualization-based-security) which is controlled through group policy