### PR TITLE
fix defaults for vagrant ssh -c on windows guests

### DIFF
--- a/lib/vagrant/action/builtin/ssh_run.rb
+++ b/lib/vagrant/action/builtin/ssh_run.rb
@@ -35,8 +35,13 @@ module Vagrant
           end
 
           # Get the command and wrap it in a login shell
-          command = ShellQuote.escape(env[:ssh_run_command], "'")
-          command = "#{env[:machine].config.ssh.shell} -c '#{command}'"
+          if env[:machine].guest.name == :windows
+            command = ShellQuote.escape(env[:ssh_run_command], "\"")
+            command = "cmd /c \"#{command}\""
+          else
+            command = ShellQuote.escape(env[:ssh_run_command], "'")
+            command = "#{env[:machine].config.ssh.shell} -c '#{command}'"
+          end
 
           # Execute!
           opts = env[:ssh_opts] || {}


### PR DESCRIPTION
Use more appropriate shell defaults when sending one-off user commands over `vagrant ssh -c ...` to Windows guests.

The current source hardcodes `bash -l`, does not allow users to override this with downstream configurations, and also hardcodes `-c` (POSIX style) flag and single (`'`) quotes, which Windows' Command Prompt does not handle properly.

For the short term, users just want `vagrant ssh -c ...` to work for Windows guests. The current source mangles the command expansion in a way that breaks if a bash.exe is not carefully setup in the Windows box. This patch corrects this behavior, using a more appropriate expansion.

In the long run, we will want all of these things to be more customizable in order to handle exotic environments (e.g. the user actually wants `vagrant ssh [-c]` to use a bash shell, or zsh, or fish, or ion, or whatever. The shell name and flag should ideally be configurable by the normal `config.vm.ssh.shell` variable (it is not!), and an auxilliary `config.vm.ssh.shell.flags` variable (TBD). The wrapping quotes should also be customizable with `config.vm.ssh.quote` (TBD) for maximum flexibility to suit the user's desired environment. For now, let's just get Windows guests working better.