### PR TITLE
Update behavior of the authentication middleware

### DIFF
--- a/lib/vagrant/shared_helpers.rb
+++ b/lib/vagrant/shared_helpers.rb
@@ -10,7 +10,7 @@ module Vagrant
   # of Vagrant that may require remote access.
   #
   # @return [String]
-  DEFAULT_SERVER_URL = "https://vagrantcloud.com"
+  DEFAULT_SERVER_URL = "https://vagrantcloud.com".freeze
 
   # Max number of seconds to wait for joining an active thread.
   #

--- a/plugins/commands/login/locales/en.yml
+++ b/plugins/commands/login/locales/en.yml
@@ -1,5 +1,17 @@
 en:
   login_command:
+    middleware:
+      authentication:
+        different_target: |-
+          Vagrant has detected a custom Vagrant server in use for downloading
+          box files. An authentication token is currently set which will be
+          added to the box request. If the custom Vagrant server should not
+          be receiving the authentication token, please unset it.
+
+            Known Vagrant server:  %{known_host}
+            Custom Vagrant server: %{custom_host}
+
+          Press ctrl-c to cancel...
     errors:
       server_error: |-
         The Vagrant Cloud server responded with a not-OK response:

--- a/test/unit/plugins/commands/login/middleware/add_authentication_test.rb
+++ b/test/unit/plugins/commands/login/middleware/add_authentication_test.rb
@@ -97,11 +97,13 @@ describe VagrantPlugins::LoginCommand::AddAuthentication do
       original = [
         "http://google.com/box.box",
         "http://vagrantcloud.com/foo.box",
-        "http://example.com/bar.box"
+        "http://example.com/bar.box",
+        "http://example.com/foo.box"
       ]
 
       expected = original.dup
-      expected.last.replace(expected.last + "?access_token=#{token}")
+      expected[2] = expected[2] + "?access_token=#{token}"
+      expected[3] = expected[3] + "?access_token=#{token}"
 
       expect(subject).to receive(:sleep).once
       expect(ui).to receive(:warn).once

--- a/test/unit/plugins/commands/login/middleware/add_authentication_test.rb
+++ b/test/unit/plugins/commands/login/middleware/add_authentication_test.rb
@@ -6,17 +6,20 @@ describe VagrantPlugins::LoginCommand::AddAuthentication do
   include_context "unit"
 
   let(:app) { lambda { |env| } }
+  let(:ui) { double("ui") }
   let(:env) { {
     env: iso_env,
+    ui: ui
   } }
 
   let(:iso_env) { isolated_environment.create_vagrant_env }
-  let(:server_url) { "http://foo.com" }
+  let(:server_url) { "http://vagrantcloud.com" }
 
   subject { described_class.new(app, env) }
 
   before do
     allow(Vagrant).to receive(:server_url).and_return(server_url)
+    allow(ui).to receive(:warn)
     stub_env("ATLAS_TOKEN" => nil)
   end
 
@@ -62,8 +65,30 @@ describe VagrantPlugins::LoginCommand::AddAuthentication do
       expect(env[:box_urls]).to eq(expected)
     end
 
-    it "appends the access token to vagrantcloud.com URLs if Atlas" do
+    it "does not append the access token to vagrantcloud.com URLs if Atlas" do
       server_url = "https://atlas.hashicorp.com"
+      allow(Vagrant).to receive(:server_url).and_return(server_url)
+      allow(subject).to receive(:sleep)
+
+      token = "foobarbaz"
+      VagrantPlugins::LoginCommand::Client.new(iso_env).store_token(token)
+
+      original = [
+        "http://google.com/box.box",
+        "http://vagrantcloud.com/foo.box",
+        "http://vagrantcloud.com/bar.box?arg=true",
+      ]
+
+      expected = original.dup
+
+      env[:box_urls] = original.dup
+      subject.call(env)
+
+      expect(env[:box_urls]).to eq(expected)
+    end
+
+    it "warns when adding token to custom server" do
+      server_url = "https://example.com"
       allow(Vagrant).to receive(:server_url).and_return(server_url)
 
       token = "foobarbaz"
@@ -71,20 +96,31 @@ describe VagrantPlugins::LoginCommand::AddAuthentication do
 
       original = [
         "http://google.com/box.box",
-        "http://app.vagrantup.com/foo.box",
         "http://vagrantcloud.com/foo.box",
-        "http://vagrantcloud.com/bar.box?arg=true",
+        "http://example.com/bar.box"
       ]
 
       expected = original.dup
-      expected[1] = "#{original[1]}?access_token=#{token}"
-      expected[2] = "#{original[2]}?access_token=#{token}"
-      expected[3] = "#{original[3]}&access_token=#{token}"
+      expected.last.replace(expected.last + "?access_token=#{token}")
+
+      expect(subject).to receive(:sleep).once
+      expect(ui).to receive(:warn).once
 
       env[:box_urls] = original.dup
       subject.call(env)
 
       expect(env[:box_urls]).to eq(expected)
+    end
+
+    it "modifies host URL to target if authorized host" do
+      originals = VagrantPlugins::LoginCommand::AddAuthentication::
+        REPLACEMENT_HOSTS.map{ |h| "http://#{h}/box.box" }
+      expected = "http://#{VagrantPlugins::LoginCommand::AddAuthentication::TARGET_HOST}/box.box"
+      env[:box_urls] = originals
+      subject.call(env)
+      env[:box_urls].each do |url|
+        expect(url).to eq(expected)
+      end
     end
 
     it "does not append multiple access_tokens" do


### PR DESCRIPTION
Always remap old hosts to target host when encountered. When custom
vagrant server is defined, warn when tokens may be attached and allow
time for user to cancel.

Fixes #9442