### PR TITLE
Use provider override for box_version if given

### DIFF
--- a/lib/vagrant/vagrantfile.rb
+++ b/lib/vagrant/vagrantfile.rb
@@ -155,6 +155,7 @@ module Vagrant
       # Track the original box so we know if we changed
       box = nil
       original_box = config.vm.box
+      original_version = config.vm.box_version
 
       # The proc below loads the box and provider overrides. This is
       # in a proc because it may have to recurse if the provider override
@@ -188,10 +189,11 @@ module Vagrant
         end
 
         # If the box changed, then we need to reload
-        if original_box != config.vm.box
+        if original_box != config.vm.box || original_version != config.vm.box_version
           # TODO: infinite loop protection?
 
           original_box = config.vm.box
+          original_version = config.vm.box_version
           load_box_proc.call
         end
       end

--- a/test/unit/vagrant/vagrantfile_test.rb
+++ b/test/unit/vagrant/vagrantfile_test.rb
@@ -288,9 +288,11 @@ describe Vagrant::Vagrantfile do
 
       configure do |config|
         config.vm.box = "base"
+        config.vm.box_version = "1.0"
 
         config.vm.provider "foo" do |_, c|
           c.vm.box = "foobox"
+          c.vm.box_version = "2.0"
         end
       end
 
@@ -300,7 +302,7 @@ describe Vagrant::Vagrantfile do
       end
       VF
 
-      iso_env.box3("foobox", "1.0", :foo, vagrantfile: <<-VF)
+      iso_env.box3("foobox", "2.0", :foo, vagrantfile: <<-VF)
       Vagrant.configure("2") do |config|
         config.ssh.port = 234
       end
@@ -311,8 +313,10 @@ describe Vagrant::Vagrantfile do
       box     = results[:box]
       expect(config.vm.box).to eq("foobox")
       expect(config.ssh.port).to eq(234)
+      expect(config.vm.box_version).to eq("2.0")
       expect(box).to_not be_nil
       expect(box.name).to eq("foobox")
+      expect(box.version).to eq("2.0")
     end
 
     it "raises an error if the machine is not found" do


### PR DESCRIPTION
Prior to this commit if an override was given for a box version, it
would be ignored. This commit ensures that the box_version override is
used when specified in a Vagrantfile.

Fixes #9452