### PR TITLE
Fix ssh binary selection on windows

### DIFF
--- a/lib/vagrant/util/ssh.rb
+++ b/lib/vagrant/util/ssh.rb
@@ -68,7 +68,10 @@ module Vagrant
         # include ssh, notably git, mingw and cygwin, but make sure ssh is in the path!
 
         # First try using the original path provided
-        ssh_path = Which.which("ssh", original_path: true)
+        if ENV["VAGRANT_PREFER_SYSTEM_BIN"] != "0"
+          ssh_path = Which.which("ssh", original_path: true)
+        end
+
         # If we didn't find an ssh executable, see if we shipped one
         if !ssh_path
           ssh_path = Which.which("ssh")

--- a/website/source/docs/other/environmental-variables.html.md
+++ b/website/source/docs/other/environmental-variables.html.md
@@ -190,7 +190,7 @@ This currently only applies to Windows systems.
 If this is set, Vagrant will prefer using utility executables (like `ssh` and `rsync`)
 from the local system instead of those vendored within the Vagrant installation.
 
-Vagrant will default to using a system provided `ssh` on windows by default. This
+Vagrant will default to using a system provided `ssh` on Windows. This
 environment variable can also be used to disable that behavior to force Vagrant to
 use the embedded `ssh` executable by setting it to `0`.
 

--- a/website/source/docs/other/environmental-variables.html.md
+++ b/website/source/docs/other/environmental-variables.html.md
@@ -185,9 +185,14 @@ required.
 
 ## `VAGRANT_PREFER_SYSTEM_BIN`
 
+This currently only applies to Windows systems.
+
 If this is set, Vagrant will prefer using utility executables (like `ssh` and `rsync`)
 from the local system instead of those vendored within the Vagrant installation.
-This currently only applies to Windows systems.
+
+Vagrant will default to using a system provided `ssh` on windows by default. This
+environment variable can also be used to disable that behavior to force Vagrant to
+use the embedded `ssh` executable by setting it to `0`.
 
 ## `VAGRANT_SKIP_SUBPROCESS_JAILBREAK`
 


### PR DESCRIPTION
Allow `VAGRANT_PREFER_SYSTEM_BIN=0` to disable using installed system ssh executable on windows.

Fixes #9433