### PR TITLE
Fix Hyper-v and VirtualBox check

### DIFF
--- a/plugins/providers/virtualbox/action/check_virtualbox.rb
+++ b/plugins/providers/virtualbox/action/check_virtualbox.rb
@@ -1,3 +1,5 @@
+require 'vagrant/util/platform'
+
 module VagrantPlugins
   module ProviderVirtualBox
     module Action
@@ -5,6 +7,7 @@ module VagrantPlugins
       class CheckVirtualbox
         def initialize(app, env)
           @app = app
+          @logger = Log4r::Logger.new("vagrant::provider::virtualbox")
         end
 
         def call(env)
@@ -12,6 +15,12 @@ module VagrantPlugins
           # ready to function. If not, then an exception will be raised
           # which will break us out of execution of the middleware sequence.
           Driver::Meta.new.verify!
+
+          if Vagrant::Util::Platform.windows? && Vagrant::Util::Platform.windows_hyperv_enabled?
+            @logger.error("Virtualbox and Hyper-V cannot be used together at the same time on Windows and will result in a system crash.")
+
+            raise Vagrant::Errors::HypervVirtualBoxError
+          end
 
           # Carry on.
           @app.call(env)

--- a/plugins/providers/virtualbox/driver/base.rb
+++ b/plugins/providers/virtualbox/driver/base.rb
@@ -78,12 +78,6 @@ module VagrantPlugins
             end
           end
 
-          if Vagrant::Util::Platform.windows? && Vagrant::Util::Platform.windows_hyperv_enabled?
-            @logger.error("Virtualbox and Hyper-V cannot be used together at the same time on Windows and will result in a system crash.")
-
-            raise Vagrant::Errors::HypervVirtualBoxError
-          end
-
           # Fall back to hoping for the PATH to work out
           @vboxmanage_path ||= "VBoxManage"
           @logger.info("VBoxManage path: #{@vboxmanage_path}")


### PR DESCRIPTION
Prior to this commit, the hyper-v and virtualbox system crash check
existed within the initialize function of the virtualbox provider. That
caused an issue when running with other providers, because the
virtualbox provider still gets initialized even if not used. This commit
changes that by placing the check inside of one of the virtualbox
provider actions that checks if virtualbox is installed and ready to
use. This action is action is used by the main vbox provider actions,
and should not be called when other providers are being used with
Vagrant.