### PR TITLE
Update URLs for the repo

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -7,7 +7,7 @@ The following guidelines for contribution should be followed if you want to subm
 ## How to prepare
 
 * You need a [GitHub account](https://github.com/signup/free)
-* Submit an [issue ticket](https://github.com/mitchellh/vagrant/issues) for your issue if there is not one yet.
+* Submit an [issue ticket](https://github.com/hashicorp/vagrant/issues) for your issue if there is not one yet.
 	* Describe the issue and include steps to reproduce when it's a bug.
 	* Ensure to mention the earliest version that you know is affected.
   * If you plan on submitting a bug report, please submit debug-level logs along

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 if File.exist?(File.expand_path("../../vagrant-spec", __FILE__))
   gem 'vagrant-spec', path: "../vagrant-spec"
 else
-  gem 'vagrant-spec', git: "https://github.com/mitchellh/vagrant-spec.git"
+  gem 'vagrant-spec', git: "https://github.com/hashicorp/vagrant-spec.git"
 end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -302,7 +302,7 @@ en:
       If you're curious what changed in the latest release, view the
       CHANGELOG below:
 
-        https://github.com/mitchellh/vagrant/blob/v%{version}/CHANGELOG.md
+        https://github.com/hashicorp/vagrant/blob/v%{version}/CHANGELOG.md
 
     cfengine_config:
       classes_array: |-
@@ -1167,7 +1167,7 @@ en:
         take a look at the Vagrant source code linked below and try
         to contribute back support. Thank you!
 
-        https://github.com/mitchellh/vagrant
+        https://github.com/hashicorp/vagrant
       rsync_error: |-
         There was an error when attempting to rsync a synced folder.
         Please inspect the error message below for more info.
@@ -2390,7 +2390,7 @@ en:
           take a look at the Vagrant source code linked below and try
           to contribute back support. Thank you!
 
-          https://github.com/mitchellh/vagrant
+          https://github.com/hashicorp/vagrant
         errors:
           ansible_command_failed: |-
             Ansible failed to complete successfully. Any error output should be
@@ -2427,7 +2427,7 @@ en:
             %{details}
 
             Sorry, but this Vagrant error should never occur.
-            Please check https://github.com/mitchellh/vagrant/issues for any
+            Please check https://github.com/hashicorp/vagrant/issues for any
             existing bug report. If needed, please create a new issue. Thank you!
           cannot_support_pip_install: |-
             Unfortunately Vagrant does not support yet installing Ansible
@@ -2437,7 +2437,7 @@ en:
             take a look at the Vagrant source code linked below and try
             to contribute back support. Thank you!
 
-            https://github.com/mitchellh/vagrant
+            https://github.com/hashicorp/vagrant
           ansible_version_mismatch: |-
             The requested Ansible version (%{required_version}) was not found on the %{system}.
             Please check the Ansible installation on your Vagrant %{system} system (currently: %{current_version}),

--- a/test/unit/plugins/synced_folders/rsync/command/rsync_auto_test.rb
+++ b/test/unit/plugins/synced_folders/rsync/command/rsync_auto_test.rb
@@ -63,7 +63,7 @@ describe VagrantPlugins::SyncedFolderRSync::Command::RsyncAuto do
     # the machines config file, they end up being a full path rather than a
     # relative path, and so these tests reflect that.
     # For reference:
-    # https://github.com/mitchellh/vagrant/blob/9c1b014536e61b332cfaa00774a87a240cce8ed9/lib/vagrant/action/builtin/synced_folders.rb#L45-L46
+    # https://github.com/hashicorp/vagrant/blob/9c1b014536e61b332cfaa00774a87a240cce8ed9/lib/vagrant/action/builtin/synced_folders.rb#L45-L46
     let(:config_synced_folders)  { {"/vagrant":
                                    {type: "rsync",
                                     exclude: false,

--- a/website/source/community.html.erb
+++ b/website/source/community.html.erb
@@ -25,7 +25,7 @@ description: |-
 </p>
 <p>
   <strong>Bug Tracker:</strong>
-  <a href="https://github.com/mitchellh/vagrant/issues">Issue tracker
+  <a href="https://github.com/hashicorp/vagrant/issues">Issue tracker
   on GitHub</a>. Please only use this for reporting bugs. Do not ask
   for general help here. Use IRC or the mailing list for that.
 </p>

--- a/website/source/docs/boxes/base.html.md
+++ b/website/source/docs/boxes/base.html.md
@@ -119,7 +119,7 @@ users, passwords, private keys, etc.).
 
 By default, Vagrant expects a "vagrant" user to SSH into the machine as.
 This user should be setup with the
-[insecure keypair](https://github.com/mitchellh/vagrant/tree/master/keys)
+[insecure keypair](https://github.com/hashicorp/vagrant/tree/master/keys)
 that Vagrant uses as a default to attempt to SSH. Also, even though
 Vagrant uses key-based authentication by default, it is a general convention
 to set the password for the "vagrant" user to "vagrant". This lets people

--- a/website/source/docs/cli/machine-readable.html.md
+++ b/website/source/docs/cli/machine-readable.html.md
@@ -35,7 +35,7 @@ of the commands. It is likely that what you may want to achieve with
 the machine-readable output is not possible due to missing information.
 
 In this case, we ask that you please
-[open an issue](https://github.com/mitchellh/vagrant/issues)
+[open an issue](https://github.com/hashicorp/vagrant/issues)
 requesting that certain information become available. We will most likely add
 it!
 

--- a/website/source/docs/docker/basics.html.md
+++ b/website/source/docs/docker/basics.html.md
@@ -88,7 +88,7 @@ you only have the overhead of one virtual machine, and only if it is
 absolutely necessary.
 
 By default, the host VM Vagrant spins up is
-[backed by boot2docker](https://github.com/mitchellh/vagrant/blob/master/plugins/providers/docker/hostmachine/Vagrantfile),
+[backed by boot2docker](https://github.com/hashicorp/vagrant/blob/master/plugins/providers/docker/hostmachine/Vagrantfile),
 because it launches quickly and uses little resources. But the host VM
 can be customized to point to _any_ Vagrantfile. This allows the host VM
 to more closely match production by running a VM running Ubuntu, RHEL,

--- a/website/source/docs/hyperv/boxes.html.md
+++ b/website/source/docs/hyperv/boxes.html.md
@@ -100,4 +100,4 @@ There is also some less structured help available from the experience of
 other users. These are not official documentation but if you are running
 into trouble they may help you:
 
-  * [Ubuntu 14.04.2 without secure boot](https://github.com/mitchellh/vagrant/issues/5419#issuecomment-86235427)
+  * [Ubuntu 14.04.2 without secure boot](https://github.com/hashicorp/vagrant/issues/5419#issuecomment-86235427)

--- a/website/source/docs/installation/source.html.md
+++ b/website/source/docs/installation/source.html.md
@@ -30,7 +30,7 @@ Clone Vagrant's repository from GitHub into the directory where you keep code on
 
 
 ```shell
-$ git clone https://github.com/mitchellh/vagrant.git
+$ git clone https://github.com/hashicorp/vagrant.git
 ```
 
 Next, `cd` into that path. All commands will be run from this path:

--- a/website/source/docs/installation/upgrading.html.md
+++ b/website/source/docs/installation/upgrading.html.md
@@ -29,7 +29,7 @@ newer Vagrantfiles may have backwards incompatible changes until 2.0 final.
 
 <div class="alert alert-info alert-block">
   <strong>Run into troubles upgrading?</strong> Please
-  <a href="https://github.com/mitchellh/vagrant/issues" class="alert-link">report an issue</a>
+  <a href="https://github.com/hashicorp/vagrant/issues" class="alert-link">report an issue</a>
   if you run into problems upgrading. Upgrades are meant to be a smooth
   process and we consider it a bug if it was not.
 </div>

--- a/website/source/docs/plugins/development-basics.html.md
+++ b/website/source/docs/plugins/development-basics.html.md
@@ -45,7 +45,7 @@ Vagrant plugin development:
 source "https://rubygems.org"
 
 group :development do
-  gem "vagrant", git: "https://github.com/mitchellh/vagrant.git"
+  gem "vagrant", git: "https://github.com/hashicorp/vagrant.git"
 end
 
 group :plugins do
@@ -165,7 +165,7 @@ should be considered bugs.
 
 Therefore, to fit into Vagrant's error handling mechanisms, subclass
 `VagrantError` and set a proper message on your exception. To see
-examples of this, look at Vagrant's [built-in errors](https://github.com/mitchellh/vagrant/blob/master/lib/vagrant/errors.rb).
+examples of this, look at Vagrant's [built-in errors](https://github.com/hashicorp/vagrant/blob/master/lib/vagrant/errors.rb).
 
 ## Console Input and Output
 
@@ -177,5 +177,5 @@ pipes are closed, there is no input pipe, etc.
 
 A UI object is available on every `Vagrant::Environment` via the `ui` property
 and is exposed within every middleware environment via the `:ui` key. UI
-objects have [decent documentation](https://github.com/mitchellh/vagrant/blob/master/lib/vagrant/ui.rb)
+objects have [decent documentation](https://github.com/hashicorp/vagrant/blob/master/lib/vagrant/ui.rb)
 within the comments of their source.

--- a/website/source/docs/plugins/index.html.md
+++ b/website/source/docs/plugins/index.html.md
@@ -19,7 +19,7 @@ _plugins_.
 Plugins are powerful, first-class citizens that extend Vagrant using a
 well-documented, stable API that can withstand major version upgrades.
 
-In fact, most of the core of Vagrant is [implemented using plugins](https://github.com/mitchellh/vagrant/tree/master/plugins).
+In fact, most of the core of Vagrant is [implemented using plugins](https://github.com/hashicorp/vagrant/tree/master/plugins).
 Since Vagrant [dogfoods](https://en.wikipedia.org/wiki/Eating_your_own_dog_food) its own
 plugin API, you can be confident that the interface is stable and well supported.
 

--- a/website/source/docs/plugins/packaging.html.md
+++ b/website/source/docs/plugins/packaging.html.md
@@ -63,7 +63,7 @@ Vagrant plugin development:
 source "https://rubygems.org"
 
 group :development do
-  gem "vagrant", git: "https://github.com/mitchellh/vagrant.git"
+  gem "vagrant", git: "https://github.com/hashicorp/vagrant.git"
 end
 
 group :plugins do
@@ -106,7 +106,7 @@ To manually test your plugin during development, use
 (thanks to the Gemfile setup we did earlier).
 
 For automated testing, the
-[vagrant-spec](https://github.com/mitchellh/vagrant-spec)
+[vagrant-spec](https://github.com/hashicorp/vagrant-spec)
 project provides helpers for both unit and acceptance testing
 plugins. See the giant README for that project for a detailed
 description of how to integrate vagrant-spec into your project.

--- a/website/source/docs/plugins/providers.html.md
+++ b/website/source/docs/plugins/providers.html.md
@@ -62,7 +62,7 @@ The provider class should subclass and implement
 return the proper parent class.
 
 This class and the methods that need to be implemented are
-[very well documented](https://github.com/mitchellh/vagrant/blob/master/lib/vagrant/plugin/v2/provider.rb). The documentation done on the class in the comments should be
+[very well documented](https://github.com/hashicorp/vagrant/blob/master/lib/vagrant/plugin/v2/provider.rb). The documentation done on the class in the comments should be
 enough to understand what needs to be done.
 
 Viewing the [AWS provider class](https://github.com/mitchellh/vagrant-aws/blob/master/lib/vagrant-aws/provider.rb) as well as the
@@ -128,12 +128,12 @@ a friendly error, so do not worry if you miss any, things will not explode
 or crash spectacularly.
 
 Take a look at how the VirtualBox provider
-[uses actions to build up complicated multi-step processes](https://github.com/mitchellh/vagrant/blob/master/plugins/providers/virtualbox/action.rb#L287). The AWS provider [uses a similar process](https://github.com/mitchellh/vagrant-aws/blob/master/lib/vagrant-aws/action.rb).
+[uses actions to build up complicated multi-step processes](https://github.com/hashicorp/vagrant/blob/master/plugins/providers/virtualbox/action.rb#L287). The AWS provider [uses a similar process](https://github.com/mitchellh/vagrant-aws/blob/master/lib/vagrant-aws/action.rb).
 
 ## Built-in Middleware
 
 To assist with common tasks, Vagrant ships with a set of
-[built-in middleware](https://github.com/mitchellh/vagrant/tree/master/lib/vagrant/action/builtin). Each of the middleware is well commented on the behavior and options
+[built-in middleware](https://github.com/hashicorp/vagrant/tree/master/lib/vagrant/action/builtin). Each of the middleware is well commented on the behavior and options
 for each, and using these built-in middleware is critical to building
 a well-behaved provider.
 

--- a/website/source/docs/plugins/provisioners.html.md
+++ b/website/source/docs/plugins/provisioners.html.md
@@ -50,7 +50,7 @@ The provisioner class should subclass and implement
 Vagrant return the proper parent class for provisioners.
 
 This class and the methods that need to be implemented are
-[very well documented](https://github.com/mitchellh/vagrant/blob/master/lib/vagrant/plugin/v2/provisioner.rb).
+[very well documented](https://github.com/hashicorp/vagrant/blob/master/lib/vagrant/plugin/v2/provisioner.rb).
 The documentation on the class in the comments should be enough
 to understand what needs to be done.
 
@@ -60,7 +60,7 @@ There are two main methods that need to be implemented: the
 The `configure` method is called early in the machine booting process
 to allow the provisioner to define new configuration on the machine, such
 as sharing folders, defining networks, etc. As an example, the
-[Chef solo provisioner](https://github.com/mitchellh/vagrant/blob/master/plugins/provisioners/chef/provisioner/chef_solo.rb#L24)
+[Chef solo provisioner](https://github.com/hashicorp/vagrant/blob/master/plugins/provisioners/chef/provisioner/chef_solo.rb#L24)
 uses this to define shared folders.
 
 The `provision` method is called when the machine is booted and ready

--- a/website/source/docs/provisioning/ansible.html.md
+++ b/website/source/docs/provisioning/ansible.html.md
@@ -125,7 +125,7 @@ end
 
 <div class="alert alert-info">
   <strong>Tip:</strong>
-  If you apply this parallel provisioning pattern with a static Ansible inventory, you will have to organize the things so that [all the relevant private keys are provided to the `ansible-playbook` command](https://github.com/mitchellh/vagrant/pull/5765#issuecomment-120247738). The same kind of considerations applies if you are using multiple private keys for a same machine (see [`config.ssh.private_key_path` SSH setting](/docs/vagrantfile/ssh_settings.html)).
+  If you apply this parallel provisioning pattern with a static Ansible inventory, you will have to organize the things so that [all the relevant private keys are provided to the `ansible-playbook` command](https://github.com/hashicorp/vagrant/pull/5765#issuecomment-120247738). The same kind of considerations applies if you are using multiple private keys for a same machine (see [`config.ssh.private_key_path` SSH setting](/docs/vagrantfile/ssh_settings.html)).
 </div>
 
 ### Force Paramiko Connection Mode

--- a/website/source/docs/synced-folders/virtualbox.html.md
+++ b/website/source/docs/synced-folders/virtualbox.html.md
@@ -36,4 +36,4 @@ In Apache:
 
     EnableSendfile Off
 
-[sendfile bug]: https://github.com/mitchellh/vagrant/issues/351#issuecomment-1339640
+[sendfile bug]: https://github.com/hashicorp/vagrant/issues/351#issuecomment-1339640

--- a/website/source/docs/vagrant-cloud/support.html.md
+++ b/website/source/docs/vagrant-cloud/support.html.md
@@ -37,7 +37,7 @@ it provides, there may be information lacking in the documentation.
 Vagrant Cloud documentation is open source.
 If you'd like to improve or correct the documentation,
 please submit a pull-request to the
-[Vagrant project on GitHub](https://github.com/mitchellh/vagrant/tree/master/website/source/docs/vagrant-cloud/).
+[Vagrant project on GitHub](https://github.com/hashicorp/vagrant/tree/master/website/source/docs/vagrant-cloud/).
 The Vagrant Cloud documentation can be found in the `/website/source/vagrant-cloud/` directory.
 
 Otherwise, to make a suggestion or report an error in documentation, please

--- a/website/source/docs/vmware/boxes.html.md
+++ b/website/source/docs/vmware/boxes.html.md
@@ -113,7 +113,7 @@ a bare minimum:
 
 * SSH server with key-based authentication setup. If you want the box to
   work with default Vagrant settings, the SSH user must be set to accept
-  the [insecure keypair](https://github.com/mitchellh/vagrant/blob/master/keys/vagrant.pub)
+  the [insecure keypair](https://github.com/hashicorp/vagrant/blob/master/keys/vagrant.pub)
   that ships with Vagrant.
 
 * [VMware Tools](https://kb.vmware.com/kb/340) so that things such as shared

--- a/website/source/intro/getting-started/install.html.md
+++ b/website/source/intro/getting-started/install.html.md
@@ -14,7 +14,7 @@ Vagrant must first be installed on the machine you want to run it on. To make
 installation easy, Vagrant is distributed as a [binary package](/downloads.html)
 for all supported platforms and architectures. This page will not cover how to
 compile Vagrant from source, as that is covered in the
-[README](https://github.com/mitchellh/vagrant/blob/master/README.md) and is only
+[README](https://github.com/hashicorp/vagrant/blob/master/README.md) and is only
 recommended for advanced users.
 
 ## Installing Vagrant

--- a/website/source/intro/vs/index.html.md
+++ b/website/source/intro/vs/index.html.md
@@ -14,7 +14,7 @@ environments. This section compares Vagrant to these other software choices.
 
 Due to the bias of the comparisons, we attempt to only use facts. If you find
 something that is invalid or out of date in the comparisons, please [open an
-issue](https://github.com/mitchellh/vagrant/issues) and we'll address it as soon
+issue](https://github.com/hashicorp/vagrant/issues) and we'll address it as soon
 as possible.
 
 Use the navigation on the left to read comparisons of Vagrant versus similar

--- a/website/source/layouts/_sidebar.erb
+++ b/website/source/layouts/_sidebar.erb
@@ -23,7 +23,7 @@
       </a>
     </li>
     <li>
-      <a href="https://github.com/mitchellh/vagrant">
+      <a href="https://github.com/hashicorp/vagrant">
         <%= inline_svg "github.svg" %> GitHub
       </a>
     </li>

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -83,7 +83,7 @@
                     </a>
                   </li>
                   <li>
-                    <a href="https://github.com/mitchellh/vagrant">
+                    <a href="https://github.com/hashicorp/vagrant">
                       <%= inline_svg "github.svg" %> GitHub
                     </a>
                   </li>
@@ -141,7 +141,7 @@
         "url": "https://www.vagrantup.com",
         "logo": "<%= File.join(base_url, image_path("logo-hashicorp.svg")) %>",
         "sameAs": [
-          "https://github.com/mitchellh/vagrant"
+          "https://github.com/hashicorp/vagrant"
         ]
       }
     </script>


### PR DESCRIPTION
Currently the URLs on the website and in the repo point to the old repo URLs under mitchellh's account. This updates the links to point directly to the Hashicorp repo(s).