### PR TITLE
Further attempt to get the IP address of HyperV guests

### DIFF
--- a/plugins/providers/hyperv/scripts/get_network_config.ps1
+++ b/plugins/providers/hyperv/scripts/get_network_config.ps1
@@ -22,6 +22,20 @@ foreach ($network in $networks) {
         break
       }
     }
+  } else {
+    # Try to discover the IP address from the neighbor cache entries
+    try {
+      $mac = (Get-VMNetworkAdapter -VM $vm).MacAddress
+      $macaddr = ($mac -replace "(\w{2})(\w{2})(\w{2})(\w{2})(\w{2})(\w{2})", '$1-$2-$3-$4-$5-$6')
+      $ip_address = (Get-NetNeighbor -LinkLayerAddress $macaddr).IPAddress
+      if (-Not ([string]::IsNullOrEmpty($ip_address))) {
+        # It's our lucky day
+        $ip4_address = $ip_address
+        break
+      }
+    } catch {
+      $ip_address = ""
+    }
   }
 }
 


### PR DESCRIPTION
For guests that don't have support for Hyper-V Integration Services, attempt to get the IP address from the neighbor cache entries.

Of course this won't always work, it requires that the host and the guest communicate with each other before, but at least gives a chance to some guest OSes to work out of the box. Only for IPv4 addresses for now.
