### PR TITLE
When matching hostonly adapter name, force common types

### DIFF
--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -480,8 +480,8 @@ module VagrantPlugins
             return interface if config[:name] && config[:name] == interface[:name]
 
             #if a config name is specified, we should only look for that.
-            if config[:name] != ""
-                next
+            if config[:name].to_s != ""
+              next
             end
 
             if interface[:ip] != ""

--- a/test/unit/plugins/providers/virtualbox/action/network_test.rb
+++ b/test/unit/plugins/providers/virtualbox/action/network_test.rb
@@ -181,4 +181,45 @@ describe VagrantPlugins::ProviderVirtualBox::Action::Network do
       end
     end
   end
+
+  describe "#hostonly_find_matching_network" do
+    let(:ip){ "192.168.55.2" }
+    let(:config){ {ip: ip, netmask: "255.255.255.0"} }
+    let(:interfaces){ [] }
+
+    before do
+      allow(driver).to receive(:read_host_only_interfaces).and_return(interfaces)
+      subject.instance_variable_set(:@env, env)
+    end
+
+    context "with no defined host interfaces" do
+      it "should return nil" do
+        expect(subject.hostonly_find_matching_network(config)).to be_nil
+      end
+    end
+
+    context "with matching host interface" do
+      let(:interfaces){ [{ip: "192.168.55.1", netmask: "255.255.255.0", name: "vnet"}] }
+
+      it "should return matching interface" do
+        expect(subject.hostonly_find_matching_network(config)).to eq(interfaces.first)
+      end
+
+      context "with matching name" do
+        let(:config){ {ip: ip, netmask: "255.255.255.0", name: "vnet"} }
+
+        it "should return matching interface" do
+          expect(subject.hostonly_find_matching_network(config)).to eq(interfaces.first)
+        end
+      end
+
+      context "with non-matching name" do
+        let(:config){ {ip: ip, netmask: "255.255.255.0", name: "unknown"} }
+
+        it "should return nil" do
+          expect(subject.hostonly_find_matching_network(config)).to be_nil
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Force a string type for comparison to prevent false positives when
the name is unset (resulting in a nil value).