### PR TITLE
ensure vagrant halt terminates with a clean and correct exit code for haiku guests

### DIFF
--- a/plugins/guests/haiku/cap/halt.rb
+++ b/plugins/guests/haiku/cap/halt.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class Halt
         def self.halt(machine)
           begin
-            machine.communicate.execute("/bin/shutdown")
+            machine.communicate.execute("/bin/shutdown -s")
           rescue IOError, Vagrant::Errors::SSHDisconnected
             # Ignore, this probably means connection closed because it
             # shut down.


### PR DESCRIPTION
The current Haiku guest plugin has `vagrant halt` exiting with a non-zero, failing exit code, as a result of how the `/bin/shutdown` program behaves in Haiku OS: It exits with value 2 rather than 0. When this happens, any programs measuring the exit value of `vagrant halt` will get the wrong impression, that Vagrant was unable to successfully halt the VM, when in fact, Vagrant *was* able to successfully halt the VM. This mistake compounds when Vagrant is integrated with other command line programs, and even worse, Vagrant's own commands such as `vagrant package` suffer early terminations as a result of the misleading exit status during the halt stage.

I'm adding a `-s` flag to `shutdown`, as this triggers an SSH disconnection error which the Haiku guest plugin already identifies as a non-error, so that the overall `vagrant halt` exit status is accurate.