### PR TITLE
Fix graceful_halt_timeout issue #8486

### DIFF
--- a/plugins/guests/windows/cap/change_host_name.rb
+++ b/plugins/guests/windows/cap/change_host_name.rb
@@ -4,10 +4,10 @@ module VagrantPlugins
       module ChangeHostName
 
         def self.change_host_name(machine, name)
-          change_host_name_and_wait(machine, name)
+          change_host_name_and_wait(machine, name, machine.config.vm.graceful_halt_timeout)
         end
 
-        def self.change_host_name_and_wait(machine, name)
+        def self.change_host_name_and_wait(machine, name, sleep_timeout)
           # If the configured name matches the current name, then bail
           # We cannot use %ComputerName% because it truncates at 15 chars
           return if machine.communicate.test("if ([System.Net.Dns]::GetHostName() -eq '#{name}') { exit 0 } exit 1")
@@ -30,6 +30,9 @@ module VagrantPlugins
           # Don't continue until the machine has shutdown and rebooted
 	  if machine.guest.capability?(:wait_for_reboot)
             machine.guest.capability(:wait_for_reboot)
+          else
+            # use graceful_halt_timeout only if guest cannot wait for reboot
+            sleep(sleep_timeout)
 	  end
         end
       end

--- a/plugins/guests/windows/cap/change_host_name.rb
+++ b/plugins/guests/windows/cap/change_host_name.rb
@@ -28,7 +28,9 @@ module VagrantPlugins
             error_key: :rename_computer_failed)
 
           # Don't continue until the machine has shutdown and rebooted
-          machine.guest.capability(:wait_for_reboot)
+	  if machine.guest.capability?(:wait_for_reboot)
+            machine.guest.capability(:wait_for_reboot)
+	  end
         end
       end
     end

--- a/plugins/guests/windows/cap/change_host_name.rb
+++ b/plugins/guests/windows/cap/change_host_name.rb
@@ -4,10 +4,10 @@ module VagrantPlugins
       module ChangeHostName
 
         def self.change_host_name(machine, name)
-          change_host_name_and_wait(machine, name, machine.config.vm.graceful_halt_timeout)
+          change_host_name_and_wait(machine, name)
         end
 
-        def self.change_host_name_and_wait(machine, name, sleep_timeout)
+        def self.change_host_name_and_wait(machine, name)
           # If the configured name matches the current name, then bail
           # We cannot use %ComputerName% because it truncates at 15 chars
           return if machine.communicate.test("if ([System.Net.Dns]::GetHostName() -eq '#{name}') { exit 0 } exit 1")
@@ -28,7 +28,7 @@ module VagrantPlugins
             error_key: :rename_computer_failed)
 
           # Don't continue until the machine has shutdown and rebooted
-          sleep(sleep_timeout)
+          machine.guest.capability(:wait_for_reboot)
         end
       end
     end

--- a/test/unit/plugins/guests/windows/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/windows/cap/change_host_name_test.rb
@@ -34,6 +34,9 @@ describe "VagrantPlugins::GuestWindows::Cap::ChangeHostName" do
         'if (!([System.Net.Dns]::GetHostName() -eq \'newhostname\')) { exit 0 } exit 1',
         exit_code: 0)
       communicator.stub_command(rename_script, exit_code: 0)
+      allow(machine).to receive(:guest)
+      allow(machine.guest).to receive(:capability)
+      allow(machine.guest).to receive(:capability?)
       described_class.change_host_name_and_wait(machine, 'newhostname')
     end
 

--- a/test/unit/plugins/guests/windows/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/windows/cap/change_host_name_test.rb
@@ -37,7 +37,7 @@ describe "VagrantPlugins::GuestWindows::Cap::ChangeHostName" do
       allow(machine).to receive(:guest)
       allow(machine.guest).to receive(:capability)
       allow(machine.guest).to receive(:capability?)
-      described_class.change_host_name_and_wait(machine, 'newhostname')
+      described_class.change_host_name_and_wait(machine, 'newhostname', 0)
     end
 
   end

--- a/test/unit/plugins/guests/windows/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/windows/cap/change_host_name_test.rb
@@ -34,7 +34,7 @@ describe "VagrantPlugins::GuestWindows::Cap::ChangeHostName" do
         'if (!([System.Net.Dns]::GetHostName() -eq \'newhostname\')) { exit 0 } exit 1',
         exit_code: 0)
       communicator.stub_command(rename_script, exit_code: 0)
-      described_class.change_host_name_and_wait(machine, 'newhostname', 0)
+      described_class.change_host_name_and_wait(machine, 'newhostname')
     end
 
   end


### PR DESCRIPTION
The current code waits for the entire value of machine.config.vm.graceful_halt_timeout when rebooting due to a hostname change.  This is not the intended use of this configuration parameter.  Graceful_halt_timeout is the amount of time to wait for a machine to respond to a graceful halt request before forcefully halting.  This change removes machine.config.vm.graceful_halt_timeout for the module in favor of using the existing wait_for_reboot code, thereby correcting issue #8486.

Fixes #8486