### PR TITLE
Fix missing "-" $script variable definition.

### DIFF
--- a/website/source/docs/provisioning/shell.html.md
+++ b/website/source/docs/provisioning/shell.html.md
@@ -107,7 +107,7 @@ Combined with a little bit more Ruby, this makes it very easy to embed
 your shell scripts directly within your Vagrantfile. Another example below:
 
 ```ruby
-$script = <<SCRIPT
+$script = <<-SCRIPT
 echo I am provisioning...
 date > /etc/vagrant_provisioned_at
 SCRIPT


### PR DESCRIPTION
In the $script variable definition there appears to be a typo of "<<SCRIPT" when it should be "<<-SCRIPT". I ran into this issue while editing the Vagrant file on a Fedora variant with ruby 2.3.3p222 (2016-11-21 revision 56859) [x86_64-linux].