### PR TITLE
Identify operating systems closely related to CoreOS

### DIFF
--- a/plugins/guests/coreos/guest.rb
+++ b/plugins/guests/coreos/guest.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
   module GuestCoreOS
     class Guest < Vagrant.plugin("2", :guest)
       def detect?(machine)
-        machine.communicate.test("cat /etc/os-release | grep ID=coreos")
+        machine.communicate.test("(cat /etc/os-release | grep ID=coreos) || (cat /etc/os-release | grep -E 'ID_LIKE=.*coreos.*')")
       end
     end
   end


### PR DESCRIPTION
If the the value of ID= is not recognised, identify the OS if it is a derivative of CoreOS
https://www.freedesktop.org/software/systemd/man/os-release.html#ID_LIKE=

This change is done to support [Flatcar Linux](https://www.flatcar-linux.org/)