### PR TITLE
Remove name from command option

### DIFF
--- a/website/source/docs/cli/up.html.md
+++ b/website/source/docs/cli/up.html.md
@@ -9,7 +9,7 @@ description: |-
 
 # Up
 
-**Command: `vagrant up [name|id]`**
+**Command: `vagrant up [id]`**
 
 This command creates and configures guest machines according to your
 [Vagrantfile](/docs/vagrantfile/).


### PR DESCRIPTION
`vagrant up` does not accept the name of a box as an argument. It only accepts `id` as per the error message when running with `name`.