### PR TITLE
Update options to define id can be used in any directory

### DIFF
--- a/website/source/docs/cli/up.html.md
+++ b/website/source/docs/cli/up.html.md
@@ -20,6 +20,11 @@ on a day-to-day basis.
 
 ## Options
 
+* `name` - Name of machine defined in [Vagrantfile](/docs/vagrantfile/)
+
+* `id` - Machine id found with `vagrant global-status`. Using `id` allows
+  you to call `vagrant up id` from any directory.
+
 * `--[no-]destroy-on-error` - Destroy the newly created machine if a fatal,
   unexpected error occurs. This will only happen on the first `vagrant up`.
   By default this is set.


### PR DESCRIPTION
[#9605]( https://github.com/hashicorp/vagrant/pull/9605)

Proposes add `name|id` to `Options` to define the ability to use `id` from any directory.