### PR TITLE
Skip link-local addresses when fixing IPv6 route

### DIFF
--- a/plugins/providers/virtualbox/action/network_fix_ipv6.rb
+++ b/plugins/providers/virtualbox/action/network_fix_ipv6.rb
@@ -10,7 +10,7 @@ module VagrantPlugins
   module ProviderVirtualBox
     module Action
       # This middleware works around a bug in VirtualBox where booting
-      # a VM with an IPv6 host-only network will someties lose the
+      # a VM with an IPv6 host-only network will sometimes lose the
       # route to that machine.
       class NetworkFixIPv6
         include Vagrant::Util::Presence
@@ -43,12 +43,15 @@ module VagrantPlugins
           # If we have no IPv6, forget it
           return if !has_v6
 
+          link_local_range = IPAddr.new("fe80::/10")
           host_only_interfaces(env).each do |interface|
             next if !present?(interface[:ipv6])
             next if interface[:status] != "Up"
 
             ip = IPAddr.new(interface[:ipv6])
             ip |= ("1" * (128 - interface[:ipv6_prefix].to_i)).to_i(2)
+
+            next if link_local_range.include?(ip)
 
             @logger.info("testing IPv6: #{ip}")
 


### PR DESCRIPTION
This crash occurs with a Linux host when a link-local address is configured for vboxnet0 (which is the default for VirtualBox 5.2.6).

Here is the stacktrace I'm getting without this patch:

```
/home/infertux/.rvm/rubies/ruby-2.5.1/lib/ruby/2.5.0/resolv-replace.rb:42:in `connect': Invalid argument - connect(2) for "fe80::ffff:ffff:ffff:ffff" port 80 (Errno::EINVAL)
	from /home/infertux/.rvm/rubies/ruby-2.5.1/lib/ruby/2.5.0/resolv-replace.rb:42:in `connect'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.0.3/plugins/providers/virtualbox/action/network_fix_ipv6.rb:56:in `block in call'
```

Unfortunately, I was unable to add a test for this as mocking the link-local IP didn't not trigger this error for some reason: https://github.com/infertux/vagrant/commit/fdbe515c6f025a9039679a763dfeb05072e4b581