### PR TITLE
Properly respect environment variable on checkpoint setup

### DIFF
--- a/lib/vagrant/util/checkpoint_client.rb
+++ b/lib/vagrant/util/checkpoint_client.rb
@@ -39,6 +39,10 @@ module Vagrant
         rescue LoadError
           @logger.warn("checkpoint library not found. disabling.")
         end
+        if ENV["VAGRANT_CHECKPOINT_DISABLE"]
+          @logger.debug("checkpoint disabled via explicit user request")
+          @enabled = false
+        end
         @files = {
           signature: env.data_dir.join("checkpoint_signature"),
           cache: env.data_dir.join("checkpoint_cache")

--- a/test/unit/vagrant/util/checkpoint_client_test.rb
+++ b/test/unit/vagrant/util/checkpoint_client_test.rb
@@ -23,7 +23,8 @@ describe Vagrant::Util::CheckpointClient do
   end
 
   describe "#setup" do
-    before{ subject.setup(env) }
+    let(:environment){ {} }
+    before{ with_temp_env(environment){ subject.setup(env) } }
 
     it "should enable after setup" do
       expect(subject.enabled).to be(true)
@@ -31,6 +32,14 @@ describe Vagrant::Util::CheckpointClient do
 
     it "should generate required paths" do
       expect(subject.files).not_to be_empty
+    end
+
+    context "with VAGRANT_CHECKPOINT_DISABLE set" do
+      let(:environment){ {"VAGRANT_CHECKPOINT_DISABLE" => "1"} }
+
+      it "should not be enabled after setup" do
+        expect(subject.enabled).to be(false)
+      end
     end
   end
 


### PR DESCRIPTION
The checkpoint update missed the environment variable check for
disabling the checks so this adds in the check and properly
disables checks when requested.