### PR TITLE
Support arrays for data_bags_path in chef-zero

### DIFF
--- a/plugins/provisioners/chef/provisioner/chef_zero.rb
+++ b/plugins/provisioners/chef/provisioner/chef_zero.rb
@@ -46,7 +46,7 @@ module VagrantPlugins
             cookbooks_path: guest_paths(@cookbook_folders),
             nodes_path: guest_paths(@node_folders),
             roles_path: guest_paths(@role_folders),
-            data_bags_path: guest_paths(@data_bags_folders).first,
+            data_bags_path: guest_paths(@data_bags_folders),
             environments_path: guest_paths(@environments_folders).first,
           })
         end


### PR DESCRIPTION
The pull request #6561 added the support for arrays for data_bags_path
in chef-solo and chef-zero, but missed a `.first` in chef-zero (which
only keeps the first data bag path). The documentation and the template
for chef-zero are already good (since #6561).

Fixes #9668.