### PR TITLE
Check Windows installed Vagrant version using --version

### DIFF
--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -561,9 +561,9 @@ module Vagrant
         def wsl_validate_matching_vagrant_versions!
           valid = false
           if Util::Which.which("vagrant.exe")
-            result = Util::Subprocess.execute("vagrant.exe", "version")
+            result = Util::Subprocess.execute("vagrant.exe", "--version")
             if result.exit_code == 0
-              windows_version = result.stdout.match(/Installed Version: (?<version>[\w.-]+)/)
+              windows_version = result.stdout.match(/Vagrant (?<version>[\w.-]+)/)
               if windows_version
                 windows_version = windows_version[:version].strip
                 valid = windows_version == Vagrant::VERSION

--- a/test/unit/vagrant/util/platform_test.rb
+++ b/test/unit/vagrant/util/platform_test.rb
@@ -185,8 +185,8 @@ describe Vagrant::Util::Platform do
 
     before do
       allow(Vagrant::Util::Which).to receive(:which).and_return(true)
-      allow(Vagrant::Util::Subprocess).to receive(:execute).with("vagrant.exe", "version").
-        and_return(double(exit_code: 0, stdout: "Installed Version: #{exe_version}"))
+      allow(Vagrant::Util::Subprocess).to receive(:execute).with("vagrant.exe", "--version").
+        and_return(double(exit_code: 0, stdout: "Vagrant #{exe_version}"))
     end
 
     it "should not raise an error" do


### PR DESCRIPTION
Using the --version flag keeps Vagrant from doing a full startup
and prevents the Vagrantfile from being parsed. This makes the
version check faster, and stops things like syntax errors within
a Vagrantfile from causing an unexpected error.

Fixes #9635