### PR TITLE
Update generated ssh private key file permissions on create

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -65,6 +65,12 @@ require 'i18n'
 # there are issues with ciphers not being properly loaded.
 require 'openssl'
 
+# If we are on Windows, load in File helpers
+if Vagrant::Util::Platform.windows?
+  require "win32-ffi-extensions"
+  require "win32/file/security"
+end
+
 # Always make the version available
 require 'vagrant/version'
 global_logger = Log4r::Logger.new("vagrant::global")

--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -1,3 +1,4 @@
+require 'etc'
 require 'logger'
 require 'pathname'
 require 'stringio'
@@ -191,6 +192,14 @@ module VagrantPlugins
           # machine automatically picks it up.
           @machine.data_dir.join("private_key").open("w+") do |f|
             f.write(priv)
+          end
+
+          # Adjust private key file permissions
+          if Vagrant::Util::Platform.windows?
+            priv_path = @machine.data_dir.join("private_key").to_s
+            File.set_permissions(priv_path, Etc.getlogin => File::FULL)
+          else
+            @machine.data_dir.join("private_key").chmod(0600)
           end
 
           # Remove the old key if it exists

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -28,6 +28,8 @@ Gem::Specification.new do |s|
   s.add_dependency "rb-kqueue", "~> 0.2.0"
   s.add_dependency "rest-client", ">= 1.6.0", "< 3.0"
   s.add_dependency "wdm", "~> 0.1.0"
+  s.add_dependency "win32-file", "~> 0.8.1"
+  s.add_dependency "win32-file-security", "~> 1.0.10"
   s.add_dependency "winrm", "~> 2.1"
   s.add_dependency "winrm-fs", "~> 1.0"
   s.add_dependency "winrm-elevated", "~> 1.1"


### PR DESCRIPTION
This updates the permissions on the automatically generated private
key file to only be readable by the user. Includes support for file
permission modification on Windows platform.

Fixes #9520 #9511 