### PR TITLE
Improve network collision error message

### DIFF
--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -280,8 +280,12 @@ module VagrantPlugins
             # interface.
             @env[:machine].provider.driver.read_bridged_interfaces.each do |interface|
               that_netaddr = network_address(interface[:ip], interface[:netmask])
-              raise Vagrant::Errors::NetworkCollision if \
-                netaddr == that_netaddr && interface[:status] != "Down"
+              if netaddr == that_netaddr && interface[:status] != "Down"
+                raise Vagrant::Errors::NetworkCollision,
+                  netaddr: netaddr,
+                  that_netaddr: that_netaddr,
+                  interface_name: interface[:name]
+              end
             end
 
             # Split the IP address into its components

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2076,6 +2076,9 @@ en:
             This will cause your specified IP to be inaccessible. Please change
             the IP or name of your host only network so that it no longer matches that of
             a bridged or non-hostonly network.
+
+            Bridged Network Address: '%{netaddr}'
+            Host-only Network '%{interface_name}': '%{that_netaddr}'
           creating: "Creating new host only network for environment..."
           enabling: "Enabling host only network..."
           not_found: |-


### PR DESCRIPTION
This commit provides a bit more information when a non-hostonly network
collides with a host network.

Fixes #9461