### PR TITLE
work around find syntax limitations in busybox-based distributions

### DIFF
--- a/plugins/synced_folders/rsync/default_unix_cap.rb
+++ b/plugins/synced_folders/rsync/default_unix_cap.rb
@@ -37,8 +37,12 @@ module VagrantPlugins
         end
         "find #{guest_path} #{exclusions}" \
           "'!' -type l -a " \
-          "'(' ! -user #{opts[:owner]} -or ! -group #{opts[:group]} ')' -exec " \
-          "chown #{opts[:owner]}:#{opts[:group]} '{}' +"
+          "'(' ! -user #{opts[:owner]} ')' -exec " \
+          "chown #{opts[:owner]}:#{opts[:group]} '{}' + && " \
+          "find #{guest_path} #{exclusions}" \
+            "'!' -type l -a " \
+            "'(' ! -group #{opts[:group]} ')' -exec " \
+            "chown #{opts[:owner]}:#{opts[:group]} '{}' +"
       end
     end
   end

--- a/test/unit/plugins/guests/linux/cap/rsync_test.rb
+++ b/test/unit/plugins/guests/linux/cap/rsync_test.rb
@@ -63,8 +63,14 @@ describe "VagrantPlugins::GuestLinux::Cap::Rsync" do
 
     it "chowns files within the guest directory" do
       comm.expect_command(
-        "find #{guest_directory} '!' -type l -a '(' ! -user #{owner} -or " \
-          "! -group #{group} ')' -exec chown #{owner}:#{group} '{}' +"
+        "find #{guest_directory} " \
+          "'!' -type l -a " \
+          "'(' ! -user #{owner} ')' -exec " \
+          "chown #{owner}:#{group} '{}' + && " \
+          "find #{guest_directory} " \
+            "'!' -type l -a " \
+            "'(' ! -group #{group} ')' -exec " \
+            "chown #{owner}:#{group} '{}' +"
       )
       cap.rsync_post(machine, options)
     end

--- a/test/unit/plugins/guests/smartos/cap/rsync_test.rb
+++ b/test/unit/plugins/guests/smartos/cap/rsync_test.rb
@@ -40,7 +40,14 @@ describe "VagrantPlugins::VagrantPlugins::Cap::Rsync" do
 
   describe ".rsync_post" do
     it 'chowns incorrectly owned files in sync dir' do
-      communicator.expect_command("pfexec find /sync_dir '!' -type l -a '(' ! -user somebody -or ! -group somegroup ')' -exec chown somebody:somegroup '{}' +")
+      communicator.expect_command("pfexec find /sync_dir " \
+        "'!' -type l -a " \
+        "'(' ! -user somebody ')' -exec " \
+        "chown somebody:somegroup '{}' + && " \
+        "find /sync_dir " \
+          "'!' -type l -a " \
+          "'(' ! -group somegroup ')' -exec " \
+          "chown somebody:somegroup '{}' +")
       plugin.rsync_post(machine, guestpath: '/sync_dir', owner: 'somebody', group: 'somegroup')
     end
   end


### PR DESCRIPTION
Evidently, busybox-based Linux environments including OpenWrt lack newer features in `find` such as being able to union parenthetical expressions with `-or`.

This breaks rsync chowning for OpenWrt boxes, unfortunately. Fortunately, this is easy to workaround by separating the expressions into distinct `find` calls.