### PR TITLE
propagate unset guestpath

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -218,7 +218,7 @@ module VagrantPlugins
           synced_folder_name = guestpath
         end
 
-        options[:guestpath] = guestpath.to_s.gsub(/\/$/, '')
+        options[:guestpath] = guestpath.to_s.gsub(/\/$/, '') if guestpath
         options[:hostpath]  = hostpath
         options[:disabled]  = false if !options.key?(:disabled)
         options = (@__synced_folders[options[:guestpath]] || {}).
@@ -641,7 +641,9 @@ module VagrantPlugins
           guestpath = Pathname.new(options[:guestpath]) if options[:guestpath]
           hostpath  = Pathname.new(options[:hostpath]).expand_path(machine.env.root_path)
 
-          if guestpath.to_s != ""
+          if guestpath.to_s == "" && id.to_s == ""
+            errors << I18n.t("vagrant.config.vm.shared_folder_requires_guestpath_or_name")
+          elsif guestpath.to_s != ""
             if guestpath.relative? && guestpath.to_s !~ /^\w+:/
               errors << I18n.t("vagrant.config.vm.shared_folder_guestpath_relative",
                                path: options[:guestpath])

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1789,6 +1789,8 @@ en:
         shared_folder_mount_options_array: |-
           Shared folder mount options specified by 'mount_options' must
           be an array of options.
+        shared_folder_requires_guestpath_or_name: |-
+          Shared folder options must include a guestpath and/or name.
 
 #-------------------------------------------------------------------------------
 # Translations for commands. e.g. `vagrant x`

--- a/test/unit/plugins/kernel_v2/config/vm_test.rb
+++ b/test/unit/plugins/kernel_v2/config/vm_test.rb
@@ -557,8 +557,8 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
       expect(sf["/vagrant"][:foo]).to eq(:bar)
     end
 
-    it "is not an error if guest path is empty" do
-      subject.synced_folder(".", "")
+    it "is not an error if guest path is empty but name is not" do
+      subject.synced_folder(".", "", name: "my-vagrant-folder")
       subject.finalize!
       assert_valid
     end
@@ -576,6 +576,18 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
       sf = subject.synced_folders
       expect(sf).to have_key("my-vagrant-folder")
       expect(sf["my-vagrant-folder"][:hostpath]).to eq(".")
+    end
+
+    it "requires either guest path or name" do
+      subject.synced_folder(".", name: nil, guestpath: nil)
+      subject.finalize!
+      assert_invalid
+    end
+
+    it "keeps nil guest path if not provided" do
+      subject.synced_folder(".", name: "my-vagrant-folder")
+      sf = subject.synced_folders
+      expect(sf["my-vagrant-folder"][:guestpath]).to be_nil
     end
   end
 


### PR DESCRIPTION
Make sure `options[:guestpath]` is not inadvertently set. Resolves #9691 