### PR TITLE
Remove turbolinks, move js to bottom

### DIFF
--- a/website/source/assets/javascripts/application.js
+++ b/website/source/assets/javascripts/application.js
@@ -1,5 +1,4 @@
 //= require jquery
-//= require turbolinks
 
 //= require hashicorp/mega-nav
 //= require hashicorp/sidebar

--- a/website/source/layouts/layout.erb
+++ b/website/source/layouts/layout.erb
@@ -29,11 +29,6 @@
 
     <%= stylesheet_link_tag "application" %>
 
-    <!--[if lt IE 9]>
-      <%= javascript_include_tag "ie-compat" %>
-    <![endif]-->
-    <%= javascript_include_tag "application" %>
-
     <!-- Typekit script to import Klavika font -->
     <script src="https://use.typekit.net/wxf7mfi.js"></script>
     <script>try{Typekit.load({ async: true });}catch(e){}</script>
@@ -113,12 +108,12 @@
       </div>
     </div>
 
+    <!--[if lt IE 9]>
+      <%= javascript_include_tag "ie-compat" %>
+    <![endif]-->
+    <%= javascript_include_tag "application" %>
+
     <script>
-      // ga async load
-      window['GoogleAnalyticsObject'] = 'ga';
-      window['ga'] = window['ga'] || function() {
-        (window['ga'].q = window['ga'].q || []).push(arguments)
-      };
       // analytics.js
       !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t){var e=document.createElement("script");e.type="text/javascript";e.async=!0;e.src=("https:"===document.location.protocol?"https://":"http://")+"cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(e,n)};analytics.SNIPPET_VERSION="4.0.0";
       analytics.load("<%= segmentId %>");


### PR DESCRIPTION
Turbolinks causes page reloads not to happen, which is throwing off our analytics dramatically, so this PR removes it (and restores analytics to normal).

I also moved the javascript tag to the bottom of the body, as script tags without `async` block the html parser, so this should speed up page load a decent bit ✨ 