### PR TITLE
Keep old functionality before PR 7233 by Default

### DIFF
--- a/plugins/provisioners/puppet/config/puppet.rb
+++ b/plugins/provisioners/puppet/config/puppet.rb
@@ -38,7 +38,7 @@ module VagrantPlugins
           @synced_folder_type    = UNSET_VALUE
           @temp_dir              = UNSET_VALUE
           @working_directory     = UNSET_VALUE
-          @structured_facts   = UNSET_VALUE
+          @structured_facts   = false
         end
 
         def nfs=(value)


### PR DESCRIPTION
PR #9670  breaks existing puppet provisioners, this sets the new structured_facts feature to false by default to avoid breaking existing functioning setups