### PR TITLE
Don't raise error if response is HTTP 416

### DIFF
--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -294,9 +294,13 @@ module Vagrant
           @logger.warn("Downloader exit code: #{result.exit_code}")
           parts    = result.stderr.split(/\n*curl:\s+\(\d+\)\s*/, 2)
           parts[1] ||= ""
-          raise Errors::DownloaderError,
-            code: result.exit_code,
-            message: parts[1].chomp
+          if parts[1].include? "416"
+            # All good actually. 416 means there is no mory bytes to download
+          else
+            raise Errors::DownloaderError,
+              code: result.exit_code,
+              message: parts[1].chomp
+          end
         end
 
         result

--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -295,7 +295,7 @@ module Vagrant
           parts    = result.stderr.split(/\n*curl:\s+\(\d+\)\s*/, 2)
           parts[1] ||= ""
           if parts[1].include? "416"
-            # All good actually. 416 means there is no mory bytes to download
+            # All good actually. 416 means there is no more bytes to download
           else
             raise Errors::DownloaderError,
               code: result.exit_code,

--- a/test/unit/vagrant/util/downloader_test.rb
+++ b/test/unit/vagrant/util/downloader_test.rb
@@ -41,6 +41,20 @@ describe Vagrant::Util::Downloader do
 
     context "with a bad exit status" do
       let(:exit_code) { 1 }
+      let(:subprocess_result_416) do
+        double("subprocess_result").tap do |result|
+          allow(result).to receive(:exit_code).and_return(exit_code)
+          allow(result).to receive(:stderr).and_return("curl: (416) The download is fine")
+        end
+      end
+
+      it "continues on if a 416 was received" do
+        expect(Vagrant::Util::Subprocess).to receive(:execute).
+          with("curl", *curl_options).
+          and_return(subprocess_result_416)
+
+        expect(subject.download!).to be(true)
+      end
 
       it "raises an exception" do
         expect(Vagrant::Util::Subprocess).to receive(:execute).


### PR DESCRIPTION
This pull request will continue when encountering an HTTP 416 error code in the downloader. It is a rebase/improvement of the PR #7885 to simplify the code a bit.

Fixes #7886