### PR TITLE
Return original URL value when unmodified

### DIFF
--- a/plugins/commands/login/middleware/add_authentication.rb
+++ b/plugins/commands/login/middleware/add_authentication.rb
@@ -38,8 +38,10 @@ module VagrantPlugins
           u = URI.parse(url)
           if u.host != TARGET_HOST && REPLACEMENT_HOSTS.include?(u.host)
             u.host = TARGET_HOST
+            u.to_s
+          else
+            url
           end
-          u.to_s
         end
 
         server_uri = URI.parse(Vagrant.server_url.to_s)

--- a/test/unit/plugins/commands/login/middleware/add_authentication_test.rb
+++ b/test/unit/plugins/commands/login/middleware/add_authentication_test.rb
@@ -125,6 +125,22 @@ describe VagrantPlugins::LoginCommand::AddAuthentication do
       end
     end
 
+    it "returns original urls when not modified" do
+      to_persist = "file:////path/to/box.box"
+      to_change = VagrantPlugins::LoginCommand::AddAuthentication::
+        REPLACEMENT_HOSTS.map{ |h| "http://#{h}/box.box" }.first
+      expected = "http://#{VagrantPlugins::LoginCommand::AddAuthentication::TARGET_HOST}/box.box"
+      env[:box_urls] = [to_persist, to_change]
+      subject.call(env)
+      check_persist, check_change = env[:box_urls]
+      expect(check_change).to eq(expected)
+      expect(check_persist).to eq(to_persist)
+      # NOTE: The behavior of URI.parse changes on Ruby 2.5 to produce
+      # the same string value. To make the test worthwhile in checking
+      # for the same value, check that the object IDs are still the same.
+      expect(check_persist.object_id).to eq(to_persist.object_id)
+    end
+
     it "does not append multiple access_tokens" do
       token = "foobarbaz"
       VagrantPlugins::LoginCommand::Client.new(iso_env).store_token(token)


### PR DESCRIPTION
Due to the behavior of URI.parse on Ruby < 2.5 returning the string
value of the parsed URI object may modify the original URL. Specifically
it will remove the `//` prefix characters from SMB paths. When no
host modifications are being made, always return the original value.

Fixes #9636