### PR TITLE
Improve messaging around not finding requested provider

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -580,6 +580,10 @@ module Vagrant
       error_key(:provider_not_found)
     end
 
+    class ProviderNotFoundSuggestion < VagrantError
+      error_key(:provider_not_found_suggestion)
+    end
+
     class ProviderNotUsable < VagrantError
       error_key(:provider_not_usable)
     end

--- a/lib/vagrant/vagrantfile.rb
+++ b/lib/vagrant/vagrantfile.rb
@@ -125,8 +125,21 @@ module Vagrant
       if provider != nil
         provider_plugin  = Vagrant.plugin("2").manager.providers[provider]
         if !provider_plugin
+          providers  = Vagrant.plugin("2").manager.providers.to_hash.keys
+          if providers
+            providers_str = providers.join(', ')
+          else
+            providers_str = "N/A"
+          end
+
+          if providers.include? provider.downcase
+            raise Errors::ProviderNotFoundSuggestion,
+              machine: name, provider: provider,
+              suggestion: provider.downcase, providers: providers_str
+          end
+
           raise Errors::ProviderNotFound,
-            machine: name, provider: provider
+            machine: name, provider: provider, providers: providers_str
         end
 
         provider_cls     = provider_plugin[0]

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1172,6 +1172,15 @@ en:
       provider_not_found: |-
         The provider '%{provider}' could not be found, but was requested to
         back the machine '%{machine}'. Please use a provider that exists.
+
+        Vagrant knows about the following providers: %{providers}
+      provider_not_found_suggestion: |-
+        The provider '%{provider}' could not be found, but was requested to
+        back the machine '%{machine}'. Please use a provider that exists.
+
+        Did you mean '%{suggestion}'?
+
+        Vagrant knows about the following providers: %{providers}
       provider_not_usable: |-
         The provider '%{provider}' that was requested to back the machine
         '%{machine}' is reporting that it isn't usable on this system. The

--- a/test/unit/vagrant/vagrantfile_test.rb
+++ b/test/unit/vagrant/vagrantfile_test.rb
@@ -329,6 +329,13 @@ describe Vagrant::Vagrantfile do
         to raise_error(Vagrant::Errors::ProviderNotFound)
     end
 
+    it "raises an error if the provider is not found but gives suggestion" do
+      register_provider("foo")
+
+      expect { subject.machine_config(:default, :Foo, boxes) }.
+        to raise_error(Vagrant::Errors::ProviderNotFoundSuggestion)
+    end
+
     it "raises an error if the provider is not usable" do
       register_provider("foo", nil, unusable: true)
 


### PR DESCRIPTION
This commit adds a bit more helpful messaging for the user when asking
for a provider that might not exist or does not follow the correct
casing. If it can find a match on a provider it knows about, it will
suggest it.

Fixes #9717