### PR TITLE
Add warning if vagrant-triggers plugin is installed

### DIFF
--- a/plugins/kernel_v2/plugin.rb
+++ b/plugins/kernel_v2/plugin.rb
@@ -40,9 +40,28 @@ module VagrantPlugins
         VMConfig
       end
 
-      config("trigger") do
-        require File.expand_path("../config/trigger", __FILE__)
-        TriggerConfig
+      plugins = Vagrant::Plugin::Manager.instance.installed_plugins
+      if !plugins.keys.include?("vagrant-triggers")
+        config("trigger") do
+          require File.expand_path("../config/trigger", __FILE__)
+          TriggerConfig
+        end
+      else
+        if !ENV["VAGRANT_USE_VAGRANT_TRIGGERS"]
+        $stderr.puts <<-EOF
+WARNING: Vagrant has detected the `vagrant-triggers` plugin. This plugin conflicts
+with the internal triggers implementation. Please uninstall the `vagrant-triggers`
+plugin and run the command again if you wish to use the core trigger feature. To
+uninstall the plugin, run the command shown below:
+
+  vagrant plugin uninstall vagrant-triggers
+
+Note that the community plugin `vagrant-triggers` and the core trigger feature
+in Vagrant do not have compatible syntax.
+
+To disable this warning, set the environment variable `VAGRANT_USE_VAGRANT_TRIGGERS`.
+EOF
+        end
       end
     end
   end

--- a/website/source/docs/other/environmental-variables.html.md
+++ b/website/source/docs/other/environmental-variables.html.md
@@ -243,3 +243,8 @@ of PowerShell. Occasionally the default can be too low and Vagrant will report
 being unable to detect the installed version of PowerShell. This environment
 variable can be used to extend the timeout used during PowerShell version
 detection.
+
+## `VAGRANT_USE_VAGRANT_TRIGGERS`
+
+Vagrant will not display the warning about disabling the core trigger feature if
+the community plugin is installed.


### PR DESCRIPTION
To allow users to continue to use the community plugin, this commit adds
a switch that will not load the core trigger feature if it detects the
community plugin is installed. It also allows the user to disable the
warning so they can continue to use the plugin without extra output.