### PR TITLE
Check neighbors for valid guest address when default lookup fails

### DIFF
--- a/plugins/providers/hyperv/scripts/get_network_config.ps1
+++ b/plugins/providers/hyperv/scripts/get_network_config.ps1
@@ -27,12 +27,14 @@ if (([string]::IsNullOrEmpty($ip4_address)) -And ([string]::IsNullOrEmpty($ip6_a
     $macaddresses = $vm | select -ExpandProperty NetworkAdapters | select MacAddress
     foreach ($macaddr in $macaddresses) {
         $macaddress = $macaddr.MacAddress -replace '(.{2})(?!$)', '${1}-'
-        $addr = Get-NetNeighbor -LinkLayerAddress $macaddress | select IPAddress
-        $ip_address = $addr.IPAddress
-        if ($ip_address.Contains(".")) {
-            $ip4_address = $ip_address
-        } elseif ($ip_address.Contains(":")) {
-            $ip6_address = $ip_address
+        $addr = Get-NetNeighbor -LinkLayerAddress $macaddress -ErrorAction SilentlyContinue | select IPAddress
+        if ($ip_address) {
+            $ip_address = $addr.IPAddress
+            if ($ip_address.Contains(".")) {
+                $ip4_address = $ip_address
+            } elseif ($ip_address.Contains(":")) {
+                $ip6_address = $ip_address
+            }
         }
     }
 }

--- a/plugins/providers/hyperv/scripts/get_network_config.ps1
+++ b/plugins/providers/hyperv/scripts/get_network_config.ps1
@@ -1,7 +1,7 @@
 Param(
     [Parameter(Mandatory=$true)]
     [string]$VmId
- )
+)
 
 # Include the following modules
 $Dir = Split-Path $script:MyInvocation.MyCommand.Path
@@ -10,33 +10,45 @@ $Dir = Split-Path $script:MyInvocation.MyCommand.Path
 $vm = Hyper-V\Get-VM -Id $VmId -ErrorAction "Stop"
 $networks = Hyper-V\Get-VMNetworkAdapter -VM $vm
 foreach ($network in $networks) {
-  if ($network.IpAddresses.Length -gt 0) {
-    foreach ($ip_address in $network.IpAddresses) {
-      if ($ip_address.Contains(".")) {
-        $ip4_address = $ip_address
-      } elseif ($ip_address.Contains(":")) {
-        $ip6_address = $ip_address
-      }
-      if (-Not ([string]::IsNullOrEmpty($ip4_address)) -Or -Not ([string]::IsNullOrEmpty($ip6_address))) {
-        # We found our IP address!
-        break
-      }
+    if ($network.IpAddresses.Length -gt 0) {
+        foreach ($ip_address in $network.IpAddresses) {
+            if ($ip_address.Contains(".") -And [string]::IsNullOrEmpty($ip4_address)) {
+                $ip4_address = $ip_address
+            } elseif ($ip_address.Contains(":") -And [string]::IsNullOrEmpty($ip6_address)) {
+                $ip6_address = $ip_address
+            }
+        }
     }
-  }
+}
+
+# If no address was found in the network settings, check for
+# neighbor with mac address and see if an IP exists
+if (([string]::IsNullOrEmpty($ip4_address)) -And ([string]::IsNullOrEmpty($ip6_address))) {
+    $macaddresses = $vm | select -ExpandProperty NetworkAdapters | select MacAddress
+    foreach ($macaddr in $macaddresses) {
+        $macaddress = $macaddr.MacAddress -replace '(.{2})(?!$)', '${1}-'
+        $addr = Get-NetNeighbor -LinkLayerAddress $macaddress | select IPAddress
+        $ip_address = $addr.IPAddress
+        if ($ip_address.Contains(".")) {
+            $ip4_address = $ip_address
+        } elseif ($ip_address.Contains(":")) {
+            $ip6_address = $ip_address
+        }
+    }
 }
 
 if (-Not ([string]::IsNullOrEmpty($ip4_address))) {
-  $guest_ipaddress = $ip4_address
+    $guest_ipaddress = $ip4_address
 } elseif (-Not ([string]::IsNullOrEmpty($ip6_address))) {
-  $guest_ipaddress = $ip6_address
+    $guest_ipaddress = $ip6_address
 }
 
 if (-Not ([string]::IsNullOrEmpty($guest_ipaddress))) {
-  $resultHash = @{
-      ip = $guest_ipaddress
-  }
-  $result = ConvertTo-Json $resultHash
-  Write-Output-Message $result
+    $resultHash = @{
+        ip = $guest_ipaddress
+    }
+    $result = ConvertTo-Json $resultHash
+    Write-Output-Message $result
 } else {
-  Write-Error-Message "Failed to determine IP address"
+    Write-Error-Message "Failed to determine IP address"
 }


### PR DESCRIPTION
If the guest address is unavailable via Hyper-V inspection, extract
MAC address of network adapters and check neighbor information for
any currently matching known address.