### PR TITLE
Update Windows Hyper-V check

### DIFF
--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -107,9 +107,12 @@ module Vagrant
           return @_windows_hyperv_enabled if defined?(@_windows_hyperv_enabled)
 
           @_windows_hyperv_enabled = -> {
-            ps_cmd = "$(Get-WindowsOptionalFeature -FeatureName Microsoft-Hyper-V-All -Online).State"
-            output = Vagrant::Util::PowerShell.execute_cmd(ps_cmd)
-            return output == 'Enabled'
+            ["Get-WindowsOptionalFeature", "Get-WindowsFeature"].each do |cmd_name|
+              ps_cmd = "$(#{cmd_name} -FeatureName Microsoft-Hyper-V-Hypervisor).State"
+              output = Vagrant::Util::PowerShell.execute_cmd(ps_cmd)
+              return true if output == "Enabled"
+            end
+            return false
           }.call
 
           return @_windows_hyperv_enabled


### PR DESCRIPTION
Checks only if the Hyper-V hypervisor is enabled instead of all
Hyper-V features. This will allow detection where Hyper-V is in
use for things like ApplicationGuard.

Uses both Get-WindowsOptionalFeature and Get-WindowsFeature to
support check on server and non-server version.