### PR TITLE
Reference Hyper-V switch by ID instead of name

### DIFF
--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -88,9 +88,9 @@ module VagrantPlugins
             switchToFind = opts[:bridge]
 
             if switchToFind
-              puts "Looking for switch with name: #{switchToFind}"
-              switch = switches.find { |s| s["Name"].downcase == switchToFind.downcase }["Name"]
-              puts "Found switch: #{switch}"
+              @logger.debug("Looking for switch with name: #{switchToFind}")
+              switch = switches.find { |s| s["Name"].downcase == switchToFind.downcase }["Id"]
+              @logger.debug("Found switch: #{switch}")
             end
           end
 
@@ -110,9 +110,9 @@ module VagrantPlugins
                 switch = switch.to_i - 1
                 switch = nil if switch < 0 || switch >= switches.length
               end
-              switch = switches[switch]["Name"]
+              switch = switches[switch]["Id"]
             else
-              switch = switches[0]["Name"]
+              switch = switches[0]["Id"]
             end
           end
 

--- a/plugins/providers/hyperv/scripts/get_switches.ps1
+++ b/plugins/providers/hyperv/scripts/get_switches.ps1
@@ -8,5 +8,5 @@ $Dir = Split-Path $script:MyInvocation.MyCommand.Path
 . ([System.IO.Path]::Combine($Dir, "utils\write_messages.ps1"))
 
 $Switches = @(Hyper-V\Get-VMSwitch `
-    | Select-Object Name,SwitchType,NetAdapterInterfaceDescription)
+    | Select-Object Name,SwitchType,NetAdapterInterfaceDescription,Id)
 Write-Output-Message $(ConvertTo-JSON $Switches)

--- a/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm_vmcx.ps1
@@ -8,7 +8,7 @@
     [Parameter(Mandatory=$true)]
     [string]$data_path,
 
-    [string]$switchname=$null,
+    [string]$switchid=$null,
     [string]$memory=$null,
     [string]$maxmemory=$null,
     [string]$cpus=$null,
@@ -83,8 +83,10 @@ if (!$memory) {
     }
 }
 
-if (!$switchname) {
+if (!$switchid) {
     $switchname = (Hyper-V\Get-VMNetworkAdapter -VM $vmConfig.VM).SwitchName
+} else {
+    $switchname = $(Hyper-V\Get-VMSwitch -Id $switchid).Name
 }
 
 # Enable nested virtualization if configured


### PR DESCRIPTION
Keep track of selected Hyper-V switch using the ID instead of name
to prevent any encoding issues that may occur switching between
PowerShell and Ruby. With the IDs staying consistent, the switch
name can be fetched from the provided ID.

Fixes #9679 #8794 #9451