### PR TITLE
Update docker provisioner for windows, fix command filter behavior for `rm`

### DIFF
--- a/plugins/communicators/winrm/command_filters/rm.rb
+++ b/plugins/communicators/winrm/command_filters/rm.rb
@@ -31,9 +31,9 @@ module VagrantPlugins
 
           ret_cmd = ''
           if recurse
-            ret_cmd = "rm \"#{dir}\" -recurse -force"
+            ret_cmd = "if (Test-Path \"#{dir}\") {Remove-Item \"#{dir}\" -force -recurse}"
           else
-            ret_cmd = "if (Test-Path #{dir}) {Remove-Item #{dir} -force}"
+            ret_cmd = "if (Test-Path \"#{dir}\") {Remove-Item \"#{dir}\" -force}"
           end
           return ret_cmd
         end

--- a/plugins/communicators/winrm/command_filters/rm.rb
+++ b/plugins/communicators/winrm/command_filters/rm.rb
@@ -33,7 +33,7 @@ module VagrantPlugins
           if recurse
             ret_cmd = "rm \"#{dir}\" -recurse -force"
           else
-            ret_cmd = "rm \"#{dir}\" -force"
+            ret_cmd = "if (Test-Path #{dir}) {Remove-Item #{dir} -force}"
           end
           return ret_cmd
         end

--- a/plugins/provisioners/docker/cap/windows/docker_daemon_running.rb
+++ b/plugins/provisioners/docker/cap/windows/docker_daemon_running.rb
@@ -1,0 +1,13 @@
+module VagrantPlugins
+  module DockerProvisioner
+    module Cap
+      module Windows
+        module DockerDaemonRunning
+          def self.docker_daemon_running(machine)
+            machine.communicate.test("tasklist | find \"`\"dockerd`\"\"")
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/provisioners/docker/client.rb
+++ b/plugins/provisioners/docker/client.rb
@@ -127,12 +127,11 @@ module VagrantPlugins
       def create_container(config)
         args = container_run_args(config)
 
-        @machine.communicate.sudo %[
-          rm -f #{config[:cidfile]}
-          docker run #{args}
-        ]
+        @machine.communicate.sudo %[rm -f #{config[:cidfile]}
+                                  ]
+        @machine.communicate.sudo %[docker run #{args}
+                                  ]
 
-        name = container_name(config)
         sha  = Digest::SHA1.hexdigest(args)
         container_data_path(config).open("w+") do |f|
           f.write(sha)

--- a/plugins/provisioners/docker/client.rb
+++ b/plugins/provisioners/docker/client.rb
@@ -127,10 +127,8 @@ module VagrantPlugins
       def create_container(config)
         args = container_run_args(config)
 
-        @machine.communicate.sudo %[rm -f #{config[:cidfile]}
-                                  ]
-        @machine.communicate.sudo %[docker run #{args}
-                                  ]
+        @machine.communicate.sudo %[rm -f "#{config[:cidfile]}"]
+        @machine.communicate.sudo %[docker run #{args}]
 
         sha  = Digest::SHA1.hexdigest(args)
         container_data_path(config).open("w+") do |f|

--- a/plugins/provisioners/docker/plugin.rb
+++ b/plugins/provisioners/docker/plugin.rb
@@ -54,6 +54,11 @@ module VagrantPlugins
         Cap::Linux::DockerDaemonRunning
       end
 
+      guest_capability("windows", "docker_daemon_running") do
+        require_relative "cap/windows/docker_daemon_running"
+        Cap::Windows::DockerDaemonRunning
+      end
+
       provisioner(:docker) do
         require_relative "provisioner"
         Provisioner

--- a/test/unit/plugins/communicators/winrm/command_filter_test.rb
+++ b/test/unit/plugins/communicators/winrm/command_filter_test.rb
@@ -54,20 +54,22 @@ describe VagrantPlugins::CommunicatorWinRM::CommandFilter, unit: true do
 
     it 'filters out rm recurse commands' do
       expect(subject.filter('rm -Rf /some/dir')).to eq(
-        "rm \"/some/dir\" -recurse -force")
+        "if (Test-Path \"/some/dir\") {Remove-Item \"/some/dir\" -force -recurse}")
       expect(subject.filter('rm -fr /some/dir')).to eq(
-        "rm \"/some/dir\" -recurse -force")
+        "if (Test-Path \"/some/dir\") {Remove-Item \"/some/dir\" -force -recurse}")
       expect(subject.filter('rm -r /some/dir')).to eq(
-        "rm \"/some/dir\" -recurse -force")
+        "if (Test-Path \"/some/dir\") {Remove-Item \"/some/dir\" -force -recurse}")
       expect(subject.filter('rm -r "/some/dir"')).to eq(
-        "rm \"/some/dir\" -recurse -force")
+        "if (Test-Path \"/some/dir\") {Remove-Item \"/some/dir\" -force -recurse}")
     end
 
     it 'filters out rm commands' do
       expect(subject.filter('rm /some/dir')).to eq(
-                                                  "if (Test-Path /some/dir) {Remove-Item /some/dir -force}")
+        "if (Test-Path \"/some/dir\") {Remove-Item \"/some/dir\" -force}")
       expect(subject.filter('rm -f /some/dir')).to eq(
-                                                     "if (Test-Path /some/dir) {Remove-Item /some/dir -force}")
+        "if (Test-Path \"/some/dir\") {Remove-Item \"/some/dir\" -force}")
+      expect(subject.filter('rm -f "/some/dir"')).to eq(
+        "if (Test-Path \"/some/dir\") {Remove-Item \"/some/dir\" -force}")
     end
 
     it 'filters out mkdir commands' do

--- a/test/unit/plugins/communicators/winrm/command_filter_test.rb
+++ b/test/unit/plugins/communicators/winrm/command_filter_test.rb
@@ -65,11 +65,9 @@ describe VagrantPlugins::CommunicatorWinRM::CommandFilter, unit: true do
 
     it 'filters out rm commands' do
       expect(subject.filter('rm /some/dir')).to eq(
-        "rm \"/some/dir\" -force")
+                                                  "if (Test-Path /some/dir) {Remove-Item /some/dir -force}")
       expect(subject.filter('rm -f /some/dir')).to eq(
-        "rm \"/some/dir\" -force")
-      expect(subject.filter('rm -f "/some/dir"')).to eq(
-        "rm \"/some/dir\" -force")
+                                                     "if (Test-Path /some/dir) {Remove-Item /some/dir -force}")
     end
 
     it 'filters out mkdir commands' do


### PR DESCRIPTION
This commit rebases #9353. It introduces a windows capability for the docker provisioner to check of the docker daemon is running. It also fixes the behavior of the `rm` filter for winrm. `rm -f dir` on linux does not result in an error, thus the winrm filter was updated since `rm`'ing a directory that doesn't exist on windows is an error.

Fixes #9339
Fixes #9280