### PR TITLE
Allow other providers in WSL

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -844,10 +844,6 @@ module Vagrant
       error_key(:vboxmanage_not_found_error)
     end
 
-    class VBoxManageNotFoundWSLError < VagrantError
-      error_key(:vboxmanage_not_found_wsl_error)
-    end
-
     class VirtualBoxBrokenVersion040214 < VagrantError
       error_key(:virtualbox_broken_version_040214)
     end

--- a/plugins/providers/virtualbox/driver/base.rb
+++ b/plugins/providers/virtualbox/driver/base.rb
@@ -74,7 +74,18 @@ module VagrantPlugins
             @logger.debug("Linux platform detected but executing within WSL. Locating VBoxManage.")
             @vboxmanage_path = Vagrant::Util::Which.which("VBoxManage") || Vagrant::Util::Which.which("VBoxManage.exe")
             if !@vboxmanage_path
-              raise Vagrant::Errors::VBoxManageNotFoundWSLError
+              # If we still don't have one, try to find it using common locations
+              drive = "/mnt/c"
+              [
+                "#{drive}/Program Files/Oracle/VirtualBox",
+                "#{drive}/Program Files (x86)/Oracle/VirtualBox"
+              ].each do |maybe|
+                path = File.join(maybe, "VBoxManage.exe")
+                if File.file?(path)
+                  @vboxmanage_path = path
+                  break
+                end
+              end
             end
           end
 

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1513,16 +1513,6 @@ en:
         log out and log back in for the new environmental variables to take
         effect. If you're on Linux or Mac, verify your PATH contains the folder
         that has VBoxManage in it.
-      vboxmanage_not_found_wsl_error: |-
-        The "VBoxManage.exe" command or one of its dependencies could not
-        be found. Please verify VirtualBox is properly installed. You can verify
-        everything is okay by running "VBoxManage.exe --version" and verifying
-        that the VirtualBox version is outputted.
-
-        If you just installed VirtualBox, you have to log out and log back in for
-        the new environmental variables to take effect. Using the VirtualBox
-        provider within the WSL requires VirtualBox executables to be available
-        on the system PATH.
       virtualbox_broken_version_040214: |-
         Vagrant detected you have VirtualBox 4.2.14 installed. VirtualBox
         4.2.14 contains a critical bug which prevents it from working with


### PR DESCRIPTION
At the moment Linux Vagrant running in WSL often complains that `VBoxManage.exe` could not be found.

Using Vagrant with cloud providers or with VMware this message is confusing.

```
$ vagrant status
The "VBoxManage.exe" command or one of its dependencies could not
be found. Please verify VirtualBox is properly installed. You can verify
everything is okay by running "VBoxManage.exe --version" and verifying
that the VirtualBox version is outputted.

If you just installed VirtualBox, you have to log out and log back in for
the new environmental variables to take effect. Using the VirtualBox
provider within the WSL requires VirtualBox executables to be available
on the system PATH.
~/code/tst/ub
$ vagrant plugin list
nokogiri (1.8.2)
vagrant-reload (0.0.1)
  - Version Constraint: > 0
vagrant-vcloud (0.5.0)
vagrant-vmware-desktop (1.0.3)
  - Version Constraint: > 0
```

I've removed the hard constraint `Vagrant::Errors::VBoxManageNotFoundWSLError`, and added to search for some typical folders for the VBoxManage.exe if it's not already in PATH.

Now I see the correct behaviour if I have installed the vagrant-vmware-desktop plugin as well:

```
$ vagrant status
Current machine states:

default                   not created (vmware_workstation)

The VMware machine has not yet been created. Run `vagrant up`
to create the machine. If a machine is not created, only the
default provider will be shown. Therefore, if a provider is not listed,
then the machine is not created for that provider.
```

Improves #9628 