### PR TITLE
Continue on if vagrant fails to parse metadata box for update

### DIFF
--- a/lib/vagrant/action/builtin/box_check_outdated.rb
+++ b/lib/vagrant/action/builtin/box_check_outdated.rb
@@ -58,6 +58,9 @@ module Vagrant
             env[:ui].warn(I18n.t(
               "vagrant.box_outdated_metadata_download_error",
               message: e.extra_data[:message]))
+          rescue Errors::BoxMetadataMalformed  => e
+            @logger.warn(e.to_s)
+            env[:ui].warn(I18n.t("vagrant.box_malformed_continue_on_update"))
           rescue Errors::VagrantError => e
             raise if !env[:box_outdated_ignore_errors]
             env[:ui].detail(I18n.t(

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -40,6 +40,9 @@ en:
       URL: %{url}
     box_loading_metadata: |-
       Loading metadata for box '%{name}'
+    box_malformed_continue_on_update: |-
+      Could not determine box updates because box metadata was malformed.
+      Vagrant will continue on...
     box_outdated: |-
       * '%{name}' for '%{provider}' is outdated! Current: %{current}. Latest: %{latest}
     box_outdated_checking_with_refresh: |-

--- a/test/unit/vagrant/action/builtin/box_check_outdated_test.rb
+++ b/test/unit/vagrant/action/builtin/box_check_outdated_test.rb
@@ -166,6 +166,17 @@ describe Vagrant::Action::Builtin::BoxCheckOutdated do
       expect(env[:box_outdated]).to be(false)
     end
 
+    it "does nothing if metadata cannot be parsed" do
+      expect(box).to receive(:has_update?).and_raise(
+        Vagrant::Errors::BoxMetadataMalformed.new(error: "Whoopsie"))
+
+      expect(app).to receive(:call).once
+
+      subject.call(env)
+
+      expect(env[:box_outdated]).to be(false)
+    end
+
     it "raises error if has_update? errors" do
       expect(box).to receive(:has_update?).and_raise(Vagrant::Errors::VagrantError)
 


### PR DESCRIPTION
Prior to this commit, vagrant would halt if it could not parse the
metadata file for a box to check for updates with. This commit changes
that to behave like when vagrant fails to download a metadata file and
continue on but warn the user it failed to check for box updates.

Fixes #7076