### PR TITLE
Use Util::SafeExec if docker-exec is run with `-t` option

### DIFF
--- a/plugins/providers/docker/command/exec.rb
+++ b/plugins/providers/docker/command/exec.rb
@@ -84,18 +84,21 @@ module VagrantPlugins
 
           # Run this interactively if asked.
           exec_options = options
-          exec_options[:stdin] = true if options[:pty]
 
-          output = ""
-          machine.provider.driver.execute(*exec_cmd, exec_options) do |type, data|
-            output += data
-          end
+          if options[:pty]
+            Kernel.system(*exec_cmd)
+          else
+            output = ""
+            machine.provider.driver.execute(*exec_cmd, exec_options) do |type, data|
+              output += data
+            end
 
-          output_options = {}
-          output_options[:prefix] = false if !options[:prefix]
+            output_options = {}
+            output_options[:prefix] = false if !options[:prefix]
 
-          if !output.empty?
-            machine.ui.output(output.chomp, **output_options)
+            if !output.empty?
+              machine.ui.output(output.chomp, **output_options)
+            end
           end
         end
       end

--- a/plugins/providers/docker/command/exec.rb
+++ b/plugins/providers/docker/command/exec.rb
@@ -1,3 +1,5 @@
+require 'vagrant/util/safe_exec'
+
 module VagrantPlugins
   module DockerProvider
     module Command
@@ -86,7 +88,7 @@ module VagrantPlugins
           exec_options = options
 
           if options[:pty]
-            Kernel.system(*exec_cmd)
+            Vagrant::Util::SafeExec.exec(exec_cmd[0], *exec_cmd[1..-1])
           else
             output = ""
             machine.provider.driver.execute(*exec_cmd, exec_options) do |type, data|


### PR DESCRIPTION
Fixes #9622
Rebase/Fixup of #9704 