### PR TITLE
workaround spurious exit status (Haiku nightly)

### DIFF
--- a/plugins/guests/haiku/cap/halt.rb
+++ b/plugins/guests/haiku/cap/halt.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class Halt
         def self.halt(machine)
           begin
-            machine.communicate.execute("/bin/shutdown")
+            machine.communicate.execute("/bin/shutdown; exit 0")
           rescue IOError, Vagrant::Errors::SSHDisconnected
             # Ignore, this probably means connection closed because it
             # shut down.


### PR DESCRIPTION
Prepare for integration with Haiku nightly, which features an incorrect exit status for `/bin/shutdown`.

In the past with Haiku alpha 4, users could work around this by shimming a shell script at `/bin/shutdown` that ran `/bin/shutdown-actual`, then exiting zero. Unfortunately, Haiku nightly has removed writeability for `/bin` paths, making this harder to patch within the guest. While Haiku is getting its stuff fixed, it would be nice if the Vagrant guest plugin recognized this behavior and wrapped it, ignoring the status for now.