### PR TITLE
allow haiku binary shadowing

### DIFF
--- a/plugins/guests/haiku/cap/halt.rb
+++ b/plugins/guests/haiku/cap/halt.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class Halt
         def self.halt(machine)
           begin
-            machine.communicate.execute("/bin/shutdown")
+            machine.communicate.execute("shutdown")
           rescue IOError, Vagrant::Errors::SSHDisconnected
             # Ignore, this probably means connection closed because it
             # shut down.


### PR DESCRIPTION
Allow shutdown and other binaries to be shadowed with binaries from `/boot/system/non-packaged/bin`, by dropping the absolute path.

This is an alternative fix to help the Vagrant Haiku guest plugin integrate better with Haiku nightly, whose `/bin/shutdown` unfortunately exits with a spurious value.