### PR TITLE
Syntax error for running remote script

### DIFF
--- a/website/source/docs/triggers/index.html.md
+++ b/website/source/docs/triggers/index.html.md
@@ -71,7 +71,7 @@ config.vm.define "ubuntu" do |ubuntu|
   ubuntu.vm.box = "ubuntu"
   ubuntu.trigger.before :destroy do |trigger|
     trigger.warn = "Dumping database to /vagrant/outfile"
-    trigger.run_remote {inline: "pg_dump dbname > /vagrant/outfile"}
+    trigger.run_remote = {inline: "pg_dump dbname > /vagrant/outfile"}
   end
 end
 ```


### PR DESCRIPTION
I either got:
`syntax error, unexpected ':', expecting '}` or `wrong number of arguments (given 1, expected 0) (ArgumentError)` until I added the `=` in.