### PR TITLE
Leverage POSIX-compliant `find` -o rather than -or 

### DIFF
--- a/plugins/synced_folders/rsync/default_unix_cap.rb
+++ b/plugins/synced_folders/rsync/default_unix_cap.rb
@@ -37,7 +37,7 @@ module VagrantPlugins
         end
         "find #{guest_path} #{exclusions}" \
           "'!' -type l -a " \
-          "'(' ! -user #{opts[:owner]} -or ! -group #{opts[:group]} ')' -exec " \
+          "'(' ! -user #{opts[:owner]} -o ! -group #{opts[:group]} ')' -exec " \
           "chown #{opts[:owner]}:#{opts[:group]} '{}' +"
       end
     end

--- a/test/unit/plugins/guests/linux/cap/rsync_test.rb
+++ b/test/unit/plugins/guests/linux/cap/rsync_test.rb
@@ -63,7 +63,7 @@ describe "VagrantPlugins::GuestLinux::Cap::Rsync" do
 
     it "chowns files within the guest directory" do
       comm.expect_command(
-        "find #{guest_directory} '!' -type l -a '(' ! -user #{owner} -or " \
+        "find #{guest_directory} '!' -type l -a '(' ! -user #{owner} -o " \
           "! -group #{group} ')' -exec chown #{owner}:#{group} '{}' +"
       )
       cap.rsync_post(machine, options)
@@ -77,7 +77,7 @@ describe "VagrantPlugins::GuestLinux::Cap::Rsync" do
         #   "find #{guest_directory} -path #{Shellwords.escape(File.join(guest_directory, excludes.first))} -prune -o " \
         #     "-path #{Shellwords.escape(File.join(guest_directory, excludes.last))} -prune -o '!' " \
         #     "-path -type l -a '(' ! -user " \
-        #     "#{owner} -or ! -group #{group} ')' -exec chown #{owner}:#{group} '{}' +"
+        #     "#{owner} -o ! -group #{group} ')' -exec chown #{owner}:#{group} '{}' +"
         # )
         cap.rsync_post(machine, options)
         excludes.each do |ex_path|

--- a/test/unit/plugins/guests/smartos/cap/rsync_test.rb
+++ b/test/unit/plugins/guests/smartos/cap/rsync_test.rb
@@ -40,7 +40,7 @@ describe "VagrantPlugins::VagrantPlugins::Cap::Rsync" do
 
   describe ".rsync_post" do
     it 'chowns incorrectly owned files in sync dir' do
-      communicator.expect_command("pfexec find /sync_dir '!' -type l -a '(' ! -user somebody -or ! -group somegroup ')' -exec chown somebody:somegroup '{}' +")
+      communicator.expect_command("pfexec find /sync_dir '!' -type l -a '(' ! -user somebody -o ! -group somegroup ')' -exec chown somebody:somegroup '{}' +")
       plugin.rsync_post(machine, guestpath: '/sync_dir', owner: 'somebody', group: 'somegroup')
     end
   end


### PR DESCRIPTION
Leverage POSIX-compliant `find` -o rather than -or when building default rsync capabilities.

In the course of working on a guest plugin for OpenWrt--which I'd also like to contribute to the community once I'm finished with its implementation--I found that OpenWrt's busybox `find` does not support (non-POSIX compliant) `-or` expressions; but rather only POSIX-compliant `-o` expressions.

GNU find explicitly points out the difference between -o and -or in their man page; BSD's man page states their implementation is a super-set of the POSIX standard; and interestingly, SmartOS' man page doesn't even mention `-or` (but one of our SmartOS rsync unit tests uses said -or form!).  

 A couple links for convience:

- https://linux.die.net/man/1/find
- https://www.freebsd.org/cgi/man.cgi?find(1)
- https://smartos.org/man/1/find