### PR TITLE
Fixes #9802: Salt Provisioner does not install specified version

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -304,6 +304,9 @@ module VagrantPlugins
             end
             bootstrap_destination = File.join(config_dir, "bootstrap_salt.ps1")
           else
+            if @config.version
+              options += " %s" % @config.version
+            end
             bootstrap_destination = File.join(config_dir, "bootstrap_salt.sh")
           end
 


### PR DESCRIPTION
Added code to add version as option to installer, if specified