### PR TITLE
Vagrant plugin updates

### DIFF
--- a/bin/vagrant
+++ b/bin/vagrant
@@ -37,13 +37,18 @@ argv.each_index do |i|
   arg = argv[i]
 
   if !arg.start_with?("-")
-    if ["plugin", "help"].include?(arg) || (arg == "box" && argv[i+1] == "list")
+    if arg == "box" && argv[i+1] == "list"
       opts[:vagrantfile_name] = ""
       ENV['VAGRANT_NO_PLUGINS'] = "1"
     end
 
-    if arg == "plugin" && argv[i+1] != "list"
-      ENV['VAGRANT_DISABLE_PLUGIN_INIT'] = "1"
+    # Do not load plugins when performing plugin operations
+    if arg == "plugin"
+      ENV['VAGRANT_NO_PLUGINS'] = "1"
+      # Only initialize plugins when listing installed plugins
+      if argv[i+1] != "list"
+        ENV['VAGRANT_DISABLE_PLUGIN_INIT'] = "1"
+      end
     end
 
     break

--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -303,6 +303,15 @@ module Vagrant
       solution = request_set.resolve(installer_set)
       activate_solution(solution)
 
+      # Remove gems which are already installed
+      request_set.sorted_requests.delete_if do |activation_req|
+        rs_spec = activation_req.spec
+        if vagrant_internal_specs.detect{|ispec| ispec.name == rs_spec.name && ispec.version == rs_spec.version }
+          @logger.debug("Removing activation request from install. Already installed. (#{rs_spec.spec.full_name})")
+          true
+        end
+      end
+
       @logger.debug("Installing required gems.")
 
       # Install all remote gems into plugin path. Set the installer to ignore dependencies


### PR DESCRIPTION
Fixes Vagrant plugin loading to prevent error suppression on failed plugin loading. Also ensures plugins are loaded for help requests so custom commands are provided in the output.

Updates the installation process to remove activation requests for already installed gem specifications that are not located within the target installation directory.

Fixes #9701 