### PR TITLE
Support Docker volume consistency for synced folders

### DIFF
--- a/plugins/providers/docker/synced_folder.rb
+++ b/plugins/providers/docker/synced_folder.rb
@@ -21,7 +21,10 @@ module VagrantPlugins
 
           host_path  = data[:hostpath]
           guest_path = data[:guestpath]
-          machine.provider_config.volumes << "#{host_path}:#{guest_path}"
+          # Append consistency option if it exists, otherwise let it nil out
+          consistency = data[:docker_consistency]
+          consistency &&= ":" + consistency
+          machine.provider_config.volumes << "#{host_path}:#{guest_path}#{consistency}"
         end
       end
     end

--- a/website/source/docs/docker/basics.html.md
+++ b/website/source/docs/docker/basics.html.md
@@ -75,6 +75,16 @@ on folders synced with a docker container.
 
 Private and public networks are not currently supported.
 
+### Volume Consistency
+
+Docker's [volume consistency](https://github.com/moby/moby/pull/31047) setting can be specified using the `docker_consistency` option when defining a synced folder. This can
+[greatly improve performance on macOS](https://docs.docker.com/docker-for-mac/osxfs-caching). An example is shown using the `cached` and `delegated` settings:
+
+```
+config.vm.synced_folder "/host/dir1", "/guest/dir1", docker_consistency: "cached"
+config.vm.synced_folder "/host/dir2", "/guest/dir2", docker_consistency: "delegated"
+```
+
 ## Host VM
 
 If the system cannot run Linux containers natively, Vagrant automatically spins


### PR DESCRIPTION
Adds the `docker_consistency` option, which sets the Docker volume
consistency level. This can be used to greatly improved synced folder
performance, especially on macOS.

Issue https://github.com/hashicorp/vagrant/issues/9811

## Testing

I built a minimal Vagrantfile to test the changes, evidenced below. `bundle exec rake` also passed.

The volume settings are visible during `vagrant up`:
```
Bringing machine 'default' up with 'docker' provider...
==> default: Creating the container...
    default:   Name: voltest_default_1525844480
    default:  Image: guilhem/vagrant-ubuntu
    default: Volume: /Users/molenik/mao-vagrant/voltest/vol1:/vol1:cached
    default: Volume: /Users/molenik/mao-vagrant/voltest:/vagrant
    default:   Port: 127.0.0.1:2222:22
    default:
    default: Container created: 36448cd7fa0068d1
==> default: Starting container...
```

And running `docker inspect` shows the affect on each mount:
```
"Mounts": [
	{
		"Type": "bind",
		"Source": "/Users/molenik/mao-vagrant/voltest/vol1",
		"Destination": "/vol1",
		"Mode": "cached",
		"RW": true,
		"Propagation": "rprivate"
	},
	{
		"Type": "bind",
		"Source": "/Users/molenik/mao-vagrant/voltest",
		"Destination": "/vagrant",
		"Mode": "",
		"RW": true,
		"Propagation": "rprivate"
	}
], ...
```