### PR TITLE
Reference Hyper-V switch by ID instead of name

### DIFF
--- a/plugins/providers/hyperv/scripts/import_vm_xml.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm_xml.ps1
@@ -4,7 +4,7 @@ Param(
     [Parameter(Mandatory=$true)]
     [string]$dest_path,
 
-    [string]$switchname=$null,
+    [string]$switchid=$null,
     [string]$memory=$null,
     [string]$maxmemory=$null,
     [string]$cpus=$null,
@@ -78,10 +78,10 @@ else {
     }
 }
 
-
-if (!$switchname) {
-    # Get the name of the virtual switch
-    $switchname = (Select-Xml -xml $vmconfig -XPath "//AltSwitchName").node."#text"
+if (!$switchid) {
+    $switchname = (Hyper-V\Get-VMNetworkAdapter -VM $vmConfig.VM).SwitchName
+} else {
+    $switchname = $(Hyper-V\Get-VMSwitch -Id $switchid).Name
 }
 
 if ($generation -eq 1) {


### PR DESCRIPTION
Keep track of selected Hyper-V switch using the ID instead of name
to prevent any encoding issues that may occur switching between
PowerShell and Ruby also when importing VM from XML file. With the IDs
staying consistent, the switch name can be fetched from the provided ID.