### PR TITLE
Introduce flag for suspending all machines

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -300,6 +300,10 @@ module Vagrant
       error_key(:command_deprecated)
     end
 
+    class CommandSuspendAllArgs < VagrantError
+      error_key(:command_suspend_all_arguments)
+    end
+
     class CommandUnavailable < VagrantError
       error_key(:command_unavailable)
     end

--- a/plugins/commands/suspend/command.rb
+++ b/plugins/commands/suspend/command.rb
@@ -8,8 +8,13 @@ module VagrantPlugins
       end
 
       def execute
+        options = {}
         opts = OptionParser.new do |o|
-          o.banner = "Usage: vagrant suspend [name|id]"
+          o.banner = "Usage: vagrant suspend [options] [name|id]"
+          o.separator ""
+          o.on("-a", "--all-global", "Suspend all running vms globally.") do |p|
+            options[:all] = true
+          end
         end
 
         # Parse the options
@@ -17,7 +22,15 @@ module VagrantPlugins
         return if !argv
 
         @logger.debug("'suspend' each target VM...")
-        with_target_vms(argv) do |vm|
+        target = []
+        if options[:all]
+          m = @env.machine_index.each { |m| m }
+          target = m.keys
+        else
+          target = argv
+        end
+
+        with_target_vms(target) do |vm|
           vm.action(:suspend)
         end
 

--- a/plugins/commands/suspend/command.rb
+++ b/plugins/commands/suspend/command.rb
@@ -24,6 +24,10 @@ module VagrantPlugins
         @logger.debug("'suspend' each target VM...")
         target = []
         if options[:all]
+          if argv.size > 0
+            raise Vagrant::Errors::CommandSuspendAllArgs
+          end
+
           m = @env.machine_index.each { |m| m }
           target = m.keys
         else

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -727,6 +727,8 @@ en:
       command_deprecated: |-
         The command 'vagrant %{name}' has been deprecated and is no longer functional
         within Vagrant.
+      command_suspend_all_arguments: |-
+        The suspend command with the `--all-global` flag does not take any arguments.
       command_unavailable: |-
         The executable '%{file}' Vagrant is trying to run was not
         found in the PATH variable. This is an error. Please verify

--- a/test/unit/plugins/commands/suspend/command_test.rb
+++ b/test/unit/plugins/commands/suspend/command_test.rb
@@ -99,5 +99,13 @@ describe VagrantPlugins::CommandSuspend::Command do
 
       expect(subject.execute).to eq(0)
     end
+
+    context "with an argument is used" do
+      let(:argv){ ["machine", "--all-global"] }
+
+      it "errors out" do
+        expect{subject.execute}.to raise_error(Vagrant::Errors::CommandSuspendAllArgs)
+      end
+    end
   end
 end

--- a/test/unit/plugins/commands/suspend/command_test.rb
+++ b/test/unit/plugins/commands/suspend/command_test.rb
@@ -1,0 +1,103 @@
+require File.expand_path("../../../../base", __FILE__)
+require Vagrant.source_root.join("plugins/commands/suspend/command")
+
+describe VagrantPlugins::CommandSuspend::Command do
+  include_context "unit"
+
+  let(:entry_klass) { Vagrant::MachineIndex::Entry }
+  let(:argv)     { [] }
+  let(:vagrantfile_content){ "" }
+  let(:iso_env) do
+    env = isolated_environment
+    env.vagrantfile(vagrantfile_content)
+    env.create_vagrant_env
+  end
+
+  subject { described_class.new(argv, iso_env) }
+
+  let(:action_runner) { double("action_runner") }
+  let(:machine) { iso_env.machine(iso_env.machine_names[0], :dummy) }
+  let(:machine2) { iso_env.machine(iso_env.machine_names[0], :dummy) }
+
+  def new_entry(name)
+    entry_klass.new.tap do |e|
+      e.name = name
+      e.vagrantfile_path = "/bar"
+    end
+  end
+
+  before do
+    allow(iso_env).to receive(:action_runner).and_return(action_runner)
+    allow(subject).to receive(:with_target_vms) { |&block| block.call machine }
+  end
+
+  context "with no argument" do
+    let(:vagrantfile_content) do
+        <<-VF
+        Vagrant.configure("2") do |config|
+          config.vm.define "app"
+          config.vm.define "db"
+        end
+        VF
+    end
+
+    it "should suspend all vms" do
+      allow(subject).to receive(:with_target_vms) { |&block|
+        block.call machine
+        block.call machine2
+      }
+      expect(machine).to receive(:action) do |name, opts|
+        expect(name).to eq(:suspend)
+      end
+      expect(machine2).to receive(:action) do |name, opts|
+        expect(name).to eq(:suspend)
+      end
+
+      expect(subject.execute).to eq(0)
+    end
+  end
+
+  context "with an argument" do
+    let(:vagrantfile_content) do
+        <<-VF
+        Vagrant.configure("2") do |config|
+          config.vm.define "app"
+          config.vm.define "db"
+        end
+        VF
+    end
+    let(:argv) { ["app"] }
+
+    it "should suspend a vm" do
+      expect(machine).to receive(:action) do |name, opts|
+        expect(name).to eq(:suspend)
+      end
+
+      expect(subject.execute).to eq(0)
+    end
+  end
+
+  context "with the global all flag" do
+    let(:argv){ ["--all-global"] }
+
+    it "should suspend all vms globally" do
+      global_env = isolated_environment
+      global_env.vagrantfile("Vagrant.configure(2){|config| config.vm.box = 'dummy'}")
+      global_venv = global_env.create_vagrant_env
+      global_machine = global_venv.machine(global_venv.machine_names[0], :dummy)
+      global_machine.id = "1234"
+      global = new_entry(global_machine.name)
+      global.provider = "dummy"
+      global.vagrantfile_path = global_env.workdir
+      locked = iso_env.machine_index.set(global)
+      iso_env.machine_index.release(locked)
+
+      allow(subject).to receive(:with_target_vms) { |&block| block.call global_machine }
+      expect(global_machine).to receive(:action) do |name, opts|
+        expect(name).to eq(:suspend)
+      end
+
+      expect(subject.execute).to eq(0)
+    end
+  end
+end


### PR DESCRIPTION
This commit introduces a new flag to the suspend command,
`--all-global`, which will suepend all vms both locally and globally.

Fixes #7221