### PR TITLE
#9174 Remove masterless? config attribute

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -385,7 +385,7 @@ module VagrantPlugins
 
           @machine.env.ui.info "Calling state.highstate... (this may take a while)"
           if @config.install_master
-            unless @config.masterless?
+            unless @config.masterless
               @machine.communicate.sudo("salt '*' saltutil.sync_all")
             end
             options = "#{get_masterless}#{get_loglevel}#{get_colorize}#{get_pillar}#{get_salt_args}"
@@ -397,7 +397,7 @@ module VagrantPlugins
           else
             if @machine.config.vm.communicator == :winrm
               opts = { elevated: true }
-              unless @config.masterless?
+              unless @config.masterless
                 @machine.communicate.execute("C:\\salt\\salt-call.bat saltutil.sync_all", opts)
               end
               # TODO: something equivalent to { error_key: :ssh_bad_exit_status_muted }?
@@ -408,7 +408,7 @@ module VagrantPlugins
                 end
               end
             else
-              unless @config.masterless?
+              unless @config.masterless
                 @machine.communicate.sudo("salt-call saltutil.sync_all")
               end
               options = "#{get_masterless}#{get_loglevel}#{get_colorize}#{get_pillar}#{get_call_args}"

--- a/test/unit/plugins/provisioners/salt/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/salt/provisioner_test.rb
@@ -55,7 +55,6 @@ describe VagrantPlugins::Salt::Provisioner do
       it "passes along extra cli flags" do
         allow(config).to receive(:run_highstate).and_return(true)
         allow(config).to receive(:verbose).and_return(true)
-        allow(config).to receive(:masterless?).and_return(false)
         allow(config).to receive(:masterless).and_return(false)
         allow(config).to receive(:minion_id).and_return(nil)
         allow(config).to receive(:log_level).and_return(nil)
@@ -74,7 +73,6 @@ describe VagrantPlugins::Salt::Provisioner do
       it "has no additional cli flags if not included" do
         allow(config).to receive(:run_highstate).and_return(true)
         allow(config).to receive(:verbose).and_return(true)
-        allow(config).to receive(:masterless?).and_return(false)
         allow(config).to receive(:masterless).and_return(false)
         allow(config).to receive(:minion_id).and_return(nil)
         allow(config).to receive(:log_level).and_return(nil)
@@ -95,7 +93,6 @@ describe VagrantPlugins::Salt::Provisioner do
       it "passes along extra cli flags" do
         allow(config).to receive(:run_highstate).and_return(true)
         allow(config).to receive(:verbose).and_return(true)
-        allow(config).to receive(:masterless?).and_return(true)
         allow(config).to receive(:masterless).and_return(true)
         allow(config).to receive(:minion_id).and_return(nil)
         allow(config).to receive(:log_level).and_return(nil)
@@ -115,7 +112,6 @@ describe VagrantPlugins::Salt::Provisioner do
       it "has no additional cli flags if not included" do
         allow(config).to receive(:run_highstate).and_return(true)
         allow(config).to receive(:verbose).and_return(true)
-        allow(config).to receive(:masterless?).and_return(true)
         allow(config).to receive(:masterless).and_return(true)
         allow(config).to receive(:minion_id).and_return(nil)
         allow(config).to receive(:log_level).and_return(nil)


### PR DESCRIPTION
Replaces the masterless? attributes in favor of the already additional available masterless (without question mark) attribute. There is no obvious reason for the existence of the masterless? attribute and it causes issues as outlined in #9174. 