### PR TITLE
Fix unused library

### DIFF
--- a/plugins/guests/redhat/cap/nfs_client.rb
+++ b/plugins/guests/redhat/cap/nfs_client.rb
@@ -5,9 +5,9 @@ module VagrantPlugins
         def self.nfs_client_install(machine)
           machine.communicate.sudo <<-EOH.gsub(/^ {12}/, '')
             if command -v dnf; then
-              dnf -y install nfs-utils nfs-utils-lib portmap
+              dnf -y install nfs-utils libnfs-utils portmap
             else
-              yum -y install nfs-utils nfs-utils-lib portmap
+              yum -y install nfs-utils libnfs-utils portmap
             fi
 
             if test $(ps -o comm= 1) == 'systemd'; then

--- a/test/unit/plugins/guests/redhat/cap/nfs_client_test.rb
+++ b/test/unit/plugins/guests/redhat/cap/nfs_client_test.rb
@@ -23,7 +23,7 @@ describe "VagrantPlugins::GuestRedHat::Cap:NFSClient" do
 
     it "installs rsync" do
       cap.nfs_client_install(machine)
-      expect(comm.received_commands[0]).to match(/install nfs-utils nfs-utils-lib portmap/)
+      expect(comm.received_commands[0]).to match(/install nfs-utils libnfs-utils portmap/)
       expect(comm.received_commands[0]).to match(/\/bin\/systemctl restart rpcbind nfs/)
     end
   end


### PR DESCRIPTION
When creating a fedora 28 guest, dnf failed while installing the nfs-utils-lib package, so I propose this change.