### PR TITLE
global status informs about --prune

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -182,9 +182,10 @@ en:
     global_status_footer: |-
       The above shows information about all known Vagrant environments
       on this machine. This data is cached and may not be completely
-      up-to-date. To interact with any of the machines, you can go to
-      that directory and run Vagrant, or you can use the ID directly
-      with Vagrant commands from any directory. For example:
+      up-to-date (use "vagrant global-status --prune" to prune invalid
+      entries). To interact with any of the machines, you can go to that
+      directory and run Vagrant, or you can use the ID directly with
+      Vagrant commands from any directory. For example:
       "vagrant destroy 1a2b3c4d"
     global_status_none: |-
       There are no active Vagrant environments on this computer! Or,


### PR DESCRIPTION
It's not obvious from the old explanation, how to get
rid of get rid of data that "may not be completely
up-to-date".

I had to google for the solution myself and found it from an old issue: https://github.com/hashicorp/vagrant/issues/4412