### PR TITLE
Fix issue 9592 when systemd-networkd is used by Debian guest

### DIFF
--- a/plugins/guests/debian/cap/configure_networks.rb
+++ b/plugins/guests/debian/cap/configure_networks.rb
@@ -109,7 +109,7 @@ module VagrantPlugins
           end
 
           remote_path = upload_tmp_file(comm, net_conf.join("\n"))
-          dest_path = "#{NETWORKD_DIRECTORY}/99-vagrant.network"
+          dest_path = "#{NETWORKD_DIRECTORY}/50-vagrant.network"
           comm.sudo(["mkdir -p #{NETWORKD_DIRECTORY}",
             "mv -f '#{remote_path}' '#{dest_path}'",
             "chown root:root '#{dest_path}'",


### PR DESCRIPTION
The PR #9646 did not fix the isue. It changed the priority of the "netplan" YAML file, not the priority of the  network file in /etc/systemd/network directory used by systemd-networkd. My PR fixes the issue for real.