### PR TITLE
ansible_local: Improve installation from PPA

### DIFF
--- a/plugins/provisioners/ansible/cap/guest/ubuntu/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/ubuntu/ansible_install.rb
@@ -18,11 +18,17 @@ module VagrantPlugins
             private
 
             def self.ansible_apt_install(machine)
-              machine.communicate.sudo "apt-get update -y -qq"
-              machine.communicate.sudo "apt-get install -y -qq software-properties-common python-software-properties"
-              machine.communicate.sudo "add-apt-repository ppa:ansible/ansible -y"
-              machine.communicate.sudo "apt-get update -y -qq"
-              machine.communicate.sudo "apt-get install -y -qq ansible"
+              unless machine.communicate.test("test -x \"$(which add-apt-repository)\"")
+                machine.communicate.sudo """
+                  apt-get update -y -qq && \
+                  apt-get install -y -qq software-properties-common
+                """
+              end
+              machine.communicate.sudo """
+                add-apt-repository ppa:ansible/ansible -y && \
+                apt-get update -y -qq && \
+                apt-get install -y -qq ansible
+              """
             end
 
           end

--- a/website/source/docs/provisioning/ansible_local.html.md
+++ b/website/source/docs/provisioning/ansible_local.html.md
@@ -73,7 +73,7 @@ This section lists the _specific_ options for the Ansible Local provisioner. In 
 - `install_mode` (`:default`, `:pip`, or `:pip_args_only`) - Select the way to automatically install Ansible on the guest system.
 
   - `:default`: Ansible is installed from the operating system package manager. This mode doesn't support `version` selection. For many platforms (e.g Debian, FreeBSD, OpenSUSE) the official package repository is used, except for the following Linux distributions:
-      - On Ubuntu-like systems, the latest Ansible release is installed from the `ppa:ansible/ansible` repository.
+      - On Ubuntu-like systems, the latest Ansible release is installed from the `ppa:ansible/ansible` repository. The compatibility is maintained only for active long-term support (LTS) versions.
       - On RedHat-like systems, the latest Ansible release is installed from the [EPEL](http://fedoraproject.org/wiki/EPEL) repository.
 
   - `:pip`: Ansible is installed from [PyPI](https://pypi.python.org/pypi) with [pip](https://pip.pypa.io) package installer. With this mode, Vagrant will systematically try to [install the latest pip version](https://pip.pypa.io/en/stable/installing/#installing-with-get-pip-py). With the `:pip` mode you can optionally install a specific Ansible release by setting the [`version`](/docs/provisioning/ansible_common.html#version) option.


### PR DESCRIPTION
- Fix #9796: Failing installation on bionic (18.04 LTS)
- Remove support for precise (12.04 LTS), which is out of public support
  (On this version, the package python-software-properties contained
  the add-apt-repository tool)
- Reduce the number of SSH calls, and avoid unnecessary apt-get calls.

This patch has been validated against the following base boxes:
* [x] bento/ubuntu-18.04
* [x] bento/ubuntu-16.04
* [x] bento/ubuntu-14.04
* [x] ubuntu/bionic64 (18.04) 
* [x] ubuntu/xenial64 (16.04)
* [x] ubuntu/trusty64 (14.04)
