### PR TITLE
Fix broken link in Vagrant Cloud API docs

### DIFF
--- a/website/source/docs/vagrant-cloud/api.html.md.erb
+++ b/website/source/docs/vagrant-cloud/api.html.md.erb
@@ -1234,7 +1234,7 @@ Response body is identical to [Reading a provider](#read-a-provider).
 
 * `provider`
     * `name` - The name of the provider.
-    * `url` - A valid URL to download this provider. If omitted, you must [upload](#TODO) the Vagrant box image for this provider to Vagrant Cloud before the provider can be used.
+    * `url` - A valid URL to download this provider. If omitted, you must [upload](#upload-a-provider) the Vagrant box image for this provider to Vagrant Cloud before the provider can be used.
 
 #### Example Request
 


### PR DESCRIPTION
This commit fixes the #TODO link with the proper docs link to upload a
provider.