### PR TITLE
Fix: Correct  typo in hyperv provider, $Enable instead of $enabled

### DIFF
--- a/plugins/providers/hyperv/scripts/set_vm_integration_services.ps1
+++ b/plugins/providers/hyperv/scripts/set_vm_integration_services.ps1
@@ -19,9 +19,9 @@ try {
 }
 
 try {
-    Set-VagrantVMService -VM $VM -Name $Name -Enable $enabled
+    Set-VagrantVMService -VM $VM -Name $Name -Enable $Enable
 } catch {
-    if($enabled){ $action = "enable" } else { $action = "disable" }
+    if($Enable){ $action = "enable" } else { $action = "disable" }
     Write-Error-Message "Failed to ${action} VM integration service ${Name}: ${PSItem}"
     exit 1
 }


### PR DESCRIPTION
I noticed that the refactored hyper-v provider fails if any `vm_integration_services` are given. This is due to a typo in the PowerShell script that sets the actual values.  I'm not sure how to implement a test for this so I am submitting this pull-request with just the minimal changes.