### PR TITLE
Fix Chef apply provisioner to not set node_name

### DIFF
--- a/plugins/provisioners/chef/provisioner/base.rb
+++ b/plugins/provisioners/chef/provisioner/base.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
 
           @logger = Log4r::Logger.new("vagrant::provisioners::chef")
 
-          if !present?(@config.node_name)
+          if @config.respond_to?(:node_name) && !present?(@config.node_name)
             # First attempt to get the node name from the hostname, and if that
             # is not present, generate/retrieve a random hostname.
             hostname = @machine.config.vm.hostname

--- a/test/unit/plugins/provisioners/chef/provisioner/base_test.rb
+++ b/test/unit/plugins/provisioners/chef/provisioner/base_test.rb
@@ -39,15 +39,20 @@ describe VagrantPlugins::Chef::Provisioner::Base do
 
     it "defaults to hostname if given" do
       machine.config.vm.hostname = "by.hostname"
-      instance = described_class.new(machine, OpenStruct.new)
+      instance = described_class.new(machine, OpenStruct.new(node_name: nil))
       expect(instance.config.node_name).to eq("by.hostname")
     end
 
     it "generates a random name if no hostname or node_name is given" do
-      config = OpenStruct.new(node_name: nil)
       machine.config.vm.hostname = nil
-      instance = described_class.new(machine, OpenStruct.new)
+      instance = described_class.new(machine, OpenStruct.new(node_name: nil))
       expect(instance.config.node_name).to match(/vagrant\-.+/)
+    end
+
+    it "does not set node_name if configuration does not define it" do
+      expect(config).to receive(:respond_to?).with(:node_name).and_return(false)
+      expect(config).not_to receive(:node_name)
+      described_class.new(machine, config)
     end
   end
 


### PR DESCRIPTION
The base chef provisioner class will set the node name automatically
if not provided in the configuration. Since the chef apply provisioner
does not provide a node_name option, setting it will invalidate the
configuration. This checks for the node name before attempting to
use it.

Fixes #9901