### PR TITLE
Fix SMB information generation when using net share

### DIFF
--- a/plugins/hosts/windows/cap/smb.rb
+++ b/plugins/hosts/windows/cap/smb.rb
@@ -38,7 +38,7 @@ module VagrantPlugins
 
           m_id = machine_id(machine)
           prune_shares = existing_shares.map do |share_name, share_info|
-            if share_info["Description"].start_with?("vgt-#{m_id}-")
+            if share_info["Description"].to_s.start_with?("vgt-#{m_id}-")
               @@logger.info("removing smb share name=#{share_name} id=#{m_id}")
               share_name
             else
@@ -159,6 +159,8 @@ module VagrantPlugins
           share_names = result.strip.split("\n").map do |line|
             line.strip.split(/\s+/).first
           end
+          # Last item is command completion notification so remove it
+          share_names.pop
           shares = {}
           share_names.each do |share_name|
             shares[share_name] = {}

--- a/test/unit/plugins/hosts/windows/cap/smb_test.rb
+++ b/test/unit/plugins/hosts/windows/cap/smb_test.rb
@@ -31,7 +31,7 @@ Share name        Resource     Remark
 vgt-CUSTOM_ID-1   /a/path      vgt-CUSTOM_ID-1
 vgt-CUSTOM_ID-2   /other/path  vgt-CUSTOM_ID-2
 my-share          /my/path     Not Vagran...
-
+The command completed successfully.
     EOF
   }
   let(:netshare1){ <<-EOF


### PR DESCRIPTION
Adds the final line of output to tests and properly simulates
failure. Fix with type casting to prevent calling methods on
nil and drop the final entry as it's not valid.

Fixes #9806