### PR TITLE
Fix hang at nmcli call on CentOS 7.5 when ssh.pty is enabled

### DIFF
--- a/lib/vagrant/util/guest_inspection.rb
+++ b/lib/vagrant/util/guest_inspection.rb
@@ -44,7 +44,7 @@ module Vagrant
         #
         # @return [Boolean]
         def nmcli?(comm)
-          comm.test("nmcli")
+          comm.test("nmcli -t")
         end
 
         # NetworkManager currently controls device
@@ -53,8 +53,8 @@ module Vagrant
         # @param device_name [String]
         # @return [Boolean]
         def nm_controlled?(comm, device_name)
-          comm.test("nmcli d show #{device_name}") &&
-            !comm.test("nmcli d show #{device_name} | grep unmanaged")
+          comm.test("nmcli -t d show #{device_name}") &&
+            !comm.test("nmcli -t d show #{device_name} | grep unmanaged")
         end
 
       end

--- a/test/unit/plugins/guests/debian/cap/configure_networks_test.rb
+++ b/test/unit/plugins/guests/debian/cap/configure_networks_test.rb
@@ -65,8 +65,8 @@ describe "VagrantPlugins::GuestDebian::Cap::ConfigureNetworks" do
     end
 
     before do
-      allow(comm).to receive(:test).with("nmcli d show eth1").and_return(false)
-      allow(comm).to receive(:test).with("nmcli d show eth2").and_return(false)
+      allow(comm).to receive(:test).with("nmcli -t d show eth1").and_return(false)
+      allow(comm).to receive(:test).with("nmcli -t d show eth2").and_return(false)
       allow(comm).to receive(:test).with("ps -o comm= 1 | grep systemd").and_return(false)
       allow(comm).to receive(:test).with("sudo systemctl status systemd-networkd.service").and_return(false)
       allow(comm).to receive(:test).with("netplan -h").and_return(false)
@@ -125,8 +125,8 @@ describe "VagrantPlugins::GuestDebian::Cap::ConfigureNetworks" do
 
         it "uses NetworkManager if detected on device" do
           allow(cap).to receive(:nm_controlled?).and_return(true)
-          allow(comm).to receive(:test).with("nmcli d show eth1").and_return(true)
-          allow(comm).to receive(:test).with("nmcli d show eth2").and_return(true)
+          allow(comm).to receive(:test).with("nmcli -t d show eth1").and_return(true)
+          allow(comm).to receive(:test).with("nmcli -t d show eth2").and_return(true)
 
           expect(cap).to receive(:upload_tmp_file).with(comm, nm_yml)
             .and_return("/tmp/vagrant-network-entry.1234")


### PR DESCRIPTION
`vagrant up` may hang at the "Configuring and enabling network
interfaces..." step when private networks and PTY allocation for SSH
are used.

The newer version of `nmcli` that is part of CentOS now will open a
pager (i.e. `less`) for certain commands if it finds a tty. This
causes the invocations of `nmcli` in `guest_inspection.rb` to hang.

`nmcli` disables the use of a pager in 'terse' (`-t`) output mode,
while still returning enough information for the uses in
`guest_inspection.rb`.