### PR TITLE
Fix the name for nfs-utils-lib package in fedora28

### DIFF
--- a/plugins/guests/redhat/cap/nfs_client.rb
+++ b/plugins/guests/redhat/cap/nfs_client.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
         def self.nfs_client_install(machine)
           machine.communicate.sudo <<-EOH.gsub(/^ {12}/, '')
             if command -v dnf; then
-              dnf -y install nfs-utils nfs-utils-lib portmap
+              dnf -y install nfs-utils libnfs-utils portmap
             else
               yum -y install nfs-utils nfs-utils-lib portmap
             fi


### PR DESCRIPTION
In fedora28, the nfs package `nfs-utils-lib` has been removed and it no longer exists. Rather, now `libnfs-utils` is used. `libnfs-utils` shall work on all distributions of fedora :) 