### PR TITLE
Disconnect all configured network adapters

### DIFF
--- a/plugins/providers/hyperv/scripts/utils/VagrantVM/VagrantVM.psm1
+++ b/plugins/providers/hyperv/scripts/utils/VagrantVM/VagrantVM.psm1
@@ -96,6 +96,9 @@ function New-VagrantVMVMCX {
         Hyper-V\Set-VMFirmware -VM $VM -EnableSecureBoot (Hyper-V\Get-VMFirmware -VM $VM).SecureBoot
     }
 
+    # Disconnect adapters from switches
+    Hyper-V\Get-VMNetworkAdapter -VM $VM | Hyper-V\Disconnect-VMNetworkAdapter
+
     # Verify new VM
     $Report = Hyper-V\Compare-VM -CompatibilityReport $VMConfig
     if($Report.Incompatibilities.Length -gt 0){


### PR DESCRIPTION
When importing a Hyper-V VM ensure all adapters are disconnected from
switches that were used when the box was built.

Fixes  #9922