### PR TITLE
Add `suspend` into a list of available actions

### DIFF
--- a/website/source/docs/triggers/configuration.html.md
+++ b/website/source/docs/triggers/configuration.html.md
@@ -21,6 +21,7 @@ The trigger class takes various options.
   - `provision`
   - `reload`
   - `resume`
+  - `suspend`
   - `up`
 
 * `ignore` (symbol, array) - Symbol or array of symbols corresponding to the action that a trigger should not fire on.


### PR DESCRIPTION
`suspend` action is not listed, even though it can be used and it works.

```
$ vagrant --version
Vagrant 2.1.1
```

```
config.trigger.before [:suspend] do |trigger|
  trigger.name = "Before suspend"
  trigger.run = {inline: "..."}
end
````