### PR TITLE
Provide custom error when attempting to push too many files with FTP

### DIFF
--- a/plugins/pushes/ftp/errors.rb
+++ b/plugins/pushes/ftp/errors.rb
@@ -1,0 +1,13 @@
+module VagrantPlugins
+  module FTPPush
+    module Errors
+      class Error < Vagrant::Errors::VagrantError
+        error_namespace("ftp_push.errors")
+      end
+
+      class TooManyFiles < Error
+        error_key(:too_many_files)
+      end
+    end
+  end
+end

--- a/plugins/pushes/ftp/locales/en.yml
+++ b/plugins/pushes/ftp/locales/en.yml
@@ -9,3 +9,8 @@ en:
             config.push.define "ftp" do |push|
               push.%{attribute} = "..."
             end
+      too_many_files: |-
+        The configured directory for Vagrant FTP push contains too many files
+        to successfully complete the command. This can be resolved by either
+        removing extraneous files from the configured directory, or updating
+        the `dir` configuration option to a subdirectory.

--- a/test/unit/plugins/pushes/ftp/push_test.rb
+++ b/test/unit/plugins/pushes/ftp/push_test.rb
@@ -73,6 +73,11 @@ describe VagrantPlugins::FTPPush::Push do
       subject.push
       expect(server.files).to eq(%w(Gemfile data.txt))
     end
+
+    it "raises informative exception when too many files to process" do
+      expect(subject).to receive(:all_files).and_raise(SystemStackError)
+      expect{ subject.push }.to raise_error(VagrantPlugins::FTPPush::Errors::TooManyFiles)
+    end
   end
 
   describe "#connect" do


### PR DESCRIPTION
When the configured directory for FTP push has too many files, it will
generate an exception and fail due to a stack overflow. When this happens
just rescue out the exception and re-raise a custom error to provide
some context to the user on the actual problem.

Fixes #9946 