### PR TITLE
Keep modified debian ansible configuration files during update

### DIFF
--- a/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
@@ -33,7 +33,7 @@ INLINE_CRIPT
 
               machine.communicate.sudo install_backports_if_wheezy_release
               machine.communicate.sudo "apt-get update -y -qq"
-              machine.communicate.sudo "apt-get install -y -qq ansible"
+              machine.communicate.sudo "apt-get install -y -qq -o Dpkg::Options::=\"--force-confold\" -o Dpkg::Options::=\"--force-confdef\" ansible"
             end
 
             def self.pip_setup(machine)


### PR DESCRIPTION
In some situations, a vagrant box may come with a pre-installed ansible package, with modified configuration.
Using the `ansible_local` provisioner with version set to `latest` may lead to an unsolvable issue if a new version of the package has emerged:
```
==> localhost: Running provisioner: ansible (ansible_local)...
    localhost: Installing Ansible...
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

apt-get install -y -qq ansible

Stdout from the command:

(Reading database ... 49896 files and directories currently installed.)
Preparing to unpack .../2.5.2+dfsg-1~bpo9+1 ...
Unpacking ansible (2.5.2+dfsg-1~bpo9+1) over (2.4.3.0+dfsg-1~bpo9+1) ...
Setting up ansible (2.5.2+dfsg-1~bpo9+1) ...

Configuration file '/etc/ansible/ansible.cfg'
 ==> Modified (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** ansible.cfg (Y/I/N/O/D/Z) [default=N] ?
Configuration file '/etc/ansible/ansible.cfg'
 ==> Modified (by you or by a script) since installation.
 ==> Package distributor has shipped an updated version.
   What would you like to do about it ?  Your options are:
    Y or I  : install the package maintainer's version
    N or O  : keep your currently-installed version
      D     : show the differences between the versions
      Z     : start a shell to examine the situation
 The default action is to keep your current version.
*** ansible.cfg (Y/I/N/O/D/Z) [default=N] ? dpkg: error processing package ansible (--configure):
 end of file on stdin at conffile prompt
Errors were encountered while processing:
 ansible


Stderr from the command:

dpkg-preconfigure: unable to re-open stdin: No such file or directory
E: Sub-process /usr/bin/dpkg returned an error code (1)
```

Setting the related dpkg options `force-confold` and `force-confdef` force dpkg to keep the modified configuration files without asking.

It's a common practice, even in ansible :) (See: https://docs.ansible.com/ansible/latest/modules/apt_module.html)