### PR TITLE
contrib/bash/completion.sh: replaced -VAGRANTSLASH- with a literal sl…

### DIFF
--- a/contrib/bash/completion.sh
+++ b/contrib/bash/completion.sh
@@ -65,7 +65,7 @@ _vagrant() {
     then
         case "$prev" in
             "init")
-              local box_list=$(find "${VAGRANT_HOME:-${HOME}/.vagrant.d}/boxes" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+              local box_list=$(find "${VAGRANT_HOME:-${HOME}/.vagrant.d}/boxes" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sed -e 's/-VAGRANTSLASH-/\//')
               COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
               return 0
             ;;
@@ -132,7 +132,7 @@ _vagrant() {
         "box")
           case "$prev" in
             "remove"|"repackage")
-              local box_list=$(find "${VAGRANT_HOME:-${HOME}/.vagrant.d}/boxes" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
+              local box_list=$(find "${VAGRANT_HOME:-${HOME}/.vagrant.d}/boxes" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sed -e 's/-VAGRANTSLASH-/\//')
               COMPREPLY=($(compgen -W "${box_list}" -- ${cur}))
               return 0
               ;;


### PR DESCRIPTION
…ash in box names

when using the bash-completion script as provided in contrib/bash/completion.sh, using the completion with box names such as 'debian/stretch64' will produce an incorrect name, because the directory in ~/.vagrant.d/boxes is actually called 'debian-VAGRANTSLASH-stretch64'. This breaks some commands like 'box remove'. The following bash log illustrates this problem:

```
$ ls ~/.vagrant.d/boxes/
debian-VAGRANTSLASH-stretch64
$ vagrant box remove [tab]
$ vagrant box remove debian-VAGRANTSLASH-stretch64
The box you requested to be removed could not be found. No
boxes named 'debian-VAGRANTSLASH-stretch64' could be found.
```

expected behavior:
```
$ ls ~/.vagrant.d/boxes/
debian-VAGRANTSLASH-stretch64
$ vagrant box remove [tab]
$ vagrant box remove debian/stretch64
Removing box 'debian/stretch64' (v9.4.0) with provider '[redacted]'...
```

a simple fix is to replace the -VAGRANTSLASH- with a literal slash in completion.sh, as suggested here: https://github.com/Bash-it/bash-it/blob/master/completion/available/vagrant.completion.bash

(Interestingly, vagrant up works with a box name such as 'debian-VAGRANTSLASH-stretch64', I am not sure if this is a bug or a feature)