### PR TITLE
Revert Vagrant plugin loading from #9808

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -337,7 +337,7 @@ if Vagrant.plugins_enabled?
             global_logger.info("Loading plugin `#{plugin_name}` with slash require: `#{plugin_slash}`")
             require plugin_slash
           else
-            raise
+            global_logger.warn("Failed to load plugin `#{plugin_name}`. Assuming library and moving on.")
           end
         end
       else


### PR DESCRIPTION
Need to revert #9808 and restore v2.1.1 behaviour in order to prevent plug-in loading regression introduced with v2.1.2. Emit a warning and proceed if plug-in doesn't load.