### PR TITLE
Update mount_shared_folder.rb

### DIFF
--- a/plugins/guests/windows/cap/mount_shared_folder.rb
+++ b/plugins/guests/windows/cap/mount_shared_folder.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
             # Ensure password is scrubbed
             Vagrant::Util::CredentialScrubber.sensitive(options[:smb_password])
           end
-          machine.communicate.execute("cmdkey /add:#{options[:smb_host]} /user:#{options[:smb_username]} /pass:#{options[:smb_password]}", {shell: :powershell, elevated: true})
+          machine.communicate.execute("cmdkey /add:#{options[:smb_host]} /user:#{options[:smb_username]} /pass:\"#{options[:smb_password]}\"", {shell: :powershell, elevated: true})
           mount_shared_folder(machine, name, guestpath, "\\\\#{options[:smb_host]}\\")
         end
 


### PR DESCRIPTION
This change allows special characters in the password such as ) which will cause cmdkey to fail without the quotes.

We should probably implement this in the following files as well.

* plugins\hosts\linux\cap\rdp.rb line 42
* plugins\hosts\windows\cap\rdp.rb line 15