### PR TITLE
Catch and allow for non-standard exit codes

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -784,6 +784,10 @@ module Vagrant
       error_key(:synced_folder_unusable)
     end
 
+    class TriggersBadExitCodes < VagrantError
+      error_key(:triggers_bad_exit_codes)
+    end
+
     class TriggersGuestNotRunning < VagrantError
       error_key(:triggers_guest_not_running)
     end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1430,6 +1430,8 @@ en:
         Trigger run failed
       triggers_guest_not_running: |-
         Could not run remote script on %{machine_name} because its state is %{state}
+      triggers_bad_exit_codes: |-
+        A script exited with an unacceptable exit code %{code}.
       triggers_no_block_given: |-
         There was an error parsing the Vagrantfile:
         No config was given for the trigger(s) %{command}.
@@ -1728,6 +1730,9 @@ en:
         on_error_bad_type: |-
           Invalid type set for `on_error` on trigger for command '%{cmd}'. `on_error` can
           only be `:halt` (default) or `:continue`.
+        exit_codes_bad_type: |-
+          Invalid type set for `exit_codes` on trigger for command '%{cmd}'. `exit_codes` can
+          only be a single integer or an array of integers.
         only_on_bad_type: |-
           Invalid type found for `only_on`. All values must be a `String` or `Regexp`.
         privileged_ignored: |-

--- a/website/source/docs/triggers/configuration.html.md
+++ b/website/source/docs/triggers/configuration.html.md
@@ -42,3 +42,5 @@ The trigger class takes various options.
   + `path`
 
 * `warn` (string) - A warning message that will be printed at the beginning of a trigger.
+
+* `exit_codes` (integer, array) - A set of acceptable exit codes to continue on. Defaults to `0` if option is absent. For now only valid with the `run` option.


### PR DESCRIPTION
Prior to this commit, the run trigger option wouldn't catch for failures
outside of the #Subprocess.execute raising exceptions. This commit fixes
that by inspecting the exit code result of the subprocess and using the
new `exit_codes` option to determine how to move forward with the
trigger.

Fixes #9997 #9992 