### PR TITLE
Add void linux host support

### DIFF
--- a/plugins/hosts/void/cap/nfs.rb
+++ b/plugins/hosts/void/cap/nfs.rb
@@ -3,7 +3,7 @@ module VagrantPlugins
     module Cap
       class NFS
         def self.nfs_check_command(env)
-          "/usr/bin/sv status nfs-server"
+          "sudo /usr/bin/sv status nfs-server"
         end
 
         def self.nfs_start_command(env)

--- a/plugins/hosts/void/cap/nfs.rb
+++ b/plugins/hosts/void/cap/nfs.rb
@@ -1,0 +1,19 @@
+module VagrantPlugins
+  module HostVoid
+    module Cap
+      class NFS
+        def self.nfs_check_command(env)
+          "/usr/bin/sv status nfs-server"
+        end
+
+        def self.nfs_start_command(env)
+          "/usr/bin/sv up nfs-server "
+        end
+
+        def self.nfs_installed(env)
+          Kernel.system("/usr/bin/xbps-query nfs-utils", [:out, :err] => "/dev/null")
+        end
+      end
+    end
+  end
+end

--- a/plugins/hosts/void/cap/nfs.rb
+++ b/plugins/hosts/void/cap/nfs.rb
@@ -7,7 +7,11 @@ module VagrantPlugins
         end
 
         def self.nfs_start_command(env)
-          "/usr/bin/sv up nfs-server "
+          <<-EOF
+            /usr/bin/ln -s /etc/sv/statd      /var/service/ && \
+            /usr/bin/ln -s /etc/sv/rpcbind    /var/service/ && \
+            /usr/bin/ln -s /etc/sv/nfs-server /var/service/
+          EOF
         end
 
         def self.nfs_installed(env)

--- a/plugins/hosts/void/cap/nfs.rb
+++ b/plugins/hosts/void/cap/nfs.rb
@@ -15,7 +15,8 @@ module VagrantPlugins
         end
 
         def self.nfs_installed(env)
-          Kernel.system("/usr/bin/xbps-query nfs-utils", [:out, :err] => "/dev/null")
+          result = Vagrant::Util::Subprocess.execute("/usr/bin/xbps-query nfs-utils")
+          result.exit_code == 0
         end
       end
     end

--- a/plugins/hosts/void/host.rb
+++ b/plugins/hosts/void/host.rb
@@ -1,0 +1,22 @@
+require 'pathname'
+
+require 'vagrant'
+
+module VagrantPlugins
+  module HostVoid
+    class Host < Vagrant.plugin("2", :host)
+      def detect?(env)
+        os_file = Pathname.new("/etc/os-release")
+
+        if os_file.exist?
+          file = os_file.open
+          while (line = file.gets) do
+            return true if line =~ /^ID="void"/
+          end
+        end
+
+        false
+      end
+    end
+  end
+end

--- a/plugins/hosts/void/plugin.rb
+++ b/plugins/hosts/void/plugin.rb
@@ -1,0 +1,30 @@
+require "vagrant"
+
+module VagrantPlugins
+  module HostVoid
+    class Plugin < Vagrant.plugin("2")
+      name "Void host"
+      description "Void linux host support."
+
+      host("void", "linux") do
+        require_relative "host"
+        Host
+      end
+
+      host_capability("void", "nfs_installed") do
+        require_relative "cap/nfs"
+        Cap::NFS
+      end
+
+      host_capability("void", "nfs_check_command") do
+        require_relative "cap/nfs"
+        Cap::NFS
+      end
+
+      host_capability("void", "nfs_start_command") do
+        require_relative "cap/nfs"
+        Cap::NFS
+      end
+    end
+  end
+end

--- a/test/unit/plugins/hosts/void/cap/nfs_test.rb
+++ b/test/unit/plugins/hosts/void/cap/nfs_test.rb
@@ -1,0 +1,62 @@
+require_relative "../../../../base"
+require_relative "../../../../../../plugins/hosts/void/cap/nfs"
+require_relative "../../../../../../lib/vagrant/util"
+
+describe VagrantPlugins::HostVoid::Cap::NFS do
+
+  include_context "unit"
+
+  let(:caps) do
+    VagrantPlugins::HostVoid::Plugin
+      .components
+      .host_capabilities[:void]
+  end
+
+  let(:env) { double("env") }
+
+  context ".nfs_check_command" do
+    it "should provide nfs_check_command capability" do
+      expect(caps.get(:nfs_check_command)).to eq(described_class)
+    end
+
+    it "should return command to execute" do
+      expect(caps.get(:nfs_check_command).nfs_check_command(env)).to be_a(String)
+    end
+  end
+
+  context ".nfs_start_command" do
+    it "should provide nfs_start_command capability" do
+      expect(caps.get(:nfs_start_command)).to eq(described_class)
+    end
+
+    it "should return command to execute" do
+      expect(caps.get(:nfs_start_command).nfs_start_command(env)).to be_a(String)
+    end
+  end
+
+  context ".nfs_installed" do
+    let(:exit_code) { 0 }
+    let(:result) { Vagrant::Util::Subprocess::Result.new(exit_code, "", "") }
+
+    before { allow(Vagrant::Util::Subprocess).to receive(:execute).
+        with(/xbps-query nfs-utils/).and_return(result) }
+
+    it "should provide nfs_installed capability" do
+      expect(caps.get(:nfs_installed)).to eq(described_class)
+    end
+
+    context "when installed" do
+      it "should return true" do
+        expect(caps.get(:nfs_installed).nfs_installed(env)).to be_truthy
+      end
+    end
+
+    context "when not installed" do
+      let(:exit_code) { 1 }
+
+      it "should return false" do
+        expect(caps.get(:nfs_installed).nfs_installed(env)).to be_falsey
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, NFS does not work correctly on void linux. This PR adds a new Void Linux host to fix this. An issue has been opened here: #10011