### PR TITLE
Download causes exception when location header is not an absolute URL

### DIFF
--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -107,16 +107,19 @@ module Vagrant
               if progress_data.include?("Location")
                 location = progress_data.scan(/Location: (.+?)$/m).flatten.compact.first.to_s.strip
                 if !location.empty?
-                  @logger.info("download redirected to #{location}")
                   location_uri = URI.parse(location)
-                  source_uri = URI.parse(source)
-                  source_host = source_uri.host.split(".", 2).last
-                  location_host = location_uri.host.split(".", 2).last
-                  if !@redirect_notify && location_host != source_host && !SILENCED_HOSTS.include?(location_host)
-                    @ui.clear_line
-                    @ui.detail "Download redirected to host: #{location_uri.host}"
+
+                  unless location_uri.host.nil?
+                    @logger.info("download redirected to #{location}")
+                    source_uri = URI.parse(source)
+                    source_host = source_uri.host.split(".", 2).last
+                    location_host = location_uri.host.split(".", 2).last
+                    if !@redirect_notify && location_host != source_host && !SILENCED_HOSTS.include?(location_host)
+                      @ui.clear_line
+                      @ui.detail "Download redirected to host: #{location_uri.host}"
+                    end
+                    @redirect_notify = true
                   end
-                  @redirect_notify = true
                 end
                 progress_data.replace("")
                 break


### PR DESCRIPTION
When I was trying to set up a Vagrant project with a `box_url` pointing to a file on Dropbox, the download process kept failing with this exception:

```
/opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/util/downloader.rb:118:in `block in download!': undefined method `split' for nil:NilClass (NoMethodError)
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/util/subprocess.rb:191:in `block in execute'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/util/subprocess.rb:180:in `each'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/util/subprocess.rb:180:in `execute'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/util/subprocess.rb:22:in `execute'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/util/downloader.rb:289:in `block in execute_curl'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/util/busy.rb:19:in `busy'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/util/downloader.rb:288:in `execute_curl'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/util/downloader.rb:189:in `download!'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/builtin/box_add.rb:463:in `download'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/builtin/box_add.rb:338:in `block in box_add'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/builtin/box_add.rb:330:in `each'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/builtin/box_add.rb:330:in `box_add'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/builtin/box_add.rb:146:in `add_direct'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/builtin/box_add.rb:120:in `call'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/builder.rb:116:in `call'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/runner.rb:66:in `block in run'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/util/busy.rb:19:in `busy'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/runner.rb:66:in `run'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/builtin/handle_box.rb:82:in `handle_box'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/builtin/handle_box.rb:42:in `block in call'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/builtin/handle_box.rb:36:in `synchronize'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/builtin/handle_box.rb:36:in `call'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/warden.rb:95:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/builder.rb:116:in `call'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/runner.rb:66:in `block in run'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/util/busy.rb:19:in `busy'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/runner.rb:66:in `run'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/builtin/call.rb:53:in `call'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/plugins/providers/virtualbox/action/check_virtualbox.rb:26:in `call'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/warden.rb:34:in `call'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/builder.rb:116:in `call'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/runner.rb:66:in `block in run'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/util/busy.rb:19:in `busy'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/action/runner.rb:66:in `run'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/machine.rb:239:in `action_raw'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/machine.rb:208:in `block in action'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/environment.rb:598:in `lock'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/machine.rb:194:in `call'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/machine.rb:194:in `action'
	from /opt/vagrant/embedded/gems/2.1.2/gems/vagrant-2.1.2/lib/vagrant/batch_action.rb:82:in `block (2 levels) in run'
```

After some investigation, I discovered that Dropbox issued a redirect to a relative URL before the actual download could start, i.e. the HTTP `Location` header looked like this:

```
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Thu, 12 Jul 2018 12:46:32 GMT
Content-Type: text/html; charset=utf-8
Location: /s/dl/o1ogd5h06f95xc1/arch-v0.1.5.box
[...]
```

The `downloader.rb` script then parses this as an absolute URL and subsequently, when the script tries to access the `host` field of the URL object, `nil` is returned, causing an exception on the call to `#split`.

My proposed solution involves parsing the URL in the `Location` header and first checking whether the `host` field of the parsed header is nil before proceeding.