### PR TITLE
Support Docker volume consistency for synced folders

### DIFF
--- a/plugins/providers/docker/synced_folder.rb
+++ b/plugins/providers/docker/synced_folder.rb
@@ -21,7 +21,10 @@ module VagrantPlugins
 
           host_path  = data[:hostpath]
           guest_path = data[:guestpath]
-          machine.provider_config.volumes << "#{host_path}:#{guest_path}"
+          # Append consistency option if it exists, otherwise let it nil out
+          consistency = data[:docker_consistency]
+          consistency &&= ":" + consistency
+          machine.provider_config.volumes << "#{host_path}:#{guest_path}#{consistency}"
         end
       end
     end

--- a/test/unit/plugins/providers/docker/synced_folder_test.rb
+++ b/test/unit/plugins/providers/docker/synced_folder_test.rb
@@ -5,13 +5,15 @@ require Vagrant.source_root.join("plugins/providers/docker/synced_folder")
 describe VagrantPlugins::DockerProvider::SyncedFolder do
   subject { described_class.new }
 
+  let(:provider_config) { double("provider_config", volumes: []) }
+  let(:machine) { double("machine") }
+
+  before do
+    allow(machine).to receive(:provider_name).and_return(:docker)
+    allow(machine).to receive(:provider_config).and_return(provider_config)
+  end
+
   describe "#usable?" do
-    let(:machine) { double("machine") }
-
-    before do
-      allow(machine).to receive(:provider_name).and_return(:docker)
-    end
-
     it "is usable" do
       expect(subject).to be_usable(machine)
     end
@@ -25,6 +27,48 @@ describe VagrantPlugins::DockerProvider::SyncedFolder do
       allow(machine).to receive(:provider_name).and_return(:virtualbox)
       expect { subject.usable?(machine, true) }.
         to raise_error(VagrantPlugins::DockerProvider::Errors::SyncedFolderNonDocker)
+    end
+  end
+
+  describe "#prepare" do
+    let(:folders) {{"/guest/dir1"=>
+                    {:guestpath=>"/guest/dir1",
+                     :hostpath=>"/Users/brian/code/vagrant-sandbox",
+                     :disabled=>false,
+                     :__vagrantfile=>true},
+                     "/dev/vagrant"=>
+                    {:guestpath=>"/dev/vagrant",
+                     :hostpath=>"/Users/brian/code/vagrant",
+                     :disabled=>false,
+                     :__vagrantfile=>true}}}
+
+    let(:consistency_folders) {{"/guest/dir1"=>
+                                {:docker_consistency=>"cached",
+                                 :guestpath=>"/guest/dir1",
+                                 :hostpath=>"/Users/brian/code/vagrant-sandbox",
+                                 :disabled=>false,
+                                 :__vagrantfile=>true},
+                                 "/dev/vagrant"=>
+                                {:docker_consistency=>"delegated",
+                                 :guestpath=>"/dev/vagrant",
+                                 :hostpath=>"/Users/brian/code/vagrant",
+                                 :disabled=>false,
+                                 :__vagrantfile=>true}}}
+    let(:options) { {} }
+
+    let(:volumes) { ["/Users/brian/code/vagrant-sandbox:/guest/dir1",
+                     "/Users/brian/code/vagrant:/dev/vagrant"] }
+    let(:consistency_volumes) { ["/Users/brian/code/vagrant-sandbox:/guest/dir1:cached",
+                                 "/Users/brian/code/vagrant:/dev/vagrant:delegated"] }
+
+    it "prepares folders to mount" do
+      subject.prepare(machine, folders, options)
+      expect(machine.provider_config.volumes).to eq(volumes)
+    end
+
+    it "sets volume consistency if specified" do
+      subject.prepare(machine, consistency_folders, options)
+      expect(machine.provider_config.volumes).to eq(consistency_volumes)
     end
   end
 end

--- a/website/source/docs/docker/basics.html.md
+++ b/website/source/docs/docker/basics.html.md
@@ -75,6 +75,16 @@ on folders synced with a docker container.
 
 Private and public networks are not currently supported.
 
+### Volume Consistency
+
+Docker's [volume consistency](https://github.com/moby/moby/pull/31047) setting can be specified using the `docker_consistency` option when defining a synced folder. This can
+[greatly improve performance on macOS](https://docs.docker.com/docker-for-mac/osxfs-caching). An example is shown using the `cached` and `delegated` settings:
+
+```
+config.vm.synced_folder "/host/dir1", "/guest/dir1", docker_consistency: "cached"
+config.vm.synced_folder "/host/dir2", "/guest/dir2", docker_consistency: "delegated"
+```
+
 ## Host VM
 
 If the system cannot run Linux containers natively, Vagrant automatically spins

--- a/website/source/docs/docker/basics.html.md
+++ b/website/source/docs/docker/basics.html.md
@@ -77,10 +77,10 @@ Private and public networks are not currently supported.
 
 ### Volume Consistency
 
-Docker's [volume consistency](https://github.com/moby/moby/pull/31047) setting can be specified using the `docker_consistency` option when defining a synced folder. This can
+Docker's [volume consistency](https://docs.docker.com/v17.09/engine/admin/volumes/bind-mounts/) setting can be specified using the `docker_consistency` option when defining a synced folder. This can
 [greatly improve performance on macOS](https://docs.docker.com/docker-for-mac/osxfs-caching). An example is shown using the `cached` and `delegated` settings:
 
-```
+```ruby
 config.vm.synced_folder "/host/dir1", "/guest/dir1", docker_consistency: "cached"
 config.vm.synced_folder "/host/dir2", "/guest/dir2", docker_consistency: "delegated"
 ```


### PR DESCRIPTION
This PR includes the work of #9812 and adds a test for the `#prepare` method and updates the documentation link for the docker feature.

Fixes #9811 