### PR TITLE
Skip link-local addresses when fixing IPv6 route

### DIFF
--- a/plugins/providers/virtualbox/action/network_fix_ipv6.rb
+++ b/plugins/providers/virtualbox/action/network_fix_ipv6.rb
@@ -43,12 +43,15 @@ module VagrantPlugins
           # If we have no IPv6, forget it
           return if !has_v6
 
+          link_local_range = IPAddr.new("fe80::/10")
           host_only_interfaces(env).each do |interface|
             next if !present?(interface[:ipv6])
             next if interface[:status] != "Up"
 
             ip = IPAddr.new(interface[:ipv6])
             ip |= ("1" * (128 - interface[:ipv6_prefix].to_i)).to_i(2)
+
+            next if link_local_range.include?(ip)
 
             @logger.info("testing IPv6: #{ip}")
 

--- a/test/unit/plugins/providers/virtualbox/action/network_fix_ipv6_test.rb
+++ b/test/unit/plugins/providers/virtualbox/action/network_fix_ipv6_test.rb
@@ -123,6 +123,23 @@ describe VagrantPlugins::ProviderVirtualBox::Action::NetworkFixIPv6 do
       expect(socket).to_not have_received(:connect)
     end
 
+    it "should ignore interfaces with link-local IPv6 address" do
+      all_networks = [{name: "vboxnet0",
+        ipv6: "fe80::ffff:ffff:ffff:ffff",
+        ipv6_prefix: 64,
+        status: 'Up'
+      }
+      ]
+      ifaces = { 1 => {type: :hostonly, hostonly: "vboxnet0"}
+      }
+      allow(machine.provider.driver).to receive(:read_network_interfaces)
+        .and_return(ifaces)
+      allow(machine.provider.driver).to receive(:read_host_only_interfaces)
+        .and_return(all_networks)
+      subject.call(env)
+      expect(socket).to_not have_received(:connect)
+    end
+
     it "should ignore nat interfaces" do
       all_networks = [{name: "vboxnet0",
                        ipv6: "",


### PR DESCRIPTION
This is #9639 with an extra commit that provides test coverage of behavior.