### PR TITLE
Add back check for Solaris derived guests

### DIFF
--- a/plugins/guests/solaris11/guest.rb
+++ b/plugins/guests/solaris11/guest.rb
@@ -8,7 +8,11 @@ module VagrantPlugins
   module GuestSolaris11
     class Guest < Vagrant.plugin("2", :guest)
       def detect?(machine)
-        machine.communicate.test("grep 'Solaris 11' /etc/release")
+        success = machine.communicate.test("grep 'Solaris 11' /etc/release")
+        return success if success
+
+        # for solaris derived guests like openindiana
+        machine.communicate.test("uname -sr | grep 'SunOS 5.11'")
       end
     end
   end


### PR DESCRIPTION
This commit adds back the `uname` test 93c571adbfab3c03fa2fa4cef406383eaf34d45d
removed to catch any solaris 11 derived guests like openindiana

Fixes #9614