### PR TITLE
Add usable_port_range to port forwarding docs

### DIFF
--- a/website/source/docs/networking/forwarded_ports.html.md
+++ b/website/source/docs/networking/forwarded_ports.html.md
@@ -113,7 +113,8 @@ will output information about any collisions detections and auto corrections
 made, so you can take notice and act accordingly.
 
 You can define allowed port range assignable by Vagrant when port collision is
-detected via `config.vm.usable_port_range` property.
+detected via [config.vm.usable_port_range](/docs/vagrantfile/machine_settings.html) property.
+
 ```ruby
 Vagrant.configure("2") do |config|
   config.vm.usable_port_range = 8000..8999

--- a/website/source/docs/networking/forwarded_ports.html.md
+++ b/website/source/docs/networking/forwarded_ports.html.md
@@ -111,3 +111,11 @@ The final `:auto_correct` parameter set to true tells Vagrant to auto
 correct any collisions. During a `vagrant up` or `vagrant reload`, Vagrant
 will output information about any collisions detections and auto corrections
 made, so you can take notice and act accordingly.
+
+You can define allowed port range assignable by Vagrant when port collision is
+detected via `config.vm.usable_port_range` property.
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.usable_port_range = 8000..8999
+end
+```


### PR DESCRIPTION
In my opinion, port forwarding docs are missing information regarding `config.vm.usable_port_range` option. I was looking for it myself, knowing I've seen it somewhere, but couldn't quite find it. Only recently I've stumbled upon this when going over Vagrantfile configuration page.

Also, on a side note, is there an option to specify which `id` of forwarded port gets which port ranges?
I've got ssh and webserver port forwarding specified and their conflict resolution ranges would be great if they were separate. Just asking though.