### PR TITLE
Ensure trigger run args are an array prior to join

### DIFF
--- a/lib/vagrant/plugin/v2/trigger.rb
+++ b/lib/vagrant/plugin/v2/trigger.rb
@@ -158,7 +158,8 @@ module Vagrant
             @machine.ui.detail(I18n.t("vagrant.trigger.run.inline", command: config.inline))
           else
             cmd = File.expand_path(config.path, @env.root_path)
-            cmd << " #{config.args.join(' ' )}" if config.args
+            args = Array(config.args)
+            cmd << " #{args.join(' ')}" if !args.empty?
             cmd = Shellwords.split(cmd)
 
             @machine.ui.detail(I18n.t("vagrant.trigger.run.script", path: config.path))

--- a/test/unit/vagrant/plugin/v2/trigger_test.rb
+++ b/test/unit/vagrant/plugin/v2/trigger_test.rb
@@ -131,11 +131,11 @@ describe Vagrant::Plugin::V2::Trigger do
       {info: "hi", run: {inline: "echo 'hi'", env: {"KEY"=>"VALUE"}},
        exit_codes: [0,50]} }
     let(:path_block) { {warn: "bye",
-                         run: {path: "script.sh", env: {"KEY"=>"VALUE"}},
+                         run: {path: "script.sh", args: "HELLO", env: {"KEY"=>"VALUE"}},
                          on_error: :continue} }
 
     let(:path_block_ps1) { {warn: "bye",
-                         run: {path: "script.ps1", env: {"KEY"=>"VALUE"}},
+                         run: {path: "script.ps1", args: ["HELLO", "THERE"], env: {"KEY"=>"VALUE"}},
                          on_error: :continue} }
 
     let(:exit_code) { 0 }

--- a/test/unit/vagrant/plugin/v2/trigger_test.rb
+++ b/test/unit/vagrant/plugin/v2/trigger_test.rb
@@ -197,7 +197,7 @@ describe Vagrant::Plugin::V2::Trigger do
       exit_codes = trigger.exit_codes
 
       expect(Vagrant::Util::PowerShell).to receive(:execute).
-        with("/vagrant/home/script.ps1", options)
+        with("/vagrant/home/script.ps1", "HELLO", "THERE", options)
       subject.send(:run, shell_config, on_error, exit_codes)
     end
 
@@ -227,7 +227,7 @@ describe Vagrant::Plugin::V2::Trigger do
       exit_codes = trigger.exit_codes
 
       expect(Vagrant::Util::Subprocess).to receive(:execute).
-        with("/vagrant/home/script.sh", options)
+        with("/vagrant/home/script.sh", "HELLO", options)
       subject.send(:run, shell_config, on_error, exit_codes)
     end
 
@@ -243,7 +243,7 @@ describe Vagrant::Plugin::V2::Trigger do
       exit_codes = trigger.exit_codes
 
       expect(Vagrant::Util::Subprocess).to receive(:execute).
-        with("/vagrant/home/script.sh", options)
+        with("/vagrant/home/script.sh", "HELLO", options)
       subject.send(:run, shell_config, on_error, exit_codes)
     end
 


### PR DESCRIPTION
Prior to this commit, if the args key was a string rather than an array
of strings, the `join` command would fail when appending the arguments
to the run command for a given script. This commit updates that by
ensuring the `args` option is an array prior to joining the arguments.

Fixes #10104