### PR TITLE
Documentation: Update `module_path` type for puppet apply provisioner

### DIFF
--- a/website/source/docs/provisioning/puppet_apply.html.md
+++ b/website/source/docs/provisioning/puppet_apply.html.md
@@ -44,7 +44,7 @@ available below this section.
 * `manifests_path` (string) - The path to the directory which contains the
   manifest files. This defaults to "manifests"
 
-* `module_path` (string) - Path, on the host, to the directory which
+* `module_path` (string or array of strings) - Path or paths, on the host, to the directory which
   contains Puppet modules, if any.
 
 * `environment` (string) - Name of the Puppet environment.


### PR DESCRIPTION
This commit updates the documentation for `module_path` to say that it
can be both a string or array of string paths.

Fixes #10091