### PR TITLE
Allow for spaces in `path` for trigger run option

### DIFF
--- a/lib/vagrant/plugin/v2/trigger.rb
+++ b/lib/vagrant/plugin/v2/trigger.rb
@@ -157,7 +157,7 @@ module Vagrant
 
             @machine.ui.detail(I18n.t("vagrant.trigger.run.inline", command: config.inline))
           else
-            cmd = File.expand_path(config.path, @env.root_path)
+            cmd = File.expand_path(config.path, @env.root_path).shellescape
             args = Array(config.args)
             cmd << " #{args.join(' ')}" if !args.empty?
             cmd = Shellwords.split(cmd)

--- a/test/unit/vagrant/plugin/v2/trigger_test.rb
+++ b/test/unit/vagrant/plugin/v2/trigger_test.rb
@@ -131,7 +131,7 @@ describe Vagrant::Plugin::V2::Trigger do
       {info: "hi", run: {inline: "echo 'hi'", env: {"KEY"=>"VALUE"}},
        exit_codes: [0,50]} }
     let(:path_block) { {warn: "bye",
-                         run: {path: "script.sh", args: "HELLO", env: {"KEY"=>"VALUE"}},
+                         run: {path: "path/to the/script.sh", args: "HELLO", env: {"KEY"=>"VALUE"}},
                          on_error: :continue} }
 
     let(:path_block_ps1) { {warn: "bye",
@@ -227,7 +227,7 @@ describe Vagrant::Plugin::V2::Trigger do
       exit_codes = trigger.exit_codes
 
       expect(Vagrant::Util::Subprocess).to receive(:execute).
-        with("/vagrant/home/script.sh", "HELLO", options)
+        with("/vagrant/home/path/to the/script.sh", "HELLO", options)
       subject.send(:run, shell_config, on_error, exit_codes)
     end
 
@@ -243,7 +243,7 @@ describe Vagrant::Plugin::V2::Trigger do
       exit_codes = trigger.exit_codes
 
       expect(Vagrant::Util::Subprocess).to receive(:execute).
-        with("/vagrant/home/script.sh", "HELLO", options)
+        with("/vagrant/home/path/to the/script.sh", "HELLO", options)
       subject.send(:run, shell_config, on_error, exit_codes)
     end
 


### PR DESCRIPTION
This pull request brings in  #9877 and updates the tests to account for when the path used has a space in it.