### PR TITLE
Fix ansible_local provisioner permission bug

### DIFF
--- a/plugins/provisioners/ansible/provisioner/guest.rb
+++ b/plugins/provisioners/ansible/provisioner/guest.rb
@@ -125,7 +125,7 @@ module VagrantPlugins
           inventory_basedir = File.join(config.tmp_path, "inventory")
           inventory_path = File.join(inventory_basedir, "vagrant_ansible_local_inventory")
 
-          @machine.communciate.sudo("mkdir -p #{inventory_path}")
+          @machine.communicate.sudo("mkdir -p #{inventory_path}")
           @machine.communicate.sudo("chown -R -h #{@machine.ssh_info[:username]} #{config.tmp_path}")
           @machine.communicate.sudo("rm -f #{inventory_path}", error_check: false)
 

--- a/plugins/provisioners/ansible/provisioner/guest.rb
+++ b/plugins/provisioners/ansible/provisioner/guest.rb
@@ -125,7 +125,8 @@ module VagrantPlugins
           inventory_basedir = File.join(config.tmp_path, "inventory")
           inventory_path = File.join(inventory_basedir, "vagrant_ansible_local_inventory")
 
-          create_and_chown_remote_folder(inventory_basedir)
+          @machine.communciate.sudo("mkdir -p #{inventory_path}")
+          @machine.communicate.sudo("chown -R -h #{@machine.ssh_info[:username]} #{config.tmp_path}")
           @machine.communicate.sudo("rm -f #{inventory_path}", error_check: false)
 
           Tempfile.open("vagrant-ansible-local-inventory-#{@machine.name}") do |f|
@@ -157,13 +158,6 @@ module VagrantPlugins
           end
 
           return machines
-        end
-
-        def create_and_chown_remote_folder(path)
-          @machine.communicate.tap do |comm|
-            comm.sudo("mkdir -p #{path}")
-            comm.sudo("chown -h #{@machine.ssh_info[:username]} #{path}")
-          end
         end
 
         def check_path(path, test_args, option_name)


### PR DESCRIPTION
When umask settings are restricted the Vagrant Ansible plugin fails on trying to copy files via `scp`.

```
Failed to upload a file to the guest VM via SCP due to a permissions
error. This is normally because the SSH user doesn't have permission
to write to the destination location. Alternately, the user running
Vagrant on the host machine may not have permission to read the file.

Source: /tmp/vagrant-ansible-local-inventory-default20180822-27107-1tw1r4z
Dest: /tmp/vagrant-ansible/inventory/vagrant_ansible_local_inventory
```

The ansible provisioner creates directory for the inventory in a tmp directory. It `chowns` the inventory directory to ensure the vagrant user can access it. However the parent directory is not necessarily accessible by non-root users.

If UMASK is set to 0077, the parent directory is only accessible by root. `scp` cannot traverse this directory to the child `inventory` directory, even though the vagrant user is the owner.

```
drwx------ 3 root root 4096 Aug 22 08:36 /tmp/vagrant-ansible
drwx------ 2 vagrant root 4096 Aug 22 08:36 inventory
```

This PR creates the `inventory` directory but chowns recursively from the vagrant-ansible tmp directory. After this change SCP should work. This assumes that `/tmp` is accessible (eXecutable) by the vagrant user.

### Work around
In the Vagrantfile configure the ansible_local `tmp_path` to be `/tmp`.

```
config.vm.provision "ansible_local" do |ansible|
  ansible.tmp_path = "/tmp"
end
```