### PR TITLE
Reset internal environment after plugin load

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -178,6 +178,10 @@ module Vagrant
       plugins = Vagrant::Plugin::Manager.instance.globalize!
       Vagrant::Plugin::Manager.instance.load_plugins(plugins)
 
+      # Reset so Vagrantfile will be reloaded with expected support for
+      # any new plugins provided
+      post_plugins_reset!
+
       # Call the hooks that does not require configurations to be loaded
       # by using a "clean" action runner
       hook(:environment_plugins_loaded, runner: Action::Runner.new(env: self))
@@ -912,6 +916,18 @@ module Vagrant
     end
 
     protected
+
+    # Unsets the internal vagrantfile and config_loader
+    # to force them to be regenerated. This is used after
+    # plugins have been loaded so that newly discovered
+    # plugin configurations are properly available
+    #
+    # @return [nil]
+    def post_plugins_reset!
+      @vagrantfile = nil
+      @config_loader = nil
+      nil
+    end
 
     # Check for any local plugins defined within the Vagrantfile. If
     # found, validate they are available. If they are not available,

--- a/test/unit/vagrant/environment_test.rb
+++ b/test/unit/vagrant/environment_test.rb
@@ -25,6 +25,13 @@ describe Vagrant::Environment do
   let(:instance)  { env.create_vagrant_env }
   subject { instance }
 
+  describe "#initialize" do
+    it "should do an internal reset after plugin loading" do
+      expect_any_instance_of(described_class).to receive(:post_plugins_reset!)
+      instance
+    end
+  end
+
   describe "#can_install_provider?" do
     let(:plugin_hosts) { {} }
     let(:plugin_host_caps) { {} }


### PR DESCRIPTION
Force the vagrantfile and configuration loader to be rebuilt after
plugins have been loaded to properly allow newly introduced plugin
configurations to be properly supported within the Vagrantfile.

Fixes #10153 #10150