### PR TITLE
Extract smblist information based on position

### DIFF
--- a/plugins/hosts/windows/cap/smb.rb
+++ b/plugins/hosts/windows/cap/smb.rb
@@ -138,15 +138,10 @@ module VagrantPlugins
           name = nil
           until share_data.empty?
             content = share_data.take_while{|line| !line.strip.empty? }
-            if content.size != 3
-              @@logger.warn("expected SMB data check to be size 3 but was size #{content.size}")
-              @@logger.debug("unprocessed SMB data: #{content.inspect}")
-              next
-            end
             share_name = content[0].strip.split(":", 2).last.strip
             shares[share_name] = {
-              "Path" => content[1].strip.split(":", 2).last.strip,
-              "Description" => content[2].strip.split(":", 2).last.strip
+              "Path" => content[-2].strip.split(":", 2).last.strip,
+              "Description" => content[-1].strip.split(":", 2).last.strip
             }
             share_data.slice!(0, content.length + 1)
           end

--- a/test/unit/plugins/hosts/windows/cap/smb_test.rb
+++ b/test/unit/plugins/hosts/windows/cap/smb_test.rb
@@ -22,6 +22,10 @@ Name        : my-share
 Path        : /my/path
 Description : Not Vagrant Owned
 
+Name        : scoped-share
+Scope       : *
+Path        : /scoped/path
+Description : Scoped Path
     EOF
   }
   let(:netsharelist){ <<-EOF
@@ -223,6 +227,28 @@ Remark     Not Vagrant Owned
       it "should not warn user" do
         expect(machine.env.ui).not_to receive(:warn)
       end
+    end
+  end
+
+  describe ".get_smbshares" do
+    before { expect(Vagrant::Util::PowerShell).to receive(:execute_cmd).and_return(smblist) }
+
+    it "should return a Hash of share information" do
+      expect(subject.get_smbshares).to be_a(Hash)
+    end
+
+    it "should provide name and description for share" do
+      shares = subject.get_smbshares
+      expect(shares["vgt-CUSTOM_ID-1"]).to be_a(Hash)
+      expect(shares["vgt-CUSTOM_ID-1"]["Path"]).to eq("/a/path")
+      expect(shares["vgt-CUSTOM_ID-1"]["Description"]).to eq("vgt-CUSTOM_ID-1")
+    end
+
+    it "should properly handle share with scope information" do
+      shares = subject.get_smbshares
+      expect(shares["scoped-share"]).to be_a(Hash)
+      expect(shares["scoped-share"]["Path"]).to eq("/scoped/path")
+      expect(shares["scoped-share"]["Description"]).to eq("Scoped Path")
     end
   end
 end


### PR DESCRIPTION
Since we are no longer extracting information based on key value due
to localization issues, use start and end locations to extract data.
This prevents errors when extra information is included like Scope.

Fixes #10151