### PR TITLE
Update Vagrant.has_plugin? helper to function prior to plugin loading

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -151,16 +151,9 @@ module Vagrant
       return true if plugin("2").manager.registered.any? { |p| p.name == name }
     end
 
-    # Make the requirement object
-    version = Gem::Requirement.new([version]) if version
-
     # Now check the plugin gem names
     require "vagrant/plugin/manager"
-    Plugin::Manager.instance.installed_specs.any? do |s|
-      match = s.name == name
-      next match if !version
-      next match && version.satisfied_by?(s.version)
-    end
+    Plugin::Manager.instance.plugin_installed?(name, version)
   end
 
   # Returns a superclass to use when creating a plugin for Vagrant.

--- a/test/unit/vagrant_test.rb
+++ b/test/unit/vagrant_test.rb
@@ -70,6 +70,7 @@ describe Vagrant do
       specs = [Gem::Specification.new]
       specs[0].name = "foo"
       allow(Vagrant::Plugin::Manager.instance).to receive(:installed_specs).and_return(specs)
+      allow(Vagrant::Plugin::Manager.instance).to receive(:ready?).and_return(true)
 
       expect(described_class.has_plugin?("foo")).to be(true)
       expect(described_class.has_plugin?("bar")).to be(false)
@@ -79,6 +80,7 @@ describe Vagrant do
       specs = [Gem::Specification.new]
       specs[0].name = "foo"
       specs[0].version = "1.2.3"
+      allow(Vagrant::Plugin::Manager.instance).to receive(:ready?).and_return(true)
       allow(Vagrant::Plugin::Manager.instance).to receive(:installed_specs).and_return(specs)
 
       expect(described_class.has_plugin?("foo", "~> 1.2.0")).to be(true)


### PR DESCRIPTION
Due to the Vagrantfile being loaded prior to plugin loading to determine
project local plugin information the Vagrant.has_plugin? helper will always
return false when the Vagrantfile is first loaded. To prevent this behavior
we can check for plugins in the plugin data files prior to the plugins
being loaded, and after they have been loaded we can fallback to the
original specification based check.

Fixes #10161