### PR TITLE
bash: complete running VM names for destroy subcommand

### DIFF
--- a/contrib/bash/completion.sh
+++ b/contrib/bash/completion.sh
@@ -79,7 +79,7 @@ _vagrant() {
               COMPREPLY=($(compgen -W "${up_commands} ${vm_list}" -- ${cur}))
               return 0
             ;;
-            "ssh"|"provision"|"reload"|"halt"|"suspend"|"resume"|"ssh-config")
+            "destroy"|"ssh"|"provision"|"reload"|"halt"|"suspend"|"resume"|"ssh-config")
               vagrant_state_file=$(__vagrantinvestigate) || return 1
               if [[ -f "${vagrant_state_file}" ]]
               then


### PR DESCRIPTION
for some reason there is currently no completion at all for the destroy
subcommand. like the other commands already present in that code block,
destroy acts on currently running VMs and so it makes sense to complete
those names.