### PR TITLE
vagrant init: Support VAGRANT_DEFAULT_TEMPLATE

### DIFF
--- a/plugins/commands/init/command.rb
+++ b/plugins/commands/init/command.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
           force: false,
           minimal: false,
           output: "Vagrantfile",
-          template: nil
+          template: ENV["VAGRANT_DEFAULT_TEMPLATE"]
         }
 
         opts = OptionParser.new do |o|

--- a/test/unit/plugins/commands/init/command_test.rb
+++ b/test/unit/plugins/commands/init/command_test.rb
@@ -55,6 +55,22 @@ describe VagrantPlugins::CommandInit::Command do
       expect(contents).to match(/config.vm.hostname = "vagrant.dev"/)
     end
 
+    it "creates a custom Vagrant file using a template provided from the environment" do
+      with_temp_env("VAGRANT_DEFAULT_TEMPLATE" => "test/unit/templates/commands/init/Vagrantfile") do
+        described_class.new([], env).execute
+      end
+      contents = File.read(vagrantfile_path)
+      expect(contents).to match(/config.vm.hostname = "vagrant.dev"/)
+    end
+
+    it "ignores the environmentally-set default template when a template is explicitly set" do
+      with_temp_env("VAGRANT_DEFAULT_TEMPLATE" => "/this_file_does_not_exist") do
+        described_class.new(["--template", "test/unit/templates/commands/init/Vagrantfile"], env).execute
+      end
+      contents = File.read(vagrantfile_path)
+      expect(contents).to match(/config.vm.hostname = "vagrant.dev"/)
+    end
+
     it "ignores the -m option when using a provided template" do
       described_class.new(["-m", "--template", ::Vagrant.source_root.join("test/unit/templates/commands/init/Vagrantfile").to_s], env).execute
       contents = File.read(vagrantfile_path)

--- a/website/source/docs/other/environmental-variables.html.md
+++ b/website/source/docs/other/environmental-variables.html.md
@@ -37,6 +37,11 @@ Vagrant to use this provider for any _new_ Vagrant environments. Existing
 Vagrant environments will continue to use the provider they came `up` with.
 Once you `vagrant destroy` existing environments, this will take effect.
 
+## `VAGRANT_DEFAULT_TEMPLATE`
+
+This configures the template used by `vagrant init` when the `--template` option
+is not provided.
+
 ## `VAGRANT_PREFERRED_PROVIDERS`
 
 This configures providers that Vagrant should prefer.


### PR DESCRIPTION
This is useful to save some typing when one regularly uses a custom template.