### PR TITLE
vagrant powershell command fixup

### DIFF
--- a/plugins/commands/powershell/command.rb
+++ b/plugins/commands/powershell/command.rb
@@ -17,8 +17,8 @@ module VagrantPlugins
           o.banner = "Usage: vagrant powershell [-- extra powershell args]"
 
           o.separator ""
-          o.separator "Opens a remote PowerShell session to the machine if it"
-          o.separator "supports powershell remoting."
+          o.separator "Opens a PowerShell session on the host to the guest"
+          o.separator "machine if both support powershell remoting."
           o.separator ""
           o.separator "Options:"
           o.separator ""

--- a/plugins/commands/powershell/command.rb
+++ b/plugins/commands/powershell/command.rb
@@ -17,6 +17,9 @@ module VagrantPlugins
           o.banner = "Usage: vagrant powershell [-- extra powershell args]"
 
           o.separator ""
+          o.separator "Opens a remote PowerShell session to the machine if it"
+          o.separator "supports powershell remoting."
+          o.separator ""
           o.separator "Options:"
           o.separator ""
 

--- a/plugins/commands/powershell/plugin.rb
+++ b/plugins/commands/powershell/plugin.rb
@@ -22,6 +22,7 @@ module VagrantPlugins
       def self.init!
         return if defined?(@_init)
         I18n.load_path << File.expand_path("templates/locales/command_ps.yml", Vagrant.source_root)
+        I18n.load_path << File.expand_path("templates/locales/comm_winrm.yml", Vagrant.source_root)
         I18n.reload!
         @_init = true
       end

--- a/website/source/docs/cli/powershell.html.md
+++ b/website/source/docs/cli/powershell.html.md
@@ -11,10 +11,11 @@ description: |-
 
 **Command: `vagrant powershell`**
 
-This will open a PowerShell prompt into a running Vagrant machine.
+This will open a PowerShell prompt on the host into a running Vagrant guest machine.
 
-This command will only work if the machine supports PowerShell. Not every
-environment will support PowerShell.
+This command will only work if the machines supports PowerShell. Not every
+environment will support PowerShell. At the moment, only Windows is supported
+with this command.
 
 ## Options
 


### PR DESCRIPTION
This pull request fixes up some of the doc strings around the `vagrant powershell` command. It also fixes a missing locales error for winrm.