### PR TITLE
Check for automatic checkpoint support before configuring

### DIFF
--- a/plugins/providers/hyperv/scripts/configure_vm.ps1
+++ b/plugins/providers/hyperv/scripts/configure_vm.ps1
@@ -106,6 +106,11 @@ if($EnableAutomaticCheckpoints) {
 }
 
 try {
+    if($autochecks -eq 1 -and (Get-Command Hyper-V\Set-VM).Parameters["AutomaticCheckpointsEnabled"] -eq $null) {
+        Write-ErrorMessage "AutomaticCheckpointsEnabled is not available"
+        exit 1
+    }
+
     Hyper-V\Set-VM -VM $VM -AutomaticCheckpointsEnabled $autochecks
 } catch {
     Write-ErrorMessage "Failed to ${AutoAction} automatic checkpoints on VM: ${PSItem}"


### PR DESCRIPTION
The AutomaticCheckpointsEnabled option may not always be available
depending on the version in use. Check for support before applying
the configured value. If automatic checkpoints are to be enabled
and support is not available, force an error.

Fixes #10175 