### PR TITLE
Check verify_host_key for falsey or :never values when generating ssh config

### DIFF
--- a/templates/commands/ssh_config/config.erb
+++ b/templates/commands/ssh_config/config.erb
@@ -2,7 +2,7 @@ Host <%= host_key %>
   HostName <%= ssh_host %>
   User <%= ssh_user %>
   Port <%= ssh_port %>
-<% if ! verify_host_key -%>
+<% if ! verify_host_key || verify_host_key == :never -%>
   UserKnownHostsFile /dev/null
   StrictHostKeyChecking no
 <% end -%>

--- a/test/unit/plugins/commands/ssh_config/command_test.rb
+++ b/test/unit/plugins/commands/ssh_config/command_test.rb
@@ -151,5 +151,19 @@ Host #{machine.name}
       subject.execute
       expect(output).to include('IdentityFile /home/vagrant/home.key')
     end
+
+    it "handles verify_host_key :never value" do
+      allow(machine).to receive(:ssh_info) { ssh_info.merge(verify_host_key: :never) }
+
+      output = ""
+      allow(subject).to receive(:safe_puts) do |data|
+        output += data if data
+      end
+
+      subject.execute
+
+      expect(output).to include('StrictHostKeyChecking ')
+      expect(output).to include('UserKnownHostsFile ')
+    end
   end
 end


### PR DESCRIPTION
Fixes #10179