### PR TITLE
Misleading warning on Windows (due to improper String comparison)

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -4,7 +4,6 @@ require "digest/md5"
 require "thread"
 
 require "log4r"
-require "vagrant/util/platform"
 
 module Vagrant
   # This represents a machine that Vagrant manages. This provides a singular

--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -4,6 +4,7 @@ require "digest/md5"
 require "thread"
 
 require "log4r"
+require "vagrant/util/platform"
 
 module Vagrant
   # This represents a machine that Vagrant manages. This provides a singular
@@ -593,7 +594,7 @@ module Vagrant
                       ).chomp
                     end
 
-      if vagrant_cwd != @env.root_path.to_s
+      if !File.identical?(vagrant_cwd.to_s, @env.root_path.to_s)
         if vagrant_cwd
           ui.warn(I18n.t(
             'vagrant.moved_cwd',


### PR DESCRIPTION
In Windows a misleading warning may appear, e.g.
```
==> default: This machine used to live in C:/ws/test_vagrant but
 it's now at c:/ws/test_vagrant. 
```

The implemented String comparison is misleading on Windows as it does not consider that paths on Windows are case insensitive. The pull request is to address that by using File.identical?() instead. 

Signed-off-by: Alexander Fischer <github@ordnungsdienst.org>