### PR TITLE
Allow non-windows hosts to pass along version

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -304,6 +304,9 @@ module VagrantPlugins
             end
             bootstrap_destination = File.join(config_dir, "bootstrap_salt.ps1")
           else
+            if @config.version
+              options += " %s" % @config.version
+            end
             bootstrap_destination = File.join(config_dir, "bootstrap_salt.sh")
           end
 

--- a/website/source/docs/provisioning/salt.html.md
+++ b/website/source/docs/provisioning/salt.html.md
@@ -75,7 +75,7 @@ distribution's stable package manager, git tree-ish, daily ppa, or testing repos
 * `bootstrap_options` (string) - Additional command-line options to
   pass to the bootstrap script.
 
-* `version`  (string, default: "2017.7.1") - Version of minion to be installed. Only supported on Windows guest machines.
+* `version`  (string, default: "2017.7.1") - Version of minion to be installed.
 
 * `python_version`  (string, default: "2") - Major Python version of minion to be installed. Only valid for minion versions >= 2017.7.0. Only supported on Windows guest machines.
 


### PR DESCRIPTION
The salt bootstrap can now accept version arguments on non-windows
hosts, so this commit allows the Vagrant provisinoer to specify a
version.

Fixes #9802 