### PR TITLE
Hardened proc disallow systemd detection

### DIFF
--- a/lib/vagrant/util/guest_inspection.rb
+++ b/lib/vagrant/util/guest_inspection.rb
@@ -12,7 +12,7 @@ module Vagrant
         #
         # @return [Boolean]
         def systemd?(comm)
-          comm.test("ps -o comm= 1 | grep systemd")
+          comm.test("sudo ps -o comm= 1 | grep systemd")
         end
 
         # systemd-networkd.service is in use

--- a/test/unit/plugins/guests/debian/cap/configure_networks_test.rb
+++ b/test/unit/plugins/guests/debian/cap/configure_networks_test.rb
@@ -67,7 +67,7 @@ describe "VagrantPlugins::GuestDebian::Cap::ConfigureNetworks" do
     before do
       allow(comm).to receive(:test).with("nmcli -t d show eth1").and_return(false)
       allow(comm).to receive(:test).with("nmcli -t d show eth2").and_return(false)
-      allow(comm).to receive(:test).with("ps -o comm= 1 | grep systemd").and_return(false)
+      allow(comm).to receive(:test).with("sudo ps -o comm= 1 | grep systemd").and_return(false)
       allow(comm).to receive(:test).with("sudo systemctl status systemd-networkd.service").and_return(false)
       allow(comm).to receive(:test).with("netplan -h").and_return(false)
     end
@@ -85,7 +85,7 @@ describe "VagrantPlugins::GuestDebian::Cap::ConfigureNetworks" do
 
     context "with systemd" do
       before do
-        expect(comm).to receive(:test).with("ps -o comm= 1 | grep systemd").and_return(true)
+        expect(comm).to receive(:test).with("sudo ps -o comm= 1 | grep systemd").and_return(true)
         allow(comm).to receive(:test).with("netplan -h").and_return(false)
       end
 


### PR DESCRIPTION
If you have a vagrant box with proc mounted with
```
proc    /proc    proc    defaults,hidepid=2     0     0
```
ps output will be limited to owned process
`sudo` should extend an output

This should fix https://github.com/hashicorp/vagrant/issues/10197