### PR TITLE
Force command to be re-run after installing local plugins

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -419,6 +419,9 @@ en:
             %{plugins}
         request_plugin_install: |-
           Install local plugins (Y/N)
+        install_rerun_command: |-
+          Vagrant has completed installing local plugins for the current Vagrant
+          project directory. Please run the requested command again.
 
         install_all: |-
           Vagrant will now install the following plugins to the local project

--- a/test/unit/vagrant/environment_test.rb
+++ b/test/unit/vagrant/environment_test.rb
@@ -25,13 +25,6 @@ describe Vagrant::Environment do
   let(:instance)  { env.create_vagrant_env }
   subject { instance }
 
-  describe "#initialize" do
-    it "should do an internal reset after plugin loading" do
-      expect_any_instance_of(described_class).to receive(:post_plugins_reset!)
-      instance
-    end
-  end
-
   describe "#can_install_provider?" do
     let(:plugin_hosts) { {} }
     let(:plugin_host_caps) { {} }
@@ -1495,6 +1488,8 @@ VF
 
       context "without plugin installed" do
 
+        before { allow(instance).to receive(:exit) }
+
         it "should prompt user before installation" do
           expect(instance.ui).to receive(:ask).and_return("n")
           expect(plugin_manager).to receive(:installed_plugins).and_return({})
@@ -1505,6 +1500,14 @@ VF
           expect(instance.ui).to receive(:ask).and_return("y")
           expect(plugin_manager).to receive(:installed_plugins).and_return({})
           expect(plugin_manager).to receive(:install_plugin).and_return(double("spec", "name" => "vagrant", "version" => "1"))
+          instance.send(:process_configured_plugins)
+        end
+
+        it "should exit after install" do
+          expect(instance.ui).to receive(:ask).and_return("y")
+          expect(plugin_manager).to receive(:installed_plugins).and_return({})
+          expect(plugin_manager).to receive(:install_plugin).and_return(double("spec", "name" => "vagrant", "version" => "1"))
+          expect(instance).to receive(:exit)
           instance.send(:process_configured_plugins)
         end
       end


### PR DESCRIPTION
Reloading the Vagrantfile causes issue with multiple evaluations
where users expect single evaluation. Instead of allowing local
plugin installation to happen prior to command execution, force
halt after installation and the command to be re-run. This will
prevent multiple loads of the Vagrantfile within a single run.

Fixes #10186, #10193