### PR TITLE
Add in logic to restart NetworkManager.service if it is enabled

### DIFF
--- a/plugins/guests/redhat/cap/change_host_name.rb
+++ b/plugins/guests/redhat/cap/change_host_name.rb
@@ -29,9 +29,9 @@ module VagrantPlugins
               }
 
               # Restart network
-              if (test -f /etc/init.d/network && /etc/init.d/network status &> /dev/null ); then
+              if test -f /etc/init.d/network; then
                 service network restart
-              elif (test -f /usr/lib/systemd/system/NetworkManager.service && systemctl is-enabled NetworkManager.service &> /dev/null ); then
+              elif systemctl -q is-enabled NetworkManager.service; then
                 systemctl restart NetworkManager.service
               else
                 printf "Could not restart the network to set the new hostname!\n"

--- a/plugins/guests/redhat/cap/change_host_name.rb
+++ b/plugins/guests/redhat/cap/change_host_name.rb
@@ -29,10 +29,10 @@ module VagrantPlugins
               }
 
               # Restart network
-              if test -f /etc/init.d/network; then
-                service network restart
-              elif systemctl -q is-enabled NetworkManager.service; then
+              if (test -f /usr/bin/systemctl && systemctl -q is-active NetworkManager.service); then
                 systemctl restart NetworkManager.service
+              elif test -f /etc/init.d/network; then
+                service network restart
               else
                 printf "Could not restart the network to set the new hostname!\n"
               fi

--- a/plugins/guests/redhat/cap/change_host_name.rb
+++ b/plugins/guests/redhat/cap/change_host_name.rb
@@ -29,7 +29,13 @@ module VagrantPlugins
               }
 
               # Restart network
-              service network restart
+              if (test -f /etc/init.d/network && /etc/init.d/network status &> /dev/null ); then
+                service network restart
+              elif (test -f /usr/lib/systemd/system/NetworkManager.service && systemctl is-enabled NetworkManager.service &> /dev/null ); then
+                systemctl restart NetworkManager.service
+              else
+                printf "Could not restart the network to set the new hostname!\n"
+              fi
             EOH
           end
         end

--- a/plugins/guests/redhat/cap/change_host_name.rb
+++ b/plugins/guests/redhat/cap/change_host_name.rb
@@ -35,6 +35,7 @@ module VagrantPlugins
                 service network restart
               else
                 printf "Could not restart the network to set the new hostname!\n"
+                exit 1
               fi
             EOH
           end

--- a/test/unit/plugins/guests/redhat/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/redhat/cap/change_host_name_test.rb
@@ -31,7 +31,7 @@ describe "VagrantPlugins::GuestRedHat::Cap::ChangeHostName" do
       expect(comm.received_commands[1]).to match(/\/etc\/sysconfig\/network-scripts\/ifcfg/)
       expect(comm.received_commands[1]).to match(/hostnamectl set-hostname --static '#{name}'/)
       expect(comm.received_commands[1]).to match(/hostnamectl set-hostname --transient '#{name}'/)
-      expect(comm.received_commands[1]).to match(/service network restart/)
+      expect(comm.received_commands[1]).to match(/service network restart|systemctl restart NetworkManager.service/)
     end
 
     it "does not change the hostname if already set" do

--- a/test/unit/plugins/guests/redhat/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/redhat/cap/change_host_name_test.rb
@@ -39,5 +39,32 @@ describe "VagrantPlugins::GuestRedHat::Cap::ChangeHostName" do
       cap.change_host_name(machine, name)
       expect(comm.received_commands.size).to eq(1)
     end
+
+    context "restarts the network" do
+      it "uses systemctl and NetworkManager.service" do
+        comm.stub_command("hostname -f | grep '^#{name}$'", exit_code: 1)
+        comm.stub_command("test -f /usr/bin/systemctl && systemctl -q is-active NetworkManager.service", exit_code: 0)
+        cap.change_host_name(machine, name)
+        expect(comm.received_commands[1]).to match(/systemctl restart NetworkManager.service/)
+      end
+
+      it "uses the service command" do
+        comm.stub_command("hostname -f | grep '^#{name}$'", exit_code: 1)
+        comm.stub_command("test -f /usr/bin/systemctl && systemctl -q is-active NetworkManager.service", exit_code: 1)
+        comm.stub_command("test -f /etc/init.d/network", exit_code: 0)
+        cap.change_host_name(machine, name)
+        expect(comm.received_commands[1]).to match(/service network restart/)
+      end
+    end
+
+    context "cannot restart the network" do
+      it "prints cannot restart message" do
+        comm.stub_command("hostname -f | grep '^#{name}$'", exit_code: 1)
+        comm.stub_command("test -f /usr/bin/systemctl && systemctl -q is-active NetworkManager.service", exit_code: 1)
+        comm.stub_command("test -f /etc/init.d/network", exit_code: 1)
+        cap.change_host_name(machine, name)
+        expect(comm.received_commands[1]).to match(/printf "Could not restart the network to set the new hostname!/)
+      end
+    end
   end
 end


### PR DESCRIPTION
This PR adds in logic to check to see if `/usr/bin/systemctl` is present and if `NetworkManager.service` is active. If it is not, it will test for the sysvinit `/etc/init.d/network` initscript. From there it will restart the respective service to set the hostname correctly. 

As of initscripts-9.83-1.fc29.x86_64 in Fedora 29 sysvinit `/etc/init.d/network` initscript [is no longer being included](https://bugzilla.redhat.com/show_bug.cgi?id=1596062#c1) and this PR will ensure that Vagrant can correctly set the hostname on old and new RHEL, CentOS and Fedora versions. 

Related URLs for more context:
https://bugzilla.redhat.com/show_bug.cgi?id=1624068
https://pagure.io/cloud-sig/issue/291#comment-528948
