### PR TITLE
Allow special characters in SMB password field

### DIFF
--- a/plugins/guests/windows/cap/mount_shared_folder.rb
+++ b/plugins/guests/windows/cap/mount_shared_folder.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
             # Ensure password is scrubbed
             Vagrant::Util::CredentialScrubber.sensitive(options[:smb_password])
           end
-          machine.communicate.execute("cmdkey /add:#{options[:smb_host]} /user:#{options[:smb_username]} /pass:#{options[:smb_password]}", {shell: :powershell, elevated: true})
+          machine.communicate.execute("cmdkey /add:#{options[:smb_host]} /user:#{options[:smb_username]} /pass:\"#{options[:smb_password]}\"", {shell: :powershell, elevated: true})
           mount_shared_folder(machine, name, guestpath, "\\\\#{options[:smb_host]}\\")
         end
 

--- a/test/unit/plugins/guests/windows/cap/mount_shared_folder_test.rb
+++ b/test/unit/plugins/guests/windows/cap/mount_shared_folder_test.rb
@@ -98,6 +98,7 @@ describe "VagrantPlugins::GuestWindows::Cap::MountSharedFolder" do
               share_name: "name",
               vm_provider_unc_path: "\\\\host\\name",
             })
+        expect(machine.communicate).to receive(:execute).with("cmdkey /add:host /user:user /pass:\"pass\"", {:shell=>:powershell, :elevated=>true})
         described_class.mount_smb_shared_folder(machine, 'name', 'guestpath', {:smb_username => "user", :smb_password => "pass", :smb_host => "host"})
       end
     end


### PR DESCRIPTION
This commit brings in PR #10004 and adds a test to ensure that the users password is quoted to allow for special characters.