### PR TITLE
Ensure file paths are identical when checking for cwd

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -4,7 +4,6 @@ require "digest/md5"
 require "thread"
 
 require "log4r"
-require "vagrant/util/platform"
 
 module Vagrant
   # This represents a machine that Vagrant manages. This provides a singular

--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -4,6 +4,7 @@ require "digest/md5"
 require "thread"
 
 require "log4r"
+require "vagrant/util/platform"
 
 module Vagrant
   # This represents a machine that Vagrant manages. This provides a singular
@@ -593,7 +594,7 @@ module Vagrant
                       ).chomp
                     end
 
-      if vagrant_cwd != @env.root_path.to_s
+      if !File.identical?(vagrant_cwd.to_s, @env.root_path.to_s)
         if vagrant_cwd
           ui.warn(I18n.t(
             'vagrant.moved_cwd',

--- a/test/unit/vagrant/machine_test.rb
+++ b/test/unit/vagrant/machine_test.rb
@@ -370,6 +370,26 @@ describe Vagrant::Machine do
       end
     end
 
+    it 'should not warn if dirs are same but different cases' do
+      action_name  = :destroy
+      callable     = lambda { |_env| }
+      original_cwd = env.cwd.to_s
+
+      allow(provider).to receive(:action).with(action_name).and_return(callable)
+      allow(subject.ui).to receive(:warn)
+
+      instance.action(action_name)
+
+      expect(subject.ui).to_not have_received(:warn)
+
+      # In cygwin or other windows shell, it might have a path like
+      # c:/path and C:/path
+      # which are the same.
+      allow(env).to receive(:root_path).and_return(original_cwd.upcase)
+      expect(subject.ui).to_not have_received(:warn)
+      instance.action(action_name)
+    end
+
     context "if in a subdir" do
       let (:data_dir) { env.cwd }
 


### PR DESCRIPTION
This commit brings in pull request https://github.com/hashicorp/vagrant/pull/10190 and adds a proper test to ensure that if two different file paths that are the same but have a different casing are not seen as different when checking for current working dir of a machine.