### PR TITLE
Update Docker containerization docs

### DIFF
--- a/website/source/intro/vs/docker.html.md
+++ b/website/source/intro/vs/docker.html.md
@@ -15,8 +15,7 @@ that can consistently run software as long as a containerization system exists.
 
 Containers are generally more lightweight than virtual machines, so starting
 and stopping containers is extremely fast. Docker uses the native
-containerization functionality on macOS and Linux, while it must start a Linux
-VM for compatibility with Windows.
+containerization functionality on macOS, Linux, and Windows.
 
 
 Currently, Docker lacks support for certain operating systems (such as

--- a/website/source/intro/vs/docker.html.md
+++ b/website/source/intro/vs/docker.html.md
@@ -14,9 +14,10 @@ workflow across multiple operating systems. Docker is a container management
 that can consistently run software as long as a containerization system exists.
 
 Containers are generally more lightweight than virtual machines, so starting
-and stopping containers is extremely fast. Most common development machines
-don't have a containerization system built-in, and Docker uses a virtual machine
-with Linux installed to provide that.
+and stopping containers is extremely fast. Docker uses the native
+containerization functionality on macOS and Linux, while it must start a Linux
+VM for compatibility with Windows.
+
 
 Currently, Docker lacks support for certain operating systems (such as
 BSD). If your target deployment is one of these operating systems,


### PR DESCRIPTION
The docs indicate that most systems must use a VM for containerization. This is no longer the case as Docker For Mac now uses HyperKit.

See https://docs.docker.com/v17.12/docker-for-mac/docker-toolbox/