### PR TITLE
Fix the broken sudoers file for OS X

### DIFF
--- a/contrib/sudoers/osx
+++ b/contrib/sudoers/osx
@@ -7,4 +7,4 @@ Cmnd_Alias VAGRANT_SMB_LIST = /usr/sbin/sharing -l
 Cmnd_Alias VAGRANT_SMB_PLOAD = /bin/launchctl load -w /System/Library/LaunchDaemons/com.apple.smb.preferences.plist
 Cmnd_Alias VAGRANT_SMB_DLOAD = /bin/launchctl load -w /System/Library/LaunchDaemons/com.apple.smbd.plist
 Cmnd_Alias VAGRANT_SMB_DSTART = /bin/launchctl start com.apple.smbd
-%admin ALL=(root) NOPASSWD: VAGRANT_EXPORTS_ADD, VAGRANT_NFSD, VAGRANT_SMB_ADD, VAGRANT_SMB_REMOVE, VAGRANT_SMB_LIST, VAGRANT_SMB_PLOAD, VAGRANT_SMB_DLOAD VAGRANT_SMB_DSTART
+%admin ALL=(root) NOPASSWD: VAGRANT_EXPORTS_ADD, VAGRANT_NFSD, VAGRANT_EXPORTS_REMOVE, VAGRANT_SMB_ADD, VAGRANT_SMB_REMOVE, VAGRANT_SMB_LIST, VAGRANT_SMB_PLOAD, VAGRANT_SMB_DLOAD, VAGRANT_SMB_DSTART


### PR DESCRIPTION
The last line was all wrong. visudo couldn't even parse it.