### PR TITLE
Add support for passing ssh config file in via config

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -452,9 +452,11 @@ module Vagrant
       info[:keys_only] ||= @config.ssh.default.keys_only
       info[:verify_host_key] ||= @config.ssh.default.verify_host_key
       info[:username] ||= @config.ssh.default.username
+      info[:remote_user] ||= @config.ssh.default.remote_user
       info[:compression] ||= @config.ssh.default.compression
       info[:dsa_authentication] ||= @config.ssh.default.dsa_authentication
       info[:extra_args] ||= @config.ssh.default.extra_args
+      info[:config] ||= @config.ssh.default.config
 
       # We set overrides if they are set. These take precedence over
       # provider-returned data.
@@ -466,7 +468,9 @@ module Vagrant
       info[:dsa_authentication] = @config.ssh.dsa_authentication
       info[:username] = @config.ssh.username if @config.ssh.username
       info[:password] = @config.ssh.password if @config.ssh.password
+      info[:remote_user] = @config.ssh.remote_user if @config.ssh.remote_user
       info[:extra_args] = @config.ssh.extra_args if @config.ssh.extra_args
+      info[:config] = @config.ssh.config if @config.ssh.config
 
       # We also set some fields that are purely controlled by Vagrant
       info[:forward_agent] = @config.ssh.forward_agent

--- a/lib/vagrant/util/ssh.rb
+++ b/lib/vagrant/util/ssh.rb
@@ -165,6 +165,10 @@ module Vagrant
             "-o", "ForwardX11Trusted=yes"]
         end
 
+        if ssh_info[:config]
+          command_options += ["-F", ssh_info[:config]]
+        end
+
         if ssh_info[:proxy_command]
           command_options += ["-o", "ProxyCommand=#{ssh_info[:proxy_command]}"]
         end

--- a/plugins/commands/ssh_config/command.rb
+++ b/plugins/commands/ssh_config/command.rb
@@ -55,6 +55,8 @@ module VagrantPlugins
             proxy_command: ssh_info[:proxy_command],
             ssh_command:   ssh_info[:ssh_command],
             forward_env:   ssh_info[:forward_env],
+            config:        ssh_info[:config],
+            remote_user:   ssh_info[:remote_user],
           }
 
           # Render the template and output directly to STDOUT

--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -408,6 +408,10 @@ module VagrantPlugins
                   connect_opts[:config] = ssh_info[:config]
                 end
 
+                if ssh_info[:remote_user]
+                  connect_opts[:remote_user] = ssh_info[:remote_user]
+                end
+
                 @logger.info("Attempting to connect to SSH...")
                 @logger.info("  - Host: #{ssh_info[:host]}")
                 @logger.info("  - Port: #{ssh_info[:port]}")

--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -366,7 +366,7 @@ module VagrantPlugins
         # Build the options we'll use to initiate the connection via Net::SSH
         common_connect_opts = {
           auth_methods:          auth_methods,
-          config:                ssh_info[:config],
+          config:                false,
           forward_agent:         ssh_info[:forward_agent],
           send_env:              ssh_info[:forward_env],
           keys_only:             ssh_info[:keys_only],
@@ -402,6 +402,10 @@ module VagrantPlugins
 
                 if ssh_info[:proxy_command]
                   connect_opts[:proxy] = Net::SSH::Proxy::Command.new(ssh_info[:proxy_command])
+                end
+
+                if ssh_info[:config]
+                  connect_opts[:config] = ssh_info[:config]
                 end
 
                 @logger.info("Attempting to connect to SSH...")

--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -366,7 +366,7 @@ module VagrantPlugins
         # Build the options we'll use to initiate the connection via Net::SSH
         common_connect_opts = {
           auth_methods:          auth_methods,
-          config:                false,
+          config:                ssh_info[:config],
           forward_agent:         ssh_info[:forward_agent],
           send_env:              ssh_info[:forward_env],
           keys_only:             ssh_info[:keys_only],

--- a/plugins/kernel_v2/config/ssh.rb
+++ b/plugins/kernel_v2/config/ssh.rb
@@ -5,7 +5,6 @@ require_relative "ssh_connect"
 module VagrantPlugins
   module Kernel_V2
     class SSHConfig < SSHConnectConfig
-      attr_accessor :config
       attr_accessor :forward_agent
       attr_accessor :forward_x11
       attr_accessor :forward_env
@@ -23,7 +22,6 @@ module VagrantPlugins
       def initialize
         super
 
-        @config                  = UNSET_VALUE
         @forward_agent           = UNSET_VALUE
         @forward_x11             = UNSET_VALUE
         @forward_env             = UNSET_VALUE
@@ -48,7 +46,6 @@ module VagrantPlugins
       def finalize!
         super
 
-        @config = false if @config == UNSET_VALUE
         @forward_agent = false if @forward_agent == UNSET_VALUE
         @forward_x11   = false if @forward_x11 == UNSET_VALUE
         @forward_env   = false if @forward_env == UNSET_VALUE

--- a/plugins/kernel_v2/config/ssh.rb
+++ b/plugins/kernel_v2/config/ssh.rb
@@ -5,6 +5,7 @@ require_relative "ssh_connect"
 module VagrantPlugins
   module Kernel_V2
     class SSHConfig < SSHConnectConfig
+      attr_accessor :config
       attr_accessor :forward_agent
       attr_accessor :forward_x11
       attr_accessor :forward_env
@@ -22,6 +23,7 @@ module VagrantPlugins
       def initialize
         super
 
+        @config                  = UNSET_VALUE
         @forward_agent           = UNSET_VALUE
         @forward_x11             = UNSET_VALUE
         @forward_env             = UNSET_VALUE
@@ -46,6 +48,7 @@ module VagrantPlugins
       def finalize!
         super
 
+        @config = false if @config == UNSET_VALUE
         @forward_agent = false if @forward_agent == UNSET_VALUE
         @forward_x11   = false if @forward_x11 == UNSET_VALUE
         @forward_env   = false if @forward_env == UNSET_VALUE

--- a/plugins/kernel_v2/config/ssh_connect.rb
+++ b/plugins/kernel_v2/config/ssh_connect.rb
@@ -3,6 +3,7 @@ module VagrantPlugins
     class SSHConnectConfig < Vagrant.plugin("2", :config)
       attr_accessor :host
       attr_accessor :port
+      attr_accessor :config
       attr_accessor :private_key_path
       attr_accessor :username
       attr_accessor :password
@@ -13,10 +14,12 @@ module VagrantPlugins
       attr_accessor :compression
       attr_accessor :dsa_authentication
       attr_accessor :extra_args
+      attr_accessor :remote_user
 
       def initialize
         @host             = UNSET_VALUE
         @port             = UNSET_VALUE
+        @config           = UNSET_VALUE
         @private_key_path = UNSET_VALUE
         @username         = UNSET_VALUE
         @password         = UNSET_VALUE
@@ -27,6 +30,7 @@ module VagrantPlugins
         @compression      = UNSET_VALUE
         @dsa_authentication = UNSET_VALUE
         @extra_args       = UNSET_VALUE
+        @remote_user      = UNSET_VALUE
       end
 
       def finalize!
@@ -42,6 +46,7 @@ module VagrantPlugins
         @compression      = true if @compression == UNSET_VALUE
         @dsa_authentication = true if @dsa_authentication == UNSET_VALUE
         @extra_args       = nil if @extra_args == UNSET_VALUE
+        @remote_user      = nil if @remote_user == UNSET_VALUE
 
         if @private_key_path && !@private_key_path.is_a?(Array)
           @private_key_path = [@private_key_path]
@@ -50,6 +55,9 @@ module VagrantPlugins
         if @paranoid
           @verify_host_key = @paranoid
         end
+
+        # Default to not loading system ssh_config file
+        @config = false if @config == UNSET_VALUE
 
         # Values for verify_host_key changed in 5.0.0 of net-ssh. If old value
         # detected, update with new value

--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -76,6 +76,11 @@ module VagrantPlugins
           proxy_command = "-o ProxyCommand='#{ssh_info[:proxy_command]}' "
         end
 
+        ssh_config_file = ""
+        if ssh_info[:config]
+          ssh_config_file = "-F #{ssh_info[:config]}"
+        end
+
         # Create the path for the control sockets. We used to do this
         # in the machine data dir but this can result in paths that are
         # too long for unix domain sockets.
@@ -90,6 +95,7 @@ module VagrantPlugins
           "ssh", "-p", "#{ssh_info[:port]}",
           "-o", "LogLevel=#{log_level}",
           proxy_command,
+          ssh_config_file,
           control_options,
         ]
 

--- a/test/unit/plugins/communicators/ssh/communicator_test.rb
+++ b/test/unit/plugins/communicators/ssh/communicator_test.rb
@@ -685,6 +685,28 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
         communicator.send(:connect)
       end
     end
+
+    context "with config configured" do
+
+      before do
+        expect(machine).to receive(:ssh_info).and_return(
+          host: '127.0.0.1',
+          port: 2222,
+          config: './ssh_config',
+          keys_only: true,
+          verify_host_key: false
+        )
+      end
+
+      it "has password defined" do
+        expect(Net::SSH).to receive(:start).with(
+          anything, anything, hash_including(
+            config: './ssh_config'
+          )
+        ).and_return(true)
+        communicator.send(:connect)
+      end
+    end
   end
 
   describe ".generate_environment_export" do

--- a/test/unit/plugins/kernel_v2/config/ssh_test.rb
+++ b/test/unit/plugins/kernel_v2/config/ssh_test.rb
@@ -8,7 +8,7 @@ describe VagrantPlugins::Kernel_V2::SSHConfig do
   describe "#default" do
     it "defaults to vagrant username" do
       subject.finalize!
-      expect(subject.default.config).to eq(false)
+      expect(subject.default.config).to be_falsey
       expect(subject.default.port).to eq(22)
       expect(subject.default.username).to eq("vagrant")
     end

--- a/test/unit/plugins/kernel_v2/config/ssh_test.rb
+++ b/test/unit/plugins/kernel_v2/config/ssh_test.rb
@@ -8,7 +8,6 @@ describe VagrantPlugins::Kernel_V2::SSHConfig do
   describe "#default" do
     it "defaults to vagrant username" do
       subject.finalize!
-      expect(subject.default.config).to be_falsey
       expect(subject.default.port).to eq(22)
       expect(subject.default.username).to eq("vagrant")
     end

--- a/test/unit/plugins/kernel_v2/config/ssh_test.rb
+++ b/test/unit/plugins/kernel_v2/config/ssh_test.rb
@@ -8,6 +8,8 @@ describe VagrantPlugins::Kernel_V2::SSHConfig do
   describe "#default" do
     it "defaults to vagrant username" do
       subject.finalize!
+      expect(subject.default.config).to eq(false)
+      expect(subject.default.port).to eq(22)
       expect(subject.default.username).to eq("vagrant")
     end
   end


### PR DESCRIPTION
This is a in order to allow using `ProxyCommand` SSH config to allow Vagrant to access hosts behind a bastion or jump host.

Couldn't get the tests to run locally, due to local plugins conflicting with the test env :( 