### PR TITLE
Fix download tracking analytics events

### DIFF
--- a/website/source/assets/javascripts/analytics.js
+++ b/website/source/assets/javascripts/analytics.js
@@ -2,14 +2,16 @@ document.addEventListener('turbolinks:load', function() {
   analytics.page()
 
   track('.downloads .download .details li a', function(el) {
-    var m = el.href.match(/vagrant_(.*?)_(.*?)_(.*?)\.zip/)
+    var version = el.dataset.version
+    var os = el.dataset.os
+    var arch = el.dataset.arch
     return {
       event: 'Download',
       category: 'Button',
-      label: 'Vagrant | v' + m[1] + ' | ' + m[2] + ' | ' + m[3],
-      version: m[1],
-      os: m[2],
-      architecture: m[3],
+      label: 'Vagrant | v' + version + ' | ' + os + ' | ' + arch,
+      version: version,
+      os: os,
+      architecture: arch,
       product: 'vagrant'
     }
   })

--- a/website/source/downloads.html.erb
+++ b/website/source/downloads.html.erb
@@ -43,7 +43,7 @@ description: |-
           <h2 class="os-name"><%= pretty_os(os) %></h2>
           <ul>
             <% arches.each do |arch, url| %>
-              <li><a href="<%= url %>"><%= pretty_arch(arch) %></a></li>
+              <li><a data-os="<%= os %>" data-arch="<%= arch%>" data-version="<%= latest_version %>" href="<%= url %>"><%= pretty_arch(arch) %></a></li>
             <% end %>
           </ul>
           <div class="clearfix"></div>


### PR DESCRIPTION
Vagrant download URLs are formatted a bit differently from the other products, so our analytics events weren't working correctly for product downloads. This PR fixes it!