### PR TITLE
Add :windows to config.vm.guest in machine settings doc

### DIFF
--- a/website/source/docs/vagrantfile/machine_settings.html.md
+++ b/website/source/docs/vagrantfile/machine_settings.html.md
@@ -125,9 +125,9 @@ Defaults to 60 seconds.
 
 `config.vm.guest` - The guest OS that will be running within this
 machine. This defaults to `:linux`, and Vagrant will auto-detect the
-proper distro. Vagrant needs to know this information to perform some
-guest OS-specific things such as mounting folders and configuring
-networks.
+proper distro. However, this should be changed to `":windows"` for Windows guests. 
+Vagrant needs to know this information to perform some guest OS-specific things 
+such as mounting folders and configuring networks.
 
 <hr>
 

--- a/website/source/docs/vagrantfile/machine_settings.html.md
+++ b/website/source/docs/vagrantfile/machine_settings.html.md
@@ -125,7 +125,7 @@ Defaults to 60 seconds.
 
 `config.vm.guest` - The guest OS that will be running within this
 machine. This defaults to `:linux`, and Vagrant will auto-detect the
-proper distro. However, this should be changed to `":windows"` for Windows guests. 
+proper distro. However, this should be changed to `:windows` for Windows guests. 
 Vagrant needs to know this information to perform some guest OS-specific things 
 such as mounting folders and configuring networks.
 


### PR DESCRIPTION
This commit updates the documentation so that it is more clear that Windows guests need to change the `config.vm.guest` option along with the `config.vm.communicator` option.