### PR TITLE
Fixes #10289: Create proper tmp dir for ControlPath

### DIFF
--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -81,7 +81,7 @@ module VagrantPlugins
         # too long for unix domain sockets.
         control_options = ""
         unless Vagrant::Util::Platform.windows?
-          controlpath = File.join(Dir.tmpdir, "ssh.#{rand(1000)}")
+          controlpath = Dir.mktmpdir("vagrant-rsync-")
           control_options = "-o ControlMaster=auto -o ControlPath=#{controlpath} -o ControlPersist=10m "
         end
 

--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -1,5 +1,6 @@
 require "ipaddr"
 require "shellwords"
+require "tmpdir"
 
 require "vagrant/util/platform"
 require "vagrant/util/subprocess"

--- a/test/unit/plugins/synced_folders/rsync/helper_test.rb
+++ b/test/unit/plugins/synced_folders/rsync/helper_test.rb
@@ -212,6 +212,20 @@ describe VagrantPlugins::SyncedFolderRSync::RsyncHelper do
         subject.rsync_single(machine, ssh_info, opts)
       end
     end
+
+    context "control sockets" do
+      it "creates a tmp dir" do
+        allow(Vagrant::Util::Platform).to receive(:windows?).and_return(false)
+        allow(Dir).to receive(:mktmpdir).with("vagrant-rsync-").
+          and_return("/tmp/vagrant-rsync-12345")
+
+        expect(Vagrant::Util::Subprocess).to receive(:execute).with(any_args) { |*args|
+          expect(args[9]).to include("ControlPath=/tmp/vagrant-rsync-12345")
+        }.and_return(result)
+
+        subject.rsync_single(machine, ssh_info, opts)
+      end
+    end
   end
 
   describe "#rsync_single with custom ssh_info" do


### PR DESCRIPTION
Prior to this commit, when creating the ControlPath tmp dir for
socket path, Vagrant would simply rely on `rand(1000)` for making unique
dirs for rsyncing files which could result in collisions. This commit
updates that be properly using `Dir.mktmpdir` with a `vagrant-rsync-`
prefix.