### PR TITLE
Fixes #10016: Add `automount` flag if specified with synced_folder

### DIFF
--- a/plugins/providers/virtualbox/driver/version_5_0.rb
+++ b/plugins/providers/virtualbox/driver/version_5_0.rb
@@ -674,6 +674,8 @@ module VagrantPlugins
               hostpath]
             args << "--transient" if folder.key?(:transient) && folder[:transient]
 
+            args << "--automount" if folder.key?(:automount) && folder[:automount]
+
             if folder[:SharedFoldersEnableSymlinksCreate]
               # Enable symlinks on the shared folder
               execute("setextradata", @uuid, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/#{folder[:name]}", "1", retryable: true)

--- a/plugins/providers/virtualbox/synced_folder.rb
+++ b/plugins/providers/virtualbox/synced_folder.rb
@@ -124,8 +124,10 @@ module VagrantPlugins
               name: os_friendly_id(id),
               hostpath: hostpath.to_s,
               transient: transient,
-              SharedFoldersEnableSymlinksCreate: enable_symlink_create
-            }
+              SharedFoldersEnableSymlinksCreate: enable_symlink_create,
+              automount: data[:automount]
+            }.delete_if { |_,v| v.nil?}
+
           end
         end
 

--- a/plugins/providers/virtualbox/synced_folder.rb
+++ b/plugins/providers/virtualbox/synced_folder.rb
@@ -125,9 +125,8 @@ module VagrantPlugins
               hostpath: hostpath.to_s,
               transient: transient,
               SharedFoldersEnableSymlinksCreate: enable_symlink_create,
-              automount: data[:automount]
-            }.delete_if { |_,v| v.nil?}
-
+              automount: !!data[:automount]
+            }
           end
         end
 

--- a/test/unit/plugins/providers/virtualbox/driver/version_5_0_test.rb
+++ b/test/unit/plugins/providers/virtualbox/driver/version_5_0_test.rb
@@ -15,6 +15,12 @@ describe VagrantPlugins::ProviderVirtualBox::Driver::Version_5_0 do
                      :transient=>false,
                      :SharedFoldersEnableSymlinksCreate=>true}]}
 
+    let(:folders_automount) { [{:name=>"folder",
+                     :hostpath=>"/Users/brian/vagrant-folder",
+                     :transient=>false,
+                     :automount=>true,
+                     :SharedFoldersEnableSymlinksCreate=>true}]}
+
     let(:folders_disabled) { [{:name=>"folder",
                      :hostpath=>"/Users/brian/vagrant-folder",
                      :transient=>false,
@@ -31,6 +37,19 @@ describe VagrantPlugins::ProviderVirtualBox::Driver::Version_5_0 do
       subject.share_folders(folders)
 
     end
+
+    it "enables automount if option is true" do
+      expect(subprocess).to receive(:execute).
+        with("VBoxManage", "setextradata", anything, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/folder", "1", {:notify=>[:stdout, :stderr]}).
+        and_return(subprocess_result(exit_code: 0))
+
+      expect(subprocess).to receive(:execute).
+        with("VBoxManage", "sharedfolder", "add", anything, "--name", "folder", "--hostpath", "/Users/brian/vagrant-folder", "--automount", {:notify=>[:stdout, :stderr]}).
+        and_return(subprocess_result(exit_code: 0))
+      subject.share_folders(folders_automount)
+
+    end
+
 
     it "disables SharedFoldersEnableSymlinksCreate if false" do
       expect(subprocess).to receive(:execute).

--- a/test/unit/plugins/providers/virtualbox/synced_folder_test.rb
+++ b/test/unit/plugins/providers/virtualbox/synced_folder_test.rb
@@ -53,6 +53,15 @@ describe VagrantPlugins::ProviderVirtualBox::SyncedFolder do
                                  :disabled=>false,
                                  :__vagrantfile=>true}} }
 
+
+    let(:folders_automount) { {"/folder"=>
+                                {:SharedFoldersEnableSymlinksCreate=>true,
+                                 :guestpath=>"/folder",
+                                 :hostpath=>"/Users/brian/vagrant-folder",
+                                 :disabled=>false,
+                                 :automount=>true,
+                                 :__vagrantfile=>true}} }
+
     let(:folders_nosymvar) { {"/folder"=>
                                 {:guestpath=>"/folder",
                                  :hostpath=>"/Users/brian/vagrant-folder",
@@ -87,6 +96,11 @@ describe VagrantPlugins::ProviderVirtualBox::SyncedFolder do
 
       expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :transient=>false, :SharedFoldersEnableSymlinksCreate=>true}])
       subject.prepare(machine, folders, nil)
+    end
+
+    it "should prepare and share the folders with automount enabled" do
+      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :transient=>false, :SharedFoldersEnableSymlinksCreate=>true, :automount=>true}])
+      subject.prepare(machine, folders_automount, nil)
     end
   end
 

--- a/test/unit/plugins/providers/virtualbox/synced_folder_test.rb
+++ b/test/unit/plugins/providers/virtualbox/synced_folder_test.rb
@@ -43,6 +43,7 @@ describe VagrantPlugins::ProviderVirtualBox::SyncedFolder do
                       {:SharedFoldersEnableSymlinksCreate=>true,
                        :guestpath=>"/folder",
                        :hostpath=>"/Users/brian/vagrant-folder",
+                       :automount=>false,
                        :disabled=>false,
                        :__vagrantfile=>true}} }
 
@@ -50,6 +51,7 @@ describe VagrantPlugins::ProviderVirtualBox::SyncedFolder do
                                 {:SharedFoldersEnableSymlinksCreate=>false,
                                  :guestpath=>"/folder",
                                  :hostpath=>"/Users/brian/vagrant-folder",
+                                 :automount=>false,
                                  :disabled=>false,
                                  :__vagrantfile=>true}} }
 
@@ -65,6 +67,7 @@ describe VagrantPlugins::ProviderVirtualBox::SyncedFolder do
     let(:folders_nosymvar) { {"/folder"=>
                                 {:guestpath=>"/folder",
                                  :hostpath=>"/Users/brian/vagrant-folder",
+                                 :automount=>false,
                                  :disabled=>false,
                                  :__vagrantfile=>true}} }
 
@@ -75,26 +78,26 @@ describe VagrantPlugins::ProviderVirtualBox::SyncedFolder do
     end
 
     it "should prepare and share the folders" do
-      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :transient=>false, :SharedFoldersEnableSymlinksCreate=>true}])
+      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :transient=>false, :automount=>false, :SharedFoldersEnableSymlinksCreate=>true}])
       subject.prepare(machine, folders, nil)
     end
 
     it "should prepare and share the folders without symlinks enabled" do
-      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :transient=>false, :SharedFoldersEnableSymlinksCreate=>false}])
+      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :transient=>false, :automount=>false, :SharedFoldersEnableSymlinksCreate=>false}])
       subject.prepare(machine, folders_disabled, nil)
     end
 
     it "should prepare and share the folders without symlinks enabled with env var set" do
       stub_env('VAGRANT_DISABLE_VBOXSYMLINKCREATE'=>'1')
 
-      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :transient=>false, :SharedFoldersEnableSymlinksCreate=>false}])
+      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :transient=>false, :automount=>false, :SharedFoldersEnableSymlinksCreate=>false}])
       subject.prepare(machine, folders_nosymvar, nil)
     end
 
     it "should prepare and share the folders and override symlink setting" do
       stub_env('VAGRANT_DISABLE_VBOXSYMLINKCREATE'=>'1')
 
-      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :transient=>false, :SharedFoldersEnableSymlinksCreate=>true}])
+      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :transient=>false, :automount=>false, :SharedFoldersEnableSymlinksCreate=>true}])
       subject.prepare(machine, folders, nil)
     end
 

--- a/website/source/docs/synced-folders/virtualbox.html.md
+++ b/website/source/docs/synced-folders/virtualbox.html.md
@@ -18,6 +18,10 @@ the guest to the host and vice versa.
 
 ## Options
 
+* `automount` (boolean) - If true, the `--automount` flag will be used when
+using the VirtualBox tools to share the folder with the guest vm. Defaults to false
+if not present.
+
 * `SharedFoldersEnableSymlinksCreate` (boolean) - If false, will disable the
 ability to create symlinks with the given virtualbox shared folder. Defaults to
 true if the option is not present.


### PR DESCRIPTION
This commit adds a new option to virtualbox synced_folders called
`automount`, where if set to true, will supply the `--automount` flag to
virtualbox.