### PR TITLE
Reliably restart Debian and Ubuntu guests networking on setting hostname

### DIFF
--- a/plugins/guests/debian/cap/change_host_name.rb
+++ b/plugins/guests/debian/cap/change_host_name.rb
@@ -92,9 +92,9 @@ module VagrantPlugins
           interfaces.each do |iface|
             logger.debug("Restarting interface #{iface} on guest #{machine.name}")
             if nettools
-             restart_command = "ifdown #{iface} && ifup #{iface}"
+             restart_command = "ifdown #{iface};ifup #{iface}"
             else
-             restart_command = "systemctl stop ifup@#{iface}.service && systemctl start ifup@#{iface}.service"
+             restart_command = "systemctl stop ifup@#{iface}.service;systemctl start ifup@#{iface}.service"
             end
             comm.sudo(restart_command)
           end

--- a/test/unit/plugins/guests/debian/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/debian/cap/change_host_name_test.rb
@@ -136,18 +136,18 @@ describe "VagrantPlugins::GuestDebian::Cap::ChangeHostName" do
 
       it "restarts every interface" do
         cap.send(:restart_each_interface, machine, logger)
-        expect(comm.received_commands[0]).to match(/ifdown eth0 && ifup eth0/)
-        expect(comm.received_commands[1]).to match(/ifdown eth1 && ifup eth1/)
-        expect(comm.received_commands[2]).to match(/ifdown eth2 && ifup eth2/)
+        expect(comm.received_commands[0]).to match(/ifdown eth0;ifup eth0/)
+        expect(comm.received_commands[1]).to match(/ifdown eth1;ifup eth1/)
+        expect(comm.received_commands[2]).to match(/ifdown eth2;ifup eth2/)
       end
     end
 
     context "with systemctl" do
       it "restarts every interface" do
         cap.send(:restart_each_interface, machine, logger)
-        expect(comm.received_commands[0]).to match(/systemctl stop ifup@eth0.service && systemctl start ifup@eth0.service/)
-        expect(comm.received_commands[1]).to match(/systemctl stop ifup@eth1.service && systemctl start ifup@eth1.service/)
-        expect(comm.received_commands[2]).to match(/systemctl stop ifup@eth2.service && systemctl start ifup@eth2.service/)
+        expect(comm.received_commands[0]).to match(/systemctl stop ifup@eth0.service;systemctl start ifup@eth0.service/)
+        expect(comm.received_commands[1]).to match(/systemctl stop ifup@eth1.service;systemctl start ifup@eth1.service/)
+        expect(comm.received_commands[2]).to match(/systemctl stop ifup@eth2.service;systemctl start ifup@eth2.service/)
       end
     end
   end


### PR DESCRIPTION
This pull request adds some additional logic that falls back to using the
ifdown/ifup tools to restart networking. On Ubuntu 14.04, the init
script was designed to always fail to restart newtorking, so it needs
to use the ifdown/up tools instead.

This pull request also uses a workaround due to how older debian
and ubuntu systems fail to properly restart networking. Instead of
relying on the init scripts or ifup/down tools to restart each interface,
this commit instead restarts each interface individually.

Related PR #10301
Related issues:  #9763 #10300
Tested against this Vagrantfile: https://github.com/briancain/congenial-octo-palm-tree/blob/master/debian/Vagrantfile against these OS's:

- debian 7
- debian 8
- debian 9
- ubuntu 12
- ubuntu 14
- ubuntu 16
- ubuntu 18