### PR TITLE
Prevent exception from raising on hyper-v check

### DIFF
--- a/test/unit/vagrant/util/platform_test.rb
+++ b/test/unit/vagrant/util/platform_test.rb
@@ -262,6 +262,13 @@ describe Vagrant::Util::Platform do
 
       expect(Vagrant::Util::Platform.windows_hyperv_enabled?).to be_falsey
     end
+
+    it "should return false if PowerShell cannot be validated" do
+      allow_any_instance_of(Vagrant::Errors::PowerShellInvalidVersion).to receive(:translate_error)
+      allow(Vagrant::Util::PowerShell).to receive(:execute_cmd).and_raise(Vagrant::Errors::PowerShellInvalidVersion)
+
+      expect(Vagrant::Util::Platform.windows_hyperv_enabled?).to be_falsey
+    end
   end
 
   context "within the WSL" do


### PR DESCRIPTION
Ignore PowerShell issues during Hyper-V enabled check. If PowerShell is required later (either by synced folders or a different provider) the PowerShell installation check will raise an error at that time.