### PR TITLE
Fixes #10224: Allow validation of config while ignoring provider

### DIFF
--- a/lib/vagrant/action/builtin/config_validate.rb
+++ b/lib/vagrant/action/builtin/config_validate.rb
@@ -12,7 +12,7 @@ module Vagrant
 
         def call(env)
           if !env.key?(:config_validate) || env[:config_validate]
-            errors = env[:machine].config.validate(env[:machine])
+            errors = env[:machine].config.validate(env[:machine], env[:ignore_provider])
 
             if errors && !errors.empty?
               raise Errors::ConfigInvalid,

--- a/lib/vagrant/config/v2/root.rb
+++ b/lib/vagrant/config/v2/root.rb
@@ -60,14 +60,18 @@ module Vagrant
         #
         # @param [Environment] env
         # @return [Hash]
-        def validate(machine)
+        def validate(machine, ignore_provider=nil)
           # Go through each of the configuration keys and validate
           errors = {}
           @keys.each do |_key, instance|
             if instance.respond_to?(:validate)
               # Validate this single item, and if we have errors then
               # we merge them into our total errors list.
-              result = instance.validate(machine)
+              if _key == :vm
+                result = instance.validate(machine, ignore_provider)
+              else
+                result = instance.validate(machine)
+              end
               if result && !result.empty?
                 errors = Util.merge_errors(errors, result)
               end

--- a/plugins/commands/validate/command.rb
+++ b/plugins/commands/validate/command.rb
@@ -8,17 +8,32 @@ module VagrantPlugins
       end
 
       def execute
+        options = {}
+
         opts = OptionParser.new do |o|
-          o.banner = "Usage: vagrant validate"
+          o.banner = "Usage: vagrant validate [options]"
+          o.separator ""
+          o.separator "Validates a Vagrantfile config"
+          o.separator ""
+          o.separator "Options:"
+          o.separator ""
+
+          o.on("-p", "--ignore-provider", "Ignores provider config options") do |p|
+            options[:ignore_provider] = p
+          end
         end
 
         # Parse the options
         argv = parse_options(opts)
         return if !argv
 
+        action_env = {}
+        if options[:ignore_provider]
+          action_env[:ignore_provider] = true
+        end
         # Validate the configuration of all machines
         with_target_vms() do |machine|
-          machine.action_raw(:config_validate, Vagrant::Action::Builtin::ConfigValidate)
+          machine.action_raw(:config_validate, Vagrant::Action::Builtin::ConfigValidate, action_env)
         end
 
         @env.ui.info(I18n.t("vagrant.commands.validate.success"))

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -582,7 +582,7 @@ module VagrantPlugins
         @__synced_folders
       end
 
-      def validate(machine)
+      def validate(machine, ignore_provider=nil)
         errors = _detected_errors
 
         if !box && !clone && !machine.provider_options[:box_optional]
@@ -737,9 +737,13 @@ module VagrantPlugins
 
         # Validate only the _active_ provider
         if machine.provider_config
-          provider_errors = machine.provider_config.validate(machine)
-          if provider_errors
-            errors = Vagrant::Config::V2::Util.merge_errors(errors, provider_errors)
+          if !ignore_provider
+            provider_errors = machine.provider_config.validate(machine)
+            if provider_errors
+              errors = Vagrant::Config::V2::Util.merge_errors(errors, provider_errors)
+            end
+          else
+            machine.ui.warn(I18n.t("vagrant.config.vm.ignore_provider_config"))
           end
         end
 

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1845,6 +1845,8 @@ en:
         hostname_invalid_characters: |-
           The hostname set for the VM should only contain letters, numbers,
           hyphens or dots. It cannot start with a hyphen or dot.
+        ignore_provider_config: |-
+          Ignoring provider config for validation...
         name_invalid: |-
           The sub-VM name '%{name}' is invalid. Please don't use special characters.
         network_ip_ends_in_one: |-

--- a/test/unit/plugins/kernel_v2/config/vm_test.rb
+++ b/test/unit/plugins/kernel_v2/config/vm_test.rb
@@ -368,6 +368,20 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
       expect { subject.finalize! }.
         to raise_error(Vagrant::Errors::VagrantfileLoadError)
     end
+
+    it "ignores providers entirely if flag is provided" do
+      subject.provider "virtualbox" do |vb|
+        vb.nope = true
+      end
+
+      subject.provider "virtualbox" do |vb|
+        vb.not_real = "foo"
+      end
+
+      subject.finalize!
+      errors = subject.validate(machine, true)
+      expect(errors).to eq({"vm"=>[]})
+    end
   end
 
   describe "#provision" do

--- a/test/unit/vagrant/config/v2/root_test.rb
+++ b/test/unit/vagrant/config/v2/root_test.rb
@@ -91,6 +91,24 @@ describe Vagrant::Config::V2::Root do
       expect(instance.validate(env)).to eq(errors)
     end
 
+    context "with vms and ignoring provider validations" do
+      let(:instance) do
+        map = { vm: Object, bar: Object }
+        described_class.new(map)
+      end
+
+      it "should pass along the ignore_provider flag for ignoring validations" do
+        errors = { "vm" => ["errors!"] }
+        env    = { "errors" => errors }
+        vm     = instance.vm
+        def vm.validate(env, param)
+          env["errors"]
+        end
+
+        expect(instance.validate({}, true)).to eq({})
+      end
+    end
+
     it "should merge errors via array concat if matching keys" do
       errors = { "foo" => ["errors!"] }
       env    = { "errors" => errors }


### PR DESCRIPTION
This commit adds a new flag to the `vagrant validate` command which
allows users to completely ignore the provider block of a config file.
This is useful for when you are running `vagrant validate` in CI and
don't want to install a valid provider to check the syntax of your
Vagratnfile. When the flag is invoked, a warning will be displayed
saying that the provider block will be ignored and not validated.