### PR TITLE
Update ordering of gem sources to ensure proper resolution

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -24,8 +24,8 @@ module Vagrant
 
     # Default gem repositories
     DEFAULT_GEM_SOURCES = [
-      "https://rubygems.org/".freeze,
-      HASHICORP_GEMSTORE
+      HASHICORP_GEMSTORE,
+      "https://rubygems.org/".freeze
     ].freeze
 
     def self.instance
@@ -62,7 +62,12 @@ module Vagrant
 
       # Add HashiCorp RubyGems source
       if !Gem.sources.include?(HASHICORP_GEMSTORE)
+        current_sources = Gem.sources.sources.dup
+        Gem.sources.clear
         Gem.sources << HASHICORP_GEMSTORE
+        current_sources.each do |src|
+          Gem.sources << src
+        end
       end
 
       # Generate dependencies for all registered plugins

--- a/test/unit/vagrant/bundler_test.rb
+++ b/test/unit/vagrant/bundler_test.rb
@@ -34,6 +34,31 @@ describe Vagrant::Bundler do
     end
   end
 
+  describe "DEFAULT_GEM_SOURCES" do
+    it "should list hashicorp gemstore first" do
+      expect(described_class.const_get(:DEFAULT_GEM_SOURCES).first).to eq(
+        described_class.const_get(:HASHICORP_GEMSTORE))
+    end
+  end
+
+  describe "#init!" do
+    context "Gem.sources" do
+      before {
+        Gem.sources.clear
+        Gem.sources << "https://rubygems.org/" }
+
+      it "should add hashicorp gem store" do
+        subject.init!([])
+        expect(Gem.sources).to include(described_class.const_get(:HASHICORP_GEMSTORE))
+      end
+
+      it "should add hashicorp gem store to start of sources list" do
+        subject.init!([])
+        expect(Gem.sources.sources.first.uri.to_s).to eq(described_class.const_get(:HASHICORP_GEMSTORE))
+      end
+    end
+  end
+
   describe "#install" do
     let(:plugins){ {"my-plugin" => {"gem_version" => "> 0"}} }
 


### PR DESCRIPTION
In recent Rubies the first dependency to satisfy the constraint will
be used regardless if higher versions are available in subsequent
sources. Move custom source to start of list when resolving plugins
to provide desired behavior.