### PR TITLE
Remove module loading from vlan script

### DIFF
--- a/plugins/providers/hyperv/scripts/set_network_vlan.ps1
+++ b/plugins/providers/hyperv/scripts/set_network_vlan.ps1
@@ -7,12 +7,6 @@ param (
     [int]$VlanId
 )
 
-# Include the following modules
-$presentDir = Split-Path -parent $PSCommandPath
-$modules = @()
-$modules += $presentDir + "\utils\write_messages.ps1"
-forEach ($module in $modules) { . $module }
-
 try {
   $vm = Hyper-V\Get-VM -Id $VmId -ErrorAction "stop"
   Hyper-V\Set-VMNetworkAdapterVlan $vm -Access -Vlanid $VlanId


### PR DESCRIPTION
Write helpers are provided by the VagrantMessages modules. This local module import is an artifact from before the provider overhaul that should have been removed then.

Fixes #10320 