### PR TITLE
Fixed hanging host name change issue

### DIFF
--- a/plugins/guests/windows/cap/change_host_name.rb
+++ b/plugins/guests/windows/cap/change_host_name.rb
@@ -27,13 +27,8 @@ module VagrantPlugins
             error_class: Errors::RenameComputerFailed,
             error_key: :rename_computer_failed)
 
-          # Don't continue until the machine has shutdown and rebooted
-	  if machine.guest.capability?(:wait_for_reboot)
-            machine.guest.capability(:wait_for_reboot)
-          else
-            # use graceful_halt_timeout only if guest cannot wait for reboot
-            sleep(sleep_timeout)
-	  end
+          # Don't continue until the machine is ready to communicate
+          machine.communicate.wait_for_ready(machine.config.vm.boot_timeout)
         end
       end
     end

--- a/test/unit/plugins/guests/windows/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/windows/cap/change_host_name_test.rb
@@ -34,9 +34,8 @@ describe "VagrantPlugins::GuestWindows::Cap::ChangeHostName" do
         'if (!([System.Net.Dns]::GetHostName() -eq \'newhostname\')) { exit 0 } exit 1',
         exit_code: 0)
       communicator.stub_command(rename_script, exit_code: 0)
-      allow(machine).to receive(:guest)
-      allow(machine.guest).to receive(:capability)
-      allow(machine.guest).to receive(:capability?)
+      allow(machine).to receive_message_chain(:config, :vm, :boot_timeout)
+      expect(machine.communicate).to receive(:wait_for_ready)
       described_class.change_host_name_and_wait(machine, 'newhostname', 0)
     end
 


### PR DESCRIPTION
### Vagrant version
Vagrant: 2.2.0

### Host operating system
Windows 10

### Guest operating system
Windows Server 2016

### Vagrantfile 
```ruby
project = 'HeavyBoxBasedOnWs2016'

Vagrant.configure('2') do |config|
 
  config.vm.box = 'HeavyBoxBasedOnWs2016'
  config.vm.hostname = "custom_host"
  config.vm.network 'private_network', ip: '192.168.50.4', auto_config: true

  config.vm.provider 'virtualbox' do |vb|
    vb.name = 'BoxBasedOnWs2016'
    vb.gui = false
  end
end
```

### Expected behavior 
Setting host name is not hanging.

### Actual behavior 
Setting host name is hanging and the only way to proceed is killing processes like this

```powershell
Get-Process | Where {$_.ProcessName -like "VBox*" -OR $_.ProcessName -like "ruby" } | foreach {Write-Host $_.ProcessName;  $_.Kill()};
```

### Possible issue

The root cause of the issue is that in some point inside reboot_detect.ps1 host can't build communication using WinRM with the guest machine and falls into some unhanded await.


```ruby

#control flow

# change_host_name.rb
machine.guest.capability(:wait_for_reboot)  

# reboot.rb: attempting to check machine state
while machine.communicate.execute(script, error_check: false)!= 0 

 # reboot_detect.ps1: we are hitting this line the last before we hang. At this point the machine is about to reboot. At the next attempt we are neither still shutting down, nor up again  => we hang.
if ($LASTEXITCODE -eq 1190) {
```

### Steps to reproduce

1) Use any heavy box (like my box)

2) Use stock mwrock/Windows2016 box.  + Patch reboot.rb and set sleep **1** instead of 10. That will force us to fall into the same issue even the box is lightweight.

```ruby
   while machine.communicate.execute(script, error_check: false) != 0
       sleep 1
   end
```

### References

Detected this issue quite a long time ago. According to the change log this issue might appear starting from 2.0.4, where reboot capability was added to change_host_name. 

### Good news
Before hitting submit decided to double checked the repo again and...found out fresh pull request which is probably solving the same issue.  ^^=) #10347. Anyway, will be glad you'll check suggested approach - it is not binding to the reboot proccess directly, instead using more abstract awaiting for communication readyness. Might be you'll find it more relevant for this particular case. Thx.