### PR TITLE
Add support for specifying the default NIC type used for guest adapters

### DIFF
--- a/plugins/providers/virtualbox/config.rb
+++ b/plugins/providers/virtualbox/config.rb
@@ -19,6 +19,13 @@ module VagrantPlugins
       # @return [Array]
       attr_reader :customizations
 
+      # Set the default type of NIC hardware to be used for network
+      # devices. By default this is "virtio". If it is set to `nil`
+      # no type will be set and VirtualBox's default will be used.
+      #
+      # @return [String]
+      attr_accessor :default_nic_type
+
       # If true, unused network interfaces will automatically be deleted.
       # This defaults to false because the detection does not work across
       # multiple users, and because on Windows this operation requires
@@ -68,6 +75,7 @@ module VagrantPlugins
         @auto_nat_dns_proxy = UNSET_VALUE
         @check_guest_additions = UNSET_VALUE
         @customizations   = []
+        @default_nic_type = UNSET_VALUE
         @destroy_unused_network_interfaces = UNSET_VALUE
         @functional_vboxsf = UNSET_VALUE
         @name             = UNSET_VALUE
@@ -158,6 +166,9 @@ module VagrantPlugins
 
         # The default name is just nothing, and we default it
         @name = nil if @name == UNSET_VALUE
+
+        @default_nic_type = "virtio" if @default_nic_type == UNSET_VALUE
+        set_default_nic_type! if @default_nic_type
       end
 
       def validate(machine)
@@ -188,6 +199,15 @@ module VagrantPlugins
         end
 
         { "VirtualBox Provider" => errors }
+      end
+
+      def set_default_nic_type!
+        network_adapters.each do |_, args|
+          _, opts = args
+          if opts && !opts.key?(:nic_type)
+            opts[:nic_type] = @default_nic_type
+          end
+        end
       end
 
       def to_s

--- a/test/unit/plugins/providers/virtualbox/config_test.rb
+++ b/test/unit/plugins/providers/virtualbox/config_test.rb
@@ -43,11 +43,39 @@ describe VagrantPlugins::ProviderVirtualBox::Config do
     it { expect(subject.gui).to be(false) }
     it { expect(subject.name).to be_nil }
     it { expect(subject.functional_vboxsf).to be(true) }
+    it { expect(subject.default_nic_type).to eq("virtio") }
 
     it "should have one NAT adapter" do
       expect(subject.network_adapters).to eql({
-        1 => [:nat, {}],
+        1 => [:nat, {nic_type: "virtio"}],
       })
+    end
+  end
+
+  describe "#default_nic_type" do
+    let(:nic_type) { "custom" }
+
+    before do
+      subject.default_nic_type = nic_type
+      subject.finalize!
+    end
+
+    it { expect(subject.default_nic_type).to eq(nic_type) }
+
+    it "should set NAT adapter nic type" do
+      expect(subject.network_adapters.values.first.last[:nic_type]).
+        to eq(nic_type)
+    end
+
+    context "when set to nil" do
+      let(:nic_type) { nil }
+
+      it { expect(subject.default_nic_type).to be_nil }
+
+      it "should not set NAT adapter nic type" do
+        expect(subject.network_adapters.values.first.last[:nic_type]).
+          to be_nil
+      end
     end
   end
 

--- a/website/source/docs/virtualbox/configuration.html.md
+++ b/website/source/docs/virtualbox/configuration.html.md
@@ -41,6 +41,27 @@ config.vm.provider "virtualbox" do |v|
 end
 ```
 
+## Default NIC Type
+
+By default Vagrant will set the NIC type for all network interfaces to
+`"virtio"`. If you would rather a different NIC type be used as the
+default for guests:
+
+```ruby
+config.vm.provider "virtualbox" do |v|
+  v.default_nic_type = "82543GC"
+end
+```
+
+or if you would like to disable the default type so VirtualBox's default
+is applied you can set the value to `nil`:
+
+```ruby
+config.vm.provider "virtualbox" do |v|
+  v.default_nic_type = nil
+end
+```
+
 ## Linked Clones
 
 By default new machines are created by importing the base box. For large


### PR DESCRIPTION
Provides support for defining the NIC type used for any guest adapter
which does not define an adapter type. This is defaulted to "virtio".