### PR TITLE
Added new config parameter "booting_wait" for delay before communicat…

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -21,6 +21,7 @@ module VagrantPlugins
       attr_accessor :allowed_synced_folder_types
       attr_accessor :base_mac
       attr_accessor :boot_timeout
+      attr_accessor :booting_wait
       attr_accessor :box
       attr_accessor :ignore_box_vagrantfile
       attr_accessor :box_check_update
@@ -51,6 +52,7 @@ module VagrantPlugins
         @allowed_synced_folder_types   = UNSET_VALUE
         @base_mac                      = UNSET_VALUE
         @boot_timeout                  = UNSET_VALUE
+        @booting_wait                  = UNSET_VALUE
         @box                           = UNSET_VALUE
         @ignore_box_vagrantfile        = UNSET_VALUE
         @box_check_update              = UNSET_VALUE
@@ -378,6 +380,7 @@ module VagrantPlugins
         @allowed_synced_folder_types = nil if @allowed_synced_folder_types == UNSET_VALUE
         @base_mac = nil if @base_mac == UNSET_VALUE
         @boot_timeout = 300 if @boot_timeout == UNSET_VALUE
+        @booting_wait = 0 if @booting_wait == UNSET_VALUE
         @box = nil if @box == UNSET_VALUE
         @ignore_box_vagrantfile = false if @ignore_box_vagrantfile == UNSET_VALUE
 

--- a/plugins/providers/virtualbox/action/boot.rb
+++ b/plugins/providers/virtualbox/action/boot.rb
@@ -15,6 +15,9 @@ module VagrantPlugins
           env[:ui].info I18n.t("vagrant.actions.vm.boot.booting")
           env[:machine].provider.driver.start(boot_mode)
 
+          # Delay for comunicator start while os booting
+          sleep(env[:machine].config.vm.booting_wait)
+
           @app.call(env)
         end
       end


### PR DESCRIPTION
(Sorry for my english) I had a problem with getting IP v4 for a NAT adapter. The delay before the launch of the communicator solves this problem.