### PR TITLE
Ignore errors when generating new VM configuration

### DIFF
--- a/plugins/providers/hyperv/scripts/utils/VagrantVM/VagrantVM.psm1
+++ b/plugins/providers/hyperv/scripts/utils/VagrantVM/VagrantVM.psm1
@@ -85,7 +85,7 @@ function New-VagrantVMVMCX {
         VhdDestinationPath = Join-Path $DataPath "Virtual Hard Disks";
         VirtualMachinePath = $DataPath;
     }
-    $VMConfig = (Hyper-V\Compare-VM -Copy -GenerateNewID @NewVMConfig)
+    $VMConfig = (Hyper-V\Compare-VM -Copy -GenerateNewID @NewVMConfig -ErrorAction SilentlyContinue)
 
     # If the config is empty it means the import failed. Attempt to provide
     # context for failure


### PR DESCRIPTION
The default error action is to stop. When generating the initial
VM configuration during import, if the Compare-VM command fails
it results in a generic error message. Instead the error should
be ignored so the source VM can be inspected and a useful error
message can be returned to the user.

Fixes: #10384 