### PR TITLE
Fixes #10393: Only use Shellwords on non-windows hosts

### DIFF
--- a/lib/vagrant/plugin/v2/trigger.rb
+++ b/lib/vagrant/plugin/v2/trigger.rb
@@ -161,7 +161,11 @@ module Vagrant
         # @param [Provisioners::Shell::Config] config A Shell provisioner config
         def run(config, on_error, exit_codes)
           if config.inline
-            cmd = Shellwords.split(config.inline)
+            if Vagrant::Util::Platform.windows?
+              cmd = config.inline
+            else
+              cmd = Shellwords.split(config.inline)
+            end
 
             @machine.ui.detail(I18n.t("vagrant.trigger.run.inline", command: config.inline))
           else

--- a/test/unit/vagrant/plugin/v2/trigger_test.rb
+++ b/test/unit/vagrant/plugin/v2/trigger_test.rb
@@ -181,7 +181,7 @@ describe Vagrant::Plugin::V2::Trigger do
       exit_codes = trigger.exit_codes
 
       expect(Vagrant::Util::PowerShell).to receive(:execute_inline).
-        with("echo", "hi", options)
+        with("echo 'hi'", options)
       subject.send(:run, shell_config, on_error, exit_codes)
     end
 


### PR DESCRIPTION
This commit updates how the trigger `run` inline option works by only
applying `Shellwords.split` to the inline command if it is going to be
run on non-Windows hosts. Otherwise pass the inline script directly to
be executed by Powershell.