### PR TITLE
Disable automatic checkpoints prior to VM removal

### DIFF
--- a/plugins/providers/hyperv/scripts/delete_vm.ps1
+++ b/plugins/providers/hyperv/scripts/delete_vm.ps1
@@ -9,6 +9,9 @@ $ErrorActionPreference = "Stop"
 
 try {
     $VM = Hyper-V\Get-VM -Id $VmId
+    if((Get-Command Hyper-V\Set-VM).Parameters["AutomaticCheckpointsEnabled"] -ne $null) {
+        Hyper-V\Set-VM -VM $VM -AutomaticCheckpointsEnabled $false -ErrorAction SilentlyContinue
+    }
     Hyper-V\Remove-VM $VM -Force
 } catch {
     Write-ErrorMessage "Failed to delete VM: ${PSItem}"


### PR DESCRIPTION
Found that vhdx files can be locked preventing removal when automatic checkpoints are enabled. After the VM is deleted, the checkpoint data is written to the file which is the underlying cause of the lock. This update simply disables automatic checkpoints before deleting the VM.

Fixes: #8754 
