### PR TITLE
Fix ordering of dnf commands based on package existance

### DIFF
--- a/plugins/guests/redhat/cap/nfs_client.rb
+++ b/plugins/guests/redhat/cap/nfs_client.rb
@@ -6,9 +6,9 @@ module VagrantPlugins
           machine.communicate.sudo <<-EOH.gsub(/^ {12}/, '')
             if command -v dnf; then
               if `dnf info -q libnfs-utils > /dev/null 2>&1` ; then 
-                dnf -y install nfs-utils libnfs-utils portmap
-              else
                 dnf -y install nfs-utils nfs-utils-lib portmap
+              else
+                dnf -y install nfs-utils libnfs-utils portmap
               fi
             else
               yum -y install nfs-utils nfs-utils-lib portmap


### PR DESCRIPTION
Consider:
% if `dnf info -q non-existant-package > /dev/null 2>&1` ; then
then> echo "package exists"
then> else
else> echo "package does not exist"
else> fi
package does not exist

The snippet in nfs_client.rb assumed the reverse.  Breaking nfs
mounting for fedora guests.