### PR TITLE
Fixes #10432: Validate that provider file exists prior to upload

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -160,6 +160,10 @@ module Vagrant
       error_key(:box_config_changing_box)
     end
 
+    class BoxFileNotExist < VagrantError
+      error_key(:box_file_not_exist)
+    end
+
     class BoxMetadataCorrupted < VagrantError
       error_key(:box_metadata_corrupted)
     end

--- a/plugins/commands/cloud/publish.rb
+++ b/plugins/commands/cloud/publish.rb
@@ -9,7 +9,7 @@ module VagrantPlugins
           options = {}
 
           opts = OptionParser.new do |o|
-            o.banner = "Usage: vagrant cloud publish [options] organization/box-name version provider-name [provider-file]"
+            o.banner = "Usage: vagrant cloud publish [options] organization/box-name version provider-name provider-file"
             o.separator ""
             o.separator "Create and release a new Vagrant Box on Vagrant Cloud"
             o.separator ""
@@ -48,19 +48,26 @@ module VagrantPlugins
           # Parse the options
           argv = parse_options(opts)
           return if !argv
+
           if argv.empty? || argv.length > 4 || argv.length < 3
             raise Vagrant::Errors::CLIInvalidUsage,
               help: opts.help.chomp
           end
-
-          @client = VagrantPlugins::CloudCommand::Util.client_login(@env, options[:username])
 
           box = argv.first.split('/', 2)
           org = box[0]
           box_name = box[1]
           version = argv[1]
           provider_name = argv[2]
-          box_file = argv[3] # path expand
+          box_file = argv[3]
+
+          if !options[:url] && !File.file?(box_file)
+            raise Vagrant::Errors::BoxFileNotExist,
+              file: box_file
+          end
+
+          @client = VagrantPlugins::CloudCommand::Util.client_login(@env, options[:username])
+
           publish_box(org, box_name, version, provider_name, box_file, options, @client.token)
         end
 

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -568,6 +568,11 @@ en:
         a new box. This box, in turn, specified a different box. This isn't
         allowed, as it could lead to infinite recursion of Vagrant configuration
         loading. Please fix this.
+      box_file_not_exist: |-
+        The file you are attempting to upload does not exist. Please recheck
+        that the file exists and was passed in correctly.
+
+        File: %{file}
       box_metadata_corrupted: |-
         The metadata associated with the box '%{name}' appears corrupted.
         This is most often caused by a disk issue or system crash. Please

--- a/test/unit/plugins/commands/cloud/publish_test.rb
+++ b/test/unit/plugins/commands/cloud/publish_test.rb
@@ -38,12 +38,23 @@ describe VagrantPlugins::CloudCommand::Command::Publish do
     allow(VagrantCloud::Provider).to receive(:new).and_return(provider)
 
     allow(File).to receive(:absolute_path).and_return("/full/#{box_path}")
+    allow(File).to receive(:file?).and_return(true)
   end
 
   context "with no arguments" do
     it "shows help" do
       expect { subject.execute }.
         to raise_error(Vagrant::Errors::CLIInvalidUsage)
+    end
+  end
+
+  context "missing required arguments" do
+    let(:argv) { ["vagrant/box", "1.0.0", "virtualbox"] }
+
+    it "shows help" do
+      allow(File).to receive(:file?).and_return(false)
+      expect { subject.execute }.
+        to raise_error(Vagrant::Errors::BoxFileNotExist)
     end
   end
 


### PR DESCRIPTION
Prior to this commit, Vagrant would attempt to path expand a file that
didn't exist if it was left out of the passed in arguments and no
`--url` was used for external box uploading. This commit fixes that by
adding some additional validation for the passed in box file.