### PR TITLE
FreeBSD: Fix rcvar in network_static templates

### DIFF
--- a/templates/guests/freebsd/network_static.erb
+++ b/templates/guests/freebsd/network_static.erb
@@ -1,6 +1,6 @@
 #VAGRANT-BEGIN
 ifconfig_<%= options[:device] %>="inet <%= options[:ip] %> netmask <%= options[:netmask] %>"
 <% if options[:gateway] %>
-default_router="<%= options[:gateway] %>"
+defaultrouter="<%= options[:gateway] %>"
 <% end %>
 #VAGRANT-END

--- a/templates/guests/freebsd/network_static6.erb
+++ b/templates/guests/freebsd/network_static6.erb
@@ -1,6 +1,6 @@
 #VAGRANT-BEGIN
 ifconfig_<%= options[:device] %>_ipv6="inet6 <%= options[:ip] %> prefixlen <%= options[:netmask] %>"
 <% if options[:gateway] %>
-ipv6_default_router="<%= options[:gateway] %>"
+ipv6_defaultrouter="<%= options[:gateway] %>"
 <% end %>
 #VAGRANT-END

--- a/test/unit/templates/guests/freebsd/network_static_test.rb
+++ b/test/unit/templates/guests/freebsd/network_static_test.rb
@@ -28,7 +28,7 @@ describe "templates/guests/freebsd/network_static" do
     expect(result).to eq <<-EOH.gsub(/^ {6}/, "")
       #VAGRANT-BEGIN
       ifconfig_eth1="inet 1.1.1.1 netmask 255.255.0.0"
-      default_router="1.2.3.4"
+      defaultrouter="1.2.3.4"
       #VAGRANT-END
     EOH
   end


### PR DESCRIPTION
The rcvar should be `defaultrouter` instead:

https://www.freebsd.org/doc/handbook/network-routing.html