### PR TITLE
Fixes #10358: Add validation error in salt provider for certain options

### DIFF
--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -177,6 +177,10 @@ module VagrantPlugins
           errors << I18n.t("vagrant.provisioners.salt.python_version")
         end
 
+        if @version && !@install_type
+          errors << I18n.t("vagrant.provisioners.salt.version_type_missing")
+        end
+
         return {"salt provisioner" => errors}
       end
     end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2701,9 +2701,11 @@ en:
         must_accept_keys: |-
           You must accept keys when running highstate with master!
         args_array: |-
-          You must set this value as an array.
+          You must set `args_array` value as an array.
         python_version: |-
-          You must set this as an integer or string that represents an integer.
+          You must set `python_version` as an integer or string that represents an integer.
+        version_type_missing: |-
+          You must set the option `install_type` when specifying a `version`.
 
     pushes:
       file:


### PR DESCRIPTION
Prior to this commit, if you specified a `version` for the salt provider
but no `install_type` Vagrant would fail to pass the proper parameters
to the bootstrap install script. This commit fixes that by adding some
validation to the salt provider if `version` is specified but not
`install_type`. It also adds some extra context for certain config
validation error messages so that the user knows what option was
incorrect, rather than the message just referring to the option as
*this*.