### PR TITLE
Use |> redirect operator

### DIFF
--- a/plugins/guests/darwin/cap/change_host_name.rb
+++ b/plugins/guests/darwin/cap/change_host_name.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
 
               # Prepend ourselves to /etc/hosts - sed on bsd is sad
               grep -w '#{name}' /etc/hosts || {
-                echo -e '127.0.0.1\\t#{name}\\t#{basename}' | cat - /etc/hosts > /tmp/tmp-hosts &&
+                echo -e '127.0.0.1\\t#{name}\\t#{basename}' | cat - /etc/hosts >| /tmp/tmp-hosts &&
                   mv /tmp/tmp-hosts /etc/hosts
               }
             EOH

--- a/plugins/guests/darwin/cap/configure_networks.rb
+++ b/plugins/guests/darwin/cap/configure_networks.rb
@@ -62,8 +62,8 @@ module VagrantPlugins
 
           machine.communicate.tap do |comm|
             comm.sudo("networksetup -detectnewhardware")
-            comm.sudo("networksetup -listnetworkserviceorder > /tmp/vagrant.interfaces")
-            comm.sudo("networksetup -listallhardwareports > /tmp/vagrant.hardware")
+            comm.sudo("networksetup -listnetworkserviceorder >| /tmp/vagrant.interfaces")
+            comm.sudo("networksetup -listallhardwareports >| /tmp/vagrant.hardware")
             comm.download("/tmp/vagrant.interfaces", tmp_ints)
             comm.download("/tmp/vagrant.hardware", tmp_hw)
           end

--- a/plugins/guests/debian/cap/change_host_name.rb
+++ b/plugins/guests/debian/cap/change_host_name.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
             basename = name.split(".", 2)[0]
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
               # Set the hostname
-              echo '#{basename}' > /etc/hostname
+              echo '#{basename}' >| /etc/hostname
 
               # Prepend ourselves to /etc/hosts
               grep -w '#{name}' /etc/hosts || {
@@ -28,7 +28,7 @@ module VagrantPlugins
               }
 
               # Update mailname
-              echo '#{name}' > /etc/mailname
+              echo '#{name}' >| /etc/mailname
 
             EOH
 

--- a/plugins/guests/debian/cap/configure_networks.rb
+++ b/plugins/guests/debian/cap/configure_networks.rb
@@ -146,13 +146,13 @@ module VagrantPlugins
           # Reconfigure /etc/network/interfaces.
           commands << <<-EOH.gsub(/^ {12}/, "")
             # Remove any previous network modifications from the interfaces file
-            sed -e '/^#VAGRANT-BEGIN/,$ d' /etc/network/interfaces > /tmp/vagrant-network-interfaces.pre
-            sed -ne '/^#VAGRANT-END/,$ p' /etc/network/interfaces | tac | sed -e '/^#VAGRANT-END/,$ d' | tac > /tmp/vagrant-network-interfaces.post
+            sed -e '/^#VAGRANT-BEGIN/,$ d' /etc/network/interfaces >| /tmp/vagrant-network-interfaces.pre
+            sed -ne '/^#VAGRANT-END/,$ p' /etc/network/interfaces | tac | sed -e '/^#VAGRANT-END/,$ d' | tac >| /tmp/vagrant-network-interfaces.post
             cat \\
               /tmp/vagrant-network-interfaces.pre \\
               /tmp/vagrant-network-entry \\
               /tmp/vagrant-network-interfaces.post \\
-              > /etc/network/interfaces
+              >| /etc/network/interfaces
             rm -f /tmp/vagrant-network-interfaces.pre
             rm -f /tmp/vagrant-network-entry
             rm -f /tmp/vagrant-network-interfaces.post

--- a/plugins/guests/freebsd/cap/change_host_name.rb
+++ b/plugins/guests/freebsd/cap/change_host_name.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
 
               # Prepend ourselves to /etc/hosts
               grep -w '#{name}' /etc/hosts || {
-                echo -e '127.0.0.1\\t#{name}\\t#{basename}' | cat - /etc/hosts > /tmp/tmp-hosts
+                echo -e '127.0.0.1\\t#{name}\\t#{basename}' | cat - /etc/hosts >| /tmp/tmp-hosts
                 mv /tmp/tmp-hosts /etc/hosts
               }
             EOH

--- a/plugins/guests/gentoo/cap/change_host_name.rb
+++ b/plugins/guests/gentoo/cap/change_host_name.rb
@@ -15,12 +15,12 @@ module VagrantPlugins
                 systemctl set-hostname '#{name}'
               else
                 hostname '#{basename}'
-                echo "hostname=#{basename}" > /etc/conf.d/hostname
+                echo "hostname=#{basename}" >| /etc/conf.d/hostname
               fi
 
               # Prepend ourselves to /etc/hosts
               grep -w '#{name}' /etc/hosts || {
-                echo -e '127.0.0.1\\t#{name}\\t#{basename}' | cat - /etc/hosts > /tmp/tmp-hosts &&
+                echo -e '127.0.0.1\\t#{name}\\t#{basename}' | cat - /etc/hosts >| /tmp/tmp-hosts &&
                   mv /tmp/tmp-hosts /etc/hosts
               }
             EOH

--- a/plugins/guests/netbsd/cap/change_host_name.rb
+++ b/plugins/guests/netbsd/cap/change_host_name.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
         def self.change_host_name(machine, name)
           if !machine.communicate.test("hostname -s | grep '^#{name}$'")
             machine.communicate.sudo(<<CMDS, {shell: "sh"})
-sed -e 's/^hostname=.*$/hostname=#{name}/' /etc/rc.conf > /tmp/rc.conf.vagrant_changehostname_#{name} &&
+sed -e 's/^hostname=.*$/hostname=#{name}/' /etc/rc.conf >| /tmp/rc.conf.vagrant_changehostname_#{name} &&
 mv /tmp/rc.conf.vagrant_changehostname_#{name} /etc/rc.conf &&
 hostname #{name}
 CMDS

--- a/plugins/guests/omnios/cap/change_host_name.rb
+++ b/plugins/guests/omnios/cap/change_host_name.rb
@@ -9,12 +9,12 @@ module VagrantPlugins
             basename = name.split(".", 2)[0]
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
               # Set hostname
-              echo '#{name}' > /etc/nodename
+              echo '#{name}' >| /etc/nodename
               hostname '#{name}'
 
               # Prepend ourselves to /etc/hosts
               grep -w '#{name}' /etc/hosts || {
-                echo -e '127.0.0.1\\t#{name}\\t#{basename}' | cat - /etc/hosts > /tmp/tmp-hosts
+                echo -e '127.0.0.1\\t#{name}\\t#{basename}' | cat - /etc/hosts >| /tmp/tmp-hosts
                 mv /tmp/tmp-hosts /etc/hosts
               }
             EOH

--- a/plugins/guests/openbsd/cap/change_host_name.rb
+++ b/plugins/guests/openbsd/cap/change_host_name.rb
@@ -11,11 +11,11 @@ module VagrantPlugins
               # Set the hostname
               hostname '#{name}'
               sed -i'' 's/^hostname=.*$/hostname=\"#{name}\"/' /etc/rc.conf
-              echo '#{name}' > /etc/myname
+              echo '#{name}' >| /etc/myname
 
               # Prepend ourselves to /etc/hosts
               grep -w '#{name}' /etc/hosts || {
-                echo -e '127.0.0.1\\t#{name}\\t#{basename}' | cat - /etc/hosts > /tmp/tmp-hosts
+                echo -e '127.0.0.1\\t#{name}\\t#{basename}' | cat - /etc/hosts >| /tmp/tmp-hosts
                 mv /tmp/tmp-hosts /etc/hosts
               }
             EOH

--- a/plugins/guests/photon/cap/change_host_name.rb
+++ b/plugins/guests/photon/cap/change_host_name.rb
@@ -9,7 +9,7 @@ module VagrantPlugins
             basename = name.split(".", 2)[0]
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
               # Set the hostname
-              echo '#{name}' > /etc/hostname
+              echo '#{name}' >| /etc/hostname
               hostname '#{name}'
 
               # Prepend ourselves to /etc/hosts

--- a/plugins/guests/redhat/cap/change_host_name.rb
+++ b/plugins/guests/redhat/cap/change_host_name.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
               # Update DNS
               sed -i 's/\\(DHCP_HOSTNAME=\\).*/\\1\"#{basename}\"/' /etc/sysconfig/network-scripts/ifcfg-*
               # Set the hostname - use hostnamectl if available
-              echo '#{name}' > /etc/hostname
+              echo '#{name}' >| /etc/hostname
               grep -w '#{name}' /etc/hosts || {
                 sed -i'' '1i 127.0.0.1\\t#{name}\\t#{basename}' /etc/hosts
               }

--- a/plugins/guests/slackware/cap/change_host_name.rb
+++ b/plugins/guests/slackware/cap/change_host_name.rb
@@ -10,7 +10,7 @@ module VagrantPlugins
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
               # Set the hostname
               chmod o+w /etc/hostname
-              echo '#{name}' > /etc/hostname
+              echo '#{name}' >| /etc/hostname
               chmod o-w /etc/hostname
               hostname -F /etc/hostname
 

--- a/plugins/guests/smartos/cap/change_host_name.rb
+++ b/plugins/guests/smartos/cap/change_host_name.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
                 #{sudo} sed -i '' 's/hostname=.*/hostname=#{name}/' /usbkey/config
               fi
 
-              #{sudo} echo '#{name}' > /etc/nodename
+              #{sudo} echo '#{name}' >| /etc/nodename
               #{sudo} hostname #{name}
             EOH
           end

--- a/plugins/guests/smartos/cap/configure_networks.rb
+++ b/plugins/guests/smartos/cap/configure_networks.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
             if network[:type].to_sym == :static
               machine.communicate.execute("#{ifconfig_cmd} inet #{network[:ip]} netmask #{network[:netmask]}")
               machine.communicate.execute("#{ifconfig_cmd} up")
-              machine.communicate.execute("#{su_cmd} sh -c \"echo '#{network[:ip]}' > /etc/hostname.#{device}\"")
+              machine.communicate.execute("#{su_cmd} sh -c \"echo '#{network[:ip]}' >| /etc/hostname.#{device}\"")
             elsif network[:type].to_sym == :dhcp
               machine.communicate.execute("#{ifconfig_cmd} dhcp start")
             end

--- a/plugins/guests/solaris/cap/change_host_name.rb
+++ b/plugins/guests/solaris/cap/change_host_name.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
 
           # Only do this if the hostname is not already set
           if !machine.communicate.test("#{su_cmd} hostname | grep '#{name}'")
-            machine.communicate.execute("#{su_cmd} sh -c \"echo '#{name}' > /etc/nodename\"")
+            machine.communicate.execute("#{su_cmd} sh -c \"echo '#{name}' >| /etc/nodename\"")
             machine.communicate.execute("#{su_cmd} uname -S #{name}")
           end
         end

--- a/plugins/guests/solaris/cap/configure_networks.rb
+++ b/plugins/guests/solaris/cap/configure_networks.rb
@@ -13,7 +13,7 @@ module VagrantPlugins
             if network[:type].to_sym == :static
               machine.communicate.execute("#{ifconfig_cmd} inet #{network[:ip]} netmask #{network[:netmask]}")
               machine.communicate.execute("#{ifconfig_cmd} up")
-              machine.communicate.execute("#{su_cmd} sh -c \"echo '#{network[:ip]}' > /etc/hostname.#{device}\"")
+              machine.communicate.execute("#{su_cmd} sh -c \"echo '#{network[:ip]}' >| /etc/hostname.#{device}\"")
             elsif network[:type].to_sym == :dhcp
               machine.communicate.execute("#{ifconfig_cmd} dhcp start")
             end

--- a/plugins/guests/suse/cap/change_host_name.rb
+++ b/plugins/guests/suse/cap/change_host_name.rb
@@ -8,7 +8,7 @@ module VagrantPlugins
           if !comm.test("hostname -f | grep '^#{name}$'", sudo: false)
             basename = name.split(".", 2)[0]
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
-              echo '#{basename}' > /etc/HOSTNAME
+              echo '#{basename}' >| /etc/HOSTNAME
               hostname '#{basename}'
 
               # Prepend ourselves to /etc/hosts

--- a/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
@@ -27,7 +27,7 @@ module VagrantPlugins
 install_backports_if_wheezy_release = <<INLINE_CRIPT
 CODENAME=`lsb_release -cs`
 if [ x$CODENAME == 'xwheezy' ]; then
-  echo 'deb http://http.debian.net/debian wheezy-backports main' > /etc/apt/sources.list.d/wheezy-backports.list
+  echo 'deb http://http.debian.net/debian wheezy-backports main' >| /etc/apt/sources.list.d/wheezy-backports.list
 fi
 INLINE_CRIPT
 

--- a/test/unit/plugins/guests/debian/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/debian/cap/change_host_name_test.rb
@@ -37,7 +37,7 @@ describe "VagrantPlugins::GuestDebian::Cap::ChangeHostName" do
     it "sets the hostname if not set" do
       comm.stub_command("hostname -f | grep '^#{name}$'", exit_code: 1)
       cap.change_host_name(machine, name)
-      expect(comm.received_commands[1]).to match(/echo 'banana-rama' > \/etc\/hostname/)
+      expect(comm.received_commands[1]).to match(/echo 'banana-rama' >| \/etc\/hostname/)
     end
 
     context "when hostnamectl is in use" do

--- a/test/unit/plugins/guests/omnios/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/omnios/cap/change_host_name_test.rb
@@ -27,7 +27,7 @@ describe "VagrantPlugins::GuestOmniOS::Cap:RSync" do
       comm.stub_command("hostname -f | grep '^#{name}$'", exit_code: 1)
       cap.change_host_name(machine, name)
 
-      expect(comm.received_commands[1]).to match(/echo '#{name}' > \/etc\/nodename/)
+      expect(comm.received_commands[1]).to match(/echo '#{name}' >| \/etc\/nodename/)
       expect(comm.received_commands[1]).to match(/hostname '#{name}'/)
     end
 

--- a/test/unit/plugins/guests/photon/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/photon/cap/change_host_name_test.rb
@@ -29,7 +29,7 @@ describe "VagrantPlugins::GuestPhoton::Cap::ChangeHostName" do
       comm.stub_command("hostname -f | grep '^#{name}$'", exit_code: 1)
 
       cap.change_host_name(machine, name)
-      expect(comm.received_commands[1]).to match(/echo '#{name}' > \/etc\/hostname/)
+      expect(comm.received_commands[1]).to match(/echo '#{name}' >| \/etc\/hostname/)
       expect(comm.received_commands[1]).to match(/hostname '#{name}'/)
     end
 

--- a/test/unit/plugins/guests/slackware/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/slackware/cap/change_host_name_test.rb
@@ -27,7 +27,7 @@ describe "VagrantPlugins::GuestSlackware::Cap::ChangeHostName" do
       comm.stub_command("hostname -f | grep '^#{name}$'", exit_code: 1)
 
       cap.change_host_name(machine, name)
-      expect(comm.received_commands[1]).to match(/echo '#{name}' > \/etc\/hostname/)
+      expect(comm.received_commands[1]).to match(/echo '#{name}' >| \/etc\/hostname/)
       expect(comm.received_commands[1]).to match(/hostname -F \/etc\/hostname/)
     end
 

--- a/test/unit/plugins/guests/smartos/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/smartos/cap/change_host_name_test.rb
@@ -32,7 +32,7 @@ describe "VagrantPlugins::GuestSmartos::Cap::ChangeHostName" do
       expect(comm.received_commands[0]).to match(/if \[ -d \/usbkey \] && \[ "\$\(zonename\)" == "global" \] ; then/)
       expect(comm.received_commands[0]).to match(/pfexec sed -i '' 's\/hostname=\.\*\/hostname=testhost\/' \/usbkey\/config/)
       expect(comm.received_commands[0]).to match(/fi/)
-      expect(comm.received_commands[0]).to match(/pfexec echo 'testhost' > \/etc\/nodename/)
+      expect(comm.received_commands[0]).to match(/pfexec echo 'testhost' >| \/etc\/nodename/)
       expect(comm.received_commands[0]).to match(/pfexec hostname testhost/)
     end
   end

--- a/test/unit/plugins/guests/smartos/cap/configure_networks_test.rb
+++ b/test/unit/plugins/guests/smartos/cap/configure_networks_test.rb
@@ -52,7 +52,7 @@ describe "VagrantPlugins::VagrantPlugins::Cap::ConfigureNetworks" do
       end
 
       it "starts writes out a hostname file" do
-        communicator.expect_command(%Q(pfexec sh -c "echo '1.1.1.1' > /etc/hostname.#{device}"))
+        communicator.expect_command(%Q(pfexec sh -c "echo '1.1.1.1' >| /etc/hostname.#{device}"))
         plugin.configure_networks(machine, [network])
       end
     end

--- a/test/unit/plugins/guests/suse/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/suse/cap/change_host_name_test.rb
@@ -28,7 +28,7 @@ describe "VagrantPlugins::GuestSUSE::Cap::ChangeHostName" do
       comm.stub_command("hostname -f | grep '^#{name}$'", exit_code: 1)
 
       cap.change_host_name(machine, name)
-      expect(comm.received_commands[1]).to match(/echo '#{basename}' > \/etc\/HOSTNAME/)
+      expect(comm.received_commands[1]).to match(/echo '#{basename}' >| \/etc\/HOSTNAME/)
       expect(comm.received_commands[1]).to match(/hostname '#{basename}'/)
     end
 


### PR DESCRIPTION
When booting Vagrant, I get the following error message when trying to set the hostname:

```
==> dev: Checking for guest additions in VM...
==> dev: Setting hostname...
The following SSH command responded with a non-zero exit status.
Vagrant assumes that this means the command failed!

# Set the hostname
echo 'dev' > /etc/hostname

# Prepend ourselves to /etc/hosts
grep -w 'dev' /etc/hosts || {
  if grep -w '^127\.0\.1\.1' /etc/hosts ; then
    sed -i'' 's/^127\.0\.1\.1\s.*$/127.0.1.1\tdev\tdev/' /etc/hosts
  else
    sed -i'' '1i 127.0.1.1\tdev\tdev' /etc/hosts
  fi
}

# Update mailname
echo 'dev' > /etc/mailname



Stdout from the command:

192.168.1.101  switch-dev


Stderr from the command:

bash: line 6: /etc/hostname: cannot overwrite existing file
bash: line 18: /etc/mailname: cannot overwrite existing file
```

The reason is that I have configured the root account to use noclobber, `set -o noclobber`. This prevents overwriting files using the `>` redirection operator.

While this configuration is somewhat unusual, it is easy to support by just using the `>|` operator instead.

I am not sure whether this operator is supported everywhere, but it is old feature, and it is supported by at least bash, zsh, ksh and tcsh.

An alternative (more conservative) approach is to simply remove the file before writing to it using `>`.