### PR TITLE
Fixes #9593: Ensure temp dir for package command is cleaned up

### DIFF
--- a/plugins/commands/package/command.rb
+++ b/plugins/commands/package/command.rb
@@ -87,7 +87,10 @@ module VagrantPlugins
           acc
         end
 
-        vm.action(:package, opts)
+        env = vm.action(:package, opts)
+        temp_dir = env["export.temp_dir"]
+      ensure
+        FileUtils.rm_rf(temp_dir) if temp_dir
       end
     end
   end

--- a/test/unit/plugins/commands/package/command_test.rb
+++ b/test/unit/plugins/commands/package/command_test.rb
@@ -109,6 +109,24 @@ describe VagrantPlugins::CommandPackage::Command do
         end
       end
     end
+  end
 
+  describe "#package_vm" do
+    context "calling the package action" do
+      let(:options) { {output: "test.box"} }
+      let(:expected_options) { {"package.output"=>"test.box"} }
+      let(:machine) { double("machine") }
+      let(:tmp_dir) { "/home/user/.vagrant.d/tmp/vagrant-package" }
+      let(:env) { {"export.temp_dir"=>tmp_dir} }
+
+      it "ensures that the package tmp dir is cleaned up" do
+        allow(FileUtils).to receive(:rm_rf).and_return(true)
+        allow(machine).to receive(:action).with(:package, expected_options).
+          and_return(env)
+
+        expect(FileUtils).to receive(:rm_rf).with(tmp_dir)
+        package_command.send(:package_vm, machine, options)
+      end
+    end
   end
 end


### PR DESCRIPTION
Prior to this commit, the package actions would create a temp dir in
the process of packaging and compressing a Vagrant box. This commit
ensures that the temp dir is removed once the command has completed so
that it doesn't leave around lots of temp directories.