### PR TITLE
Fixes #10463: Display version update on stderr instead of stdout

### DIFF
--- a/lib/vagrant/util/checkpoint_client.rb
+++ b/lib/vagrant/util/checkpoint_client.rb
@@ -159,11 +159,11 @@ module Vagrant
       def version_check
         latest_version = Gem::Version.new(result["current_version"])
         installed_version = Gem::Version.new(VERSION)
-        ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Basic.new, "vagrant")
+        ui = Vagrant::UI::Prefixed.new(env.ui, "vagrant")
         if latest_version > installed_version
           @logger.info("new version of Vagrant available - #{latest_version}")
-          ui.error(I18n.t("vagrant.version_upgrade_available", latest_version: latest_version, installed_version: installed_version))
-          env.ui.error("")
+          ui.info(I18n.t("vagrant.version_upgrade_available", latest_version: latest_version, installed_version: installed_version), channel: :error)
+          env.ui.info("", channel: :error)
         else
           @logger.debug("vagrant is currently up to date")
         end

--- a/lib/vagrant/util/checkpoint_client.rb
+++ b/lib/vagrant/util/checkpoint_client.rb
@@ -159,11 +159,11 @@ module Vagrant
       def version_check
         latest_version = Gem::Version.new(result["current_version"])
         installed_version = Gem::Version.new(VERSION)
-        ui = Vagrant::UI::Prefixed.new(env.ui, "vagrant")
+        ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Basic.new, "vagrant")
         if latest_version > installed_version
           @logger.info("new version of Vagrant available - #{latest_version}")
-          ui.info(I18n.t("vagrant.version_upgrade_available", latest_version: latest_version, installed_version: installed_version))
-          env.ui.info("")
+          ui.error(I18n.t("vagrant.version_upgrade_available", latest_version: latest_version, installed_version: installed_version))
+          env.ui.error("")
         else
           @logger.debug("vagrant is currently up to date")
         end

--- a/test/unit/vagrant/util/checkpoint_client_test.rb
+++ b/test/unit/vagrant/util/checkpoint_client_test.rb
@@ -175,7 +175,7 @@ describe Vagrant::Util::CheckpointClient do
       let(:result) { {"current_version" => new_version} }
 
       it "should not display upgrade information" do
-        expect(prefixed_ui).not_to receive(:info).at_least(:once)
+        expect(prefixed_ui).not_to receive(:error).at_least(:once)
         subject.version_check
       end
     end

--- a/test/unit/vagrant/util/checkpoint_client_test.rb
+++ b/test/unit/vagrant/util/checkpoint_client_test.rb
@@ -175,7 +175,7 @@ describe Vagrant::Util::CheckpointClient do
       let(:result) { {"current_version" => new_version} }
 
       it "should not display upgrade information" do
-        expect(prefixed_ui).not_to receive(:error).at_least(:once)
+        expect(prefixed_ui).not_to receive(:info).at_least(:once)
         subject.version_check
       end
     end


### PR DESCRIPTION
This commit updates the behavior of printing the checkpoint version
check for Vagrant. To allow users to filter out the message, it updates
the version check to go to stderr. It updates the UI class for printing
the version check to be a "basic" class, so that the message continues
to be the same color instead of a red error message.