### PR TITLE
Adjust requirement on warnings for VirtualBox NIC

### DIFF
--- a/plugins/providers/virtualbox/action/set_default_nic_type.rb
+++ b/plugins/providers/virtualbox/action/set_default_nic_type.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
       class SetDefaultNICType
         # Defines versions of VirtualBox with susceptible implementation
         # of the E1000 devices.
-        E1000_SUSCEPTIBLE = Gem::Requirement.new("<= 5.2.22").freeze
+        E1000_SUSCEPTIBLE = Gem::Requirement.new("< 5.2.22").freeze
 
         def initialize(app, env)
           @logger = Log4r::Logger.new("vagrant::plugins::virtualbox::set_default_nic_type")

--- a/test/unit/plugins/providers/virtualbox/action/set_default_nic_type_test.rb
+++ b/test/unit/plugins/providers/virtualbox/action/set_default_nic_type_test.rb
@@ -91,7 +91,7 @@ describe VagrantPlugins::ProviderVirtualBox::Action::SetDefaultNICType do
     end
 
     context "when virtualbox version is has susceptible E1000" do
-      let(:virtualbox_version) { "5.2.22" }
+      let(:virtualbox_version) { "5.2.21" }
 
       it "should output a warning" do
         expect(machine.ui).to receive(:warn)


### PR DESCRIPTION
The changeset _did_ get included in the 5.2.22 release so adjust
the requirement to only warn on previous versions

Fixes #10481