### PR TITLE
Only prepare 10 shares per command to prevent exceeding allowed command size

### DIFF
--- a/test/unit/plugins/hosts/windows/cap/smb_test.rb
+++ b/test/unit/plugins/hosts/windows/cap/smb_test.rb
@@ -228,6 +228,18 @@ Remark     Not Vagrant Owned
         expect(machine.env.ui).not_to receive(:warn)
       end
     end
+
+    context "when more than 10 shares are defined" do
+      let(:folders) {
+        Hash[12.times.map{|i| ["/path#{i}", {hostpath: "/host#{i}"}]}]
+      }
+
+      after{ subject.smb_prepare(env, machine, folders, options) }
+
+      it "should execute multiple powershell commands" do
+        expect(Vagrant::Util::PowerShell).to receive(:execute).twice.with(any_args, sudo: true)
+      end
+    end
   end
 
   describe ".get_smbshares" do


### PR DESCRIPTION
When a large number of shares are defined it may cause the generated
command to exceed the maximum allowed length. To prevent this, only
allow 10 shares to be processed at a time.

Fixes #10483