### PR TITLE
Update behavior of `snapshot restore` and `snapshot pop`

### DIFF
--- a/plugins/commands/snapshot/command/pop.rb
+++ b/plugins/commands/snapshot/command/pop.rb
@@ -17,6 +17,9 @@ module VagrantPlugins
         def execute
           options = {}
           options[:snapshot_delete] = true
+          options[:provision_ignore_sentinel] = false
+          options[:snapshot_start] = true
+
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant snapshot pop [options] [vm-name]"
             o.separator ""
@@ -25,6 +28,9 @@ module VagrantPlugins
 
             o.on("--no-delete", "Don't delete the snapshot after the restore") do
                 options[:snapshot_delete] = false
+            end
+            o.on("--no-start", "Don't start the snapshot after the restore") do
+              options[:snapshot_start] = false
             end
           end
 

--- a/plugins/commands/snapshot/command/restore.rb
+++ b/plugins/commands/snapshot/command/restore.rb
@@ -13,12 +13,18 @@ module VagrantPlugins
 
         def execute
           options = {}
+          options[:provision_ignore_sentinel] = false
+          options[:snapshot_start] = true
 
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant snapshot restore [options] [vm-name] <name>"
             o.separator ""
             build_start_options(o, options)
             o.separator "Restore a snapshot taken previously with snapshot save."
+
+            o.on("--no-start", "Don't start the snapshot after the restore") do
+              options[:snapshot_start] = false
+            end
           end
 
           # Parse the options

--- a/plugins/providers/virtualbox/action.rb
+++ b/plugins/providers/virtualbox/action.rb
@@ -267,7 +267,11 @@ module VagrantPlugins
               end
             end
 
-            b2.use action_start
+            b2.use Call, IsEnvSet, :snapshot_start do |env2, b3|
+              if env2[:result]
+                b3.use action_start
+              end
+            end
           end
         end
       end

--- a/website/source/docs/cli/snapshot.html.md
+++ b/website/source/docs/cli/snapshot.html.md
@@ -56,6 +56,8 @@ the pushed state.
 * `--no-delete` - Prevents deletion of the snapshot after restoring
     (so that you can restore to the same point again later).
 
+* `--no-start` - Prevents the guest from being started after restore
+
 # Snapshot Save
 
 **Command: `vagrant snapshot save [vm-name] NAME`**
@@ -71,6 +73,8 @@ This command restores the named snapshot.
 
 * `--[no-]provision` - Force the provisioners to run (or prevent them
     from doing so).
+
+* `--no-start` - Prevents the guest from being started after restore
 
 # Snapshot List
 


### PR DESCRIPTION
Both of these commands failed to default the options disabling
the provisioning from ignoring the sentinel file. This resulted
in different behavior than what was seen with the `up` and
`resume` commands which would only provision items with run set
to "always". This defaults the options to proper match the behavior
of `up` and `resume` to be consistent.

This also adds an extra `--no-start` flag to allow users to restore
a snapshot but not start the restored guest immediately.

Fixes #6752