### PR TITLE
Use specific Vagrant box in tutorial setup

### DIFF
--- a/website/source/intro/getting-started/project_setup.html.md
+++ b/website/source/intro/getting-started/project_setup.html.md
@@ -25,7 +25,7 @@ please follow along in your terminal:
 ```
 $ mkdir vagrant_getting_started
 $ cd vagrant_getting_started
-$ vagrant init
+$ vagrant init hasicorp/precise64
 ```
 
 This will place a `Vagrantfile` in your current directory. You can


### PR DESCRIPTION
This commit ensures that a proper box is used during the project setup
tutorial. Otherwise later down the road uesrs will run into Vagrant
saying that the box `base` doesn't exist.