### PR TITLE
Validate hostnamectl command is in working state

### DIFF
--- a/lib/vagrant/util/guest_inspection.rb
+++ b/lib/vagrant/util/guest_inspection.rb
@@ -36,8 +36,12 @@ module Vagrant
         #
         # @param [Vagrant::Plugin::V2::Communicator] comm Guest communicator
         # @return [Boolean]
+        # NOTE: This test includes actually calling `hostnamectl` to verify
+        # that it is in working order. This prevents attempts to use the
+        # hostnamectl command when it is available, but dbus is not which
+        # renders the command useless
         def hostnamectl?(comm)
-          comm.test("command -v hostnamectl")
+          comm.test("command -v hostnamectl && hostnamectl")
         end
 
         ## netplan helpers


### PR DESCRIPTION
When checking if the hostnamectl command should be used for configuring
the guest hostname, ensure the command returns a valid result. The
hostnamectl command relies on dbus and if dbus is not available the
command will simply fail.

Fixes #10501