### PR TITLE
Fixes #10509:  Catch InvalidVersion errors from vagrant_cloud client

### DIFF
--- a/plugins/commands/cloud/publish.rb
+++ b/plugins/commands/cloud/publish.rb
@@ -127,6 +127,10 @@ module VagrantPlugins
               @env.ui.error(e)
               return 1
             end
+          rescue VagrantCloud::InvalidVersion => e
+            @env.ui.error(I18n.t("cloud_command.errors.publish.fail", org: org, box_name: box_name))
+            @env.ui.error(e)
+            return 1
           end
 
           begin

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency "winrm", "~> 2.1"
   s.add_dependency "winrm-fs", "~> 1.0"
   s.add_dependency "winrm-elevated", "~> 1.1"
-  s.add_dependency "vagrant_cloud", "~> 2.0.0"
+  s.add_dependency "vagrant_cloud", "~> 2.0.2"
 
   # NOTE: The ruby_dep gem is an implicit dependency from the listen gem. Later versions
   # of the ruby_dep gem impose an aggressive constraint on the required ruby version (>= 2.2.5).


### PR DESCRIPTION
This pull request adds a new rescue to the `publish` command for when the
client detects an invalid version prior to making the API request to
create that version.

It also bumps the version dependency of `vargant_cloud` to 2.0.2, which hasn't been released yet. This is required as the new error namespace is in that version.

Relies on this being merged/released: https://github.com/hashicorp/vagrant_cloud/pull/45

Fixes #10509