### PR TITLE
Fix guest network configuration by properly extracting extra options

### DIFF
--- a/plugins/guests/alt/cap/configure_networks.rb
+++ b/plugins/guests/alt/cap/configure_networks.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
           end.compact
           networks.each.with_index do |network, i|
             network[:device] = interfaces[network[:interface]]
-            extra_opts = net_configs[i].dup || {}
+            extra_opts = net_configs[i] ? net_configs[i].dup : {}
 
             if nmcli_installed
               # Now check if the device is actively being managed by NetworkManager

--- a/plugins/guests/alt/cap/configure_networks.rb
+++ b/plugins/guests/alt/cap/configure_networks.rb
@@ -19,9 +19,12 @@ module VagrantPlugins
 
           # Check if NetworkManager is installed on the system
           nmcli_installed = nmcli?(comm)
+          net_configs = machine.config.vm.networks.map do |type, opts|
+            opts if type.to_s.end_with?("_network")
+          end.compact
           networks.each.with_index do |network, i|
             network[:device] = interfaces[network[:interface]]
-            extra_opts = machine.config.vm.networks[i].last.dup
+            extra_opts = net_configs[i].dup || {}
 
             if nmcli_installed
               # Now check if the device is actively being managed by NetworkManager
@@ -46,7 +49,7 @@ module VagrantPlugins
             end
 
             # Render a new configuration
-            template_options = network.merge(extra_opts)
+            template_options = extra_opts.merge(network)
 
             # ALT expects netmasks to be in the CIDR notation, but users may
             # specify IPV4 netmasks like "255.255.255.0". This magic converts

--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -24,7 +24,7 @@ module VagrantPlugins
           end.compact
           networks.each.with_index do |network, i|
             network[:device] = interfaces[network[:interface]]
-            extra_opts = net_configs[i].dup || {}
+            extra_opts = net_configs[i] ? net_configs[i].dup : {}
 
             if nmcli_installed
               # Now check if the device is actively being managed by NetworkManager

--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -19,9 +19,12 @@ module VagrantPlugins
 
           # Check if NetworkManager is installed on the system
           nmcli_installed = nmcli?(comm)
+          net_configs = machine.config.vm.networks.map do |type, opts|
+            opts if type.to_s.end_with?("_network")
+          end.compact
           networks.each.with_index do |network, i|
             network[:device] = interfaces[network[:interface]]
-            extra_opts = machine.config.vm.networks[i].last.dup
+            extra_opts = net_configs[i].dup || {}
 
             if nmcli_installed
               # Now check if the device is actively being managed by NetworkManager
@@ -47,7 +50,7 @@ module VagrantPlugins
 
             # Render a new configuration
             entry = TemplateRenderer.render("guests/redhat/network_#{network[:type]}",
-              options: network.merge(extra_opts),
+              options: extra_opts.merge(network),
             )
 
             # Upload the new configuration


### PR DESCRIPTION
Extra options are extracted from the machine configuration for the
network being configured to allow for customized network manager
behavior. The network entries must be filtered to remove non-network
entries (like port forwards) before accessing by index.

Related to #9546