### PR TITLE
Add reboot option to shell provisioner

### DIFF
--- a/plugins/provisioners/shell/config.rb
+++ b/plugins/provisioners/shell/config.rb
@@ -17,6 +17,7 @@ module VagrantPlugins
       attr_accessor :sensitive
       attr_accessor :powershell_args
       attr_accessor :powershell_elevated_interactive
+      attr_accessor :reboot
       attr_accessor :reset
 
       def initialize
@@ -32,6 +33,7 @@ module VagrantPlugins
         @keep_color            = UNSET_VALUE
         @name                  = UNSET_VALUE
         @sensitive             = UNSET_VALUE
+        @reboot                = UNSET_VALUE
         @reset                 = UNSET_VALUE
         @powershell_args       = UNSET_VALUE
         @powershell_elevated_interactive  = UNSET_VALUE
@@ -50,6 +52,7 @@ module VagrantPlugins
         @keep_color           = false if @keep_color == UNSET_VALUE
         @name                 = nil if @name == UNSET_VALUE
         @sensitive            = false if @sensitive == UNSET_VALUE
+        @reboot               = false if @reboot == UNSET_VALUE
         @reset                = false if @reset == UNSET_VALUE
         @powershell_args      = "-ExecutionPolicy Bypass" if @powershell_args == UNSET_VALUE
         @powershell_elevated_interactive = false if @powershell_elevated_interactive == UNSET_VALUE
@@ -71,7 +74,7 @@ module VagrantPlugins
         # Validate that the parameters are properly set
         if path && inline
           errors << I18n.t("vagrant.provisioners.shell.path_and_inline_set")
-        elsif !path && !inline && !reset
+        elsif !path && !inline && !reset && !reboot
           errors << I18n.t("vagrant.provisioners.shell.no_path_or_inline")
         end
 

--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -31,7 +31,11 @@ module VagrantPlugins
           provision_ssh(args)
         end
       ensure
-        @machine.communicate.reset! if config.reset
+        if config.reboot
+          @machine.guest.capability(:reboot)
+        else
+          @machine.communicate.reset! if config.reset
+        end
       end
 
       protected

--- a/test/unit/plugins/provisioners/shell/config_test.rb
+++ b/test/unit/plugins/provisioners/shell/config_test.rb
@@ -134,6 +134,14 @@ describe "VagrantPlugins::Shell::Config" do
       result = subject.validate(machine)
       expect(result["shell provisioner"]).to be_empty
     end
+
+    it "returns no error when inline and path are unset but reboot is true" do
+      subject.reboot = true
+      subject.finalize!
+
+      result = subject.validate(machine)
+      expect(result["shell provisioner"]).to be_empty
+    end
   end
 
   describe 'finalize!' do

--- a/website/source/docs/provisioning/shell.html.md
+++ b/website/source/docs/provisioning/shell.html.md
@@ -75,6 +75,9 @@ The remainder of the available options are optional:
   guests use a scheduled task to run as a true administrator without the
   WinRM limitations.
 
+* `reboot` (boolean) - Reboot the guest. This requires the guest to have a
+  reboot capability implemented.
+
 * `reset` (boolean) - Reset the communicator to the machine after completion. This
   is useful when a shell may need to be reloaded.
 


### PR DESCRIPTION
Adds a `reboot` option which allows the guest to be rebooted after
the completion of a shell provisioning task. The guest must support
the `:reboot` capability. Like the `reset` option, the `reboot`
option may be provided without defining `inline` or `file` options
when a reboot may be required between other provisioners.

Fixes #8639