### PR TITLE
Fix to check Salt plugin requirements in Windows

### DIFF
--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -75,9 +75,10 @@ module VagrantPlugins
         end
 
         found = true
+        binary_check = @machine.config.vm.communicator == :winrm ? "dir" : "which"
         for binary in desired_binaries
           @machine.env.ui.info "Checking if %s is installed" % binary
-          if !@machine.communicate.test("which %s" % binary)
+          if !@machine.communicate.test("%s %s" % [binary_check, binary])
             @machine.env.ui.info "%s was not found." % binary
             found = false
           else


### PR DESCRIPTION
Salt provisioner plugin will check if necessary binaries are installed with `dir` command in a Windows environment.  This prevents re-installation of Salt on every provision.

Fixes #10531 