### PR TITLE
Disabled salt provision required install_type check on Windows

### DIFF
--- a/plugins/provisioners/salt/config.rb
+++ b/plugins/provisioners/salt/config.rb
@@ -177,8 +177,11 @@ module VagrantPlugins
           errors << I18n.t("vagrant.provisioners.salt.python_version")
         end
 
-        if @version && !@install_type
-          errors << I18n.t("vagrant.provisioners.salt.version_type_missing")
+        # install_type is not supported in a Windows environment
+        if machine.config.vm.communicator != :winrm
+          if @version && !@install_type
+            errors << I18n.t("vagrant.provisioners.salt.version_type_missing")
+          end
         end
 
         return {"salt provisioner" => errors}

--- a/test/unit/plugins/provisioners/salt/config_test.rb
+++ b/test/unit/plugins/provisioners/salt/config_test.rb
@@ -156,5 +156,25 @@ describe VagrantPlugins::Salt::Config do
         expect(result[error_key]).to_not be_empty
       end
     end
+
+    context "version" do
+      it "is valid if is set without install_type on Windows" do
+        allow(machine.config.vm).to receive(:communicator).and_return(:winrm)
+
+        subject.version = "2018.3.3"
+        subject.finalize!
+
+        result = subject.validate(machine)
+        expect(result[error_key]).to be_empty
+      end
+
+      it "is invalid if is set without install_type on Linux" do
+        subject.version = "2018.3.3"
+        subject.finalize!
+
+        result = subject.validate(machine)
+        expect(result[error_key]).to_not be_empty
+      end
+    end
   end
 end


### PR DESCRIPTION
Salt provisioner will no longer require an unsupported argument on Windows when specifying `version`.

Fixes #10538

Note:  The Salt provisioner plugin does not currently support **winssh**.  I am matching the current convention for the plugin by only checking **winrm** to determine the guest OS.