### PR TITLE
ansible_ssh_host in the example is deprecated

### DIFF
--- a/website/source/docs/provisioning/ansible_local.html.md
+++ b/website/source/docs/provisioning/ansible_local.html.md
@@ -202,8 +202,8 @@ You need to create a static `inventory` file that corresponds to your `Vagrantfi
 
 ```
 controller ansible_connection=local
-node1      ansible_ssh_host=172.17.177.21 ansible_ssh_private_key_file=/vagrant/.vagrant/machines/node1/virtualbox/private_key
-node2      ansible_ssh_host=172.17.177.22 ansible_ssh_private_key_file=/vagrant/.vagrant/machines/node2/virtualbox/private_key
+node1      ansible_host=172.17.177.21 ansible_ssh_private_key_file=/vagrant/.vagrant/machines/node1/virtualbox/private_key
+node2      ansible_host=172.17.177.22 ansible_ssh_private_key_file=/vagrant/.vagrant/machines/node2/virtualbox/private_key
 
 [nodes]
 node[1:2]


### PR DESCRIPTION
Need to use ansible_host these days. See https://docs.ansible.com/ansible/2.3/intro_inventory.html deprecation note (it was deprecated in 2.0 apparently)