### PR TITLE
dependency: update net-ssh version

### DIFF
--- a/test/unit/plugins/communicators/ssh/communicator_test.rb
+++ b/test/unit/plugins/communicators/ssh/communicator_test.rb
@@ -565,11 +565,13 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
       end
 
       it "includes the default cipher array for encryption" do
-        cipher_array = %w(aes128-cbc 3des-cbc blowfish-cbc cast128-cbc
-                         aes192-cbc aes256-cbc rijndael-cbc@lysator.liu.se
-                         idea-cbc arcfour128 arcfour256 arcfour
-                         aes128-ctr aes192-ctr aes256-ctr
-                         cast128-ctr blowfish-ctr 3des-ctr none)
+        cipher_array = %w(aes256-ctr aes192-ctr aes128-ctr 
+                          aes256-cbc aes192-cbc aes128-cbc
+                          rijndael-cbc@lysator.liu.se blowfish-ctr
+                          blowfish-cbc cast128-ctr cast128-cbc
+                          3des-ctr 3des-cbc idea-cbc arcfour256
+                          arcfour128 arcfour none)
+
         expect(Net::SSH).to receive(:start).with(
           nil, nil, hash_including(
             encryption: cipher_array

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_dependency "listen", "~> 3.1.5"
   s.add_dependency "hashicorp-checkpoint", "~> 0.1.5"
   s.add_dependency "log4r", "~> 1.1.9", "< 1.1.11"
-  s.add_dependency "net-ssh", "~> 5.0.0"
+  s.add_dependency "net-ssh", "~> 5.1.0"
   s.add_dependency "net-sftp", "~> 2.1"
   s.add_dependency "net-scp", "~> 1.2.0"
   s.add_dependency "rb-kqueue", "~> 0.2.0"


### PR DESCRIPTION
There is new net-ssh release [1] with a fix needed for vagrant-kubevirt.

Fixes: https://github.com/hashicorp/vagrant/issues/10421

[1] https://github.com/net-ssh/net-ssh/releases/tag/v5.1.0