### PR TITLE
Fix grep command for network interface of CoreOS guest

### DIFF
--- a/plugins/guests/coreos/cap/configure_networks.rb
+++ b/plugins/guests/coreos/cap/configure_networks.rb
@@ -12,7 +12,7 @@ module VagrantPlugins
           machine.communicate.tap do |comm|
             # Read network interface names
             interfaces = []
-            comm.sudo("ifconfig | grep '(e[n,t][h,s,p][[:digit:]]([a-z][[:digit:]])?' | cut -f1 -d:") do |_, result|
+            comm.sudo("ifconfig | grep -E '(e[n,t][h,s,p][[:digit:]]([a-z][[:digit:]])?)' | cut -f1 -d:") do |_, result|
               interfaces = result.split("\n")
             end
 

--- a/test/unit/plugins/guests/coreos/cap/configure_networks_test.rb
+++ b/test/unit/plugins/guests/coreos/cap/configure_networks_test.rb
@@ -21,7 +21,7 @@ describe "VagrantPlugins::GuestCoreOS::Cap::ConfigureNetworks" do
 
     allow(described_class).to receive(:get_ip).and_return("1.2.3.4")
 
-    comm.stub_command("ifconfig | grep '(e[n,t][h,s,p][[:digit:]]([a-z][[:digit:]])?' | cut -f1 -d:",
+    comm.stub_command("ifconfig | grep -E '(e[n,t][h,s,p][[:digit:]]([a-z][[:digit:]])?)' | cut -f1 -d:",
       stdout: "eth1\neth2")
   end
 


### PR DESCRIPTION
Quote from https://github.com/hashicorp/vagrant/pull/6610#issuecomment-449678760,

> In #6608, the grep command is
> 
> `grep -E '(e[n,t][h,s,p][[:digit:]]([a-z][[:digit:]])?)'`
> 
> but in this PR, it is
> 
> `grep '(e[n,t][h,s,p][[:digit:]]([a-z][[:digit:]])?'`
> 
> No -E and no last close parenthesis.
> I think the former is correct one.

As written, the code is just copied from #6608, not my code.