### PR TITLE
Remove tmpdir after rsync completes

### DIFF
--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -1,3 +1,4 @@
+require "fileutils"
 require "ipaddr"
 require "shellwords"
 require "tmpdir"
@@ -232,6 +233,8 @@ module VagrantPlugins
               message: err.to_s
           end
         end
+      ensure
+        FileUtils.remove_entry_secure(controlpath) if controlpath
       end
 
       # Check if rsync versions support using chown option

--- a/test/unit/plugins/synced_folders/rsync/helper_test.rb
+++ b/test/unit/plugins/synced_folders/rsync/helper_test.rb
@@ -300,6 +300,10 @@ describe VagrantPlugins::SyncedFolderRSync::RsyncHelper do
         end
 
         subject.rsync_single(machine, ssh_info, opts)
+
+        unless Vagrant::Util::Platform.windows?
+          expect(File.exist?("/tmp/vagrant-rsync-12345")).to be_falsey
+        end
       end
     end
   end


### PR DESCRIPTION
I noticed that rsync doesn't clean up its directories in /tmp. Using rsync-auto, by the end of the working day, I'd have dozens of /tmp/vagrant-rsync dirs. This patch removes the tmpdir after the rsync command completes.

This is my first Ruby code, so I'm not sure I used appropriate library function, or if any library requires are needed for FileUtils. Anyway, it seems to work for me.