### PR TITLE
Do not assume root group on FreeBSD during rsync_post

### DIFF
--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -67,6 +67,11 @@ module VagrantPlugins
         # Folder options
         opts[:owner] ||= ssh_info[:username]
         opts[:group] ||= ssh_info[:username]
+        
+        # On freebsd the root user belongs to the wheel group
+        if machine.guest.name == :freebsd && ssh_info[:username] == 'root'
+          opts[:group] = 'wheel'
+        end
 
         # set log level
         log_level = ssh_info[:log_level] || "FATAL"


### PR DESCRIPTION
This is an attempt to fix the issue #10443

It "fixes" the issue described above but hardcoding `:freebsd` in the `helper.rb` file does not seem like the 'correct' approach.

I am not expecting the code to be merged as-is. I have not tested this PR for regressions.
Any help in pointing me into the right direction is much appreciated.

```
nrocco@macbook vagrant-testing % vagrant provision
==> vm0: Rsyncing folder: /Users/nrocco/Develop/vagrant-testing/ => /vagrant
==> vm0: Running provisioner: shell...
    vm0: Running: /var/folders/bh/z8cxtzk971d45xd7gz50sb5r0000gn/T/vagrant-shell20190105-3221-1448omt.sh
    vm0: Hello World!
    vm0: FreeBSD e4f8c67a 10.3-RELEASE FreeBSD 10.3-RELEASE #0 r297264: Fri Mar 25 02:10:02 UTC 2016     root@releng1.nyi.freebsd.org:/usr/obj/usr/src/sys/GENERIC  amd64
```

Fixes #10443