### PR TITLE
Show source and destination locations with file provisioner

### DIFF
--- a/plugins/provisioners/file/provisioner.rb
+++ b/plugins/provisioners/file/provisioner.rb
@@ -38,6 +38,8 @@ module VagrantPlugins
           end
           comm.execute(command)
 
+          @machine.ui.detail(I18n.t("vagrant.actions.vm.provision.file.locations",
+                                   src: source, dst: destination))
           # now upload the file
           comm.upload(source, destination)
         end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2323,6 +2323,8 @@ en:
           disabled_by_sentinel: |-
             Machine already provisioned. Run `vagrant provision` or use the `--provision`
             flag to force provisioning. Provisioners marked to run always will still run.
+          file:
+            locations: "%{src} => %{dst}"
         resume:
           resuming: Resuming suspended VM...
           unpausing: |-


### PR DESCRIPTION
Prior to this commit, Vagrants output would only show that a file
provisioner was running, but had no detail as to what file was being
copied to where. This is especially confusing if a Vagrantfile has
multiple file provisioners. This commit updates that by showing the
source and destination of the file so that it's clearer what is being
copied and to where.