### PR TITLE
Fixes #10339: Show box version during outdated check

### DIFF
--- a/lib/vagrant/action/builtin/box_check_outdated.rb
+++ b/lib/vagrant/action/builtin/box_check_outdated.rb
@@ -51,7 +51,8 @@ module Vagrant
 
           env[:ui].output(I18n.t(
             "vagrant.box_outdated_checking_with_refresh",
-            name: box.name))
+            name: box.name,
+            version: box.version))
           update = nil
           begin
             update = box.has_update?(constraints, download_options: download_options)

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -46,7 +46,7 @@ en:
     box_outdated: |-
       * '%{name}' for '%{provider}' is outdated! Current: %{current}. Latest: %{latest}
     box_outdated_checking_with_refresh: |-
-      Checking if box '%{name}' is up to date...
+      Checking if box '%{name}' version '%{version}' is up to date...
     box_outdated_local: |-
       A newer version of the box '%{name}' is available and already
       installed, but your Vagrant machine is running against


### PR DESCRIPTION
This commit updates the output Vagrant displays when checking if a box
is out of date by adding the version.