### PR TITLE
Fixes #10585: Properly set DHCP for systemd-networkd ips

### DIFF
--- a/plugins/guests/debian/cap/configure_networks.rb
+++ b/plugins/guests/debian/cap/configure_networks.rb
@@ -89,7 +89,9 @@ module VagrantPlugins
             net_conf << "[Match]"
             net_conf << "Name=#{dev_name}"
             net_conf << "[Network]"
-            if network[:ip]
+            if network[:type].to_s == "dhcp"
+              net_conf << "DHCP=yes"
+            else
               mask = network[:netmask]
               if mask && IPAddr.new(network[:ip]).ipv4?
                 begin
@@ -102,8 +104,6 @@ module VagrantPlugins
               net_conf << "DHCP=no"
               net_conf << "Address=#{address}"
               net_conf << "Gateway=#{network[:gateway]}" if network[:gateway]
-            else
-              net_conf << "DHCP=yes"
             end
 
             remote_path = upload_tmp_file(comm, net_conf.join("\n"))


### PR DESCRIPTION
Prior to this commit, if a debian system requested an DHCP address using
systemd-network, Vagrant would ignore it and instead use the configured
IP from the virtualbox network action. This commit fixes that by instead
looking if DHCP was requested, and if so, use that option for an IP.