### PR TITLE
Make sure that ips array contains unique values

### DIFF
--- a/plugins/hosts/linux/cap/nfs.rb
+++ b/plugins/hosts/linux/cap/nfs.rb
@@ -67,6 +67,7 @@ module VagrantPlugins
 
           nfs_opts_setup(folders)
           folders = folder_dupe_check(folders)
+          ips = ips.uniq
           output = Vagrant::Util::TemplateRenderer.render('nfs/exports_linux',
                                            uuid: id,
                                            ips: ips,

--- a/test/unit/plugins/hosts/linux/cap/nfs_test.rb
+++ b/test/unit/plugins/hosts/linux/cap/nfs_test.rb
@@ -132,16 +132,16 @@ describe VagrantPlugins::HostLinux::Cap::NFS do
     end
 
     it "should export new entries" do
-      cap.nfs_export(env, ui, SecureRandom.uuid, ["127.0.0.1"], "tmp" => {:hostpath => "/tmp"})
+      cap.nfs_export(env, ui, SecureRandom.uuid, ["127.0.0.1", "127.0.0.1"], "tmp" => {:hostpath => "/tmp"})
       exports_content = File.read(exports_path)
-      expect(exports_content).to match(/\/tmp.*127\.0\.0\.1/)
+      expect(exports_content.scan(/\/tmp.*127\.0\.0\.1/).length).to be(1)
     end
 
     it "should not remove existing entries" do
       File.write(exports_path, "/custom/directory hostname1(rw,sync,no_subtree_check)")
-      cap.nfs_export(env, ui, SecureRandom.uuid, ["127.0.0.1"], "tmp" => {:hostpath => "/tmp"})
+      cap.nfs_export(env, ui, SecureRandom.uuid, ["127.0.0.1", "127.0.0.1"], "tmp" => {:hostpath => "/tmp"})
       exports_content = File.read(exports_path)
-      expect(exports_content).to match(/\/tmp.*127\.0\.0\.1/)
+      expect(exports_content.scan(/\/tmp.*127\.0\.0\.1/).length).to be(1)
       expect(exports_content).to match(/\/custom\/directory.*hostname1/)
     end
 


### PR DESCRIPTION
This is a workaround to fix #10591.

I'm not completely sure if this is a proper one - there might be something wrong with my network setup / other code that propagates `ips` array with duplicate addresses - maybe that other code should be fixed instead, but at least this prevents Vagrant from creating duplicate entries in my `/etc/exports` file.