### PR TITLE
Change remaining box_client_cert refs to box_download_client_cert

### DIFF
--- a/plugins/commands/box/command/add.rb
+++ b/plugins/commands/box/command/add.rb
@@ -86,7 +86,7 @@ module VagrantPlugins
             box_force: options[:force],
             box_download_ca_cert: options[:ca_cert],
             box_download_ca_path: options[:ca_path],
-            box_client_cert: options[:client_cert],
+            box_download_client_cert: options[:client_cert],
             box_download_insecure: options[:insecure],
             box_download_location_trusted: options[:location_trusted],
             ui: Vagrant::UI::Prefixed.new(@env.ui, "box"),

--- a/plugins/commands/box/command/update.rb
+++ b/plugins/commands/box/command/update.rb
@@ -158,7 +158,7 @@ module VagrantPlugins
             box_version: update[1].version,
             ui: ui,
             box_force: force,
-            box_client_cert: download_options[:client_cert],
+            box_download_client_cert: download_options[:client_cert],
             box_download_ca_cert: download_options[:ca_cert],
             box_download_ca_path: download_options[:ca_path],
             box_download_insecure: download_options[:insecure]

--- a/test/unit/plugins/commands/box/command/update_test.rb
+++ b/test/unit/plugins/commands/box/command/update_test.rb
@@ -100,7 +100,7 @@ describe VagrantPlugins::CommandBox::Command::Update do
             expect(opts[:box_version]).to eq("1.1")
             expect(opts[:box_download_ca_path]).to be_nil
             expect(opts[:box_download_ca_cert]).to be_nil
-            expect(opts[:box_client_cert]).to be_nil
+            expect(opts[:box_download_client_cert]).to be_nil
             expect(opts[:box_download_insecure]).to be_nil
           end
 
@@ -206,7 +206,7 @@ describe VagrantPlugins::CommandBox::Command::Update do
               action_called = true
               expect(opts[:box_download_ca_cert]).to eq("foo")
               expect(opts[:box_download_ca_path]).to eq("bar")
-              expect(opts[:box_client_cert]).to eq("baz")
+              expect(opts[:box_download_client_cert]).to eq("baz")
               expect(opts[:box_download_insecure]).to be(true)
             end
 
@@ -355,7 +355,7 @@ describe VagrantPlugins::CommandBox::Command::Update do
             expect(action_runner).to receive(:run).with(any_args) { |action, opts|
               expect(opts[:box_download_ca_cert]).to eq("oof")
               expect(opts[:box_download_ca_path]).to eq("rab")
-              expect(opts[:box_client_cert]).to eq("zab")
+              expect(opts[:box_download_client_cert]).to eq("zab")
               expect(opts[:box_download_insecure]).to be(false)
               true
             }
@@ -378,7 +378,7 @@ describe VagrantPlugins::CommandBox::Command::Update do
               expect(action_runner).to receive(:run).with(any_args) { |action, opts|
                 expect(opts[:box_download_ca_cert]).to eq("foo")
                 expect(opts[:box_download_ca_path]).to eq("bar")
-                expect(opts[:box_client_cert]).to eq("baz")
+                expect(opts[:box_download_client_cert]).to eq("baz")
                 expect(opts[:box_download_insecure]).to be(true)
                 true
               }


### PR DESCRIPTION
This fixes issues with box add/update when self hosting boxes with client
cert authentication. The --cert option was not being added to the curl subprocess resulting in a 400 bad request response.