### PR TITLE
implement nfs shared folders for ipv6

### DIFF
--- a/plugins/guests/linux/cap/nfs.rb
+++ b/plugins/guests/linux/cap/nfs.rb
@@ -1,3 +1,4 @@
+require "ipaddr"
 require_relative "../../../synced_folders/unix_mount_helpers"
 
 module VagrantPlugins
@@ -30,7 +31,13 @@ module VagrantPlugins
 
             machine.communicate.sudo("mkdir -p #{guest_path}")
 
-            command = "mount -o #{mount_opts} #{ip}:#{host_path} #{guest_path}"
+            addr = IPAddr.new(ip)
+
+            if addr.ipv6?
+              command = "mount -o #{mount_opts} [#{ip}]:#{host_path} #{guest_path}"
+            else
+              command = "mount -o #{mount_opts} #{ip}:#{host_path} #{guest_path}"
+            end
 
             # Run the command, raising a specific error.
             retryable(on: Vagrant::Errors::NFSMountFailed, tries: 3, sleep: 5) do

--- a/test/unit/plugins/guests/linux/cap/mount_nfs_test.rb
+++ b/test/unit/plugins/guests/linux/cap/mount_nfs_test.rb
@@ -32,6 +32,24 @@ describe "VagrantPlugins::GuestLinux::Cap::MountNFS" do
       )
     end
 
+    context "with ipv6" do
+      let(:ip) { "fd63:acd4:5c42:0530::1" }
+
+      it "mounts the folder" do
+        folders = {
+          "/vagrant-nfs" => {
+            type: :nfs,
+            guestpath: "/guest",
+            hostpath: "/host",
+          }
+        }
+        cap.mount_nfs_folder(machine, ip, folders)
+
+        expect(comm.received_commands[0]).to match(/mkdir -p #{guestpath}/)
+        expect(comm.received_commands[1]).to match(/\[fd63:acd4:5c42:0530::1\]:#{hostpath} #{guestpath}/)
+      end
+    end
+
     it "mounts the folder" do
       folders = {
         "/vagrant-nfs" => {

--- a/test/unit/plugins/providers/virtualbox/action/prepare_nfs_settings_test.rb
+++ b/test/unit/plugins/providers/virtualbox/action/prepare_nfs_settings_test.rb
@@ -53,6 +53,10 @@ describe VagrantPlugins::ProviderVirtualBox::Action::PrepareNFSSettings do
       [{name: "vmnet2", ip: "1.2.3.4"}]
     }
 
+    let(:guest_ip) {
+      "2.3.4.5"
+    }
+
     before do
       # We can't be on Windows, because NFS gets disabled on Windows
       allow(Vagrant::Util::Platform).to receive(:windows?).and_return(false)
@@ -65,11 +69,28 @@ describe VagrantPlugins::ProviderVirtualBox::Action::PrepareNFSSettings do
         2 => {type: :hostonly, hostonly: "vmnet2"},
       })
       allow(driver).to receive(:read_host_only_interfaces).and_return(host_only_interfaces)
-      allow(driver).to receive(:read_guest_ip).with(1).and_return("2.3.4.5")
+      allow(driver).to receive(:read_guest_ip).with(1).and_return(guest_ip)
 
       # override sleep to 0 so test does not take seconds
       retry_options = subject.retry_options
       allow(subject).to receive(:retry_options).and_return(retry_options.merge(sleep: 0))
+    end
+
+    context "with ipv6 addresses" do
+      let(:host_only_interfaces) {
+        [{name: "vmnet2", ipv6: "fd63:acd4:5c42:0530::1"}]
+      }
+
+      let(:guest_ip) {
+        "fd63:acd4:5c42:0530::2"
+      }
+
+      it "sets nfs_host_ip and nfs_machine_ip properly" do
+        subject.call(env)
+
+        expect(env[:nfs_host_ip]).to eq("fd63:acd4:5c42:0530::1")
+        expect(env[:nfs_machine_ip]).to eq("fd63:acd4:5c42:0530::2")
+      end
     end
 
     context "with host interface netmask defined" do


### PR DESCRIPTION
I tried to use nfs shared folders with ipv6 (virtualbox and linux guest), but it did not work. The changes below should make it work. Maybe not the cleanest solution, so any feedback is welcome.