### PR TITLE
Fix format finalization of plugins in Vagrantfile

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1813,6 +1813,8 @@ en:
         sensitive_bad_type: |-
           Invalid type provided for `sensitive`. The sensitive option expects a string
           or an array of strings.
+        plugins_invalid_format: |-
+          Invalid type provided for `plugins`.
         plugins_bad_key: |-
           Invalid plugin configuration detected for `%{plugin_name}` plugin.
 

--- a/test/unit/plugins/kernel_v2/config/vagrant_test.rb
+++ b/test/unit/plugins/kernel_v2/config/vagrant_test.rb
@@ -56,4 +56,54 @@ describe VagrantPlugins::Kernel_V2::VagrantConfig do
       subject.finalize!
     end
   end
+
+  describe "#plugins" do
+    it "converts string into hash of plugins" do
+      subject.plugins = "vagrant-plugin"
+      subject.finalize!
+      expect(subject.plugins).to be_a(Hash)
+    end
+
+    it "converts array of strings into hash of plugins" do
+      subject.plugins = ["vagrant-plugin", "vagrant-other-plugin"]
+      subject.finalize!
+      expect(subject.plugins).to be_a(Hash)
+      expect(subject.plugins.keys).to eq(["vagrant-plugin", "vagrant-other-plugin"])
+    end
+
+    it "does not convert hash" do
+      plugins = {"vagrant-plugin" => {}}
+      subject.plugins = plugins
+      subject.finalize
+      expect(subject.plugins).to eq(plugins)
+    end
+
+    it "converts array of mixed strings and hashes" do
+      subject.plugins = ["vagrant-plugin", {"vagrant-other-plugin" => {:version => "1"}}]
+      subject.finalize!
+      expect(subject.plugins["vagrant-plugin"]).to eq({})
+      expect(subject.plugins["vagrant-other-plugin"]).to eq({"version" => "1"})
+    end
+
+    it "generates a validation error when incorrect type is provided" do
+      subject.plugins = 0
+      subject.finalize!
+      result = subject.validate(machine)
+      expect(result.values).not_to be_empty
+    end
+
+    it "generates a validation error when invalid option is provided" do
+      subject.plugins = {"vagrant-plugin" => {"badkey" => true}}
+      subject.finalize!
+      result = subject.validate(machine)
+      expect(result.values).not_to be_empty
+    end
+
+    it "generates a validation error when options are incorrect type" do
+      subject.plugins = {"vagrant-plugin" => 1}
+      subject.finalize!
+      result = subject.validate(machine)
+      expect(result.values).not_to be_empty
+    end
+  end
 end


### PR DESCRIPTION
Properly supports mixed types within arrays and adds
coverage on formatting different variations of values.

Fixes #10658