### PR TITLE
Fixes #10663: Ignore boxes in collection with malformed version numbers

### DIFF
--- a/lib/vagrant/box_collection.rb
+++ b/lib/vagrant/box_collection.rb
@@ -233,14 +233,23 @@ module Vagrant
             version = versiondir.basename.to_s
 
             versiondir.children(true).each do |provider|
+              # Ensure version of box is correct before continuing
+              if !Gem::Version.correct?(version)
+                ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
+                ui.warn(I18n.t("vagrant.box_version_malformed",
+                              version: version, box_name: box_name))
+                @logger.debug("Invalid version #{version} for box #{box_name}")
+                next
+              end
+
               # Verify this is a potentially valid box. If it looks
               # correct enough then include it.
               if provider.directory? && provider.join("metadata.json").file?
                 provider_name = provider.basename.to_s.to_sym
-                @logger.debug("Box: #{box_name} (#{provider_name})")
+                @logger.debug("Box: #{box_name} (#{provider_name}, #{version})")
                 results << [box_name, version, provider_name]
               else
-                @logger.debug("Invalid box, ignoring: #{provider}")
+                @logger.debug("Invalid box #{box_name}, ignoring: #{provider}")
               end
             end
           end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -82,6 +82,8 @@ en:
       * '%{name}' for '%{provider}' (v%{version}) is up to date
     box_up_to_date_single: |-
       Box '%{name}' (v%{version}) is running the latest version.
+    box_version_malformed:
+      Invalid version '%{version}' for '%{box_name}', ignoring...
     cfengine_bootstrapping: |-
       Bootstrapping CFEngine with policy server: %{policy_server}...
     cfengine_bootstrapping_policy_hub: |-


### PR DESCRIPTION
Prior to this commit, if a box some how got on disk that had an
incorrect or invalid version number that did not match Gem::Version,
Vagrant would throw an exception when attempting to generate a list of
the boxes on disk. This commit fixes that by looking at the version from
the path generated, and shows a warning to the user about the box and
skips it from the list so they at least know about the problematic box
and can still get a list of boxes.