### PR TITLE
Add `vagrant validate` parameters to docs

### DIFF
--- a/website/source/docs/cli/validate.html.md
+++ b/website/source/docs/cli/validate.html.md
@@ -12,6 +12,10 @@ description: |-
 
 This command validates your [Vagrantfile](/docs/vagrantfile/).
 
+## Options
+
+* `--ignore-provider` - Ignores provider config options.
+
 ## Examples
 
 ```sh


### PR DESCRIPTION
The `vagrant validate` command has a parameter `-p`/ `--ignore-provider` which ignores when no provider is installed. This was submitted in #10351 but not documented. This is the only change in this PR.