### PR TITLE
Allow to override the CUSTOM_HOST_NOTIFY_WAIT setting

### DIFF
--- a/plugins/commands/login/middleware/add_authentication.rb
+++ b/plugins/commands/login/middleware/add_authentication.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
         "atlas.hashicorp.com".freeze
       ].freeze
       TARGET_HOST = "vagrantcloud.com".freeze
-      CUSTOM_HOST_NOTIFY_WAIT = 5
+      CUSTOM_HOST_NOTIFY_WAIT = if !ENV["CUSTOM_HOST_NOTIFY_WAIT"].to_s.empty? then ENV["CUSTOM_HOST_NOTIFY_WAIT"].to_i else 5 end
 
       def self.custom_host_notified!
         @_host_notify = true


### PR DESCRIPTION
This PR refers to the issue reported in #9928. While it doesn't fix/address the actual problem it allows the user to override the hard-coded 5s delay by setting the environment variable CUSTOM_HOST_NOTIFY_WAIT.

E.g.: `CUSTOM_HOST_NOTIFY_WAIT=0 vagrant up`