### PR TITLE
Fixes #10682: Move over AddAuthentication middleware and hooks

### DIFF
--- a/plugins/commands/cloud/auth/middleware/add_authentication.rb
+++ b/plugins/commands/cloud/auth/middleware/add_authentication.rb
@@ -1,10 +1,10 @@
 require "cgi"
 require "uri"
 
-require_relative "../client"
+require Vagrant.source_root.join("plugins/commands/cloud/client/client")
 
 module VagrantPlugins
-  module LoginCommand
+  module CloudCommand
     class AddAuthentication
       REPLACEMENT_HOSTS = [
         "app.vagrantup.com".freeze,
@@ -27,7 +27,7 @@ module VagrantPlugins
 
       def initialize(app, env)
         @app = app
-        LoginCommand::Plugin.init!
+        CloudCommand::Plugin.init!
       end
 
       def call(env)
@@ -56,7 +56,7 @@ module VagrantPlugins
 
             if u.host == server_uri.host
               if server_uri.host != TARGET_HOST && !self.class.custom_host_notified?
-                env[:ui].warn(I18n.t("login_command.middleware.authentication.different_target",
+                env[:ui].warn(I18n.t("cloud_command.middleware.authentication.different_target",
                   custom_host: server_uri.host, known_host: TARGET_HOST) + "\n")
                 sleep CUSTOM_HOST_NOTIFY_WAIT
                 self.class.custom_host_notified!

--- a/plugins/commands/cloud/locales/en.yml
+++ b/plugins/commands/cloud/locales/en.yml
@@ -1,5 +1,17 @@
 en:
   cloud_command:
+    middleware:
+      authentication:
+        different_target: |-
+          Vagrant has detected a custom Vagrant server in use for downloading
+          box files. An authentication token is currently set which will be
+          added to the box request. If the custom Vagrant server should not
+          be receiving the authentication token, please unset it.
+
+            Known Vagrant server:  %{known_host}
+            Custom Vagrant server: %{custom_host}
+
+          Press ctrl-c to cancel...
     publish:
       update_continue: |-
         %{obj} already exists, updating instead...

--- a/plugins/commands/cloud/plugin.rb
+++ b/plugins/commands/cloud/plugin.rb
@@ -17,6 +17,11 @@ module VagrantPlugins
         Command::Root
       end
 
+      action_hook(:cloud_authenticated_boxes, :authenticate_box_url) do |hook|
+        require_relative "auth/middleware/add_authentication"
+        hook.prepend(AddAuthentication)
+      end
+
       protected
 
       def self.init!

--- a/plugins/commands/login/plugin.rb
+++ b/plugins/commands/login/plugin.rb
@@ -17,11 +17,6 @@ module VagrantPlugins
         VagrantPlugins::CloudCommand::AuthCommand::Command::Login
       end
 
-      action_hook(:cloud_authenticated_boxes, :authenticate_box_url) do |hook|
-        require_relative "middleware/add_authentication"
-        hook.prepend(AddAuthentication)
-      end
-
       protected
 
       def self.init!

--- a/test/unit/plugins/commands/cloud/auth/middleware/add_authentication_test.rb
+++ b/test/unit/plugins/commands/cloud/auth/middleware/add_authentication_test.rb
@@ -1,8 +1,8 @@
-require File.expand_path("../../../../../base", __FILE__)
+require File.expand_path("../../../../../../base", __FILE__)
 
-require Vagrant.source_root.join("plugins/commands/login/middleware/add_authentication")
+require Vagrant.source_root.join("plugins/commands/cloud/auth/middleware/add_authentication")
 
-describe VagrantPlugins::LoginCommand::AddAuthentication do
+describe VagrantPlugins::CloudCommand::AddAuthentication do
   include_context "unit"
 
   let(:app) { lambda { |env| } }
@@ -26,7 +26,7 @@ describe VagrantPlugins::LoginCommand::AddAuthentication do
   describe "#call" do
     it "does nothing if we have no server set" do
       allow(Vagrant).to receive(:server_url).and_return(nil)
-      VagrantPlugins::LoginCommand::Client.new(iso_env).store_token("foo")
+      VagrantPlugins::CloudCommand::Client.new(iso_env).store_token("foo")
 
       original = ["foo", "#{server_url}/bar"]
       env[:box_urls] = original.dup
@@ -47,7 +47,7 @@ describe VagrantPlugins::LoginCommand::AddAuthentication do
 
     it "appends the access token to the URL of server URLs" do
       token = "foobarbaz"
-      VagrantPlugins::LoginCommand::Client.new(iso_env).store_token(token)
+      VagrantPlugins::CloudCommand::Client.new(iso_env).store_token(token)
 
       original = [
         "http://google.com/box.box",
@@ -71,7 +71,7 @@ describe VagrantPlugins::LoginCommand::AddAuthentication do
       allow(subject).to receive(:sleep)
 
       token = "foobarbaz"
-      VagrantPlugins::LoginCommand::Client.new(iso_env).store_token(token)
+      VagrantPlugins::CloudCommand::Client.new(iso_env).store_token(token)
 
       original = [
         "http://google.com/box.box",
@@ -92,7 +92,7 @@ describe VagrantPlugins::LoginCommand::AddAuthentication do
       allow(Vagrant).to receive(:server_url).and_return(server_url)
 
       token = "foobarbaz"
-      VagrantPlugins::LoginCommand::Client.new(iso_env).store_token(token)
+      VagrantPlugins::CloudCommand::Client.new(iso_env).store_token(token)
 
       original = [
         "http://google.com/box.box",
@@ -115,9 +115,9 @@ describe VagrantPlugins::LoginCommand::AddAuthentication do
     end
 
     it "modifies host URL to target if authorized host" do
-      originals = VagrantPlugins::LoginCommand::AddAuthentication::
+      originals = VagrantPlugins::CloudCommand::AddAuthentication::
         REPLACEMENT_HOSTS.map{ |h| "http://#{h}/box.box" }
-      expected = "http://#{VagrantPlugins::LoginCommand::AddAuthentication::TARGET_HOST}/box.box"
+      expected = "http://#{VagrantPlugins::CloudCommand::AddAuthentication::TARGET_HOST}/box.box"
       env[:box_urls] = originals
       subject.call(env)
       env[:box_urls].each do |url|
@@ -136,9 +136,9 @@ describe VagrantPlugins::LoginCommand::AddAuthentication do
 
     it "returns original urls when not modified" do
       to_persist = "file:////path/to/box.box"
-      to_change = VagrantPlugins::LoginCommand::AddAuthentication::
+      to_change = VagrantPlugins::CloudCommand::AddAuthentication::
         REPLACEMENT_HOSTS.map{ |h| "http://#{h}/box.box" }.first
-      expected = "http://#{VagrantPlugins::LoginCommand::AddAuthentication::TARGET_HOST}/box.box"
+      expected = "http://#{VagrantPlugins::CloudCommand::AddAuthentication::TARGET_HOST}/box.box"
       env[:box_urls] = [to_persist, to_change]
       subject.call(env)
       check_persist, check_change = env[:box_urls]
@@ -152,7 +152,7 @@ describe VagrantPlugins::LoginCommand::AddAuthentication do
 
     it "does not append multiple access_tokens" do
       token = "foobarbaz"
-      VagrantPlugins::LoginCommand::Client.new(iso_env).store_token(token)
+      VagrantPlugins::CloudCommand::Client.new(iso_env).store_token(token)
 
       original = [
         "#{server_url}/foo.box?access_token=existing",


### PR DESCRIPTION
Prior to this commit, the AddAuthentication hooks still existed in a
deprecated class LoginCommand. This commit fixes that by moving it over
to the vagrant cloud cli namespace instead.