### PR TITLE
Cleanup rsync tmp folders

### DIFF
--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -234,7 +234,7 @@ module VagrantPlugins
           end
         end
       ensure
-        FileUtils.remove_entry_secure(controlpath) if controlpath
+        FileUtils.remove_entry_secure(controlpath, true) if controlpath
       end
 
       # Check if rsync versions support using chown option

--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -1,3 +1,4 @@
+require "fileutils"
 require "ipaddr"
 require "shellwords"
 require "tmpdir"
@@ -232,6 +233,8 @@ module VagrantPlugins
               message: err.to_s
           end
         end
+      ensure
+        FileUtils.remove_entry_secure(controlpath) if controlpath
       end
 
       # Check if rsync versions support using chown option

--- a/test/unit/plugins/synced_folders/rsync/helper_test.rb
+++ b/test/unit/plugins/synced_folders/rsync/helper_test.rb
@@ -292,11 +292,8 @@ describe VagrantPlugins::SyncedFolderRSync::RsyncHelper do
           expect(args[9]).to include("ControlPath=/tmp/vagrant-rsync-12345")
         }.and_return(result)
 
+        expect(FileUtils).to receive(:remove_entry_secure).with("/tmp/vagrant-rsync-12345").and_return(true)
         subject.rsync_single(machine, ssh_info, opts)
-
-        unless Vagrant::Util::Platform.windows?
-          expect(File.exist?("/tmp/vagrant-rsync-12345")).to be_falsey
-        end
       end
     end
   end

--- a/test/unit/plugins/synced_folders/rsync/helper_test.rb
+++ b/test/unit/plugins/synced_folders/rsync/helper_test.rb
@@ -292,7 +292,7 @@ describe VagrantPlugins::SyncedFolderRSync::RsyncHelper do
           expect(args[9]).to include("ControlPath=/tmp/vagrant-rsync-12345")
         }.and_return(result)
 
-        expect(FileUtils).to receive(:remove_entry_secure).with("/tmp/vagrant-rsync-12345").and_return(true)
+        expect(FileUtils).to receive(:remove_entry_secure).with("/tmp/vagrant-rsync-12345", true).and_return(true)
         subject.rsync_single(machine, ssh_info, opts)
       end
 
@@ -305,7 +305,7 @@ describe VagrantPlugins::SyncedFolderRSync::RsyncHelper do
           expect(args).not_to include("ControlPath=/tmp/vagrant-rsync-12345")
         }.and_return(result)
 
-        expect(FileUtils).not_to receive(:remove_entry_secure).with("/tmp/vagrant-rsync-12345")
+        expect(FileUtils).not_to receive(:remove_entry_secure).with("/tmp/vagrant-rsync-12345", true)
         subject.rsync_single(machine, ssh_info, opts)
       end
     end

--- a/test/unit/plugins/synced_folders/rsync/helper_test.rb
+++ b/test/unit/plugins/synced_folders/rsync/helper_test.rb
@@ -293,6 +293,10 @@ describe VagrantPlugins::SyncedFolderRSync::RsyncHelper do
         }.and_return(result)
 
         subject.rsync_single(machine, ssh_info, opts)
+
+        unless Vagrant::Util::Platform.windows?
+          expect(File.exist?("/tmp/vagrant-rsync-12345")).to be_falsey
+        end
       end
     end
   end

--- a/test/unit/plugins/synced_folders/rsync/helper_test.rb
+++ b/test/unit/plugins/synced_folders/rsync/helper_test.rb
@@ -295,6 +295,19 @@ describe VagrantPlugins::SyncedFolderRSync::RsyncHelper do
         expect(FileUtils).to receive(:remove_entry_secure).with("/tmp/vagrant-rsync-12345").and_return(true)
         subject.rsync_single(machine, ssh_info, opts)
       end
+
+      it "does not create tmp dir on windows platforms" do
+        allow(Vagrant::Util::Platform).to receive(:windows?).and_return(true)
+        allow(Dir).to receive(:mktmpdir).with("vagrant-rsync-").
+          and_return("/tmp/vagrant-rsync-12345")
+
+        expect(Vagrant::Util::Subprocess).to receive(:execute).with(any_args) { |*args|
+          expect(args).not_to include("ControlPath=/tmp/vagrant-rsync-12345")
+        }.and_return(result)
+
+        expect(FileUtils).not_to receive(:remove_entry_secure).with("/tmp/vagrant-rsync-12345")
+        subject.rsync_single(machine, ssh_info, opts)
+      end
     end
   end
 


### PR DESCRIPTION
This pull request ensures that the tmp folder created by rsync gets properly cleaned up on the host.