### PR TITLE
Update communicator upload behavior to handle `/.` path directives

### DIFF
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -317,10 +317,11 @@ module VagrantPlugins
               else
                 dest = to
                 if to.end_with?(File::SEPARATOR)
-                  create_remote_directory(dest)
                   dest = File.join(to, File.basename(path))
                 end
               end
+              @logger.debug("Ensuring remote directory exists for destination upload")
+              create_remote_directory(File.dirname(dest))
               @logger.debug("Uploading file #{path} to remote #{dest}")
               upload_file = File.open(path, "rb")
               begin

--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -9,6 +9,7 @@ require 'log4r'
 require 'net/ssh'
 require 'net/ssh/proxy/command'
 require 'net/scp'
+require 'net/sftp'
 
 require 'vagrant/util/ansi_escape_code_remover'
 require 'vagrant/util/file_mode'
@@ -290,14 +291,46 @@ module VagrantPlugins
       def upload(from, to)
         @logger.debug("Uploading: #{from} to #{to}")
 
-        scp_connect do |scp|
-          if File.directory?(from)
-            # Recursively upload directories
-            scp.upload!(from, to, recursive: true)
+        if File.directory?(from)
+          if from.end_with?(".")
+            @logger.debug("Uploading directory contents of: #{from}")
+            from = from.sub(/\.$/, "")
           else
-            # Open file read only to fix issue [GH-1036]
-            scp.upload!(File.open(from, "r"), to)
+            @logger.debug("Uploading full directory container of: #{from}")
+            to = File.join(to, File.basename(File.expand_path(from)))
           end
+        end
+
+        scp_connect do |scp|
+          uploader = lambda do |path, remote_dest=nil|
+            if File.directory?(path)
+              Dir.new(path).each do |entry|
+                next if entry == "." || entry == ".."
+                full_path = File.join(path, entry)
+                dest = File.join(to, path.sub(/^#{Regexp.escape(from)}/, ""))
+                create_remote_directory(dest)
+                uploader.call(full_path, dest)
+              end
+            else
+              if remote_dest
+                dest = File.join(remote_dest, File.basename(path))
+              else
+                dest = to
+                if to.end_with?(File::SEPARATOR)
+                  create_remote_directory(dest)
+                  dest = File.join(to, File.basename(path))
+                end
+              end
+              @logger.debug("Uploading file #{path} to remote #{dest}")
+              upload_file = File.open(path, "rb")
+              begin
+                scp.upload!(upload_file, dest)
+              ensure
+                upload_file.close
+              end
+            end
+          end
+          uploader.call(from)
         end
       rescue RuntimeError => e
         # Net::SCP raises a runtime error for this so the only way we have
@@ -729,6 +762,10 @@ module VagrantPlugins
       def generate_environment_export(env_key, env_value)
         template = machine_config_ssh.export_command_template
         template.sub("%ENV_KEY%", env_key).sub("%ENV_VALUE%", env_value) + "\n"
+      end
+
+      def create_remote_directory(dir)
+        execute("mkdir -p \"#{dir}\"")
       end
 
       def machine_config_ssh

--- a/plugins/communicators/winrm/shell.rb
+++ b/plugins/communicators/winrm/shell.rb
@@ -108,6 +108,13 @@ module VagrantPlugins
       # @return [FixNum] Total size transfered from host to guest
       def upload(from, to)
         file_manager = WinRM::FS::FileManager.new(connection)
+        if from.is_a?(String) && File.directory?(from)
+          if from.end_with?(".")
+            from = from[0, from.length - 1]
+          else
+            to = File.join(to, File.basename(File.expand_path(from)))
+          end
+        end
         if from.is_a?(Array)
           # Preserve return FixNum of bytes transfered
           return_bytes = 0

--- a/test/unit/plugins/communicators/ssh/communicator_test.rb
+++ b/test/unit/plugins/communicators/ssh/communicator_test.rb
@@ -497,12 +497,39 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
   describe ".upload" do
     before do
       expect(communicator).to receive(:scp_connect).and_yield(scp)
+      allow(communicator).to receive(:create_remote_directory)
     end
 
-    it "uploads a directory if local path is a directory" do
-      Dir.mktmpdir('vagrant-test') do |dir|
-        expect(scp).to receive(:upload!).with(dir, '/destination', recursive: true)
-        communicator.upload(dir, '/destination')
+    context "directory uploads" do
+      let(:test_dir) { @dir }
+      let(:test_file) { File.join(test_dir, "test-file") }
+      let(:dir_name) { File.basename(test_dir) }
+      let(:file_name) { File.basename(test_file) }
+
+      before do
+        @dir = Dir.mktmpdir("vagrant-test")
+        FileUtils.touch(test_file)
+      end
+
+      after { FileUtils.rm_rf(test_dir) }
+
+      it "uploads directory when directory path provided" do
+        expect(scp).to receive(:upload!).with(instance_of(File),
+          File.join("", "destination", dir_name, file_name))
+        communicator.upload(test_dir, "/destination")
+      end
+
+      it "uploads contents of directory when dot suffix provided on directory" do
+        expect(scp).to receive(:upload!).with(instance_of(File),
+          File.join("", "destination", file_name))
+        communicator.upload(File.join(test_dir, "."), "/destination")
+      end
+
+      it "creates directories before upload" do
+        expect(communicator).to receive(:create_remote_directory).with(
+          /#{Regexp.escape(File.join("", "destination", dir_name))}/)
+        allow(scp).to receive(:upload!)
+        communicator.upload(test_dir, "/destination")
       end
     end
 
@@ -511,6 +538,17 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
       begin
         expect(scp).to receive(:upload!).with(instance_of(File), '/destination/file')
         communicator.upload(file.path, '/destination/file')
+      ensure
+        file.delete
+      end
+    end
+
+    it "uploads file to directory if destination ends with file separator" do
+      file = Tempfile.new('vagrant-test')
+      begin
+        expect(scp).to receive(:upload!).with(instance_of(File), "/destination/dir/#{File.basename(file.path)}")
+        expect(communicator).to receive(:create_remote_directory).with("/destination/dir/")
+        communicator.upload(file.path, "/destination/dir/")
       ensure
         file.delete
       end
@@ -609,7 +647,7 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
       end
 
       it "includes the default cipher array for encryption" do
-        cipher_array = %w(aes256-ctr aes192-ctr aes128-ctr 
+        cipher_array = %w(aes256-ctr aes192-ctr aes128-ctr
                           aes256-cbc aes192-cbc aes128-cbc
                           rijndael-cbc@lysator.liu.se blowfish-ctr
                           blowfish-cbc cast128-ctr cast128-cbc

--- a/test/unit/plugins/communicators/ssh/communicator_test.rb
+++ b/test/unit/plugins/communicators/ssh/communicator_test.rb
@@ -547,8 +547,19 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
       file = Tempfile.new('vagrant-test')
       begin
         expect(scp).to receive(:upload!).with(instance_of(File), "/destination/dir/#{File.basename(file.path)}")
-        expect(communicator).to receive(:create_remote_directory).with("/destination/dir/")
+        expect(communicator).to receive(:create_remote_directory).with("/destination/dir")
         communicator.upload(file.path, "/destination/dir/")
+      ensure
+        file.delete
+      end
+    end
+
+    it "creates remote directory path to destination on upload" do
+      file = Tempfile.new('vagrant-test')
+      begin
+        expect(scp).to receive(:upload!).with(instance_of(File), "/destination/dir/file.txt")
+        expect(communicator).to receive(:create_remote_directory).with("/destination/dir")
+        communicator.upload(file.path, "/destination/dir/file.txt")
       ensure
         file.delete
       end

--- a/test/unit/plugins/communicators/winssh/communicator_test.rb
+++ b/test/unit/plugins/communicators/winssh/communicator_test.rb
@@ -226,12 +226,14 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
 
   describe ".upload" do
     before do
+      allow(communicator).to receive(:create_remote_directory)
       expect(communicator).to receive(:scp_connect).and_yield(scp)
     end
 
     it "uploads a directory if local path is a directory" do
       Dir.mktmpdir('vagrant-test') do |dir|
-        expect(scp).to receive(:upload!).with(dir, 'C:\destination', recursive: true)
+        FileUtils.touch(File.join(dir, "test-file"))
+        expect(scp).to receive(:upload!).with(an_instance_of(File), /test-file/)
         communicator.upload(dir, 'C:\destination')
       end
     end

--- a/test/unit/plugins/provisioners/file/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/file/provisioner_test.rb
@@ -34,8 +34,6 @@ describe VagrantPlugins::FileUpload::Provisioner do
       allow(config).to receive(:source).and_return("/source")
       allow(config).to receive(:destination).and_return("/foo/bar")
 
-      expect(communicator).to receive(:execute).with("mkdir -p \"/foo\"")
-
       subject.provision
     end
 
@@ -43,16 +41,12 @@ describe VagrantPlugins::FileUpload::Provisioner do
       allow(config).to receive(:source).and_return("/source")
       allow(config).to receive(:destination).and_return("/foo bar/bar")
 
-      expect(communicator).to receive(:execute).with("mkdir -p \"/foo bar\"")
-
       subject.provision
     end
 
     it "creates the destination directory above file" do
       allow(config).to receive(:source).and_return("/source/file.sh")
       allow(config).to receive(:destination).and_return("/foo/bar/file.sh")
-
-      expect(communicator).to receive(:execute).with("mkdir -p \"/foo/bar\"")
 
       subject.provision
     end
@@ -105,21 +99,12 @@ describe VagrantPlugins::FileUpload::Provisioner do
       subject.provision
     end
 
-    it "sends an array of files and folders if winrm and destination doesn't end with file separator" do
-      files = ["/source/file.py", "/source/folder"]
-      allow(Dir).to receive(:[]).and_return(files)
-      allow(config).to receive(:source).and_return("/source")
-      allow(config).to receive(:destination).and_return("/foo/bar")
+    it "appends a '/.' to expanded source if defined in original source" do
+      allow(config).to receive(:source).and_return("/source/.")
       allow(File).to receive(:directory?).with("/source").and_return(true)
-      allow(machine.config.vm).to receive(:communicator).and_return(:winrm)
+      allow(config).to receive(:destination).and_return("/foo/bar")
 
-      expect(guest).to receive(:capability?).
-        with(:shell_expand_guest_path).and_return(true)
-      expect(guest).to receive(:capability).
-        with(:shell_expand_guest_path, "/foo/bar").and_return("/foo/bar")
-
-      expect(communicator).to receive(:upload)
-        .with(files, "/foo/bar")
+      expect(communicator).to receive(:upload).with("/source/.", "/foo/bar")
 
       subject.provision
     end


### PR DESCRIPTION
This update was prompted by updates in openssh to the scp behavior
making source directory paths suffixed with `.` no longer valid
resulting in errors on upload. The upload implementation within
the ssh communicator has been updated to retain the existing
behavior.

Included in this update is modifications to the winrm communicator
so the upload functionality matches that of the ssh communicator
respecting the trailing `.` behavior on source paths. With the
communicators updated to properly handle the paths, the file
provisioner was also updated to simply apply previously defined
path update rules only.

Fixes #10675 #10697 