### PR TITLE
Added --no-same-owner & --no-same-permissions flags to bsdtar in box_…

### DIFF
--- a/lib/vagrant/box_collection.rb
+++ b/lib/vagrant/box_collection.rb
@@ -116,7 +116,7 @@ module Vagrant
           # Extract the box into a temporary directory.
           @logger.debug("Unpacking box into temporary directory: #{temp_dir}")
           result = Util::Subprocess.execute(
-            "bsdtar", "-v", "-x", "-m", "-s", "|\\\\\|/|", "-C", temp_dir.to_s, "-f", path.to_s)
+            "bsdtar", "--no-same-owner", "--no-same-permissions", "-v", "-x", "-m", "-s", "|\\\\\|/|", "-C", temp_dir.to_s, "-f", path.to_s)
           if result.exit_code != 0
             raise Errors::BoxUnpackageFailure,
               output: result.stderr.to_s


### PR DESCRIPTION
…collection.rb

As discussed in #10705 this pull request fixes some edge case behaviour when trying to unpack a vagrant box as a root user. 