### PR TITLE
Relax WebMock dependency.

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "~> 12.0.0"
   s.add_development_dependency "rspec", "~> 3.5.0"
   s.add_development_dependency "rspec-its", "~> 1.2.0"
-  s.add_development_dependency "webmock", "~> 2.3.1"
+  s.add_development_dependency "webmock", ">= 2.3.1"
   s.add_development_dependency "fake_ftp", "~> 0.1.1"
 
   # The following block of code determines the files that should be included


### PR DESCRIPTION
Testing with Ruby 2.6, it seems that Vagrant test suite is passing just fine using WebMock 3.5.1