### PR TITLE
Corrected config.vm.provision syntax error

### DIFF
--- a/website/source/intro/getting-started/provisioning.html.md
+++ b/website/source/intro/getting-started/provisioning.html.md
@@ -44,7 +44,7 @@ look like this:
 ```ruby
 Vagrant.configure("2") do |config|
   config.vm.box = "hashicorp/precise64"
-  config.vm.provision :shell, path: "bootstrap.sh"
+  config.vm.provision "shell", path: "bootstrap.sh"
 end
 ```
 


### PR DESCRIPTION
The example Vagrant file command to execute a shell gave the following runtime exception error: 

"Vagrantfile:11: syntax error, unexpected tLABEL
g.vm.provision = :shell, path: "bootstrap.sh"

I'm proposing a fix I found on the hashicorp website that appears to be working for me ( on my mac ).