### PR TITLE
Fixes #10723: Fix bug instance var in Vagrant Cloud CLI optparse

### DIFF
--- a/plugins/commands/cloud/box/create.rb
+++ b/plugins/commands/cloud/box/create.rb
@@ -19,7 +19,7 @@ module VagrantPlugins
               o.on("-d", "--description DESCRIPTION", String, "Full description of the box") do |d|
                 options[:description] = d
               end
-              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |t|
+              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |u|
                 options[:username] = u
               end
               o.on("-s", "--short-description DESCRIPTION", String, "Short description of the box") do |s|

--- a/plugins/commands/cloud/box/delete.rb
+++ b/plugins/commands/cloud/box/delete.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
               o.separator "Options:"
               o.separator ""
 
-              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |t|
+              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |u|
                 options[:username] = u
               end
             end

--- a/plugins/commands/cloud/provider/create.rb
+++ b/plugins/commands/cloud/provider/create.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
               o.separator "Options:"
               o.separator ""
 
-              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |t|
+              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |u|
                 options[:username] = u
               end
             end

--- a/plugins/commands/cloud/provider/delete.rb
+++ b/plugins/commands/cloud/provider/delete.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
               o.separator "Options:"
               o.separator ""
 
-              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |t|
+              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |u|
                 options[:username] = u
               end
             end

--- a/plugins/commands/cloud/provider/update.rb
+++ b/plugins/commands/cloud/provider/update.rb
@@ -16,7 +16,7 @@ module VagrantPlugins
               o.separator "Options:"
               o.separator ""
 
-              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |t|
+              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |u|
                 options[:username] = u
               end
             end

--- a/plugins/commands/cloud/provider/upload.rb
+++ b/plugins/commands/cloud/provider/upload.rb
@@ -17,7 +17,7 @@ module VagrantPlugins
               o.separator "Options:"
               o.separator ""
 
-              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |t|
+              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |u|
                 options[:username] = u
               end
             end

--- a/plugins/commands/cloud/publish.rb
+++ b/plugins/commands/cloud/publish.rb
@@ -40,7 +40,7 @@ module VagrantPlugins
             o.on("-s", "--short-description DESCRIPTION", String, "Short description of the box") do |s|
               options[:short_description] = s
             end
-            o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |t|
+            o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |u|
               options[:username] = u
             end
           end

--- a/plugins/commands/cloud/search.rb
+++ b/plugins/commands/cloud/search.rb
@@ -37,7 +37,7 @@ module VagrantPlugins
             o.on("--sort-by SORT", "Field to sort results on (created, downloads, updated) Default: downloads") do |s|
               options[:sort] = s
             end
-            o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |t|
+            o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address to login with") do |u|
               options[:username] = u
             end
           end

--- a/plugins/commands/cloud/version/create.rb
+++ b/plugins/commands/cloud/version/create.rb
@@ -19,7 +19,7 @@ module VagrantPlugins
               o.on("-d", "--description DESCRIPTION", String, "A description for this version") do |d|
                 options[:description] = d
               end
-              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |t|
+              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |u|
                 options[:username] = u
               end
             end

--- a/plugins/commands/cloud/version/delete.rb
+++ b/plugins/commands/cloud/version/delete.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
               o.separator ""
               o.separator "Options:"
               o.separator ""
-              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |t|
+              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |u|
                 options[:username] = u
               end
             end

--- a/plugins/commands/cloud/version/release.rb
+++ b/plugins/commands/cloud/version/release.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
               o.separator ""
               o.separator "Options:"
               o.separator ""
-              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |t|
+              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |u|
                 options[:username] = u
               end
             end

--- a/plugins/commands/cloud/version/revoke.rb
+++ b/plugins/commands/cloud/version/revoke.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
               o.separator ""
               o.separator "Options:"
               o.separator ""
-              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |t|
+              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |u|
                 options[:username] = u
               end
             end

--- a/plugins/commands/cloud/version/update.rb
+++ b/plugins/commands/cloud/version/update.rb
@@ -19,7 +19,7 @@ module VagrantPlugins
               o.on("-d", "--description DESCRIPTION", "A description for this version") do |d|
                 options[:description] = d
               end
-              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |t|
+              o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |u|
                 options[:username] = u
               end
             end


### PR DESCRIPTION
This commit uses the correct instance variable for the optparse library
when reading in the command line flags for various Vagrant Cloud CLI
commands.