### PR TITLE
Removed bridged interface status check

### DIFF
--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -149,7 +149,6 @@ module VagrantPlugins
         def bridged_adapter(config)
           # Find the bridged interfaces that are available
           bridgedifs = @env[:machine].provider.driver.read_bridged_interfaces
-          bridgedifs.delete_if { |interface| interface[:status] == "Down" || interface[:status] == "Unknown" }
 
           # The name of the chosen bridge interface will be assigned to this
           # variable.


### PR DESCRIPTION
I was trying to setup bridged networking under Windows using the adapter that is available only in Virtualbox. It is configured [like this](https://i.imgur.com/7m4sXa9.png): all protocols disabled, only "Virtualbox NDIS6 Bridged Networking Driver" and some packet capture driver enabled. I have this network avaiable only to guests. It works OK in manually configured VMs.

It is reported by `vboxmanage list bridgedifs` as having status `down`:
```
Name:            Realtek RTL8139/810x Family Fast Ethernet NIC
GUID:            485edeef-dac5-4a3f-8cf6-350400279b75
DHCP:            Disabled
IPAddress:       0.0.0.0
NetworkMask:     0.0.0.0
IPV6Address:
IPV6NetworkMaskPrefixLength: 0
HardwareAddress: 00:00:00:00:00:00
MediumType:      Ethernet
Wireless:        No
Status:          Down
VBoxNetworkName: HostInterfaceNetworking-Realtek RTL8139/810x Family Fast Ethernet NIC
```
In `vagrantfile` it is configured like this:
```
    config.vm.network "public_network", bridge: "Realtek RTL8139/810x Family Fast Ethernet NIC", 
              mac: "0800274A1383"
```

So Vagrant couldn't find the adapter:
```
==> default: Specific bridge 'Realtek RTL8139/810x Family Fast Ethernet NIC' not
 found. You may be asked to specify
==> default: which network to bridge to.
```

That's because of the adapter was [removed from list](https://github.com/hashicorp/vagrant/blob/b886ec0b323163920202baec6424b64ccfcc56bc/plugins/providers/virtualbox/action/network.rb#L152):
```
bridgedifs.delete_if { |interface| interface[:status] == "Down" || interface[:status] == "Unknown" }
```
So I thought this check can be completely removed - if someone sets the adapter name he probably knows what is he doing.

Another scenario for misbehavior like this, can be temporary connection, when the bridged adapter is connected only occasionally, but needs to be configured in the guest.