### PR TITLE
Fix #10604: Network (-ing for Alpine)

### DIFF
--- a/test/unit/plugins/guests/alt/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/alt/cap/change_host_name_test.rb
@@ -30,7 +30,7 @@ describe "VagrantPlugins::GuestALT::Cap::ChangeHostName" do
       expect(comm.received_commands[1]).to match(/\/etc\/sysconfig\/network/)
       expect(comm.received_commands[1]).to match(/hostnamectl set-hostname --static '#{name}'/)
       expect(comm.received_commands[1]).to match(/hostnamectl set-hostname --transient '#{name}'/)
-      expect(comm.received_commands[1]).to match(/service network restart/)
+      expect(comm.received_commands[1]).to match(/service \$?net([a-z_]+|work(ing)?) restart/)
     end
 
     it "does not change the hostname if already set" do


### PR DESCRIPTION
Fixes #10604: the basic setup of hostname and network on Alpine boxes (...the
ones using ALT Linux as the base plugin. Most of the Alpine boxes being
regularly maintained are using the ALT Linux plugin base. Though the
setup of hostname and networking are broken. This is a minimalistic
fix until there are the proper Alpine plugin modules.

Fixes the unclean boot of Alpine boxes when the following options are specified:

`config.vm.hostname`
`config.vm.network`