### PR TITLE
BSD: VirtualBox shared folders naming convention

### DIFF
--- a/plugins/guests/bsd/cap/mount_virtualbox_shared_folder.rb
+++ b/plugins/guests/bsd/cap/mount_virtualbox_shared_folder.rb
@@ -1,7 +1,7 @@
 module VagrantPlugins
   module GuestBSD
     module Cap
-      class VirtualBox
+      class MountVirtualBoxSharedFolder
         # BSD-based guests do not currently support VirtualBox synced folders.
         # Instead of raising an error about a missing capability, this defines
         # the capability and then provides a more detailed error message,

--- a/plugins/guests/bsd/plugin.rb
+++ b/plugins/guests/bsd/plugin.rb
@@ -42,8 +42,8 @@ module VagrantPlugins
       end
 
       guest_capability(:bsd, :mount_virtualbox_shared_folder) do
-        require_relative "cap/virtualbox"
-        Cap::VirtualBox
+        require_relative "cap/mount_virtualbox_shared_folder"
+        Cap::MountVirtualBoxSharedFolder
       end
 
       guest_capability(:bsd, :remove_public_key) do

--- a/plugins/guests/freebsd/cap/mount_virtualbox_shared_folder.rb
+++ b/plugins/guests/freebsd/cap/mount_virtualbox_shared_folder.rb
@@ -3,7 +3,7 @@ require_relative "../../../synced_folders/unix_mount_helpers"
 module VagrantPlugins
   module GuestFreeBSD
     module Cap
-      class VirtualBox
+      class MountVirtualBoxSharedFolder
         extend SyncedFolder::UnixMountHelpers
 
         def self.mount_virtualbox_shared_folder(machine, name, guestpath, options)

--- a/plugins/guests/freebsd/plugin.rb
+++ b/plugins/guests/freebsd/plugin.rb
@@ -52,8 +52,13 @@ module VagrantPlugins
       end
 
       guest_capability(:freebsd, :mount_virtualbox_shared_folder) do
-        require_relative "cap/virtualbox"
-        Cap::VirtualBox
+        require_relative "cap/mount_virtualbox_shared_folder"
+        Cap::MountVirtualBoxSharedFolder
+      end
+
+      guest_capability(:freebsd, :unmount_virtualbox_shared_folder) do
+        require_relative "cap/mount_virtualbox_shared_folder"
+        Cap::MountVirtualBoxSharedFolder
       end
     end
   end

--- a/test/unit/plugins/guests/bsd/cap/mount_virtual_box_shared_folder_test.rb
+++ b/test/unit/plugins/guests/bsd/cap/mount_virtual_box_shared_folder_test.rb
@@ -1,6 +1,6 @@
 require_relative "../../../../base"
 
-describe "VagrantPlugins::GuestBSD::Cap::VirtualBox" do
+describe "VagrantPlugins::GuestBSD::Cap::MountVirtualBoxSharedFolder" do
   let(:caps) do
     VagrantPlugins::GuestBSD::Plugin
       .components

--- a/test/unit/plugins/guests/freebsd/cap/mount_virtual_box_shared_folder_test.rb
+++ b/test/unit/plugins/guests/freebsd/cap/mount_virtual_box_shared_folder_test.rb
@@ -1,6 +1,6 @@
 require_relative "../../../../base"
 
-describe "VagrantPlugins::GuestFreeBSD::Cap::VirtualBox" do
+describe "VagrantPlugins::GuestFreeBSD::Cap::MountVirtualBoxSharedFolder" do
   let(:caps) do
     VagrantPlugins::GuestFreeBSD::Plugin
       .components


### PR DESCRIPTION
This is a follow-up of #10717 to use the same naming convention as on Linux guests, in order to reduce the diffs.

Also adds the missing capability to `unmount_virtualbox_shared_folder` on FreeBSD guests.