### PR TITLE
FreeBSD: Simplify the listing of interfaces

### DIFF
--- a/plugins/guests/freebsd/cap/configure_networks.rb
+++ b/plugins/guests/freebsd/cap/configure_networks.rb
@@ -18,8 +18,8 @@ module VagrantPlugins
           # Remove any previous network additions to the configuration file.
           commands << "sed -i '' -e '/^#VAGRANT-BEGIN/,/^#VAGRANT-END/ d' /etc/rc.conf"
 
-          comm.sudo("ifconfig -a | grep -o '^[0-9a-z]*' | grep -v '^lo'", options) do |_, stdout|
-            interfaces = stdout.split("\n")
+          comm.sudo("ifconfig -l ether", options) do |_, stdout|
+            interfaces = stdout.split
           end
 
           networks.each.with_index do |network, i|

--- a/test/unit/plugins/guests/freebsd/cap/configure_networks_test.rb
+++ b/test/unit/plugins/guests/freebsd/cap/configure_networks_test.rb
@@ -13,8 +13,7 @@ describe "VagrantPlugins::GuestFreeBSD::Cap::ConfigureNetworks" do
 
   before do
     allow(machine).to receive(:communicate).and_return(comm)
-    comm.stub_command("ifconfig -a | grep -o '^[0-9a-z]*' | grep -v '^lo'",
-      stdout: "em1\nem2")
+    comm.stub_command("ifconfig -l ether", stdout: "em1 em2")
   end
 
   after do


### PR DESCRIPTION
According to [ifconfig(8)], to list only Ethernet interfaces, excluding all other interface types, including the loopback interface, the command to use should be:

    ifconfig -l ether

Related to: #8760

[ifconfig(8)]: https://www.freebsd.org/cgi/man.cgi?query=ifconfig&sektion=8
