### PR TITLE
Add a new --args parameter to rsync command

### DIFF
--- a/plugins/synced_folders/rsync/command/rsync.rb
+++ b/plugins/synced_folders/rsync/command/rsync.rb
@@ -27,6 +27,9 @@ module VagrantPlugins
             o.on("--[no-]rsync-chown", "Use rsync to modify ownership") do |chown|
               options[:rsync_chown] = chown
             end
+            o.on("--verbose", "Enable verbose output") do |v|
+              options[:verbose] = v
+            end
           end
 
           # Parse the options and return if we don't have any target.
@@ -65,6 +68,9 @@ module VagrantPlugins
             folders.each do |id, folder_opts|
               if options.has_key?(:rsync_chown)
                 folder_opts = folder_opts.merge(rsync_ownership: options[:rsync_chown])
+              end
+              if options.has_key?(:verbose)
+                folder_opts = folder_opts.merge(verbose: options[:verbose])
               end
               RsyncHelper.rsync_single(machine, ssh_info, folder_opts)
             end

--- a/plugins/synced_folders/rsync/command/rsync.rb
+++ b/plugins/synced_folders/rsync/command/rsync.rb
@@ -27,6 +27,9 @@ module VagrantPlugins
             o.on("--[no-]rsync-chown", "Use rsync to modify ownership") do |chown|
               options[:rsync_chown] = chown
             end
+            o.on("--args ARGS", String, "Override rsync arguments given in shared folder configuration (bash syntax)") do |args|
+              options[:override_args] = Shellwords.split(args)
+            end
             o.on("--verbose", "Enable verbose output") do |v|
               options[:verbose] = v
             end
@@ -68,6 +71,9 @@ module VagrantPlugins
             folders.each do |id, folder_opts|
               if options.has_key?(:rsync_chown)
                 folder_opts = folder_opts.merge(rsync_ownership: options[:rsync_chown])
+              end
+              if options.has_key?(:override_args)
+                folder_opts = folder_opts.merge(args: options[:override_args])
               end
               if options.has_key?(:verbose)
                 folder_opts = folder_opts.merge(verbose: options[:verbose])

--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -185,6 +185,11 @@ module VagrantPlugins
           "#{username}@#{host}:#{guestpath}",
         ].flatten
 
+        if opts.include?(:verbose)
+          machine.ui.info(I18n.t("vagrant.rsync_command_dump",
+                                 command: command))
+        end
+
         # The working directory should be the root path
         command_opts = {}
         command_opts[:workdir] = machine.env.root_path.to_s

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -243,6 +243,7 @@ en:
       fix the issue:
 
       %{message}
+    rsync_command_dump: "Running rsync command: %{command}"
     rsync_communicator_not_ready: |-
       The machine is reporting that it is not ready for rsync to
       communicate with it. Verify that this machine is properly running.


### PR DESCRIPTION
This command lets the user override the default arguments to rsync on the command line. I also added the --verbose switch, and it now prints the full rsync command when in verbose mode.