### PR TITLE
Advanced folder sync config for puppet shared folders.

### DIFF
--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -31,7 +31,11 @@ module VagrantPlugins
           folder_opts = {}
           folder_opts[:type] = @config.synced_folder_type if @config.synced_folder_type
           folder_opts[:owner] = "root" if !@config.synced_folder_type
-          folder_opts[:args] = @config.synced_folder_args if @config.synced_folder_args
+          if @config.synced_folder_args.is_a?(Hash)
+            folder_opts.merge!(@config.synced_folder_args)
+          else
+            folder_opts[:args] = @config.synced_folder_args if @config.synced_folder_args
+          end
           folder_opts[:nfs__quiet] = true
 
           if @config.environment_path.is_a?(Array)

--- a/website/source/docs/provisioning/puppet_apply.html.md
+++ b/website/source/docs/provisioning/puppet_apply.html.md
@@ -63,9 +63,9 @@ available below this section.
   this will use the default synced folder type. For example, you can set this
   to "nfs" to use NFS synced folders.
 
-* `synced_folder_args` (array) - Arguments that are passed to the folder sync.
+* `synced_folder_args` (array or hash) - Arguments that are passed to the folder sync.
   For example ['-a', '--delete', '--exclude=fixtures'] for the rsync sync
-  command.
+  command or { nfs_version: 4, nfs_udp: false } for the nfs mount.
 
 * `temp_dir` (string) - The directory where all the data associated with
   the Puppet run (manifest files, modules, etc.) will be stored on the


### PR DESCRIPTION
Allows configuring the shared folder config by supplying
a hash in stead of an array. Only few (rsync?) shared-folder
types use the :args key used here.