### PR TITLE
Remove *I* from documentation

### DIFF
--- a/website/source/docs/provisioning/ansible.html.md
+++ b/website/source/docs/provisioning/ansible.html.md
@@ -15,7 +15,7 @@ The Vagrant Ansible provisioner allows you to provision the guest using [Ansible
 
 <div class="alert alert-warning">
   <strong>Warning:</strong>
-  If you are not familiar with Ansible and Vagrant already, I recommend starting with the <a href="/docs/provisioning/shell.html">shell provisioner</a>. However, if you are comfortable with Vagrant already, Vagrant is a great way to learn Ansible.
+  If you are not familiar with Ansible and Vagrant already, we recommend starting with the <a href="/docs/provisioning/shell.html">shell provisioner</a>. However, if you are comfortable with Vagrant already, Vagrant is a great way to learn Ansible.
 </div>
 
 ## Setup Requirements

--- a/website/source/docs/provisioning/ansible_local.html.md
+++ b/website/source/docs/provisioning/ansible_local.html.md
@@ -15,7 +15,7 @@ The Vagrant Ansible Local provisioner allows you to provision the guest using [A
 
 <div class="alert alert-warning">
   <strong>Warning:</strong>
-  If you are not familiar with Ansible and Vagrant already, I recommend starting with the <a href="/docs/provisioning/shell.html">shell provisioner</a>. However, if you are comfortable with Vagrant already, Vagrant is a great way to learn Ansible.
+  If you are not familiar with Ansible and Vagrant already, we recommend starting with the <a href="/docs/provisioning/shell.html">shell provisioner</a>. However, if you are comfortable with Vagrant already, Vagrant is a great way to learn Ansible.
 </div>
 
 ## Setup Requirements

--- a/website/source/docs/provisioning/chef_zero.html.md
+++ b/website/source/docs/provisioning/chef_zero.html.md
@@ -22,7 +22,7 @@ and client key registration.
 
 <div class="alert alert-warning">
   <strong>Warning:</strong> If you are not familiar with Chef and Vagrant already,
-  I recommend starting with the <a href="/docs/provisioning/shell.html">shell
+  we recommend starting with the <a href="/docs/provisioning/shell.html">shell
   provisioner</a>. However, if you are comfortable with Vagrant already, Vagrant
   is the best way to learn Chef.
 </div>

--- a/website/source/docs/provisioning/shell.html.md
+++ b/website/source/docs/provisioning/shell.html.md
@@ -123,7 +123,7 @@ Vagrant.configure("2") do |config|
 end
 ```
 
-I understand that if you are not familiar with Ruby, the above may seem very
+It is understandable that if you are not familiar with Ruby, the above may seem very
 advanced or foreign. But do not fear, what it is doing is quite simple:
 the script is assigned to a global variable `$script`. This global variable
 contains a string which is then passed in as the inline script to the


### PR DESCRIPTION
Removing I since it does not really make sense while reading the
documentation.