### PR TITLE
Ensure non-existent machines do not attempt to list snapshots

### DIFF
--- a/plugins/commands/snapshot/command/pop.rb
+++ b/plugins/commands/snapshot/command/pop.rb
@@ -23,8 +23,10 @@ module VagrantPlugins
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant snapshot pop [options] [vm-name]"
             o.separator ""
+            o.separator "Restore state that was pushed onto the snapshot stack"
+            o.separator "with `vagrant snapshot push`."
+            o.separator ""
             build_start_options(o, options)
-            o.separator "Restore state that was pushed with `vagrant snapshot push`."
 
             o.on("--no-delete", "Don't delete the snapshot after the restore") do
                 options[:snapshot_delete] = false

--- a/plugins/providers/virtualbox/cap.rb
+++ b/plugins/providers/virtualbox/cap.rb
@@ -29,6 +29,7 @@ module VagrantPlugins
       #
       # @return [Array<String>] Snapshot Name
       def self.snapshot_list(machine)
+        return [] if machine.id.nil?
         machine.provider.driver.list_snapshots(machine.id)
       end
     end

--- a/test/unit/plugins/providers/virtualbox/cap_test.rb
+++ b/test/unit/plugins/providers/virtualbox/cap_test.rb
@@ -40,4 +40,19 @@ describe VagrantPlugins::ProviderVirtualBox::Cap do
       expect(described_class.forwarded_ports(machine)).to be(nil)
     end
   end
+
+  describe "#snapshot_list" do
+    it "returns all the snapshots" do
+      allow(machine).to receive(:id).and_return("1234")
+      allow(driver).to receive(:list_snapshots).with(machine.id).
+        and_return(["backup", "old"])
+
+      expect(described_class.snapshot_list(machine)).to eq(["backup", "old"])
+    end
+
+    it "returns empty array when the machine is does not exist" do
+      allow(machine).to receive(:id).and_return(nil)
+      expect(described_class.snapshot_list(machine)).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
Prior to this pull request, if a snapshot restore was run on an entire
environment with some non-existent guests, Vagrant would attempt to list
their snapshots with a nil id. This commit fixes that by returning an
empty list of snapshots if the machine has not been created yet.