### PR TITLE
VAGRANT_DISABLE_VBOXSYMLINKCREATE is not true by default

### DIFF
--- a/website/source/docs/other/environmental-variables.html.md
+++ b/website/source/docs/other/environmental-variables.html.md
@@ -135,7 +135,7 @@ This can be disabled setting this environment variable.
 ## `VAGRANT_DISABLE_VBOXSYMLINKCREATE`
 
 If set, this will disable the ability to create symlinks with all virtualbox
-shared folders. Defaults to true if the option is not set. This can be overridden
+shared folders. Defaults to false if the option is not set. This can be overridden
 on a per-folder basis within your Vagrantfile config by settings the
 `SharedFoldersEnableSymlinksCreate` option to true.
 


### PR DESCRIPTION
This text was introduced in https://github.com/hashicorp/vagrant/pull/9354 ([commit](https://github.com/hashicorp/vagrant/commit/b16ca2e384a4d548d5b907e00662693ce05cca4b#diff-aa3fa2a3966ebd8cc74d249fa15dfc46)):

> `VAGRANT_DISABLE_VBOXSYMLINKCREATE`
> If set, this will disable the ability to create symlinks with all virtualbox shared folders. Defaults to true if the option is not set. This can be overridden on a per-folder basis within your Vagrantfile config by settings the `SharedFoldersEnableSymlinksCreate` option to true.

I read "Defaults to true if the option is not set." that `VAGRANT_DISABLE_VBOXSYMLINKCREATE` defaults to true if not set, and that is not correct. If not set, I see this warning on `vagrant up`:

```
Vagrant is currently configured to create VirtualBox synced folders with
the `SharedFoldersEnableSymlinksCreate` option enabled. If the Vagrant
guest is not trusted, you may want to disable this option. For more
information on this option, please refer to the VirtualBox manual:

  https://www.virtualbox.org/manual/ch04.html#sharedfolders

This option can be disabled globally with an environment variable:

  VAGRANT_DISABLE_VBOXSYMLINKCREATE=1

or on a per folder basis within the Vagrantfile:

  config.vm.synced_folder '/host/path', '/guest/path', SharedFoldersEnableSymlinksCreate: false
```