### PR TITLE
Set gemrc through configuration method rather than relying on environment variable

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -12,8 +12,6 @@ require "rubygems/name_tuple"
 require_relative "shared_helpers"
 require_relative "version"
 require_relative "util/safe_env"
-require_relative "util/platform"
-require "vagrant/util/subprocess"
 
 module Vagrant
   # This class manages Vagrant's interaction with Bundler. Vagrant uses
@@ -43,6 +41,9 @@ module Vagrant
       @plugin_gem_path = Vagrant.user_data_path.join("gems", RUBY_VERSION).freeze
       @logger = Log4r::Logger.new("vagrant::bundler")
 
+      # TODO: Remove fix when https://github.com/rubygems/rubygems/pull/2735
+      # gets merged and released
+      #
       # Because of a rubygems bug, we need to set the gemrc file path
       # through this method rather than relying on the environment varible
       # GEMRC. On windows, that path gets split on `:`: and `;`, which means

--- a/test/unit/vagrant/bundler_test.rb
+++ b/test/unit/vagrant/bundler_test.rb
@@ -28,6 +28,19 @@ describe Vagrant::Bundler do
     expect(subject.env_plugin_gem_path).to be_nil
   end
 
+  describe "#initialize" do
+    let(:gemrc_location) { "C:\\My\\Config\\File" }
+
+    it "should set up GEMRC through a flag instead of GEMRC" do
+      allow(ENV).to receive(:[]).with("VAGRANT_HOME")
+      allow(ENV).to receive(:[]).with("USERPROFILE")
+
+      allow(ENV).to receive(:[]).with("GEMRC").and_return(gemrc_location)
+      expect(Gem::ConfigFile).to receive(:new).with(["--config-file", gemrc_location])
+      init_subject = described_class.new
+    end
+  end
+
   describe "#deinit" do
     it "should provide method for backwards compatibility" do
       subject.deinit


### PR DESCRIPTION
Prior to this pull request, when Vagrant attempted to use the rubygems library, it
would attempt to pass in a gemrc through an environment variable that
the rubygems library would try to split and parse. This is normally
fine, as the method in question would return empty if that file did not
exist. However if the user had a file that matches the drive that
Vagrant was installed on, rubygems would fail saying the folder was not
a file (or a gemrc, in this case).

This commit works around that by instead configuring the gemrc location
through ruby with `Gem.configuration`.

Related rubygems issue rubygems/rubygems#2733


Fixes #10800, Fixes #9148