### PR TITLE
Fixes #10813: Add install link docs to Share tutorial

### DIFF
--- a/website/source/intro/getting-started/share.html.md
+++ b/website/source/intro/getting-started/share.html.md
@@ -23,7 +23,10 @@ world with an Internet connection. It will give you a URL that will route
 directly to your Vagrant environment from any device in the world that is
 connected to the Internet.
 
-Run `vagrant share`:
+First, follow the [installation guide](/docs/share/#installation) before getting
+started. You need the `vagrant-share` plugin for the rest of the tutorial to work.
+
+Next, run `vagrant share`:
 
 ```
 $ vagrant share
@@ -48,7 +51,7 @@ Vagrant Share is much more powerful than simply HTTP sharing. For more
 details, see the [complete Vagrant Share documentation](/docs/share/).
 
 Note: Vagrant Share now defaults to using the `ngrok` driver.
-The `classic` driver has been deprecated. 
+The `classic` driver has been deprecated.
 
 ~> **Vagrant share is not designed to serve production traffic!** Please do not
 rely on Vagrant share outside of development or Q/A. The Vagrant share service


### PR DESCRIPTION
This commit adds a note and link on how to install vagrant-share before
the vagrant share tutorial starts. This ensures that users know they
need the plugin installed since it no longer comes with Vagrant core.