### PR TITLE
Fixes #10798: Enhance how docker compose driver path expands

### DIFF
--- a/templates/locales/providers_docker.yml
+++ b/templates/locales/providers_docker.yml
@@ -104,6 +104,12 @@ en:
       destroy the container and recreate it.
     waiting_for_running: |-
       Waiting for container to enter "running" state...
+    volume_path_not_expanded: |-
+      Host path `%{host}` exists as a `volumes` key and is a folder on disk. Vagrant
+      will not expand this key like it used to and instead leave it as is defined.
+      If this folder is intended to be used, make sure its full path is defined
+      in your `volumes` config. More information can be found on volumes in the
+      docker compose documentation.
 
     messages:
       destroying: |-

--- a/test/unit/plugins/providers/docker/driver_compose_test.rb
+++ b/test/unit/plugins/providers/docker/driver_compose_test.rb
@@ -106,6 +106,22 @@ describe VagrantPlugins::DockerProvider::Driver::Compose do
       end
     end
 
+    context 'with a volumes key in use for mounting' do
+      let(:compose_config) { {"volumes"=>{"my_volume_key"=>"data"}} }
+
+      before do
+        params[:volumes] = 'my_volume_key:my/guest/path'
+        allow(Pathname).to receive(:new).with('./path').and_call_original
+        allow(Pathname).to receive(:new).with('my_volume_key').and_call_original
+        allow(Pathname).to receive(:new).with('/compose/cwd/my_volume_key').and_call_original
+        allow(subject).to receive(:get_composition).and_return(compose_config)
+      end
+
+      it 'should not expand the relative host directory' do
+        expect(docker_yml).to receive(:write).with(%r{my_volume_key})
+      end
+    end
+
     it 'links containers' do
       params[:links].each do |link|
         expect(docker_yml).to receive(:write).with(/#{link}/)


### PR DESCRIPTION
Prior to this commit, the docker compose driver would _always_ path
expand a host volume no matter what. This is not always the correct
option, for example if that host volume is actually a reference to a key
inside a `volumes` hash instead of a path on disk. This commit changes
that by looking to see if the requested host volume is actually a
defined key inside the compose config, and if not, it will path expand
it like before. Otherwise it will leave the key "as is".