### PR TITLE
Fixes #10823: Use Process.exit! for abort trigger option

### DIFF
--- a/lib/vagrant/plugin/v2/trigger.rb
+++ b/lib/vagrant/plugin/v2/trigger.rb
@@ -301,7 +301,7 @@ module Vagrant
         # @param [Integer] code Code to exit Vagrant on
         def trigger_abort(exit_code)
           @ui.warn(I18n.t("vagrant.trigger.abort"))
-          exit(exit_code)
+          Process.exit!(exit_code)
         end
 
         # Calls the given ruby block for execution

--- a/test/unit/vagrant/plugin/v2/trigger_test.rb
+++ b/test/unit/vagrant/plugin/v2/trigger_test.rb
@@ -414,12 +414,14 @@ describe Vagrant::Plugin::V2::Trigger do
 
   context "#trigger_abort" do
     it "system exits when called" do
+      allow(Process).to receive(:exit!).and_return(true)
       output = ""
       allow(machine.ui).to receive(:warn) do |data|
         output << data
       end
 
-      expect { subject.send(:trigger_abort, 3) }.to raise_error(SystemExit)
+      expect(Process).to receive(:exit!).with(3)
+      subject.send(:trigger_abort, 3)
     end
   end
 


### PR DESCRIPTION
Prior to this commit, the `abort` option for triggers would just call
`exit`, which would end up raising a SystemExit exception, signaling
Vagrant to abort. This broke down however in a multithreaded context
like when running multiple guests at once on supported providers,
resulting in Vagrant failing to exit cleanly and instead raise an
exception. This commit changes that by instead using `Process.exit!` to
abort Vagrant.