### PR TITLE
Separate snapshot names when listing snapshots

### DIFF
--- a/plugins/commands/snapshot/command/list.rb
+++ b/plugins/commands/snapshot/command/list.rb
@@ -32,8 +32,9 @@ module VagrantPlugins
               next
             end
 
+            vm.ui.output("", prefix: true)
             snapshots.each do |snapshot|
-              vm.ui.output(snapshot, prefix: false)
+              vm.ui.detail(snapshot, prefix: false)
             end
           end
 

--- a/test/unit/plugins/commands/snapshot/command/list_test.rb
+++ b/test/unit/plugins/commands/snapshot/command/list_test.rb
@@ -72,9 +72,10 @@ describe VagrantPlugins::CommandSnapshot::Command::List do
         allow(machine.provider).to receive(:capability).with(:snapshot_list).
           and_return(["foo", "bar", "baz"])
 
-        expect(iso_env.ui).to receive(:output).with(/foo/, anything)
-        expect(iso_env.ui).to receive(:output).with(/bar/, anything)
-        expect(iso_env.ui).to receive(:output).with(/baz/, anything)
+        expect(iso_env.ui).to receive(:output).with(/default/, anything)
+        expect(iso_env.ui).to receive(:detail).with(/foo/, anything)
+        expect(iso_env.ui).to receive(:detail).with(/bar/, anything)
+        expect(iso_env.ui).to receive(:detail).with(/baz/, anything)
         expect(subject.execute).to eq(0)
       end
     end


### PR DESCRIPTION
Prior to this commit, Vagrant would list all machine snapshots in a flat
list, without showing which snapshots were associated with which guests.
This commit fixes that by placing some separation to make it clear which
snapshots belong to which guests.