### PR TITLE
Continue updating environment boxes if metadata not found

### DIFF
--- a/plugins/commands/box/command/update.rb
+++ b/plugins/commands/box/command/update.rb
@@ -128,7 +128,13 @@ module VagrantPlugins
             if download_options[:insecure].nil?
               download_options[:insecure] = machine.config.vm.box_download_insecure
             end
-            box_update(box, version, machine.ui, download_options, force)
+
+            begin
+              box_update(box, version, machine.ui, download_options, force)
+            rescue Vagrant::Errors::BoxUpdateNoMetadata => e
+              machine.ui.warn(e)
+              next
+            end
           end
         end
 

--- a/test/unit/plugins/commands/box/command/update_test.rb
+++ b/test/unit/plugins/commands/box/command/update_test.rb
@@ -405,6 +405,24 @@ describe VagrantPlugins::CommandBox::Command::Update do
             end
           end
 
+          context "ignoring boxes with no metadata" do
+            before do
+              allow(subject).to receive(:with_target_vms) { |&block| block.call machine }
+            end
+
+            let(:box) do
+              box_dir = test_iso_env.box3("foo", "1.0", :virtualbox)
+              box = Vagrant::Box.new(
+                "foo", :virtualbox, "1.0", box_dir, metadata_url: "foo")
+              allow(box).to receive(:has_update?).and_raise(Vagrant::Errors::BoxUpdateNoMetadata, name: "foo")
+              box
+            end
+
+            it "continues to update the rest of the boxes in the environment" do
+              subject.execute
+            end
+          end
+
           context "force flag is specified on the command line" do
             let(:argv) { ["--force"].concat(download_options) }
 


### PR DESCRIPTION
Prior to this commit, if a user ran a `vagrant box update` on their
entire environment and one of the boxes did not have a metadata file,
the rest of the boxes in the update would be skipped. This commit fixes
that by providing an option to ingore those boxes, so that the rest of
the boxes could check for updates.