### PR TITLE
Ubuntu 12 is now EOL'd, so use Ubuntu 18 instead

### DIFF
--- a/website/source/intro/getting-started/index.html.md
+++ b/website/source/intro/getting-started/index.html.md
@@ -36,13 +36,13 @@ provider for the getting started guide, please install that as well.
 ## Up and Running
 
 ```
-$ vagrant init hashicorp/precise64
+$ vagrant init hashicorp/bionic64
 $ vagrant up
 ```
 
 After running the above two commands, you will have a fully running
 virtual machine in [VirtualBox](https://www.virtualbox.org) running
-Ubuntu 12.04 LTS 64-bit. You can SSH into this machine with
+Ubuntu 18 LTS 64-bit. You can SSH into this machine with
 `vagrant ssh`, and when you are done playing around, you can terminate the
 virtual machine with `vagrant destroy`.
 


### PR DESCRIPTION
While reading the docs, I noticed Ubuntu 12 was referenced. Since [Ubuntu 12.04 was officially EOL'd in April 2019](https://www.ubuntu.com/about/release-cycle), I recommend switching to a newer version as the default image. 

I'm mostly thinking about this to help newcomers avoid unexpected dependency installation troubles right after they pull up a new VM, since I imagine some packages will stop being supported soon on 12.

Perhaps the version should be specified more precisely than "Ubuntu 18" ? 