### PR TITLE
Search for running_vm_list only in `machines` folder

### DIFF
--- a/contrib/bash/completion.sh
+++ b/contrib/bash/completion.sh
@@ -85,7 +85,7 @@ _vagrant() {
               then
                 running_vm_list=$(grep 'active' "${vagrant_state_file}" | sed -e 's/"active"://' | tr ',' '\n' | cut -d '"' -f 2 | tr '\n' ' ')
               else
-                running_vm_list=$(find "${vagrant_state_file}" -type f -name "id" | awk -F"/" '{print $(NF-2)}')
+                running_vm_list=$(find "${vagrant_state_file}/machines" -type f -name "id" | awk -F"/" '{print $(NF-2)}')
               fi
               COMPREPLY=($(compgen -W "${running_vm_list}" -- ${cur}))
               return 0


### PR DESCRIPTION
otherwise it might catch a non-machine id, in my case, for hostmanager plugin