### PR TITLE
Ensure guest names are string when filtering trigger configs

### DIFF
--- a/lib/vagrant/plugin/v2/trigger.rb
+++ b/lib/vagrant/plugin/v2/trigger.rb
@@ -110,7 +110,7 @@ module Vagrant
             match = false
             if trigger.only_on
               trigger.only_on.each do |o|
-                if o.match(guest_name)
+                if o.match(guest_name.to_s)
                   # trigger matches on current guest, so we're fine to use it
                   match = true
                   break

--- a/plugins/kernel_v2/config/vm_trigger.rb
+++ b/plugins/kernel_v2/config/vm_trigger.rb
@@ -117,7 +117,7 @@ module VagrantPlugins
         @command = command.to_sym
         @ruby_block = UNSET_VALUE
 
-        @logger.debug("Trigger defined for command: #{command}")
+        @logger.debug("Trigger defined for: #{command}")
       end
 
       # Config option `ruby` for a trigger which reads in a ruby block and sets

--- a/test/unit/vagrant/plugin/v2/trigger_test.rb
+++ b/test/unit/vagrant/plugin/v2/trigger_test.rb
@@ -74,7 +74,7 @@ describe Vagrant::Plugin::V2::Trigger do
 
       after_triggers = triggers.after_triggers
       expect(after_triggers.size).to eq(3)
-      subject.send(:filter_triggers, after_triggers, "ubuntu", :action)
+      subject.send(:filter_triggers, after_triggers, :ubuntu, :action)
       expect(after_triggers.size).to eq(2)
     end
 


### PR DESCRIPTION
Prior to this commit, if a guest name was given as a symbol, the
filter_triggers method would fail to properly match it with the only_on
option, as it is not a valid type to the #String.match method. This
commit fixes that by converting the parameter to a string so that it can
be properly matched on the guest.

Relates to https://github.com/hashicorp/vagrant/issues/10852