### PR TITLE
Fixes #10856: Add common chef config options to nav bar

### DIFF
--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -94,6 +94,7 @@
           <li<%= sidebar_current("provisioning-ansible") %>><a href="/docs/provisioning/ansible.html">Ansible</a></li>
           <li<%= sidebar_current("provisioning-ansible-local") %>><a href="/docs/provisioning/ansible_local.html">Ansible Local</a></li>
           <li<%= sidebar_current("provisioning-cfengine") %>><a href="/docs/provisioning/cfengine.html">CFEngine</a></li>
+          <li<%= sidebar_current("provisioning-chefcommon") %>><a href="/docs/provisioning/chef_common.html">Chef Common Configuration</a></li>
           <li<%= sidebar_current("provisioning-chefsolo") %>><a href="/docs/provisioning/chef_solo.html">Chef Solo</a></li>
           <li<%= sidebar_current("provisioning-chefzero") %>><a href="/docs/provisioning/chef_zero.html">Chef Zero</a></li>
           <li<%= sidebar_current("provisioning-chefclient") %>><a href="/docs/provisioning/chef_client.html">Chef Client</a></li>


### PR DESCRIPTION
This commit updates the provisioner nav bar on the docs website to
include the common chef configuration documentation. This makes these
options more discoverable, as before it was hidden in a URL link inside
of the other chef docs.