### PR TITLE
providers/docker: Add usability test

### DIFF
--- a/plugins/providers/docker/provider.rb
+++ b/plugins/providers/docker/provider.rb
@@ -11,6 +11,14 @@ module VagrantPlugins
     class Provider < Vagrant.plugin("2", :provider)
       @@host_vm_mutex = Mutex.new
 
+      def self.usable?(raise_error=false)
+        Driver.new.execute("docker", "version")
+        true
+      rescue Vagrant::Errors::CommandUnavailable, Errors::ExecuteError
+        raise if raise_error
+        return false
+      end
+
       def initialize(machine)
         @logger  = Log4r::Logger.new("vagrant::provider::docker")
         @machine = machine

--- a/test/unit/support/shared/virtualbox_context.rb
+++ b/test/unit/support/shared/virtualbox_context.rb
@@ -28,6 +28,11 @@ shared_context "virtualbox" do
     allow(subprocess).to receive(:execute).
       with("VBoxManage", "showvminfo", kind_of(String), kind_of(Hash)).
       and_return(subprocess_result(exit_code: 0))
+
+    # apparently this is also used in docker tests
+    allow(subprocess).to receive(:execute).
+      with("docker", "version", an_instance_of(Hash)).
+      and_return(subprocess_result(exit_code: 0))
   end
 
   around do |example|


### PR DESCRIPTION
This allows Vagrant to fallback from the Docker provider to an alternate provider if `docker` isn’t installed, like the documentation [claims](https://www.vagrantup.com/docs/providers/basic_usage.html#default-provider) it should.