### PR TITLE
Update Example Ubuntu init

### DIFF
--- a/website/source/intro/getting-started/index.html.md
+++ b/website/source/intro/getting-started/index.html.md
@@ -36,13 +36,13 @@ provider for the getting started guide, please install that as well.
 ## Up and Running
 
 ```
-$ vagrant init hashicorp/precise64
+$ vagrant init ubuntu/bionic64
 $ vagrant up
 ```
 
 After running the above two commands, you will have a fully running
 virtual machine in [VirtualBox](https://www.virtualbox.org) running
-Ubuntu 12.04 LTS 64-bit. You can SSH into this machine with
+Ubuntu 18.04 LTS 64-bit. You can SSH into this machine with
 `vagrant ssh`, and when you are done playing around, you can terminate the
 virtual machine with `vagrant destroy`.
 


### PR DESCRIPTION
Ubuntu 12.04 is no longer supported and it can be confusing for new users to install such an old OS.