### PR TITLE
Support loading plugin information from nested Vagrantfiles

### DIFF
--- a/test/unit/vagrant/util/ssh_test.rb
+++ b/test/unit/vagrant/util/ssh_test.rb
@@ -39,7 +39,7 @@ describe Vagrant::Util::SSH do
       dsa_authentication: true
     }}
 
-    let(:ssh_path) { "/usr/bin/ssh" }
+    let(:ssh_path) { /.*ssh/ }
 
     it "searches original PATH for executable" do
       expect(Vagrant::Util::Which).to receive(:which).with("ssh", original_path: true).and_return("valid-return")
@@ -96,8 +96,6 @@ describe Vagrant::Util::SSH do
         compression: true,
         dsa_authentication: true
       }}
-
-      let(:ssh_path) { "/usr/bin/ssh" }
 
       it "uses the IdentityFile argument and escapes the '%' character" do
         allow(Vagrant::Util::SafeExec).to receive(:exec).and_return(nil)
@@ -247,7 +245,7 @@ describe Vagrant::Util::SSH do
       it "enables ssh config loading" do
         allow(Vagrant::Util::SafeExec).to receive(:exec).and_return(nil)
         expect(Vagrant::Util::SafeExec).to receive(:exec) do |exe_path, *args|
-          expect(exe_path).to eq(ssh_path)
+          expect(exe_path).to match(ssh_path)
           config_options = ["-F", "/path/to/config"]
           expect(args & config_options).to eq(config_options)
         end


### PR DESCRIPTION
Since plugin installation happens when the environment is first
initialized, attempt to determine the provider in use and load
any box provided Vagrantfiles to include any plugin configuration
they may include.