### PR TITLE
Add usability check for docker plus tests

### DIFF
--- a/plugins/providers/docker/provider.rb
+++ b/plugins/providers/docker/provider.rb
@@ -11,6 +11,14 @@ module VagrantPlugins
     class Provider < Vagrant.plugin("2", :provider)
       @@host_vm_mutex = Mutex.new
 
+      def self.usable?(raise_error=false)
+        Driver.new.execute("docker", "version")
+        true
+      rescue Vagrant::Errors::CommandUnavailable, Errors::ExecuteError
+        raise if raise_error
+        return false
+      end
+
       def initialize(machine)
         @logger  = Log4r::Logger.new("vagrant::provider::docker")
         @machine = machine

--- a/plugins/providers/docker/provider.rb
+++ b/plugins/providers/docker/provider.rb
@@ -11,14 +11,6 @@ module VagrantPlugins
     class Provider < Vagrant.plugin("2", :provider)
       @@host_vm_mutex = Mutex.new
 
-      def self.usable?(raise_error=false)
-        Driver.new.execute("docker", "version")
-        true
-      rescue Vagrant::Errors::CommandUnavailable, Errors::ExecuteError
-        raise if raise_error
-        return false
-      end
-
       def initialize(machine)
         @logger  = Log4r::Logger.new("vagrant::provider::docker")
         @machine = machine
@@ -51,6 +43,14 @@ module VagrantPlugins
         end
 
         @driver
+      end
+
+      def usable?(raise_error=false)
+        driver.execute("docker", "version")
+        true
+      rescue Vagrant::Errors::CommandUnavailable, Errors::ExecuteError
+        raise if raise_error
+        return false
       end
 
       # This returns the {Vagrant::Machine} that is our host machine.

--- a/test/unit/plugins/providers/docker/provider_test.rb
+++ b/test/unit/plugins/providers/docker/provider_test.rb
@@ -1,0 +1,128 @@
+require_relative "../../../base"
+
+require Vagrant.source_root.join("plugins/providers/docker/provider")
+
+describe VagrantPlugins::DockerProvider::Provider do
+  let(:driver_obj){ double("driver") }
+  let(:provider){ double("provider", driver: driver_obj) }
+  let(:provider_config){ double("provider_config", force_host_vm: false) }
+  let(:ssh) { double("ssh", guest_port: 22) }
+  let(:config) { double("config", ssh: ssh) }
+  let(:machine){ double("machine", provider: provider, provider_config: provider_config, config: config) }
+
+
+  let(:platform)   { double("platform") }
+
+  subject { described_class.new(machine) }
+
+  before do
+    stub_const("Vagrant::Util::Platform", platform)
+    allow(machine).to receive(:id).and_return("foo")
+  end
+
+  describe ".usable?" do
+    subject { described_class.new(machine) }
+
+    it "returns true if usable" do
+      allow(provider_config).to receive(:compose).and_return(false)
+      allow(subject.driver).to receive(:execute).with("docker", "version").and_return(true)
+      expect(subject).to be_usable
+    end
+
+    it "raises an exception if docker is not available" do
+      allow(VagrantPlugins::DockerProvider::Driver).to receive(:new).and_return(driver_obj)
+      allow(provider_config).to receive(:compose).and_return(false)
+      allow(platform).to receive(:windows?).and_return(false)
+      allow(platform).to receive(:darwin?).and_return(false)
+
+      allow(driver_obj).to receive(:execute).with("docker", "version").
+        and_raise(Vagrant::Errors::CommandUnavailable, file: "docker")
+
+      expect { subject.usable?(true) }.
+        to raise_error(Vagrant::Errors::CommandUnavailable)
+    end
+  end
+
+  describe "#driver" do
+    it "is initialized" do
+      allow(provider_config).to receive(:compose).and_return(false)
+      allow(platform).to receive(:windows?).and_return(false)
+      allow(platform).to receive(:darwin?).and_return(false)
+      expect(subject.driver).to be_kind_of(VagrantPlugins::DockerProvider::Driver)
+    end
+  end
+
+  describe "#state" do
+    it "returns not_created if no ID" do
+      allow(machine).to receive(:id).and_return(nil)
+
+      expect(subject.state.id).to eq(:not_created)
+    end
+
+    it "calls an action to determine the ID" do
+      allow(provider_config).to receive(:compose).and_return(false)
+      allow(platform).to receive(:windows?).and_return(false)
+      allow(platform).to receive(:darwin?).and_return(false)
+      allow(machine).to receive(:id).and_return("foo")
+
+      expect(subject.state.id).to eq(:not_created)
+    end
+  end
+
+  describe "#host_vm" do
+    let(:host_env) { double("host_env", root_path: "/vagrant.d", default_provider: :virtualbox) }
+
+    it "returns the host machine object" do
+      allow(machine.provider_config).to receive(:vagrant_vagrantfile).and_return("/path/to/Vagrantfile")
+      allow(machine.provider_config).to receive(:vagrant_machine).and_return(:default)
+      allow(machine).to receive(:env).and_return(true)
+      allow(machine.env).to receive(:root_path).and_return("/.vagrant.d")
+      allow(machine.env).to receive(:home_path).and_return("/path/to")
+      allow(machine.env).to receive(:ui_class).and_return(true)
+
+      expect(Vagrant::Environment).to receive(:new).and_return(host_env)
+
+      allow(host_env).to receive(:machine).and_return(true)
+      subject.host_vm
+    end
+  end
+
+  describe "#ssh_info" do
+    let(:result) { "127.0.0.1" }
+    let(:exit_code) { 0 }
+    let(:ssh_info) {{:host=>result,:port=>22}}
+
+    let(:network_settings) { {"NetworkSettings" => {"Bridge"=>"", "SandboxID"=>"randomid", "HairpinMode"=>false, "LinkLocalIPv6Address"=>"", "LinkLocalIPv6PrefixLen"=>0, "Ports"=>{"443/tcp"=>nil, "80/tcp"=>nil}, "SandboxKey"=>"/var/run/docker/netns/158b7024a9e4", "SecondaryIPAddresses"=>nil, "SecondaryIPv6Addresses"=>nil, "EndpointID"=>"randomEndpointID", "Gateway"=>"172.17.0.1", "GlobalIPv6Address"=>"", "GlobalIPv6PrefixLen"=>0, "IPAddress"=>"127.0.0.1", "IPPrefixLen"=>16, "IPv6Gateway"=>"", "MacAddress"=>"02:42:ac:11:00:02", "Networks"=>{"bridge"=>{"IPAMConfig"=>nil, "Links"=>nil, "Aliases"=>nil, "NetworkID"=>"networkIDVar", "EndpointID"=>"endpointIDVar", "Gateway"=>"127.0.0.1", "IPAddress"=>"127.0.0.1", "IPPrefixLen"=>16, "IPv6Gateway"=>"", "GlobalIPv6Address"=>"", "GlobalIPv6PrefixLen"=>0, "MacAddress"=>"02:42:ac:11:00:02", "DriverOpts"=>nil}}}} }
+
+    let(:empty_network_settings) { {"NetworkSettings" => {"Bridge"=>"", "SandboxID"=>"randomid", "HairpinMode"=>false, "LinkLocalIPv6Address"=>"", "LinkLocalIPv6PrefixLen"=>0, "Ports"=>"", "SandboxKey"=>"/var/run/docker/netns/158b7024a9e4", "SecondaryIPAddresses"=>nil, "SecondaryIPv6Addresses"=>nil, "EndpointID"=>"randomEndpointID", "Gateway"=>"172.17.0.1", "GlobalIPv6Address"=>"", "GlobalIPv6PrefixLen"=>0, "IPAddress"=>"", "IPPrefixLen"=>16, "IPv6Gateway"=>"", "MacAddress"=>"02:42:ac:11:00:02", "Networks"=>{"bridge"=>{"IPAMConfig"=>nil, "Links"=>nil, "Aliases"=>nil, "NetworkID"=>"networkIDVar", "EndpointID"=>"endpointIDVar", "Gateway"=>"127.0.0.1", "IPAddress"=>"127.0.0.1", "IPPrefixLen"=>16, "IPv6Gateway"=>"", "GlobalIPv6Address"=>"", "GlobalIPv6PrefixLen"=>0, "MacAddress"=>"02:42:ac:11:00:02", "DriverOpts"=>nil}}}} }
+
+    before do
+      allow(VagrantPlugins::DockerProvider::Driver).to receive(:new).and_return(driver_obj)
+      allow(machine).to receive(:action).with(:read_state).and_return(machine_state_id: :running)
+    end
+
+    it "returns nil if a port info is nil from the driver" do
+      allow(provider_config).to receive(:compose).and_return(false)
+      allow(platform).to receive(:windows?).and_return(false)
+      allow(platform).to receive(:darwin?).and_return(false)
+      allow(driver_obj).to receive(:created?).and_return(true)
+      allow(driver_obj).to receive(:state).and_return(:running)
+
+      allow(driver_obj).to receive(:inspect_container).and_return(empty_network_settings)
+
+      expect(subject.ssh_info).to eq(nil)
+    end
+
+    it "should receive a valid address" do
+      allow(provider_config).to receive(:compose).and_return(false)
+      allow(platform).to receive(:windows?).and_return(false)
+      allow(platform).to receive(:darwin?).and_return(false)
+      allow(driver_obj).to receive(:created?).and_return(true)
+      allow(driver_obj).to receive(:state).and_return(:running)
+      allow(driver_obj).to receive(:execute).with(:get_network_config).and_return(result)
+      allow(driver_obj).to receive(:inspect_container).and_return(network_settings)
+
+      expect(subject.ssh_info).to eq(ssh_info)
+    end
+  end
+end

--- a/test/unit/plugins/providers/virtualbox/provider_test.rb
+++ b/test/unit/plugins/providers/virtualbox/provider_test.rb
@@ -1,0 +1,93 @@
+require_relative "../../../base"
+
+require Vagrant.source_root.join("plugins/providers/virtualbox/provider")
+
+describe VagrantPlugins::ProviderVirtualBox::Provider do
+  let(:driver){ double("driver") }
+  let(:provider){ double("provider", driver: driver) }
+  let(:provider_config){ double("provider_config") }
+  let(:machine){ double("machine", uid: "1000", provider: provider, provider_config: provider_config) }
+
+  let(:platform)   { double("platform") }
+
+  subject { described_class.new(machine) }
+
+  before do
+    stub_const("Vagrant::Util::Platform", platform)
+    allow(platform).to receive(:windows?).and_return(false)
+    allow(platform).to receive(:cygwin?).and_return(false)
+    allow(platform).to receive(:wsl?).and_return(false)
+    allow(platform).to receive(:wsl_windows_access_bypass?).and_return(false)
+    allow(machine).to receive(:id).and_return("foo")
+  end
+
+  describe ".usable?" do
+    subject { described_class }
+
+    it "returns true if usable" do
+      allow(VagrantPlugins::ProviderVirtualBox::Driver::Meta).to receive(:new).and_return(driver)
+      expect(subject).to be_usable
+    end
+
+    it "raises an exception if virtualbox is not available" do
+      allow(VagrantPlugins::ProviderVirtualBox::Driver::Meta).to receive(:new).
+        and_raise(Vagrant::Errors::VirtualBoxNotDetected)
+
+      expect { subject.usable?(true) }.
+        to raise_error(Vagrant::Errors::VirtualBoxNotDetected)
+    end
+
+    it "raises an exception if virtualbox is the wrong version" do
+      allow(VagrantPlugins::ProviderVirtualBox::Driver::Meta).to receive(:new).
+        and_raise(Vagrant::Errors::VirtualBoxInvalidVersion, supported_versions: "1,2,3")
+
+      expect { subject.usable?(true) }.
+        to raise_error(Vagrant::Errors::VirtualBoxInvalidVersion)
+    end
+  end
+
+  describe "#driver" do
+    it "is initialized" do
+      expect(subject.driver).to be_kind_of(VagrantPlugins::ProviderVirtualBox::Driver::Meta)
+    end
+  end
+
+  describe "#state" do
+    it "returns not_created if no ID" do
+      allow(machine).to receive(:id).and_return(nil)
+      allow(machine).to receive(:data_dir).and_return(".vagrant")
+
+      expect(subject.state.id).to eq(:not_created)
+    end
+  end
+
+  describe "#ssh_info" do
+    let(:result) { "127.0.0.1" }
+    let(:exit_code) { 0 }
+    let(:ssh_info) {{:host=>result,:port=>22}}
+    let(:ssh) { double("ssh", guest_port: 22) }
+    let(:config) { double("config", ssh: ssh) }
+
+    before do
+      allow(VagrantPlugins::ProviderVirtualBox::Driver::Meta).to receive(:new).and_return(driver)
+      allow(machine).to receive(:action).with(:read_state).and_return(machine_state_id: :running)
+      allow(machine).to receive(:data_dir).and_return(".vagrant")
+      allow(driver).to receive(:uuid).and_return("1234")
+      allow(driver).to receive(:read_state).and_return(:running)
+      allow(driver).to receive(:ssh_port).and_return(22)
+      allow(machine).to receive(:config).and_return(config)
+    end
+
+    it "returns nil if machine state is not running" do
+      allow(driver).to receive(:read_state).and_return(:not_created)
+      expect(subject.ssh_info).to eq(nil)
+    end
+
+    it "should receive a valid address" do
+      allow(driver).to receive(:execute).with(:get_network_config).and_return(result)
+
+      allow(driver).to receive(:read_guest_ip).and_return({"ip" => "127.0.0.1"})
+      expect(subject.ssh_info).to eq(ssh_info)
+    end
+  end
+end

--- a/test/unit/plugins/providers/virtualbox/provider_test.rb
+++ b/test/unit/plugins/providers/virtualbox/provider_test.rb
@@ -6,7 +6,8 @@ describe VagrantPlugins::ProviderVirtualBox::Provider do
   let(:driver){ double("driver") }
   let(:provider){ double("provider", driver: driver) }
   let(:provider_config){ double("provider_config") }
-  let(:machine){ double("machine", uid: "1000", provider: provider, provider_config: provider_config) }
+  let(:uid) { "1000" }
+  let(:machine){ double("machine", uid: uid, provider: provider, provider_config: provider_config) }
 
   let(:platform)   { double("platform") }
 
@@ -19,6 +20,8 @@ describe VagrantPlugins::ProviderVirtualBox::Provider do
     allow(platform).to receive(:wsl?).and_return(false)
     allow(platform).to receive(:wsl_windows_access_bypass?).and_return(false)
     allow(machine).to receive(:id).and_return("foo")
+
+    allow(Process).to receive(:uid).and_return(uid)
   end
 
   describe ".usable?" do
@@ -48,7 +51,8 @@ describe VagrantPlugins::ProviderVirtualBox::Provider do
 
   describe "#driver" do
     it "is initialized" do
-      expect(subject.driver).to be_kind_of(VagrantPlugins::ProviderVirtualBox::Driver::Meta)
+      allow(VagrantPlugins::ProviderVirtualBox::Driver::Meta).to receive(:new).and_return(driver)
+      expect(subject.driver).to be(driver)
     end
   end
 

--- a/test/unit/support/shared/virtualbox_context.rb
+++ b/test/unit/support/shared/virtualbox_context.rb
@@ -30,9 +30,9 @@ shared_context "virtualbox" do
       and_return(subprocess_result(exit_code: 0))
 
     # apparently this is also used in docker tests
-    allow(subprocess).to receive(:execute).
-      with("docker", "version", an_instance_of(Hash)).
-      and_return(subprocess_result(exit_code: 0))
+    #allow(subprocess).to receive(:execute).
+    #  with("docker", "version", an_instance_of(Hash)).
+    #  and_return(subprocess_result(exit_code: 0))
   end
 
   around do |example|

--- a/test/unit/support/shared/virtualbox_context.rb
+++ b/test/unit/support/shared/virtualbox_context.rb
@@ -28,6 +28,11 @@ shared_context "virtualbox" do
     allow(subprocess).to receive(:execute).
       with("VBoxManage", "showvminfo", kind_of(String), kind_of(Hash)).
       and_return(subprocess_result(exit_code: 0))
+
+    # apparently this is also used in docker tests
+    allow(subprocess).to receive(:execute).
+      with("docker", "version", an_instance_of(Hash)).
+      and_return(subprocess_result(exit_code: 0))
   end
 
   around do |example|

--- a/test/unit/support/shared/virtualbox_context.rb
+++ b/test/unit/support/shared/virtualbox_context.rb
@@ -28,11 +28,6 @@ shared_context "virtualbox" do
     allow(subprocess).to receive(:execute).
       with("VBoxManage", "showvminfo", kind_of(String), kind_of(Hash)).
       and_return(subprocess_result(exit_code: 0))
-
-    # apparently this is also used in docker tests
-    #allow(subprocess).to receive(:execute).
-    #  with("docker", "version", an_instance_of(Hash)).
-    #  and_return(subprocess_result(exit_code: 0))
   end
 
   around do |example|


### PR DESCRIPTION
A cleanup pull request built off of https://github.com/hashicorp/vagrant/pull/10879

Adds proper unit tests for the docker and virtualbox provider class, and a little bit of cleanup for the `usable?` method for the docker provider.