### PR TITLE
Handle strict dependency enforcement when installed within system

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -76,12 +76,8 @@ module Vagrant
 
       # Add HashiCorp RubyGems source
       if !Gem.sources.include?(HASHICORP_GEMSTORE)
-        current_sources = Gem.sources.sources.dup
-        Gem.sources.clear
-        Gem.sources << HASHICORP_GEMSTORE
-        current_sources.each do |src|
-          Gem.sources << src
-        end
+        sources = [HASHICORP_GEMSTORE] + Gem.sources.sources
+        Gem.sources.replace(sources)
       end
 
       # Generate dependencies for all registered plugins

--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -313,6 +313,12 @@ module Vagrant
         @logger.debug("Enabling strict dependency enforcement")
         plugin_deps += vagrant_internal_specs.map do |spec|
           next if system_plugins.include?(spec.name)
+          # If we are not running within the installer and
+          # we are not within a bundler environment then we
+          # only want activated specs
+          if !Vagrant.in_installer? && !Vagrant.in_bundler?
+            next if !spec.activated?
+          end
           Gem::Dependency.new(spec.name, spec.version)
         end.compact
       else
@@ -415,8 +421,13 @@ module Vagrant
       Gem::Resolver.compose_sets(*sets)
     end
 
-    # @return [Array<[Gem::Specification, String]>] spec and directory pairs
+    # @return [Array<[Gem::Specification]>] spec list
     def vagrant_internal_specs
+      # activate any dependencies up front so we can always
+      # pin them when resolving
+      Gem::Specification.find { |s| s.name == "vagrant" && s.activated? }.
+        runtime_dependencies.each { |d| gem d.name, *d.requirement.as_list }
+      # discover all the gems we have available
       list = {}
       directories = [Gem::Specification.default_specifications_dir]
       Gem::Specification.find_all{true}.each do |spec|

--- a/lib/vagrant/shared_helpers.rb
+++ b/lib/vagrant/shared_helpers.rb
@@ -35,6 +35,14 @@ module Vagrant
     !!ENV["VAGRANT_INSTALLER_ENV"]
   end
 
+  # This returns a true/false if we are running within a bundler environment
+  #
+  # @return [Boolean]
+  def self.in_bundler?
+    !!ENV["BUNDLE_GEMFILE"] &&
+      !defined?(::Bundler).nil?
+  end
+
   # Returns the path to the embedded directory of the Vagrant installer,
   # if there is one (if we're running in an installer).
   #

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -703,10 +703,9 @@ en:
         plugins in the `plugins` group in your Gemfile or manually require
         them in a Vagrantfile.
       bundler_error: |-
-        Bundler, the underlying system Vagrant uses to install plugins,
-        reported an error. The error is shown below. These errors are usually
-        caused by misconfigured plugin installations or transient network
-        issues. The error from Bundler is:
+        Vagrant failed to properly resolve required dependencies. These
+        errors can commonly be caused by misconfigured plugin installations
+        or transient network issues. The reported error is:
 
         %{message}
       cant_read_mac_addresses: |-


### PR DESCRIPTION
When installed outside of the official installer and not running
within a bundler environment, properly activate core dependencies
and properly enforce constraints.