### PR TITLE
Fixes #10895: Use relative paths to machines folder path for Listener

### DIFF
--- a/plugins/synced_folders/rsync/command/rsync_auto.rb
+++ b/plugins/synced_folders/rsync/command/rsync_auto.rb
@@ -121,9 +121,13 @@ module VagrantPlugins
 
               if folder_opts[:exclude]
                 Array(folder_opts[:exclude]).each do |pattern|
-                  ignores << RsyncHelper.exclude_to_regexp(hostpath, pattern.to_s)
+                  ignores << RsyncHelper.exclude_to_regexp(pattern.to_s)
                 end
               end
+
+              # Always ignore Vagrant
+              ignores << /.vagrant\//
+              ignores.uniq!
             end
           end
 

--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -16,7 +16,13 @@ module VagrantPlugins
 
       # This converts an rsync exclude pattern to a regular expression
       # we can send to Listen.
-      def self.exclude_to_regexp(path, exclude)
+      #
+      # Note: Listen expects a path relative to the parameter passed into the
+      # Listener, not a fully qualified path
+      #
+      # @param [String]  - exclude path
+      # @return [Regexp] - A regex of the path, modified, to exclude
+      def self.exclude_to_regexp(exclude)
         start_anchor = false
 
         if exclude.start_with?("/")
@@ -24,19 +30,14 @@ module VagrantPlugins
           exclude      = exclude[1..-1]
         end
 
-        path   = "#{path}/" if !path.end_with?("/")
-        regexp = "^#{Regexp.escape(path)}"
-        regexp += ".*" if !start_anchor
-
         # This is not an ideal solution, but it's a start. We can improve and
         # keep unit tests passing in the future.
         exclude = exclude.gsub("**", "|||GLOBAL|||")
         exclude = exclude.gsub("*", "|||PATH|||")
         exclude = exclude.gsub("|||PATH|||", "[^/]*")
         exclude = exclude.gsub("|||GLOBAL|||", ".*")
-        regexp += exclude
 
-        Regexp.new(regexp)
+        Regexp.new(exclude)
       end
 
       def self.rsync_single(machine, ssh_info, opts)

--- a/test/unit/plugins/synced_folders/rsync/command/rsync_auto_test.rb
+++ b/test/unit/plugins/synced_folders/rsync/command/rsync_auto_test.rb
@@ -66,15 +66,12 @@ describe VagrantPlugins::SyncedFolderRSync::Command::RsyncAuto do
     # https://github.com/hashicorp/vagrant/blob/9c1b014536e61b332cfaa00774a87a240cce8ed9/lib/vagrant/action/builtin/synced_folders.rb#L45-L46
     let(:config_synced_folders)  { {"/vagrant":
       {type: "rsync",
-        exclude: false,
         hostpath: "/Users/brian/code/vagrant-sandbox"},
       "/vagrant/other-dir":
       {type: "rsync",
-        exclude: false,
         hostpath: "/Users/brian/code/vagrant-sandbox/other-dir"},
       "/vagrant/relative-dir":
       {type: "rsync",
-        exclude: false,
         hostpath: "/Users/brian/code/relative-dir"}}}
 
     before do
@@ -103,6 +100,11 @@ describe VagrantPlugins::SyncedFolderRSync::Command::RsyncAuto do
         with("Watching: /Users/brian/code/relative-dir")
       expect(helper_class).to receive(:rsync_single)
 
+      expect(Listen).to receive(:to).
+        with("/Users/brian/code/vagrant-sandbox",
+             "/Users/brian/code/relative-dir",
+             {:ignore=>[/.vagrant\//],
+                        :force_polling=>false})
       subject.execute
     end
 

--- a/test/unit/plugins/synced_folders/rsync/helper_test.rb
+++ b/test/unit/plugins/synced_folders/rsync/helper_test.rb
@@ -32,23 +32,23 @@ describe VagrantPlugins::SyncedFolderRSync::RsyncHelper do
     let(:path) { "/foo/bar" }
 
     it "converts a directory match" do
-      expect(described_class.exclude_to_regexp(path, "foo/")).
-        to eq(/^#{Regexp.escape(path)}\/.*foo\//)
+      expect(described_class.exclude_to_regexp("foo/")).
+        to eq(/foo\//)
     end
 
     it "converts the start anchor" do
-      expect(described_class.exclude_to_regexp(path, "/foo")).
-        to eq(/^\/foo\/bar\/foo/)
+      expect(described_class.exclude_to_regexp("/foo")).
+        to eq(/foo/)
     end
 
     it "converts the **" do
-      expect(described_class.exclude_to_regexp(path, "fo**o")).
-        to eq(/^#{Regexp.escape(path)}\/.*fo.*o/)
+      expect(described_class.exclude_to_regexp("fo**o")).
+        to eq(/fo.*o/)
     end
 
     it "converts the *" do
-      expect(described_class.exclude_to_regexp(path, "fo*o")).
-        to eq(/^#{Regexp.escape(path)}\/.*fo[^\/]*o/)
+      expect(described_class.exclude_to_regexp("fo*o")).
+        to eq(/fo[^\/]*o/)
     end
   end
 


### PR DESCRIPTION
Prior to this commit, the rsync helper expanded all exclude paths that
should be ignored to be full qualified and regexp escaped. However the
Listen gem expects these ignore paths to be relative to the path passed
into the listener, not a full path. This commit fixes that by using the
path given by the user for the `rsync__exclude` option