### PR TITLE
Minor spelling fixes

### DIFF
--- a/website/source/docs/docker/configuration.html.md
+++ b/website/source/docs/docker/configuration.html.md
@@ -23,7 +23,7 @@ One of the following settings is required when using the Docker provider:
 
   * `git_repo` (string) - The URL of a git repository to build the image from.
     Supports pulling specific tags, branches and revision, consult the
-    [docker documenation](https://docs.docker.com/engine/reference/commandline/build/#/git-repositories)
+    [docker documentation](https://docs.docker.com/engine/reference/commandline/build/#/git-repositories)
     for more information.
 
 ### Optional

--- a/website/source/docs/experimental/index.html.md
+++ b/website/source/docs/experimental/index.html.md
@@ -10,7 +10,7 @@ description: |-
 
 Some features that aren't ready for release can be enabled through this feature
 flag. There are a couple of different ways of going about enabling these features.
-It is also worth noting that Vagrant will not validate the existance of a feature
+It is also worth noting that Vagrant will not validate the existence of a feature
 flag.
 
 For example if you are on Linux or Mac, and you wish to enable every single experimental feature, you can set the flag

--- a/website/source/docs/installation/backwards-compatibility.html.md
+++ b/website/source/docs/installation/backwards-compatibility.html.md
@@ -3,7 +3,7 @@ layout: "docs"
 page_title: "Backwards Compatibility"
 sidebar_current: "installation-backwards-compatibility"
 description: |-
-  Vagrant makes a very strict backwards-compatability promise.
+  Vagrant makes a very strict backwards-compatibility promise.
 ---
 
 # Backwards Compatibility

--- a/website/source/docs/triggers/configuration.html.md
+++ b/website/source/docs/triggers/configuration.html.md
@@ -121,7 +121,7 @@ end
 
 Triggers _without_ the type option will run before or after a Vagrant guest.
 
-Older Vagrant versions will unfortunetly not be able to properly parse the new
+Older Vagrant versions will unfortunately not be able to properly parse the new
 `:type` option. If you are worried about older clients failing to parse your Vagrantfile,
 you can guard the new trigger based on the version of Vagrant:
 


### PR DESCRIPTION
`docker run    -v $(pwd):/scripts    --workdir=/scripts    nickg/misspell:latest    misspell -w -source=text website/`