### PR TITLE
Support loading machine configuration without provider validation

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -955,7 +955,7 @@ module Vagrant
       provider = guess_provider
       vagrantfile.machine_names.each do |mname|
         ldp = @local_data_path.join("machines/#{mname}/#{provider}") if @local_data_path
-        plugins << vagrantfile.machine_config(mname, guess_provider, boxes, ldp)[:config]
+        plugins << vagrantfile.machine_config(mname, guess_provider, boxes, ldp, false)[:config]
       end
       result = plugins.reverse.inject(Vagrant::Util::HashWithIndifferentAccess.new) do |memo, val|
         Vagrant::Util::DeepMerge.deep_merge(memo, val.vagrant.plugins)


### PR DESCRIPTION
Allow Vagrantfile#machine_config to load properly when the requested
provider may not be currently available. Update the Environment to
utilize this when searching for plugin information to properly allow
box provided Vagrantfiles to define required plugins.