### PR TITLE
Fix provider name not work when specified

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -938,7 +938,7 @@ module Vagrant
           break
         end
       end
-      return gp if gp
+      return gp.to_sym if gp
       begin
         default_provider
       rescue Errors::NoDefaultProvider

--- a/test/unit/vagrant/environment_test.rb
+++ b/test/unit/vagrant/environment_test.rb
@@ -1447,7 +1447,7 @@ VF
         let(:argv) { ["--provider=single_arg"] }
 
         it "should return the provider name" do
-          expect(subject.send(:guess_provider)).to eq("single_arg")
+          expect(subject.send(:guess_provider)).to eq(:single_arg)
         end
       end
 
@@ -1455,7 +1455,7 @@ VF
         let(:argv) { ["--provider", "double_arg"] }
 
         it "should return the provider name" do
-          expect(subject.send(:guess_provider)).to eq("double_arg")
+          expect(subject.send(:guess_provider)).to eq(:double_arg)
         end
       end
     end


### PR DESCRIPTION
Neither --provider=hyperv or --provider hyperv works in the latest head.
Provider name should be symbol in guess_provider.