### PR TITLE
Fixes #10912: Update chef install check for guests

### DIFF
--- a/plugins/provisioners/chef/cap/freebsd/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/freebsd/chef_installed.rb
@@ -10,7 +10,7 @@ module VagrantPlugins
             command = "test -x #{knife}"
 
             if version != :latest
-              command << "&& #{knife} --version | grep 'Chef: #{version}'"
+              command << "&& #{knife} --version | grep '#{version}'"
             end
 
             machine.communicate.test(command, sudo: true)

--- a/plugins/provisioners/chef/cap/linux/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/linux/chef_installed.rb
@@ -10,7 +10,7 @@ module VagrantPlugins
             command = "test -x #{knife}"
 
             if version != :latest
-              command << "&& #{knife} --version | grep 'Chef: #{version}'"
+              command << "&& #{knife} --version | grep '#{version}'"
             end
 
             machine.communicate.test(command, sudo: true)

--- a/plugins/provisioners/chef/cap/omnios/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/omnios/chef_installed.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
             command = "test -x #{knife}"
 
             if version != :latest
-              command << "&& #{knife} --version | grep 'Chef: #{version}'"
+              command << "&& #{knife} --version | grep '#{version}'"
             end
 
             machine.communicate.test(command, sudo: true)         

--- a/plugins/provisioners/chef/cap/windows/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/windows/chef_installed.rb
@@ -7,9 +7,9 @@ module VagrantPlugins
           # @return [true, false]
           def self.chef_installed(machine, product, version)
             if version != :latest
-              command = 'if ((&knife --version) -Match "Chef: ' + version.to_s + '"){ exit 0 } else { exit 1 }'
+              command = 'if ((&knife --version) -Match "' + version.to_s + '"){ exit 0 } else { exit 1 }'
             else
-              command = 'if ((&knife --version) -Match "Chef: *"){ exit 0 } else { exit 1 }'
+              command = 'if ((&knife --version) -Match "Chef*"){ exit 0 } else { exit 1 }'
             end
             machine.communicate.test(command, sudo: true)
           end

--- a/plugins/provisioners/chef/provisioner/base.rb
+++ b/plugins/provisioners/chef/provisioner/base.rb
@@ -69,7 +69,7 @@ module VagrantPlugins
           # Checks for the existence of chef binary and error if it
           # doesn't exist.
           if windows?
-            command = "if ((&'#{binary}' -v) -Match 'Chef: *'){ exit 0 } else { exit 1 }"
+            command = "if ((&'#{binary}' -v) -Match 'Chef*'){ exit 0 } else { exit 1 }"
           else
             command = "sh -c 'command -v #{binary}'"
           end

--- a/test/unit/plugins/provisioners/chef/cap/freebsd/chef_installed_test.rb
+++ b/test/unit/plugins/provisioners/chef/cap/freebsd/chef_installed_test.rb
@@ -1,0 +1,41 @@
+require_relative "../../../../../base"
+
+require Vagrant.source_root.join("plugins/provisioners/chef/cap/freebsd/chef_installed")
+
+describe VagrantPlugins::Chef::Cap::FreeBSD::ChefInstalled do
+  include_context "unit"
+
+  let(:iso_env) do
+    # We have to create a Vagrantfile so there is a root path
+    env = isolated_environment
+    env.vagrantfile("")
+    env.create_vagrant_env
+  end
+
+  let(:machine) { iso_env.machine(iso_env.machine_names[0], :dummy) }
+  let(:communicator) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+  let(:config)  { double("config") }
+
+  subject { described_class }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(communicator)
+  end
+
+  describe "#chef_installed" do
+    let(:version) { "15.0.0" }
+    let(:command) { "test -x /opt/chef_solo/bin/knife&& /opt/chef_solo/bin/knife --version | grep '15.0.0'" }
+
+    it "returns true if installed" do
+      expect(machine.communicate).to receive(:test).
+        with(command, sudo: true).and_return(true)
+      subject.chef_installed(machine, "chef_solo", version)
+    end
+
+    it "returns false if not installed" do
+      expect(machine.communicate).to receive(:test).
+        with(command, sudo: true).and_return(false)
+      expect(subject.chef_installed(machine, "chef_solo", version)).to be_falsey
+    end
+  end
+end

--- a/test/unit/plugins/provisioners/chef/cap/linux/chef_installed_test.rb
+++ b/test/unit/plugins/provisioners/chef/cap/linux/chef_installed_test.rb
@@ -1,0 +1,41 @@
+require_relative "../../../../../base"
+
+require Vagrant.source_root.join("plugins/provisioners/chef/cap/linux/chef_installed")
+
+describe VagrantPlugins::Chef::Cap::Linux::ChefInstalled do
+  include_context "unit"
+
+  let(:iso_env) do
+    # We have to create a Vagrantfile so there is a root path
+    env = isolated_environment
+    env.vagrantfile("")
+    env.create_vagrant_env
+  end
+
+  let(:machine) { iso_env.machine(iso_env.machine_names[0], :dummy) }
+  let(:communicator) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+  let(:config)  { double("config") }
+
+  subject { described_class }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(communicator)
+  end
+
+  describe "#chef_installed" do
+    let(:version) { "15.0.0" }
+    let(:command) { "test -x /opt/chef_solo/bin/knife&& /opt/chef_solo/bin/knife --version | grep '15.0.0'" }
+
+    it "returns true if installed" do
+      expect(machine.communicate).to receive(:test).
+        with(command, sudo: true).and_return(true)
+      subject.chef_installed(machine, "chef_solo", version)
+    end
+
+    it "returns false if not installed" do
+      expect(machine.communicate).to receive(:test).
+        with(command, sudo: true).and_return(false)
+      expect(subject.chef_installed(machine, "chef_solo", version)).to be_falsey
+    end
+  end
+end

--- a/test/unit/plugins/provisioners/chef/cap/omnios/chef_installed_test.rb
+++ b/test/unit/plugins/provisioners/chef/cap/omnios/chef_installed_test.rb
@@ -1,0 +1,41 @@
+require_relative "../../../../../base"
+
+require Vagrant.source_root.join("plugins/provisioners/chef/cap/omnios/chef_installed")
+
+describe VagrantPlugins::Chef::Cap::OmniOS::ChefInstalled do
+  include_context "unit"
+
+  let(:iso_env) do
+    # We have to create a Vagrantfile so there is a root path
+    env = isolated_environment
+    env.vagrantfile("")
+    env.create_vagrant_env
+  end
+
+  let(:machine) { iso_env.machine(iso_env.machine_names[0], :dummy) }
+  let(:communicator) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+  let(:config)  { double("config") }
+
+  subject { described_class }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(communicator)
+  end
+
+  describe "#chef_installed" do
+    let(:version) { "15.0.0" }
+    let(:command) { "test -x /opt/chef_solo/bin/knife&& /opt/chef_solo/bin/knife --version | grep '15.0.0'" }
+
+    it "returns true if installed" do
+      expect(machine.communicate).to receive(:test).
+        with(command, sudo: true).and_return(true)
+      subject.chef_installed(machine, "chef_solo", version)
+    end
+
+    it "returns false if not installed" do
+      expect(machine.communicate).to receive(:test).
+        with(command, sudo: true).and_return(false)
+      expect(subject.chef_installed(machine, "chef_solo", version)).to be_falsey
+    end
+  end
+end

--- a/test/unit/plugins/provisioners/chef/cap/windows/chef_installed_test.rb
+++ b/test/unit/plugins/provisioners/chef/cap/windows/chef_installed_test.rb
@@ -1,0 +1,41 @@
+require_relative "../../../../../base"
+
+require Vagrant.source_root.join("plugins/provisioners/chef/cap/windows/chef_installed")
+
+describe VagrantPlugins::Chef::Cap::Windows::ChefInstalled do
+  include_context "unit"
+
+  let(:iso_env) do
+    # We have to create a Vagrantfile so there is a root path
+    env = isolated_environment
+    env.vagrantfile("")
+    env.create_vagrant_env
+  end
+
+  let(:machine) { iso_env.machine(iso_env.machine_names[0], :dummy) }
+  let(:communicator) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+  let(:config)  { double("config") }
+
+  subject { described_class }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(communicator)
+  end
+
+  describe "#chef_installed" do
+    let(:version) { "15.0.0" }
+    let(:command) { "if ((&knife --version) -Match \"15.0.0\"){ exit 0 } else { exit 1 }" }
+
+    it "returns true if installed" do
+      expect(machine.communicate).to receive(:test).
+        with(command, sudo: true).and_return(true)
+      subject.chef_installed(machine, "chef_solo", version)
+    end
+
+    it "returns false if not installed" do
+      expect(machine.communicate).to receive(:test).
+        with(command, sudo: true).and_return(false)
+      expect(subject.chef_installed(machine, "chef_solo", version)).to be_falsey
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit, the chef_installed capability was looking for a
string that has recently changed in newer versions of chef. This commit
fixes that by instead just looking for the right version that was
configured for the chef client, rather than the specific string that
could change again in the future.