### PR TITLE
Add force flag for package command

### DIFF
--- a/lib/vagrant/action.rb
+++ b/lib/vagrant/action.rb
@@ -15,6 +15,7 @@ module Vagrant
       autoload :Confirm, "vagrant/action/builtin/confirm"
       autoload :ConfigValidate, "vagrant/action/builtin/config_validate"
       autoload :DestroyConfirm, "vagrant/action/builtin/destroy_confirm"
+      autoload :PackageOutputOverwriteConfirm, "vagrant/action/builtin/package_output_overwrite_confirm"
       autoload :EnvSet,  "vagrant/action/builtin/env_set"
       autoload :GracefulHalt, "vagrant/action/builtin/graceful_halt"
       autoload :HandleBox, "vagrant/action/builtin/handle_box"

--- a/lib/vagrant/action/builtin/package_output_overwrite_confirm.rb
+++ b/lib/vagrant/action/builtin/package_output_overwrite_confirm.rb
@@ -1,0 +1,28 @@
+require_relative "confirm"
+
+module Vagrant
+  module Action
+    module Builtin
+      class PackageOutputOverwriteConfirm < Confirm
+        def initialize(app, env)
+          force_key = "package.force_output_overwrite"
+          message = I18n.t("vagrant.actions.general.package.output_exists.overwrite_confirmation",
+                           name: env["package.output"])
+
+          super(app, env, message, force_key, allowed: %w(y n Y N))
+        end
+
+        def call(env)
+          output = File.expand_path(env["package.output"], Dir.pwd)
+
+          if File.exist?(output)
+            super
+          else
+            env[:result] = true
+            @app.call(env)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant/action/general/package.rb
+++ b/lib/vagrant/action/general/package.rb
@@ -31,15 +31,10 @@ module Vagrant
         # @param [String] output path to the output file
         # @param [String] directory path to a directory containing the files
         def self.validate!(output, directory)
-          filename = File.basename(output.to_s)
           output   = fullpath(output)
 
           if File.directory?(output)
             raise Vagrant::Errors::PackageOutputDirectory
-          end
-
-          if File.exist?(output)
-            raise Vagrant::Errors::PackageOutputExists, filename: filename
           end
 
           if !Vagrant::Util::Presence.present?(directory) || !File.directory?(directory)
@@ -101,7 +96,7 @@ module Vagrant
           @env = env
 
           # There are certain exceptions that we don't delete the file for.
-          ignore_exc = [Errors::PackageOutputDirectory, Errors::PackageOutputExists]
+          ignore_exc = [Errors::PackageOutputDirectory]
           ignore_exc.each do |exc|
             return if env["vagrant.error"].is_a?(exc)
           end

--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -552,10 +552,6 @@ module Vagrant
       error_key(:output_is_directory, "vagrant.actions.general.package")
     end
 
-    class PackageOutputExists < VagrantError
-      error_key(:output_exists, "vagrant.actions.general.package")
-    end
-
     class PackageRequiresDirectory < VagrantError
       error_key(:requires_directory, "vagrant.actions.general.package")
     end

--- a/plugins/commands/package/command.rb
+++ b/plugins/commands/package/command.rb
@@ -32,6 +32,10 @@ module VagrantPlugins
           o.on("--vagrantfile FILE", "Vagrantfile to package with the box") do |v|
             options[:vagrantfile] = v
           end
+
+          o.on("-f", "--force", "Vagrantfile to package with the box") do |f|
+            options[:force_output_overwrite] = f
+          end
         end
 
         # Parse the options

--- a/plugins/providers/hyperv/action.rb
+++ b/plugins/providers/hyperv/action.rb
@@ -79,10 +79,16 @@ module VagrantPlugins
             b2.use PackageSetupFiles
             b2.use action_halt
             b2.use SyncedFolderCleanup
-            b2.use Package
-            b2.use PackageVagrantfile
-            b2.use PackageMetadataJson
-            b2.use Export
+            b2.use Call, PackageOutputOverwriteConfirm do |env2, b3|
+              if env2[:result]
+                b3.use Package
+                b3.use PackageVagrantfile
+                b3.use PackageMetadataJson
+                b3.use Export
+              else
+                b3.use MessageWillNotOverwritePackageOutput
+              end
+            end
           end
         end
       end

--- a/plugins/providers/virtualbox/action.rb
+++ b/plugins/providers/virtualbox/action.rb
@@ -30,6 +30,7 @@ module VagrantPlugins
       autoload :MessageNotCreated, File.expand_path("../action/message_not_created", __FILE__)
       autoload :MessageNotRunning, File.expand_path("../action/message_not_running", __FILE__)
       autoload :MessageWillNotDestroy, File.expand_path("../action/message_will_not_destroy", __FILE__)
+      autoload :MessageWillNotOverwritePackageOutput, File.expand_path("../action/message_will_not_overwrite_package_output", __FILE__)
       autoload :Network, File.expand_path("../action/network", __FILE__)
       autoload :NetworkFixIPv6, File.expand_path("../action/network_fix_ipv6", __FILE__)
       autoload :Package, File.expand_path("../action/package", __FILE__)
@@ -163,11 +164,18 @@ module VagrantPlugins
             b2.use ClearForwardedPorts
             b2.use PrepareNFSValidIds
             b2.use SyncedFolderCleanup
-            b2.use Package
-            b2.use Export
-            b2.use PackageVagrantfile
+            b2.use Call, PackageOutputOverwriteConfirm do |env2, b3|
+              if env2[:result]
+                b3.use Package
+                b3.use Export
+                b3.use PackageVagrantfile
+              else
+                b3.use MessageWillNotOverwritePackageOutput
+              end
+            end
           end
         end
+
       end
 
       # This action just runs the provisioners on the machine.

--- a/plugins/providers/virtualbox/action/message_will_not_overwrite_package_output.rb
+++ b/plugins/providers/virtualbox/action/message_will_not_overwrite_package_output.rb
@@ -1,0 +1,17 @@
+module VagrantPlugins
+  module ProviderVirtualBox
+    module Action
+      class MessageWillNotOverwritePackageOutput
+        def initialize(app, env)
+          @app = app
+        end
+
+        def call(env)
+          env[:ui].info I18n.t("vagrant.actions.general.package.output_exists.will_not_overwrite",
+                              name: env[:machine].name)
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2426,9 +2426,11 @@ en:
           packaging: "Packaging additional file: %{file}"
           compressing: "Compressing package to: %{fullpath}"
           box_folder: "Creating new folder: %{folder_path}"
-          output_exists: |-
-            The specified file '%{filename}' to save the package as already exists. Please
-            remove this file or specify a different file name for outputting.
+          output_exists:
+            overwrite_confirmation: "Are you sure you want to overwrite '%{name}'? [y/N] "
+            will_not_overwrite: |-
+                The VM '%{name}' will not be packaged, since the confirmation
+                was declined.
           output_is_directory: |-
             The specified output is a directory. Please specify a path including
             a filename.

--- a/test/unit/vagrant/action/builtin/package_output_overwrite_confirm_test.rb
+++ b/test/unit/vagrant/action/builtin/package_output_overwrite_confirm_test.rb
@@ -1,0 +1,43 @@
+require File.expand_path("../../../../base", __FILE__)
+
+describe Vagrant::Action::Builtin::PackageOutputOverwriteConfirm do
+  let(:app) {lambda {|env|}}
+  let(:output) {"output.box"}
+  let(:env) {{"package.output" => output, ui: double("ui")}}
+  let(:message) {"Are you sure you want to overwrite 'output.box'? [y/N] "}
+
+  context "when package output file exist" do
+    before do
+      allow(File).to receive(:expand_path).with(output, any_args).and_return(output)
+      allow(File).to receive(:exist?).with(output).and_return(true)
+    end
+
+    %w(y Y).each do |valid|
+      it "should set the result to true if '#{valid}' is given" do
+        expect(env[:ui]).to receive(:ask).with(message).and_return(valid)
+        described_class.new(app, env).call(env)
+        expect(env[:result]).to be
+      end
+    end
+
+    %w(n N).each do |valid|
+      it "should set the result to true if '#{valid}' is given" do
+        expect(env[:ui]).to receive(:ask).with(message).and_return(valid)
+        described_class.new(app, env).call(env)
+        expect(env[:result]).to be false
+      end
+    end
+  end
+
+  context "when package output file don't exist" do
+    before do
+      allow(File).to receive(:expand_path).with(output, any_args).and_return(output)
+      allow(File).to receive(:exist?).with(output).and_return(false)
+    end
+
+    it "should set the result to true" do
+      described_class.new(app, env).call(env)
+      expect(env[:result]).to be
+    end
+  end
+end

--- a/test/unit/vagrant/action/general/package_test.rb
+++ b/test/unit/vagrant/action/general/package_test.rb
@@ -26,7 +26,6 @@ describe Vagrant::Action::General::Package do
       allow(described_class).to receive(:fullpath).and_return(output)
       allow(File).to receive(:directory?).with(output).and_return(false)
       allow(File).to receive(:directory?).with(directory).and_return(true)
-      allow(File).to receive(:exist?).and_return(false)
       allow(Vagrant::Util::Presence).to receive(:present?).with(directory).and_return(true)
     end
 
@@ -34,18 +33,11 @@ describe Vagrant::Action::General::Package do
       expect { described_class.validate!(output, directory) }.not_to raise_error
     end
 
-    it "should raise error when output directory exists" do
+    it "should raise error when output is a directory" do
       expect(File).to receive(:directory?).with(output).and_return(true)
       expect {
         described_class.validate!(output, directory)
       }.to raise_error(Vagrant::Errors::PackageOutputDirectory)
-    end
-
-    it "should raise error if output path exists" do
-      expect(File).to receive(:exist?).with(output).and_return(true)
-      expect {
-        described_class.validate!(output, directory)
-      }.to raise_error(Vagrant::Errors::PackageOutputExists)
     end
 
     it "should raise error if directory value not provided" do
@@ -124,16 +116,6 @@ describe Vagrant::Action::General::Package do
 
     context "when vagrant error is PackageOutputDirectory" do
       let(:error) { Vagrant::Errors::PackageOutputDirectory.new }
-
-      it "should not do anything" do
-        expect(File).not_to receive(:exist?)
-        expect(File).not_to receive(:delete)
-        subject.recover(env)
-      end
-    end
-
-    context "when vagrant error is PackageOutputExists" do
-      let(:error) { Vagrant::Errors::PackageOutputExists.new }
 
       it "should not do anything" do
         expect(File).not_to receive(:exist?)


### PR DESCRIPTION
As mentioned in #10433,
- when the package output file already exists and force flag is not specified, the user is prompted for overwrite
- when the package output file exists and force flag is specified, the output file is overwritten without prompting the user

**Acceptance test:**
The acceptance test is failing in my machine mostly with the following error:
```
stderr: /Users/arunvelsriram/hashicorp/vagrant/lib/vagrant/environment.rb:1024:in `process_configured_plugins': undefined method `installed_plugins' for nil:NilClass (NoMethodError)
        from /Users/arunvelsriram/hashicorp/vagrant/lib/vagrant/environment.rb:178:in `initialize'
        from /Users/arunvelsriram/hashicorp/vagrant/bin/vagrant:145:in `new'
        from /Users/arunvelsriram/hashicorp/vagrant/bin/vagrant:145:in `<top (required)>'
        from /Users/arunvelsriram/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/bin/vagrant:23:in `load'
        from /Users/arunvelsriram/.rbenv/versions/2.6.2/lib/ruby/gems/2.6.0/bin/vagrant:23:in `<main>'
```

Perhaps, am missing something. Here is my `vagrant-spec.config.rb`:
```
require_relative "test/acceptance/base"

Vagrant::Spec::Acceptance.configure do |c|
  c.component_paths << File.expand_path("../test/acceptance", __FILE__)
  c.skeleton_paths << File.expand_path("../test/acceptance/skeletons", __FILE__)

  c.provider "virtualbox",
             box: "ubuntu/xenial64",
             contexts: ["provider-context/virtualbox"]
end
```
I would appreciate any help on the acceptance test.