### PR TITLE
Fix plugin discovery loading when no data directory is available

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -1021,7 +1021,11 @@ module Vagrant
         ui.warn(I18n.t("vagrant.plugins.local.install_rerun_command"))
         exit(-1)
       end
-      Vagrant::Plugin::Manager.instance.local_file.installed_plugins
+      if Vagrant::Plugin::Manager.instance.local_file
+        Vagrant::Plugin::Manager.instance.local_file.installed_plugins
+      else
+        {}
+      end
     end
 
     # This method copies the private key into the home directory if it

--- a/test/unit/vagrant/environment_test.rb
+++ b/test/unit/vagrant/environment_test.rb
@@ -1561,10 +1561,18 @@ VF
       allow(plugin_manager).to receive(:load_plugins)
     end
 
+    context "when local data directory does not exist" do
+      let(:local_file) { nil }
+
+      it "should properly return empty result" do
+        expect(instance.send(:process_configured_plugins)).to be_empty
+      end
+    end
+
     context "plugins are disabled" do
       before{ allow(Vagrant).to receive(:plugins_enabled?).and_return(false) }
 
-      it "should return nil" do
+      it "should return empty result" do
         expect(instance.send(:process_configured_plugins)).to be_nil
       end
     end


### PR DESCRIPTION
If the local data directory is not available, there will be no
local file to reference. Asking the manager for the full list
of plugins will prevent errors when the local file is unset.