### PR TITLE
Fix the date of 2.2.5 release in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
-## 2.2.5 (July 19, 2019)
+## 2.2.5 (June 19, 2019)
 
 FEATURES:
 


### PR DESCRIPTION
Also referenced in [this issue](https://github.com/hashicorp/vagrant/issues/10930).