### PR TITLE
virtualbox: Fix usability test to reject bad installs without crashing

### DIFF
--- a/plugins/providers/virtualbox/provider.rb
+++ b/plugins/providers/virtualbox/provider.rb
@@ -8,9 +8,10 @@ module VagrantPlugins
       def self.installed?
         Driver::Meta.new
         true
-      rescue Vagrant::Errors::VirtualBoxInvalidVersion
-        return false
-      rescue Vagrant::Errors::VirtualBoxNotDetected
+      rescue Vagrant::Errors::VirtualBoxInvalidVersion,
+             Vagrant::Errors::VirtualBoxNotDetected,
+             Vagrant::Errors::VirtualBoxKernelModuleNotLoaded,
+             Vagrant::Errors::VirtualBoxInstallIncomplete
         return false
       end
 
@@ -19,10 +20,10 @@ module VagrantPlugins
         # version and all that, which checks for VirtualBox being present
         Driver::Meta.new
         true
-      rescue Vagrant::Errors::VirtualBoxInvalidVersion
-        raise if raise_error
-        return false
-      rescue Vagrant::Errors::VirtualBoxNotDetected
+      rescue Vagrant::Errors::VirtualBoxInvalidVersion,
+             Vagrant::Errors::VirtualBoxNotDetected,
+             Vagrant::Errors::VirtualBoxKernelModuleNotLoaded,
+             Vagrant::Errors::VirtualBoxInstallIncomplete
         raise if raise_error
         return false
       end

--- a/test/unit/plugins/providers/virtualbox/provider_test.rb
+++ b/test/unit/plugins/providers/virtualbox/provider_test.rb
@@ -47,6 +47,22 @@ describe VagrantPlugins::ProviderVirtualBox::Provider do
       expect { subject.usable?(true) }.
         to raise_error(Vagrant::Errors::VirtualBoxInvalidVersion)
     end
+
+    it "raises an exception if virtualbox kernel module is not loaded" do
+      allow(VagrantPlugins::ProviderVirtualBox::Driver::Meta).to receive(:new).
+        and_raise(Vagrant::Errors::VirtualBoxKernelModuleNotLoaded)
+
+      expect { subject.usable?(true) }.
+        to raise_error(Vagrant::Errors::VirtualBoxKernelModuleNotLoaded)
+    end
+
+    it "raises an exception if virtualbox installation is incomplete" do
+      allow(VagrantPlugins::ProviderVirtualBox::Driver::Meta).to receive(:new).
+        and_raise(Vagrant::Errors::VirtualBoxInstallIncomplete)
+
+      expect { subject.usable?(true) }.
+        to raise_error(Vagrant::Errors::VirtualBoxInstallIncomplete)
+    end
   end
 
   describe "#driver" do


### PR DESCRIPTION
If VirtualBox is installed but the kernel module is missing or the service is stopped, the usability test should fail without crashing so we can fall back to other providers.