### PR TITLE
replace call to enter-pssession with a native ruby REPL within winrm

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_dependency "net-sftp", "~> 2.1"
   s.add_dependency "net-scp", "~> 1.2.0"
   s.add_dependency "rb-kqueue", "~> 0.2.0"
+  s.add_dependency "rb-readline", "~ 0.5.5"
   s.add_dependency "rest-client", ">= 1.6.0", "< 3.0"
   s.add_dependency "rubyzip", "~> 1.2.2"
   s.add_dependency "wdm", "~> 0.1.0"


### PR DESCRIPTION
rather than shelling out to `Enter-PSSession`, the `winrm` gem can be used to connect to WinRM directly. This permits `vagrant powershell` to be used on platforms other than Windows (#7849).