### PR TITLE
Do not list / load dependencies if `vagrant` spec is not loaded

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -421,8 +421,9 @@ module Vagrant
     def vagrant_internal_specs
       # activate any dependencies up front so we can always
       # pin them when resolving
-      Gem::Specification.find { |s| s.name == "vagrant" && s.activated? }.
-        runtime_dependencies.each { |d| gem d.name, *d.requirement.as_list }
+      if (vs = Gem::Specification.find { |s| s.name == "vagrant" && s.activated? })
+        vs.runtime_dependencies.each { |d| gem d.name, *d.requirement.as_list }
+      end
       # discover all the gems we have available
       list = {}
       directories = [Gem::Specification.default_specifications_dir]


### PR DESCRIPTION
in `vagrant_internal_specs` as this fails, due to `find` returning `nil`.

_ _ _ _

On Fedora we run the test suite without bundler loaded / installed, during a package build. The addition of https://github.com/hashicorp/vagrant/commit/062ef52816b125e118e6806dc49d42e8415713ec#diff-04eb3e04ebc04adf4ab7a99c0bc923d7R428 makes the test suite fail badly.