### PR TITLE
gemspec: drop rubyforge_project, it is EOL

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version     = "~> 2.2", "< 2.7"
   s.required_rubygems_version = ">= 1.3.6"
-  s.rubyforge_project         = "vagrant"
 
   s.add_dependency "bcrypt_pbkdf", "~> 1.0.0"
   s.add_dependency "childprocess", "~> 0.6.0"


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement.