### PR TITLE
Fixes issue hashicorp#10973: checks that VMMS WMI reference is null & throws appropriately

### DIFF
--- a/plugins/providers/hyperv/scripts/utils/VagrantVM/VagrantVM.psm1
+++ b/plugins/providers/hyperv/scripts/utils/VagrantVM/VagrantVM.psm1
@@ -355,6 +355,9 @@ function Report-ErrorVagrantVMImport {
     )
 
     $ManagementService = Get-WmiObject -Namespace 'root\virtualization\v2' -Class 'Msvm_VirtualSystemManagementService'
+    if($null -eq $ManagementService) {
+        throw 'The Hyper-V Virtual Machine Management Service (VMMS) is not running.'
+    }
 
     # Relative path names will fail when attempting to import a system
     # definition so always ensure we are using the full path to the


### PR DESCRIPTION
This is a simple check that may save some debugging time. I don't know whether the change should just encompass an error message here or if this should be another pre-flight check; please let me know if you have any suggestions.

I didn't see any Pester tests or anything similar for these scripts, so I'm assuming this logic isn't tested automatically, but if you think they'd be more helpful than painful to include I'd be happy to add some.

**FYI** - I ran tests locally and several broke, but the same ones broke when I ran them on the tip of `master`, so I'm assuming it's a problem with my local config. (Running them on Windows 10 WSL, Ubuntu 16.04.) The behavior was correct when I manually tested it against an updated local installation.

Error message before:
```
> vagrant up
Bringing machine 'default' up with 'hyperv' provider...
==> default: Verifying Hyper-V is enabled...
==> default: Verifying Hyper-V is accessible...
==> default: Importing a Hyper-V instance
    default: Creating and registering the VM...
An error occurred while executing a PowerShell script. This error
is shown below. Please read the error message and see if this is
a configuration error with your system. If it is not, then please
report a bug.

Script: import_vm.ps1
Error:

You cannot call a method on a null-valued expression.
```

Error message after:
```
> vagrant up
Bringing machine 'default' up with 'hyperv' provider...
==> default: Verifying Hyper-V is enabled...
==> default: Verifying Hyper-V is accessible...
==> default: Importing a Hyper-V instance
    default: Creating and registering the VM...
An error occurred while executing a PowerShell script. This error
is shown below. Please read the error message and see if this is
a configuration error with your system. If it is not, then please
report a bug.

Script: import_vm.ps1
Error:

The Hyper-V Virtual Machine Management Service (VMMS) is not running.
```