### PR TITLE
add option to disable creation of VirtualBox DHCP server

### DIFF
--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -251,6 +251,7 @@ module VagrantPlugins
             mac:         nil,
             nic_type:    nil,
             type:        :static,
+            dhcp_server: true,
           }.merge(options)
 
           # Make sure the type is a symbol
@@ -347,7 +348,7 @@ module VagrantPlugins
             @logger.info("Created network: #{interface[:name]}")
           end
 
-          if config[:type] == :dhcp
+          if config[:type] == :dhcp && config[:dhcp_server]
             create_dhcp_server_if_necessary(interface, config)
           end
 

--- a/website/source/docs/virtualbox/networking.html.md
+++ b/website/source/docs/virtualbox/networking.html.md
@@ -39,6 +39,33 @@ Vagrant.configure("2") do |config|
 end
 ```
 
+## VirtualBox Host DHCP Server
+
+By default, when specifying a `private_network` with a type of `dhcp` the
+Vagrant VirtualBox provider will attempt to find or create an appropriate
+host-only network. If the network does not have a DHCP server configured the
+provider will attempt to provision one. Sometimes this feature is undesirable.
+For example, perhaps resolving dynamic DNS records between guests sharing
+a private network is required. The DHCP server built into VirtualBox does
+not support dynamic DNS resolution so an alternative is needed.
+
+<div class="alert alert-warning">
+  <strong>Advanced topic!</strong> This is a reasonably advanced topic that
+  requires configuration outside of Vagrant. The example below requires
+  a DHCP server or relay configured outside of VirtualBox responds to
+  requests on the designated host-only network.
+</div>
+
+To override the default behavior and prevent the Vagrant VirtualBox
+provider from creating a DHCP server for the defined host-only network:
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.network "private_network", type: "dhcp", name: "vboxnet0",
+    virtualbox__dhcp_server: false
+end
+```
+
 ## VirtualBox NIC Type
 
 You can specify a specific NIC type for the created network interface


### PR DESCRIPTION
Fixes #10982: Prevent creation of VirtualBox DHCP server

This PR adds the `virtualbox__dhcp_server` network interface configuration option which allows to disable the default creation of a VirtualBox DHCP server.