### PR TITLE
Bump rspec-its dependency

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
   # from within rspec
   s.add_development_dependency "rake", "~> 12.0.0"
   s.add_development_dependency "rspec", "~> 3.5.0"
-  s.add_development_dependency "rspec-its", "~> 1.2.0"
+  s.add_development_dependency "rspec-its", "~> 1.3.0"
   s.add_development_dependency "webmock", "~> 2.3.1"
   s.add_development_dependency "fake_ftp", "~> 0.1.1"
 


### PR DESCRIPTION
rspec-its version 1.3.0 has been released, this PR updates the gemspec to use the latest version.