### PR TITLE
Unrestrict rspec-its dependency

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
   # from within rspec
   s.add_development_dependency "rake", "~> 12.0.0"
   s.add_development_dependency "rspec", "~> 3.5.0"
-  s.add_development_dependency "rspec-its", "~> 1.2.0"
+  s.add_development_dependency "rspec-its", ">= 1.2.0"
   s.add_development_dependency "webmock", "~> 2.3.1"
   s.add_development_dependency "fake_ftp", "~> 0.1.1"
 


### PR DESCRIPTION
as It works fine [in Fedora](https://copr-be.cloud.fedoraproject.org/results/pvalena/vagrant/fedora-rawhide-x86_64/00978596-vagrant/) with rspec-its 1.3.0 (test suite execution is in [build.log](https://copr-be.cloud.fedoraproject.org/results/pvalena/vagrant/fedora-rawhide-x86_64/00978596-vagrant/build.log.gz)).