### PR TITLE
File provisioner must search files in VAGRANT_CWD

### DIFF
--- a/plugins/provisioners/file/provisioner.rb
+++ b/plugins/provisioners/file/provisioner.rb
@@ -3,7 +3,7 @@ module VagrantPlugins
     class Provisioner < Vagrant.plugin("2", :provisioner)
       def provision
         @machine.communicate.tap do |comm|
-          source = File.expand_path(config.source)
+          source = "#{@machine.env.cwd}/#{config.source}"
           destination = expand_guest_path(config.destination)
 
           # If the source is a directory determine if any path modifications


### PR DESCRIPTION
Currently, if you try to use `VAGRANT_CWD` to `vagrant up` a machine in a different folder than the current shell `$PWD`, it will fail while provisioning files.

Minimum failing example:

```bash
mkdir -p machine/files/

cat > machine/files/test <<EoF
# placeholder
EoF

cat > machine/test.vagrant <<EoF
# -*- mode: ruby -*-
# vi: set ft=ruby :

Vagrant.configure("2") do |config|

  config.vm.box = "debian/buster64"

  config.vm.provision "file",
    source: "files/test",
    destination: "/tmp/files/test"
end
EoF

export VAGRANT_VAGRANTFILE=test.vagrant
export VAGRANT_CWD=machine

vagrant up
```