### PR TITLE
 Update docs with newly supported hashicorp/bionic64 box

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ installed. After this,
 
 To build your first virtual environment:
 
-    vagrant init hashicorp/precise32
+    vagrant init hashicorp/bionic64
     vagrant up
 
 Note: The above `vagrant up` command will also trigger Vagrant to download the
-`precise32` box via the specified URL. Vagrant only does this if it detects that
+`bionic64` box via the specified URL. Vagrant only does this if it detects that
 the box doesn't already exist on your system.
 
 ## Getting Started Guide

--- a/website/source/docs/boxes.html.md
+++ b/website/source/docs/boxes.html.md
@@ -78,4 +78,6 @@ For other users, we recommend the [Bento boxes](https://vagrantcloud.com/bento).
 
 These are the only two officially-recommended box sets.
 
+Special thanks to the Bento project for providing a solid base template for the `hashicorp/bionic64` box.
+
 ~> **It is often a point of confusion**, but Canonical (the company that makes the Ubuntu operating system) publishes boxes under the "ubuntu" namespace on Vagrant Cloud. These boxes only support Virtualbox and do not provide an ideal experience for most users. If you encounter issues with these boxes, please try the Bento boxes instead.

--- a/website/source/docs/boxes.html.md
+++ b/website/source/docs/boxes.html.md
@@ -48,8 +48,8 @@ with how to add it, but they all follow the same format:
 $ vagrant box add USER/BOX
 ```
 
-For example: `vagrant box add hashicorp/precise64`. You can also quickly
-initialize a Vagrant environment with `vagrant init hashicorp/precise64`.
+For example: `vagrant box add hashicorp/bionic64`. You can also quickly
+initialize a Vagrant environment with `vagrant init hashicorp/bionic64`.
 
 ~> **Namespaces do not guarantee canonical boxes!** A common misconception is
 that a namespace like "ubuntu" represents the canonical space for Ubuntu boxes.
@@ -60,17 +60,17 @@ with third-party published boxes.
 
 ## Official Boxes
 
-HashiCorp (the makers of Vagrant) publish a basic Ubuntu 12.04 (32 and 64-bit) box that is available for minimal use cases. It is highly optimized, small in size, and includes support for Virtualbox and VMware. You can use it like this:
+HashiCorp (the makers of Vagrant) publish a basic Ubuntu 18.04 64-bit box that is available for minimal use cases. It is highly optimized, small in size, and includes support for Virtualbox, Hyper-V, and VMware. You can use it like this:
 
 ```shell
-$ vagrant init hashicorp/precise64
+$ vagrant init hashicorp/bionic64
 ```
 
 or you can update your `Vagrantfile` as follows:
 
 ```ruby
 Vagrant.configure("2") do |config|
-  config.vm.box = "hashicorp/precise64"
+  config.vm.box = "hashicorp/bionic64"
 end
 ```
 

--- a/website/source/docs/boxes/base.html.md
+++ b/website/source/docs/boxes/base.html.md
@@ -17,7 +17,7 @@ not made by repackaging an existing Vagrant environment (hence the "base"
 in the "base box").
 
 For example, the Ubuntu boxes provided by the Vagrant project (such as
-"precise64") are base boxes. They were created from a minimal Ubuntu install
+"bionic64") are base boxes. They were created from a minimal Ubuntu install
 from an ISO, rather than repackaging an existing environment.
 
 Base boxes are extremely useful for having a clean slate starting point from

--- a/website/source/docs/boxes/format.html.md
+++ b/website/source/docs/boxes/format.html.md
@@ -95,15 +95,15 @@ It is a JSON document, structured in the following way:
 
 ```json
 {
-  "name": "hashicorp/precise64",
-  "description": "This box contains Ubuntu 12.04 LTS 64-bit.",
+  "name": "hashicorp/bionic64",
+  "description": "This box contains Ubuntu 18.04 LTS 64-bit.",
   "versions": [
     {
       "version": "0.1.0",
       "providers": [
         {
           "name": "virtualbox",
-          "url": "http://somewhere.com/precise64_010_virtualbox.box",
+          "url": "http://somewhere.com/bionic64_010_virtualbox.box",
           "checksum_type": "sha1",
           "checksum": "foo"
         }

--- a/website/source/docs/boxes/info.html.md
+++ b/website/source/docs/boxes/info.html.md
@@ -16,7 +16,7 @@ website for users to learn more:
 
 ```
 brian@localghost % vagrant box list -i
-hashicorp/precise64     (virtualbox, 1.0.0)
+hashicorp/bionic64     (virtualbox, 1.0.0)
   - author: brian
   - homepage: https://www.vagrantup.com
 ```

--- a/website/source/docs/boxes/versioning.html.md
+++ b/website/source/docs/boxes/versioning.html.md
@@ -32,8 +32,8 @@ to update your own custom boxes with versions. That is covered in
 to see all available versions of a box, you will have to find the box
 on [HashiCorp's Vagrant Cloud](/docs/vagrant-cloud). An easy way to find a box
 is to use the url `https://vagrantcloud.com/$USER/$BOX`. For example, for
-the `hashicorp/precise64` box, you can find information about it at
-`https://vagrantcloud.com/hashicorp/precise64`.
+the `hashicorp/bionic64` box, you can find information about it at
+`https://vagrantcloud.com/hashicorp/bionic64`.
 
 You can check if the box you are using is outdated with `vagrant box outdated`.
 This can check if the box in your current Vagrant environment is outdated

--- a/website/source/docs/cli/box.html.md
+++ b/website/source/docs/cli/box.html.md
@@ -33,7 +33,7 @@ one of three things:
 
 * A shorthand name from the
 [public catalog of available Vagrant images](https://vagrantcloud.com/boxes/search),
-such as "hashicorp/precise64".
+such as "hashicorp/bionic64".
 
 * File path or HTTP URL to a box in a [catalog](https://vagrantcloud.com/boxes/search).
 For HTTP, basic authentication is supported and `http_proxy` environmental

--- a/website/source/docs/cli/init.html.md
+++ b/website/source/docs/cli/init.html.md
@@ -43,19 +43,19 @@ setting in the created Vagrantfile.
 Create a base Vagrantfile:
 
 ```sh
-$ vagrant init hashicorp/precise64
+$ vagrant init hashicorp/bionic64
 ```
 
 Create a minimal Vagrantfile (no comments or helpers):
 
 ```sh
-$ vagrant init -m hashicorp/precise64
+$ vagrant init -m hashicorp/bionic64
 ```
 
 Create a new Vagrantfile, overwriting the one at the current path:
 
 ```sh
-$ vagrant init -f hashicorp/precise64
+$ vagrant init -f hashicorp/bionic64
 ```
 
 Create a Vagrantfile with the specific box, from the specific box URL:
@@ -67,5 +67,5 @@ $ vagrant init my-company-box https://boxes.company.com/my-company.box
 Create a Vagrantfile, locking the box to a version constraint:
 
 ```sh
-$ vagrant init --box-version '> 0.1.5' hashicorp/precise64
+$ vagrant init --box-version '> 0.1.5' hashicorp/bionic64
 ```

--- a/website/source/docs/cli/ssh.html.md
+++ b/website/source/docs/cli/ssh.html.md
@@ -55,13 +55,13 @@ $ vagrant ssh node1
 
 Welcome to your Vagrant-built virtual machine.
 Last login: Fri Sep 14 06:23:18 2012 from 10.0.2.2
-vagrant@precise64:~$ logout
+vagrant@bionic64:~$ logout
 Connection to 127.0.0.1 closed.
 $ vagrant ssh node2
 
 Welcome to your Vagrant-built virtual machine.
 Last login: Fri Sep 14 06:23:18 2012 from 10.0.2.2
-vagrant@precise64:~$ logout
+vagrant@bionic64:~$ logout
 Connection to 127.0.0.1 closed.
 $
 ```
@@ -85,7 +85,7 @@ $ vagrant ssh 13759ff
 
 Welcome to your Vagrant-built virtual machine.
 Last login: Fri Jul 20 15:19:36 2018 from 10.0.2.2
-vagrant@precise64:~$ logout
+vagrant@bionic64:~$ logout
 Connection to 127.0.0.1 closed.
 $
 ```

--- a/website/source/docs/hyperv/usage.html.md
+++ b/website/source/docs/hyperv/usage.html.md
@@ -22,4 +22,4 @@ permissions.
 
 Boxes for Hyper-V can be easily found on
 [HashiCorp's Vagrant Cloud](https://vagrantcloud.com/boxes/search). To get started, you might
-want to try the `hashicorp/precise64` box.
+want to try the `hashicorp/bionic64` box.

--- a/website/source/docs/installation/source.html.md
+++ b/website/source/docs/installation/source.html.md
@@ -61,7 +61,7 @@ This will generate files in `exec/`, including `vagrant`. You can now specify
 the full path to the `exec/vagrant` anywhere on your operating system:
 
 ```shell
-$ /path/to/vagrant/exec/vagrant init -m hashicorp/precise64
+$ /path/to/vagrant/exec/vagrant init -m hashicorp/bionic64
 ```
 
 Note that you _will_ receive warnings that running Vagrant like this is not

--- a/website/source/docs/providers/basic_usage.html.md
+++ b/website/source/docs/providers/basic_usage.html.md
@@ -7,7 +7,7 @@ description: |-
   with the VMware Fusion provider, or any other provider. A box must be
   installed for each provider, and can share the same name as other boxes as
   long as the providers differ. So you can have both a VirtualBox and VMware
-  Fusion "precise64" box.
+  Fusion "bionic64" box.
 ---
 
 # Basic Provider Usage
@@ -18,12 +18,12 @@ Vagrant boxes are all provider-specific. A box for VirtualBox is incompatible
 with the VMware Fusion provider, or any other provider. A box must be installed
 for each provider, and can share the same name as other boxes as long
 as the providers differ. So you can have both a VirtualBox and VMware Fusion
-"precise64" box.
+"bionic64" box.
 
 Installing boxes has not changed at all:
 
 ```
-$ vagrant box add hashicorp/precise64
+$ vagrant box add hashicorp/bionic64
 ```
 
 Vagrant now automatically detects what provider a box is for. This is
@@ -32,8 +32,8 @@ to the name, as can be seen below.
 
 ```
 $ vagrant box list
-precise64 (virtualbox)
-precise64 (vmware_fusion)
+bionic64 (virtualbox)
+bionic64 (vmware_fusion)
 ```
 
 ## Vagrant Up

--- a/website/source/docs/providers/configuration.html.md
+++ b/website/source/docs/providers/configuration.html.md
@@ -5,7 +5,7 @@ sidebar_current: "providers-configuration"
 description: |-
   While well-behaved Vagrant providers should work with any Vagrantfile with
   sane defaults, providers generally expose unique configuration options so that
-  you can get the most out of each provider.  
+  you can get the most out of each provider
 ---
 
 # Configuration
@@ -71,16 +71,16 @@ Example:
 
 ```ruby
 Vagrant.configure("2") do |config|
-  config.vm.box = "precise64"
+  config.vm.box = "bionic64"
 
   config.vm.provider "vmware_fusion" do |v, override|
-    override.vm.box = "precise64_fusion"
+    override.vm.box = "bionic64_fusion"
   end
 end
 ```
 
-In the above case, Vagrant will use the "precise64" box by default, but
-will use "precise64_fusion" if the VMware Fusion provider is used.
+In the above case, Vagrant will use the "bionic64" box by default, but
+will use "bionic64_fusion" if the VMware Fusion provider is used.
 
 <div class="alert alert-info">
   <strong>The Vagrant Way:</strong> The proper "Vagrant way" is to

--- a/website/source/docs/provisioning/salt.html.md
+++ b/website/source/docs/provisioning/salt.html.md
@@ -30,7 +30,7 @@ on a single minion, without a master:
 ```ruby
   Vagrant.configure("2") do |config|
     ## Choose your base box
-    config.vm.box = "precise64"
+    config.vm.box = "bionic64"
 
     ## For masterless, mount your salt file root
     config.vm.synced_folder "salt/roots/", "/srv/salt/"

--- a/website/source/docs/vagrant-cloud/boxes/catalog.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/catalog.html.md
@@ -16,10 +16,10 @@ You don't need a Vagrant Cloud account to use public boxes.
 
 1. Once you find a box, click its name to learn more about it.
 
-1. When you're ready to use it, copy the name, such as "hashicorp/precise64"
-   and initialize your Vagrant project with `vagrant init hashicorp/precise64`.
+1. When you're ready to use it, copy the name, such as "hashicorp/bionic64"
+   and initialize your Vagrant project with `vagrant init hashicorp/bionic64`.
    Or, if you already have a Vagrant project created, modify the Vagrantfile
-   to use the box: `config.vm.box = "hashicorp/precise64"`
+   to use the box: `config.vm.box = "hashicorp/bionic64"`
 
 ## Provider Support
 

--- a/website/source/docs/vagrant-cloud/boxes/release-workflow.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/release-workflow.html.md
@@ -10,7 +10,7 @@ Creating new boxes through their [release lifecycle](/docs/vagrant-cloud/boxes/l
 is possible through the Vagrant Cloud website, but you can also automate
 the task via the Vagrant Cloud API.
 
-1. Create box, or locate a boxes `tag`, like `hashicorp/precise64`
+1. Create box, or locate a boxes `tag`, like `hashicorp/bionic64`
 2. After some event, like the end of a CI build, you may want to
 release a new version of the box. To do this, first use the API to
 create a new version with a version number and a short description

--- a/website/source/docs/vagrant-cloud/boxes/using.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/using.html.md
@@ -15,7 +15,7 @@ for a Vagrant environment. We've made it extremely easy to do that:
 
 1. Once you find a box, click its name to learn more about it.
 
-1. When you're ready to use it, copy the name, such as "hashicorp/precise64"
-   and initialize your Vagrant project with `vagrant init hashicorp/precise64`.
+1. When you're ready to use it, copy the name, such as "hashicorp/bionic64"
+   and initialize your Vagrant project with `vagrant init hashicorp/bionic64`.
    Or, if you already have a Vagrant project created, modify the Vagrantfile
-   to use the box: `config.vm.box = "hashicorp/precise64"`
+   to use the box: `config.vm.box = "hashicorp/bionic64"`

--- a/website/source/docs/vmware/boxes.html.md
+++ b/website/source/docs/vmware/boxes.html.md
@@ -42,10 +42,10 @@ $ tree
 |-- ...
 |-- disk.vmdk
 |-- metadata.json
-|-- precise64.nvram
-|-- precise64.vmsd
-|-- precise64.vmx
-|-- precise64.vmxf
+|-- bionic64.nvram
+|-- bionic64.vmsd
+|-- bionic64.vmx
+|-- bionic64.vmxf
 
 0 directories, 17 files
 ```

--- a/website/source/docs/vmware/usage.html.md
+++ b/website/source/docs/vmware/usage.html.md
@@ -23,9 +23,9 @@ Specifying the `--parallel` option will have no effect.
 To get started, create a new `Vagrantfile` that points to a VMware box:
 
 ```ruby
-# vagrant init hashicorp/precise64
+# vagrant init hashicorp/bionic64
 Vagrant.configure("2") do |config|
-  config.vm.box = "hashicorp/precise64"
+  config.vm.box = "hashicorp/bionic64"
 end
 ```
 

--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -39,17 +39,17 @@ description: |-
           <span class="circle"></span>
           <span class="circle"></span>
           <div class="terminal-content">
-            <span class="command">$ vagrant init hashicorp/precise64</span>
+            <span class="command">$ vagrant init hashicorp/bionic64</span>
             <span>&nbsp;</span>
             <span class="command">$ vagrant up</span>
             <span>Bringing machine 'default' up with 'virtualbox' provider...</span>
-            <span>==> default: Importing base box 'hashicorp/precise64'...</span>
+            <span>==> default: Importing base box 'hashicorp/bionic64'...</span>
             <span>==> default: Forwarding ports...</span>
             <span>    default: 22 (guest) => 2222 (host) (adapter 1)</span>
             <span>==> default: Waiting for machine to boot...</span>
             <span>&nbsp;</span>
             <span class="command">$ vagrant ssh</span>
-            <span>vagrant@precise64:~$ _</span>
+            <span>vagrant@bionic64:~$ _</span>
           </div>
         </div>
       </div>

--- a/website/source/intro/getting-started/boxes.html.md
+++ b/website/source/intro/getting-started/boxes.html.md
@@ -30,24 +30,24 @@ under a specific name so that multiple Vagrant environments can re-use it.
 If you have not added a box yet, you can do so now:
 
 ```
-$ vagrant box add hashicorp/precise64
+$ vagrant box add hashicorp/bionic64
 ```
 
-This will download the box named "hashicorp/precise64" from
+This will download the box named "hashicorp/bionic64" from
 [HashiCorp's Vagrant Cloud box catalog](https://vagrantcloud.com/boxes/search), a place where you can find
 and host boxes. While it is easiest to download boxes from HashiCorp's Vagrant Cloud
 you can also add boxes from a local file, custom URL, etc.
 
 Boxes are globally stored for the current user. Each project uses a box
 as an initial image to clone from, and never modifies the actual base
-image. This means that if you have two projects both using the `hashicorp/precise64`
+image. This means that if you have two projects both using the `hashicorp/bionic64`
 box we just added, adding files in one guest machine will have no effect
 on the other machine.
 
 In the above command, you will notice that boxes are namespaced. Boxes are
 broken down into two parts - the username and the box name - separated by a
 slash. In the example above, the username is "hashicorp", and the box is
-"precise64". You can also specify boxes via URLs or local file paths, but that
+"bionic64". You can also specify boxes via URLs or local file paths, but that
 will not be covered in the getting started guide.
 
 ~> **Namespaces do not guarantee canonical boxes!** A common misconception is
@@ -65,11 +65,11 @@ contents to the following:
 
 ```ruby
 Vagrant.configure("2") do |config|
-  config.vm.box = "hashicorp/precise64"
+  config.vm.box = "hashicorp/bionic64"
 end
 ```
 
-The "hashicorp/precise64" in this case must match the name you used to add
+The "hashicorp/bionic64" in this case must match the name you used to add
 the box above. This is how Vagrant knows what box to use. If the box was not
 added before, Vagrant will automatically download and add the box when it is
 run.
@@ -79,7 +79,7 @@ for example:
 
 ```ruby
 Vagrant.configure("2") do |config|
-  config.vm.box = "hashicorp/precise64"
+  config.vm.box = "hashicorp/bionic64"
   config.vm.box_version = "1.1.0"
 end
 ```
@@ -88,8 +88,8 @@ You may also specify the URL to a box directly using `config.vm.box_url`:
 
 ```ruby
 Vagrant.configure("2") do |config|
-  config.vm.box = "hashicorp/precise64"
-  config.vm.box_url = "https://vagrantcloud.com/hashicorp/precise64"
+  config.vm.box = "hashicorp/bionic64"
+  config.vm.box_url = "https://vagrantcloud.com/hashicorp/bionic64"
 end
 ```
 
@@ -99,7 +99,7 @@ with it a little bit.
 ## Finding More Boxes
 
 For the remainder of this getting started guide, we will only use the
-"hashicorp/precise64" box we added previously. But soon after finishing
+"hashicorp/bionic64" box we added previously. But soon after finishing
 this getting started guide, the first question you will probably have is
 "where do I find more boxes?"
 

--- a/website/source/intro/getting-started/index.html.md
+++ b/website/source/intro/getting-started/index.html.md
@@ -36,7 +36,7 @@ provider for the getting started guide, please install that as well.
 ## Up and Running
 
 ```
-$ vagrant init hashicorp/precise64
+$ vagrant init hashicorp/bionic64
 $ vagrant up
 ```
 

--- a/website/source/intro/getting-started/networking.html.md
+++ b/website/source/intro/getting-started/networking.html.md
@@ -32,7 +32,7 @@ is a simple edit to the Vagrantfile, which now looks like this:
 
 ```ruby
 Vagrant.configure("2") do |config|
-  config.vm.box = "hashicorp/precise64"
+  config.vm.box = "hashicorp/bionic64"
   config.vm.provision :shell, path: "bootstrap.sh"
   config.vm.network :forwarded_port, guest: 80, host: 4567
 end

--- a/website/source/intro/getting-started/project_setup.html.md
+++ b/website/source/intro/getting-started/project_setup.html.md
@@ -25,7 +25,7 @@ please follow along in your terminal:
 ```
 $ mkdir vagrant_getting_started
 $ cd vagrant_getting_started
-$ vagrant init hashicorp/precise64
+$ vagrant init hashicorp/bionic64
 ```
 
 This will place a `Vagrantfile` in your current directory. You can

--- a/website/source/intro/getting-started/provisioning.html.md
+++ b/website/source/intro/getting-started/provisioning.html.md
@@ -43,7 +43,7 @@ look like this:
 
 ```ruby
 Vagrant.configure("2") do |config|
-  config.vm.box = "hashicorp/precise64"
+  config.vm.box = "hashicorp/bionic64"
   config.vm.provision :shell, path: "bootstrap.sh"
 end
 ```
@@ -70,7 +70,7 @@ that the provisioning works by loading a file from SSH within the machine:
 ```
 $ vagrant ssh
 ...
-vagrant@precise64:~$ wget -qO- 127.0.0.1
+vagrant@bionic64:~$ wget -qO- 127.0.0.1
 ```
 
 This works because in the shell script above we installed Apache and

--- a/website/source/intro/getting-started/synced_folders.html.md
+++ b/website/source/intro/getting-started/synced_folders.html.md
@@ -24,7 +24,7 @@ Note that when you `vagrant ssh` into your machine, you're in `/home/vagrant`.
 
 If your terminal displays an error about incompatible guest additions (or no
 guest additions), you may need to update your box or choose a different box such
-as `hashicorp/precise64`. Some users have also had success with the
+as `hashicorp/bionic64`. Some users have also had success with the
 [vagrant-vbguest](https://github.com/dotless-de/vagrant-vbguest) plugin, but it
 is not officially supported by the Vagrant core team.
 
@@ -35,7 +35,7 @@ $ vagrant up
 ...
 $ vagrant ssh
 ...
-vagrant@precise64:~$ ls /vagrant
+vagrant@bionic64:~$ ls /vagrant
 Vagrantfile
 ```
 
@@ -44,8 +44,8 @@ is actually the same Vagrantfile that is on your actual host machine.
 Go ahead and touch a file to prove it to yourself:
 
 ```
-vagrant@precise64:~$ touch /vagrant/foo
-vagrant@precise64:~$ exit
+vagrant@bionic64:~$ touch /vagrant/foo
+vagrant@bionic64:~$ exit
 $ ls
 foo Vagrantfile
 ```

--- a/website/source/intro/getting-started/up.html.md
+++ b/website/source/intro/getting-started/up.html.md
@@ -36,7 +36,7 @@ and one command in your terminal, we brought up a fully functional, SSH accessib
 virtual machine. Cool. The SSH session can be terminated with `CTRL+D`.
 
 ```
-vagrant@precise64:~$ logout
+vagrant@bionic64:~$ logout
 Connection to 127.0.0.1 closed.
 ```
 


### PR DESCRIPTION
This PR updates the documentation to use `hashicorp/bionic64`

https://app.vagrantup.com/hashicorp/boxes/bionic64

Fixes https://github.com/hashicorp/vagrant/issues/8888