### PR TITLE
Fix documentation typos/punctuation.

### DIFF
--- a/website/source/docs/vagrant-cloud/boxes/catalog.html.md
+++ b/website/source/docs/vagrant-cloud/boxes/catalog.html.md
@@ -12,14 +12,14 @@ for a Vagrant environment.
 
 You don't need a Vagrant Cloud account to use public boxes.
 
-1. Go to the [Box search page](https://vagrantcloud.com/boxes/search)
+1. Go to the [Box search page](https://vagrantcloud.com/boxes/search).
 
 1. Once you find a box, click its name to learn more about it.
 
 1. When you're ready to use it, copy the name, such as "hashicorp/precise64"
    and initialize your Vagrant project with `vagrant init hashicorp/precise64`.
    Or, if you already have a Vagrant project created, modify the Vagrantfile
-   to use the box: `config.vm.box = "hashicorp/precise64"`
+   to use the box: `config.vm.box = "hashicorp/precise64"`.
 
 ## Provider Support
 
@@ -34,13 +34,13 @@ it's important to keep in mind whose box you're using. Here
 are some things to note when you're choosing a box:
 
 - __The username of the user__. If it's `bento` or `canonical`, you can likely
-trust the box more than an anonymous user
+trust the box more than an anonymous user.
 - __The number of downloads of the box__. Heavily downloaded boxes
 are likely vetted more often by other members of the community. HashiCorp
 responds to reports of malicious software distributed via Vagrant Cloud
-and takes down boxes
+and takes down boxes.
 - __The latest release date__. More up-to-date boxes contain up-to-date
-software
-- __Availability of the box download__. Vagrant Cloud periodically checks if box
-has is publicly accessible. You can see this information on the box
-page next to the provider
+software.
+- __Availability of the box download__. Vagrant Cloud periodically checks if a box
+is publicly accessible. You can see this information on the box
+page next to the provider.


### PR DESCRIPTION
This was originally supposed to fix the typo at the bottom of the page, but it appears that fix was already made 17 days ago (and my fork was 19 days old). 

I'm still submitting the pull request because I added periods throughout the page, and because I think the "Choosing the Right Box" section should be overhauled. The first item only lists `bento` and `canonical` the latter of which isn't even a user.  A more comprehensive list would be helpful, and possibly broken out between distro maintained boxes like `ubuntu` / `centos`, and projects which maintained collections of boxes for a variety of operating systems, like `bento`. But before I submit, I have a conflict of interest, so I don't know if should I make that change.

I wanted to add the support email address to the blurb on malicious boxes as well, so that if people find evil lurking somewhere, they can report it. The latest release point needs to be rewritten so it makes sense. Namely, look for boxes which are updated periodically, and/or which have been released recently, as they will contain more up-to-date software.

And finally the last item just doesn't make sense. I think it's trying to say the page will say whether a box is `Hosted by Vagrant Cloud ` or `Externally hosted (cloud.centos.org) ` /  ` Externally hosted (cloud-images.ubuntu.com) `, etc, but wanted to check before submitting.