### PR TITLE
Introduce new Provisioner options: before and after

### DIFF
--- a/lib/vagrant/action/builtin/mixin_provisioners.rb
+++ b/lib/vagrant/action/builtin/mixin_provisioners.rb
@@ -74,7 +74,6 @@ module Vagrant
             idx = 0
             if options[:before]
               idx = final_provs.each_with_index.map { |(p,o), i| i if o[:name].to_s == options[:before] }.reject(&:nil?).first
-              idx -= 1 unless idx == 0
               final_provs.insert(idx, [p, options])
             elsif options[:after]
               idx = final_provs.each_with_index.map { |(p,o), i| i if o[:name].to_s == options[:after] }.reject(&:nil?).first

--- a/lib/vagrant/action/builtin/mixin_provisioners.rb
+++ b/lib/vagrant/action/builtin/mixin_provisioners.rb
@@ -45,8 +45,6 @@ module Vagrant
 
         # Sorts provisioners based on order specified with before/after options
         #
-        # TODO: make sure all defined provisioners work here (i.e. even thoughs defined in separate but loaded Vagrantfile)
-        #
         # @return [Array<Provisioner, Hash>]
         def sort_provisioner_instances(pvs)
           final_provs = []
@@ -70,8 +68,6 @@ module Vagrant
           # extract all provisioners
           all_provs = pvs.map { |p,o| [p,o] if o[:before] == :all || o[:after] == :all }.reject(&:nil?)
 
-          # TODO: Log here, that provisioner order is being changed
-
           # insert provisioners in order
           final_provs = root_provs
           dep_provs.each do |p,options|
@@ -90,26 +86,22 @@ module Vagrant
           # Add :each and :all provisioners in reverse to preserve order in Vagrantfile
 
           # add each to final array
-          # TODO: This doesn't work if before each provisioners are defined before after provisioners
-          #
-          # Maybe do before and after individually instead??
-          tmp_final_provs = final_provs.dup
-          index_offset = 0
+          tmp_final_provs = []
           final_provs.each_with_index.map do |(prv,o), i|
+            tmp_before = []
+            tmp_after = []
+
             each_provs.reverse_each do |p, options|
-              idx = 0
               if options[:before]
-                idx = (i+index_offset+1)-1 unless i == 0
-                puts "b: #{idx}"
-                index_offset += 1
-                tmp_final_provs.insert(idx, [p,options])
+                tmp_before << [p,options]
               elsif options[:after]
-                idx = (i+index_offset)+1
-                index_offset += 1
-                puts "a: #{idx}"
-                tmp_final_provs.insert(idx, [p,options])
+                tmp_after << [p,options]
               end
             end
+
+            tmp_final_provs += tmp_before unless tmp_before.empty?
+            tmp_final_provs += [[prv,o]]
+            tmp_final_provs += tmp_after unless tmp_after.empty?
           end
           final_provs = tmp_final_provs
 

--- a/lib/vagrant/action/builtin/mixin_provisioners.rb
+++ b/lib/vagrant/action/builtin/mixin_provisioners.rb
@@ -55,17 +55,18 @@ module Vagrant
 
           # extract root provisioners
           root_provs = pvs.map { |p,o| [p,o] if o[:before].nil? && o[:after].nil? }.reject(&:nil?)
+
+          if root_provs.size == pvs.size
+            # no dependencies found
+            return pvs
+          end
+
           # extract dependency provisioners
           dep_provs = pvs.map { |p,o| [p,o] if (!o[:before].nil? && !o[:before].is_a?(Symbol)) || (!o[:after].nil? && !o[:after].is_a?(Symbol)) }.reject(&:nil?)
           # extract each provisioners
           each_provs = pvs.map { |p,o| [p,o] if o[:before] == :each || o[:after] == :each }.reject(&:nil?)
           # extract all provisioners
           all_provs = pvs.map { |p,o| [p,o] if o[:before] == :all || o[:after] == :all }.reject(&:nil?)
-
-          if root_provs.size == pvs.size
-            # no dependencies found
-            return pvs
-          end
 
           # TODO: Log here, that provisioner order is being changed
 

--- a/lib/vagrant/action/builtin/mixin_provisioners.rb
+++ b/lib/vagrant/action/builtin/mixin_provisioners.rb
@@ -90,20 +90,23 @@ module Vagrant
           # Add :each and :all provisioners in reverse to preserve order in Vagrantfile
 
           # add each to final array
-          # TODO: Account for additional tmp_final size after insert for BOTH before/after cases (if both shortcuts are used)
+          # TODO: This doesn't work if before each provisioners are defined before after provisioners
+          #
+          # Maybe do before and after individually instead??
           tmp_final_provs = final_provs.dup
-          before_extra_index = 1 # offset for final array size
-          after_extra_index = 0
-          each_provs.reverse_each do |p,options|
-            idx = 0
-            final_provs.each_with_index.map do |(prv,o), i|
+          index_offset = 0
+          final_provs.each_with_index.map do |(prv,o), i|
+            each_provs.reverse_each do |p, options|
+              idx = 0
               if options[:before]
-                idx = (i+before_extra_index)-1 unless i == 0
-                before_extra_index += 1
+                idx = (i+index_offset+1)-1 unless i == 0
+                puts "b: #{idx}"
+                index_offset += 1
                 tmp_final_provs.insert(idx, [p,options])
               elsif options[:after]
-                idx = (i+after_extra_index)+1
-                after_extra_index += 1
+                idx = (i+index_offset)+1
+                index_offset += 1
+                puts "a: #{idx}"
                 tmp_final_provs.insert(idx, [p,options])
               end
             end
@@ -132,6 +135,13 @@ module Vagrant
 
           # Return the type map
           @_provisioner_types
+        end
+
+        # @private
+        # Reset the cached values for platform. This is not considered a public
+        # API and should only be used for testing.
+        def self.reset!
+          instance_variables.each(&method(:remove_instance_variable))
         end
       end
     end

--- a/lib/vagrant/action/builtin/mixin_provisioners.rb
+++ b/lib/vagrant/action/builtin/mixin_provisioners.rb
@@ -37,14 +37,84 @@ module Vagrant
             [result, options]
           end
 
+          @_provisioner_instances = sort_provisioner_instances(@_provisioner_instances)
           return @_provisioner_instances.compact
         end
 
         # Sorts provisioners based on order specified with before/after options
         #
+        # TODO: make sure all defined provisioners work here (i.e. even thoughs defined in separate but loaded Vagrantfile)
+        #
         # @return [Array<Provisioner, Hash>]
         def sort_provisioner_instances(pvs)
-          return pvs
+          final_provs = []
+          root_provs = []
+          dep_provs = []
+          each_provs = []
+          all_provs = []
+
+          # extract root provisioners
+          root_provs = pvs.map { |p,o| [p,o] if o[:before].nil? && o[:after].nil? }.reject(&:nil?)
+          # extract dependency provisioners
+          dep_provs = pvs.map { |p,o| [p,o] if (!o[:before].nil? && !o[:before].is_a?(Symbol)) || (!o[:after].nil? && !o[:after].is_a?(Symbol)) }.reject(&:nil?)
+          # extract each provisioners
+          each_provs = pvs.map { |p,o| [p,o] if o[:before] == :each || o[:after] == :each }.reject(&:nil?)
+          # extract all provisioners
+          all_provs = pvs.map { |p,o| [p,o] if o[:before] == :all || o[:after] == :all }.reject(&:nil?)
+
+          if root_provs.size == pvs.size
+            # no dependencies found
+            return pvs
+          end
+
+          # TODO: Log here, that provisioner order is being changed
+
+          # insert provisioners in order
+          final_provs = root_provs
+          dep_provs.each do |p,options|
+            if options[:before]
+              idx = final_provs.each_with_index.map { |(p,o), i| i if o[:name].to_s == options[:before] }.reject(&:nil?).first
+              idx -= 1 unless idx == 0
+              final_provs.insert(idx, [p, options])
+            elsif options[:after]
+              idx = final_provs.each_with_index.map { |(p,o), i| i if o[:name].to_s == options[:after] }.reject(&:nil?).first
+              idx += 1
+              final_provs.insert(idx, [p, options])
+            end
+          end
+
+          # add each to final array
+          tmp_final_provs = final_provs.dup
+          extra_index = 0
+          each_provs.reverse_each do |p,options|
+            final_provs.each_with_index.map do |(prv,o), i|
+              if options[:before]
+                idx = i-1 unless idx == 0
+                idx += extra_index
+                extra_index += 1
+                tmp_final_provs.insert(idx, [p,options])
+              elsif options[:after]
+                idx = i+1
+                idx += extra_index
+                extra_index += 1
+                tmp_final_provs.insert(idx, [p,options])
+              end
+            end
+          end
+          final_provs = tmp_final_provs
+
+          # add all to final array
+          tmp_final_provs = final_provs.dup
+          all_provs.reverse_each do |p,options|
+            if options[:before]
+              tmp_final_provs.insert(0, [p,options])
+            elsif options[:after]
+              tmp_final_provs.push([p,options])
+            end
+          end
+          final_provs = tmp_final_provs
+
+          return final_provs
         end
 
         # This will return a mapping of a provisioner instance to its

--- a/lib/vagrant/action/builtin/mixin_provisioners.rb
+++ b/lib/vagrant/action/builtin/mixin_provisioners.rb
@@ -29,6 +29,8 @@ module Vagrant
             options = {
               name: provisioner.name,
               run:  provisioner.run,
+              before:  provisioner.before,
+              after:  provisioner.after,
             }
 
             # Return the result
@@ -36,6 +38,13 @@ module Vagrant
           end
 
           return @_provisioner_instances.compact
+        end
+
+        # Sorts provisioners based on order specified with before/after options
+        #
+        # @return [Array<Provisioner, Hash>]
+        def sort_provisioner_instances(pvs)
+          return pvs
         end
 
         # This will return a mapping of a provisioner instance to its

--- a/lib/vagrant/action/builtin/mixin_provisioners.rb
+++ b/lib/vagrant/action/builtin/mixin_provisioners.rb
@@ -57,6 +57,7 @@ module Vagrant
             return pvs
           end
 
+          # ensure placeholder variables are Arrays
           dep_provs = []
           each_provs = []
           all_provs = []
@@ -83,8 +84,6 @@ module Vagrant
           end
 
           # Add :each and :all provisioners in reverse to preserve order in Vagrantfile
-
-          # add each to final array
           tmp_final_provs = []
           final_provs.each_with_index.map do |(prv,o), i|
             tmp_before = []
@@ -104,16 +103,14 @@ module Vagrant
           end
           final_provs = tmp_final_provs
 
-          # add all to final array
-          tmp_final_provs = final_provs.dup
+          # Add all to final array
           all_provs.reverse_each do |p,options|
             if options[:before]
-              tmp_final_provs.insert(0, [p,options])
+              final_provs.insert(0, [p,options])
             elsif options[:after]
-              tmp_final_provs.push([p,options])
+              final_provs.push([p,options])
             end
           end
-          final_provs = tmp_final_provs
 
           return final_provs
         end

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -760,6 +760,13 @@ module VagrantPlugins
             next
           end
 
+          require 'pry'
+          binding.pry
+          #provisioner_errors = vm_provisioner.validate(machine)
+          #if provisioner_errors
+          #  errors = Vagrant::Config::V2::Util.merge_errors(errors, provisioner_errors)
+          #end
+
           if vm_provisioner.config
             provisioner_errors = vm_provisioner.config.validate(machine)
             if provisioner_errors

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -767,7 +767,7 @@ module VagrantPlugins
             next
           end
 
-          provisioner_names = @provisioners.map { |i| i.name if i.name != vm_provisioner.name }.reject(&:blank?)
+          provisioner_names = @provisioners.map { |i| i.name if i.name != vm_provisioner.name }.reject(&:nil?)
           provisioner_errors = vm_provisioner.validate(machine, provisioner_names)
           if provisioner_errors
             errors = Vagrant::Config::V2::Util.merge_errors(errors, provisioner_errors)

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -7,6 +7,7 @@ require "vagrant/action/builtin/mixin_synced_folders"
 require "vagrant/config/v2/util"
 require "vagrant/util/platform"
 require "vagrant/util/presence"
+require "vagrant/util/experimental"
 
 require File.expand_path("../vm_provisioner", __FILE__)
 require File.expand_path("../vm_subvm", __FILE__)
@@ -338,7 +339,11 @@ module VagrantPlugins
             after = options.delete(:after)
           end
 
-          prov = VagrantConfigProvisioner.new(name, type.to_sym, before, after)
+          if Vagrant::Util::Experimental.feature_enabled?("dependency_provisioners")
+            prov = VagrantConfigProvisioner.new(name, type.to_sym, before, after)
+          else
+            prov = VagrantConfigProvisioner.new(name, type.to_sym)
+          end
           @provisioners << prov
         end
 

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -772,8 +772,7 @@ module VagrantPlugins
             next
           end
 
-          provisioner_names = @provisioners.map { |i| i.name if i.name != vm_provisioner.name }.reject(&:nil?)
-          provisioner_errors = vm_provisioner.validate(machine, provisioner_names)
+          provisioner_errors = vm_provisioner.validate(machine, @provisioners)
           if provisioner_errors
             errors = Vagrant::Config::V2::Util.merge_errors(errors, provisioner_errors)
           end

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -340,7 +340,8 @@ module VagrantPlugins
           end
 
           if Vagrant::Util::Experimental.feature_enabled?("dependency_provisioners")
-            prov = VagrantConfigProvisioner.new(name, type.to_sym, before, after)
+            opts = {before: before, after: after}
+            prov = VagrantConfigProvisioner.new(name, type.to_sym, opts)
           else
             prov = VagrantConfigProvisioner.new(name, type.to_sym)
           end

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -767,7 +767,8 @@ module VagrantPlugins
             next
           end
 
-          provisioner_errors = vm_provisioner.validate(machine)
+          provisioner_names = @provisioners.map { |i| i.name if i.name != vm_provisioner.name }.reject(&:blank?)
+          provisioner_errors = vm_provisioner.validate(machine, provisioner_names)
           if provisioner_errors
             errors = Vagrant::Config::V2::Util.merge_errors(errors, provisioner_errors)
           end

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -331,7 +331,14 @@ module VagrantPlugins
         end
 
         if !prov
-          prov = VagrantConfigProvisioner.new(name, type.to_sym)
+          if options.key?(:before)
+            before = options.delete(:before)
+          end
+          if options.key?(:after)
+            after = options.delete(:after)
+          end
+
+          prov = VagrantConfigProvisioner.new(name, type.to_sym, before, after)
           @provisioners << prov
         end
 
@@ -760,12 +767,10 @@ module VagrantPlugins
             next
           end
 
-          require 'pry'
-          binding.pry
-          #provisioner_errors = vm_provisioner.validate(machine)
-          #if provisioner_errors
-          #  errors = Vagrant::Config::V2::Util.merge_errors(errors, provisioner_errors)
-          #end
+          provisioner_errors = vm_provisioner.validate(machine)
+          if provisioner_errors
+            errors = Vagrant::Config::V2::Util.merge_errors(errors, provisioner_errors)
+          end
 
           if vm_provisioner.config
             provisioner_errors = vm_provisioner.config.validate(machine)

--- a/plugins/kernel_v2/config/vm_provisioner.rb
+++ b/plugins/kernel_v2/config/vm_provisioner.rb
@@ -45,12 +45,12 @@ module VagrantPlugins
 
       # The name of a provisioner to run before it has started
       #
-      # @return [String]
+      # @return [String, Symbol]
       attr_accessor :before
 
       # The name of a provisioner to run after it is finished
       #
-      # @return [String]
+      # @return [String, Symbol]
       attr_accessor :after
 
       def initialize(name, type, before=nil, after=nil)

--- a/plugins/kernel_v2/config/vm_provisioner.rb
+++ b/plugins/kernel_v2/config/vm_provisioner.rb
@@ -125,7 +125,8 @@ module VagrantPlugins
               errors << I18n.t("vagrant.provisioners.base.missing_provisioner_name",
                                name: @before,
                                machine_name: machine.name,
-                               action: "before")
+                               action: "before",
+                               provisioner_name: @name)
             end
           end
         end
@@ -142,7 +143,8 @@ module VagrantPlugins
               errors << I18n.t("vagrant.provisioners.base.missing_provisioner_name",
                                name: @after,
                                machine_name: machine.name,
-                               action: "after")
+                               action: "after",
+                               provisioner_name: @name)
             end
           end
         end

--- a/plugins/kernel_v2/config/vm_provisioner.rb
+++ b/plugins/kernel_v2/config/vm_provisioner.rb
@@ -115,6 +115,10 @@ module VagrantPlugins
 
         provisioner_names = provisioners.map { |i| i.name if i.name != name }.reject(&:nil?)
 
+        if @before && @after
+          errors << I18n.t("vagrant.provisioners.base.both_before_after_set")
+        end
+
         if @before
           if !VALID_BEFORE_AFTER_TYPES.include?(@before)
             if @before.is_a?(Symbol) && !VALID_BEFORE_AFTER_TYPES.include?(@before)

--- a/plugins/kernel_v2/config/vm_provisioner.rb
+++ b/plugins/kernel_v2/config/vm_provisioner.rb
@@ -29,7 +29,7 @@ module VagrantPlugins
       # @return [Object]
       attr_accessor :config
 
-      # When to run this provisioner. Either "once" or "always"
+      # When to run this provisioner. Either "once", "always", or "never"
       #
       # @return [String]
       attr_accessor :run

--- a/plugins/kernel_v2/config/vm_provisioner.rb
+++ b/plugins/kernel_v2/config/vm_provisioner.rb
@@ -105,23 +105,27 @@ module VagrantPlugins
         @config.finalize!
       end
 
-      # TODO: This isn't being called
-      #
       # @return [Array] array of strings of error messages from config option validation
       def validate(machine)
         errors = _detected_errors
 
         if @before
           if @before.is_a?(Symbol) && !VALID_BEFORE_AFTER_TYPES.include?(@before)
-            errors << "Before symbol is not a valid symbol"
+            errors << I18n.t("vagrant.provisioners.base.invalid_alias_value", opt: "before", alias: VALID_BEFORE_AFTER_TYPES.join(", "))
+          elsif !@before.is_a?(String) && !VALID_BEFORE_AFTER_TYPES.include?(@before)
+            errors << I18n.t("vagrant.provisioners.base.wrong_type", opt: "before")
           end
         end
 
         if @after
           if @after.is_a?(Symbol) && !VALID_BEFORE_AFTER_TYPES.include?(@after)
-            errors << "After symbol is not a valid symbol"
+            errors << I18n.t("vagrant.provisioners.base.invalid_alias_value", opt: "after", alias: VALID_BEFORE_AFTER_TYPES.join(", "))
+          elsif !@after.is_a?(String) && !VALID_BEFORE_AFTER_TYPES.include?(@after)
+            errors << I18n.t("vagrant.provisioners.base.wrong_type", opt: "after")
           end
         end
+
+        {"provisioner" => errors}
       end
 
       # Returns whether the provisioner used was invalid or not. A provisioner

--- a/plugins/kernel_v2/config/vm_provisioner.rb
+++ b/plugins/kernel_v2/config/vm_provisioner.rb
@@ -105,23 +105,43 @@ module VagrantPlugins
         @config.finalize!
       end
 
+      # @param [Vagrant::Machine] machine - machine to validate against
+      # @param [Array<Symbol>] provisioner_names - Names of provisioners for a given machine
       # @return [Array] array of strings of error messages from config option validation
-      def validate(machine)
+      def validate(machine, provisioner_names)
         errors = _detected_errors
 
         if @before
-          if @before.is_a?(Symbol) && !VALID_BEFORE_AFTER_TYPES.include?(@before)
-            errors << I18n.t("vagrant.provisioners.base.invalid_alias_value", opt: "before", alias: VALID_BEFORE_AFTER_TYPES.join(", "))
-          elsif !@before.is_a?(String) && !VALID_BEFORE_AFTER_TYPES.include?(@before)
-            errors << I18n.t("vagrant.provisioners.base.wrong_type", opt: "before")
+          if !VALID_BEFORE_AFTER_TYPES.include?(@before)
+            if @before.is_a?(Symbol) && !VALID_BEFORE_AFTER_TYPES.include?(@before)
+              errors << I18n.t("vagrant.provisioners.base.invalid_alias_value", opt: "before", alias: VALID_BEFORE_AFTER_TYPES.join(", "))
+            elsif !@before.is_a?(String) && !VALID_BEFORE_AFTER_TYPES.include?(@before)
+              errors << I18n.t("vagrant.provisioners.base.wrong_type", opt: "before")
+            end
+
+            if !provisioner_names.include?(@before.to_sym)
+              errors << I18n.t("vagrant.provisioners.base.missing_provisioner_name",
+                               name: @before,
+                               machine_name: machine.name,
+                               action: "before")
+            end
           end
         end
 
         if @after
-          if @after.is_a?(Symbol) && !VALID_BEFORE_AFTER_TYPES.include?(@after)
-            errors << I18n.t("vagrant.provisioners.base.invalid_alias_value", opt: "after", alias: VALID_BEFORE_AFTER_TYPES.join(", "))
-          elsif !@after.is_a?(String) && !VALID_BEFORE_AFTER_TYPES.include?(@after)
-            errors << I18n.t("vagrant.provisioners.base.wrong_type", opt: "after")
+          if !VALID_BEFORE_AFTER_TYPES.include?(@after)
+            if @after.is_a?(Symbol)
+              errors << I18n.t("vagrant.provisioners.base.invalid_alias_value", opt: "after", alias: VALID_BEFORE_AFTER_TYPES.join(", "))
+            elsif !@after.is_a?(String)
+              errors << I18n.t("vagrant.provisioners.base.wrong_type", opt: "after")
+            end
+
+            if !provisioner_names.include?(@after.to_sym)
+              errors << I18n.t("vagrant.provisioners.base.missing_provisioner_name",
+                               name: @after,
+                               machine_name: machine.name,
+                               action: "after")
+            end
           end
         end
 

--- a/plugins/kernel_v2/config/vm_provisioner.rb
+++ b/plugins/kernel_v2/config/vm_provisioner.rb
@@ -3,7 +3,7 @@ require 'log4r'
 module VagrantPlugins
   module Kernel_V2
     # Represents a single configured provisioner for a VM.
-    class VagrantConfigProvisioner
+    class VagrantConfigProvisioner < Vagrant.plugin("2", :config)
       # Defaults
       VALID_BEFORE_AFTER_TYPES = [:each, :all].freeze
 
@@ -53,7 +53,7 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :after
 
-      def initialize(name, type)
+      def initialize(name, type, before=nil, after=nil)
         @logger = Log4r::Logger.new("vagrant::config::vm::provisioner")
         @logger.debug("Provisioner defined: #{name}")
 
@@ -64,8 +64,8 @@ module VagrantPlugins
         @preserve_order = false
         @run     = nil
         @type    = type
-        @before  = nil
-        @after   = nil
+        @before  = before #these aren't being properly set
+        @after   = after
 
         # Attempt to find the provisioner...
         if !Vagrant.plugin("2").manager.provisioners[type]

--- a/plugins/kernel_v2/config/vm_provisioner.rb
+++ b/plugins/kernel_v2/config/vm_provisioner.rb
@@ -4,6 +4,9 @@ module VagrantPlugins
   module Kernel_V2
     # Represents a single configured provisioner for a VM.
     class VagrantConfigProvisioner
+      # Defaults
+      VALID_BEFORE_AFTER_TYPES = [:each, :all].freeze
+
       # Unique name for this provisioner
       #
       # @return [String]
@@ -100,6 +103,25 @@ module VagrantPlugins
         return if invalid?
 
         @config.finalize!
+      end
+
+      # TODO: This isn't being called
+      #
+      # @return [Array] array of strings of error messages from config option validation
+      def validate(machine)
+        errors = _detected_errors
+
+        if @before
+          if @before.is_a?(Symbol) && !VALID_BEFORE_AFTER_TYPES.include?(@before)
+            errors << "Before symbol is not a valid symbol"
+          end
+        end
+
+        if @after
+          if @after.is_a?(Symbol) && !VALID_BEFORE_AFTER_TYPES.include?(@after)
+            errors << "After symbol is not a valid symbol"
+          end
+        end
       end
 
       # Returns whether the provisioner used was invalid or not. A provisioner

--- a/plugins/kernel_v2/config/vm_provisioner.rb
+++ b/plugins/kernel_v2/config/vm_provisioner.rb
@@ -113,7 +113,7 @@ module VagrantPlugins
       def validate(machine, provisioners)
         errors = _detected_errors
 
-        provisioner_names = provisioners.map { |i| i.name.to_s if i.name != name }.reject(&:nil?)
+        provisioner_names = provisioners.map { |i| i.name.to_s if i.name != name }.compact
 
         if @before && @after
           errors << I18n.t("vagrant.provisioners.base.both_before_after_set")

--- a/plugins/kernel_v2/config/vm_provisioner.rb
+++ b/plugins/kernel_v2/config/vm_provisioner.rb
@@ -64,7 +64,7 @@ module VagrantPlugins
         @preserve_order = false
         @run     = nil
         @type    = type
-        @before  = before #these aren't being properly set
+        @before  = before
         @after   = after
 
         # Attempt to find the provisioner...

--- a/plugins/kernel_v2/config/vm_provisioner.rb
+++ b/plugins/kernel_v2/config/vm_provisioner.rb
@@ -40,6 +40,16 @@ module VagrantPlugins
       # @return [Boolean]
       attr_accessor :preserve_order
 
+      # The name of a provisioner to run before it has started
+      #
+      # @return [String]
+      attr_accessor :before
+
+      # The name of a provisioner to run after it is finished
+      #
+      # @return [String]
+      attr_accessor :after
+
       def initialize(name, type)
         @logger = Log4r::Logger.new("vagrant::config::vm::provisioner")
         @logger.debug("Provisioner defined: #{name}")
@@ -51,6 +61,8 @@ module VagrantPlugins
         @preserve_order = false
         @run     = nil
         @type    = type
+        @before  = nil
+        @after   = nil
 
         # Attempt to find the provisioner...
         if !Vagrant.plugin("2").manager.provisioners[type]

--- a/plugins/kernel_v2/config/vm_provisioner.rb
+++ b/plugins/kernel_v2/config/vm_provisioner.rb
@@ -105,6 +105,8 @@ module VagrantPlugins
         @config.finalize!
       end
 
+      # Validates the before/after options
+      #
       # @param [Vagrant::Machine] machine - machine to validate against
       # @param [Array<Symbol>] provisioner_names - Names of provisioners for a given machine
       # @return [Array] array of strings of error messages from config option validation

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2490,7 +2490,7 @@ en:
         invalid_alias_value: |-
           Provisioner option `%{opt}` is not set as a valid type. Must be a string, or one of the alias shortcuts: %{alias}
         missing_provisioner_name: |-
-          Could not find provisioner name `%{name}` defined for machine `%{machine_name}` to run provisioner `%{action}`.
+          Could not find provisioner name `%{name}` defined for machine `%{machine_name}` to run provisioner `%{action}` "%{provisioner_name}".
         wrong_type: |-
           Provisioner option `%{opt}` is not set as a valid type. Must be a string.
       chef:

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2487,6 +2487,8 @@ en:
 
     provisioners:
       base:
+        both_before_after_set: |-
+          Dependency provisioners cannot currently set both `before` and `after` options.
         dependency_provisioner_dependency: |-
           Dependency provisioner "%{name}" relies on another dependency provisioner "%{dep_name}". This is currently not supported.
         invalid_alias_value: |-

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2486,6 +2486,11 @@ en:
           VirtualBox has successfully been installed!
 
     provisioners:
+      base:
+        invalid_alias_value: |-
+          Provisioner option `%{opt}` is not set as a valid type. Must be a string, or one of the alias shortcuts: %{alias}
+        wrong_type: |-
+          Provisioner option `%{opt}` is not set as a valid type. Must be a string.
       chef:
         chef_not_detected: |-
           The chef binary (either `chef-solo` or `chef-client`) was not found on

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2487,6 +2487,8 @@ en:
 
     provisioners:
       base:
+        dependency_provisioner_dependency: |-
+          Dependency provisioner "%{name}" relies on another dependency provisioner "%{dep_name}". This is currently not supported.
         invalid_alias_value: |-
           Provisioner option `%{opt}` is not set as a valid type. Must be a string, or one of the alias shortcuts: %{alias}
         missing_provisioner_name: |-

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2489,6 +2489,8 @@ en:
       base:
         invalid_alias_value: |-
           Provisioner option `%{opt}` is not set as a valid type. Must be a string, or one of the alias shortcuts: %{alias}
+        missing_provisioner_name: |-
+          Could not find provisioner name `%{name}` defined for machine `%{machine_name}` to run provisioner `%{action}`.
         wrong_type: |-
           Provisioner option `%{opt}` is not set as a valid type. Must be a string.
       chef:

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2490,7 +2490,7 @@ en:
         invalid_alias_value: |-
           Provisioner option `%{opt}` is not set as a valid type. Must be a string, or one of the alias shortcuts: %{alias}
         missing_provisioner_name: |-
-          Could not find provisioner name `%{name}` defined for machine `%{machine_name}` to run provisioner `%{action}` "%{provisioner_name}".
+          Could not find provisioner name `%{name}` defined for machine `%{machine_name}` to run provisioner "%{provisioner_name}" `%{action}`.
         wrong_type: |-
           Provisioner option `%{opt}` is not set as a valid type. Must be a string.
       chef:

--- a/test/unit/vagrant/action/builtin/mixin_provisioners_test.rb
+++ b/test/unit/vagrant/action/builtin/mixin_provisioners_test.rb
@@ -1,0 +1,203 @@
+require File.expand_path("../../../../base", __FILE__)
+require Vagrant.source_root.join("plugins/kernel_v2/config/vm")
+
+require "vagrant/action/builtin/mixin_provisioners"
+
+describe Vagrant::Action::Builtin::MixinProvisioners do
+  include_context "unit"
+
+  let(:sandbox) { isolated_environment }
+  let(:iso_env) do
+    # We have to create a Vagrantfile so there is a root path
+    sandbox.vagrantfile("")
+    sandbox.create_vagrant_env
+  end
+
+  let(:provisioner_config){ {} }
+  let(:provisioner_one) do
+    prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("spec-test", :shell)
+    prov.config = provisioner_config
+    prov
+  end
+  let(:provisioner_two) do
+    prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("spec-test", :shell)
+    prov.config = provisioner_config
+    prov
+  end
+
+  let(:provisioner_instances) { [provisioner_one,provisioner_two] }
+
+  let(:ui) { double("ui") }
+  let(:vm) { double("vm", provisioners: provisioner_instances) }
+  let(:config) { double("config", vm: vm) }
+  let(:machine) { double("machine", ui: ui, config: config) }
+
+  let(:env) {{ machine: machine, ui: machine.ui, root_path: Pathname.new(".") }}
+
+  subject do
+    Class.new do
+      extend Vagrant::Action::Builtin::MixinProvisioners
+    end
+  end
+
+  after do
+    sandbox.close
+  end
+
+  describe "#provisioner_instances" do
+    it "returns all the instances of configured provisioners" do
+      result = subject.provisioner_instances(env)
+      expect(result.size).to eq(provisioner_instances.size)
+      shell_one = result.first
+      expect(shell_one.first).to be_a(VagrantPlugins::Shell::Provisioner)
+      shell_two = result[1]
+      expect(shell_two.first).to be_a(VagrantPlugins::Shell::Provisioner)
+    end
+  end
+
+  context "#sort_provisioner_instances" do
+    describe "with no dependency provisioners" do
+      it "returns the original array" do
+        result = subject.provisioner_instances(env)
+        expect(result.size).to eq(provisioner_instances.size)
+        shell_one = result.first
+        expect(shell_one.first).to be_a(VagrantPlugins::Shell::Provisioner)
+        shell_two = result[1]
+        expect(shell_two.first).to be_a(VagrantPlugins::Shell::Provisioner)
+      end
+    end
+
+    describe "with before and after dependency provisioners" do
+      let(:provisioner_config){ {} }
+      let(:provisioner_root) do
+        prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("root-test", :shell)
+        prov.config = provisioner_config
+        prov
+      end
+      let(:provisioner_before) do
+        prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("before-test", :shell)
+        prov.config = provisioner_config
+        prov.before = "root-test"
+        prov
+      end
+      let(:provisioner_after) do
+        prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("after-test", :shell)
+        prov.config = provisioner_config
+        prov.after = "root-test"
+        prov
+      end
+      let(:provisioner_instances) { [provisioner_root,provisioner_before,provisioner_after] }
+
+      it "returns the array in the correct order" do
+        result = subject.provisioner_instances(env)
+        expect(result[0].last[:name]).to eq("before-test")
+        expect(result[1].last[:name]).to eq("root-test")
+        expect(result[2].last[:name]).to eq("after-test")
+      end
+    end
+
+    describe "with before :each dependency provisioners" do
+      let(:provisioner_config){ {} }
+      let(:provisioner_root) do
+        prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("root-test", :shell)
+        prov.config = provisioner_config
+        prov
+      end
+      let(:provisioner_root2) do
+        prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("root2-test", :shell)
+        prov.config = provisioner_config
+        prov
+      end
+      let(:provisioner_before) do
+        prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("before-test", :shell)
+        prov.config = provisioner_config
+        prov.before = :each
+        prov
+      end
+
+      let(:provisioner_instances) { [provisioner_root,provisioner_root2,provisioner_before] }
+
+      it "puts the each shortcut provisioners in place" do
+        result = subject.provisioner_instances(env)
+
+        expect(result[0].last[:name]).to eq("before-test")
+        expect(result[1].last[:name]).to eq("root-test")
+        expect(result[2].last[:name]).to eq("before-test")
+        expect(result[3].last[:name]).to eq("root2-test")
+      end
+    end
+
+    describe "with after :each dependency provisioners" do
+      let(:provisioner_config){ {} }
+      let(:provisioner_root) do
+        prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("root-test", :shell)
+        prov.config = provisioner_config
+        prov
+      end
+      let(:provisioner_root2) do
+        prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("root2-test", :shell)
+        prov.config = provisioner_config
+        prov
+      end
+      let(:provisioner_after) do
+        prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("after-test", :shell)
+        prov.config = provisioner_config
+        prov.after = :each
+        prov
+      end
+
+      let(:provisioner_instances) { [provisioner_root,provisioner_root2,provisioner_after] }
+
+      it "puts the each shortcut provisioners in place" do
+        result = subject.provisioner_instances(env)
+
+        expect(result[0].last[:name]).to eq("root-test")
+        expect(result[1].last[:name]).to eq("after-test")
+        expect(result[2].last[:name]).to eq("root2-test")
+        expect(result[3].last[:name]).to eq("after-test")
+      end
+    end
+
+    describe "with before and after :each dependency provisioners" do
+      let(:provisioner_config){ {} }
+      let(:provisioner_root) do
+        prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("root-test", :shell)
+        prov.config = provisioner_config
+        prov
+      end
+      let(:provisioner_root2) do
+        prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("root2-test", :shell)
+        prov.config = provisioner_config
+        prov
+      end
+      let(:provisioner_after) do
+        prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("after-test", :shell)
+        prov.config = provisioner_config
+        prov.after = :each
+        prov
+      end
+      let(:provisioner_before) do
+        prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("before-test", :shell)
+        prov.config = provisioner_config
+        prov.before = :each
+        prov
+      end
+
+      let(:provisioner_instances) { [provisioner_root,provisioner_root2,provisioner_before,provisioner_after] }
+
+      it "puts the each shortcut provisioners in place" do
+        result = subject.provisioner_instances(env)
+        result.each do |p,o|
+          puts o[:name]
+        end
+
+        expect(result[0].last[:name]).to eq("before-test")
+        expect(result[1].last[:name]).to eq("root-test")
+        expect(result[2].last[:name]).to eq("after-test")
+        expect(result[3].last[:name]).to eq("before-test")
+        expect(result[4].last[:name]).to eq("root2-test")
+        expect(result[5].last[:name]).to eq("after-test")
+      end
+    end
+  end
+end

--- a/test/unit/vagrant/action/builtin/mixin_provisioners_test.rb
+++ b/test/unit/vagrant/action/builtin/mixin_provisioners_test.rb
@@ -197,5 +197,42 @@ describe Vagrant::Action::Builtin::MixinProvisioners do
         expect(result[5].last[:name]).to eq("after-test")
       end
     end
+
+    describe "with before and after :all dependency provisioners" do
+      let(:provisioner_config){ {} }
+      let(:provisioner_root) do
+        prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("root-test", :shell)
+        prov.config = provisioner_config
+        prov
+      end
+      let(:provisioner_root2) do
+        prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("root2-test", :shell)
+        prov.config = provisioner_config
+        prov
+      end
+      let(:provisioner_after) do
+        prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("after-test", :shell)
+        prov.config = provisioner_config
+        prov.after = :all
+        prov
+      end
+      let(:provisioner_before) do
+        prov = VagrantPlugins::Kernel_V2::VagrantConfigProvisioner.new("before-test", :shell)
+        prov.config = provisioner_config
+        prov.before = :all
+        prov
+      end
+
+      let(:provisioner_instances) { [provisioner_root,provisioner_root2,provisioner_before,provisioner_after] }
+
+      it "puts the each shortcut provisioners in place" do
+        result = subject.provisioner_instances(env)
+
+        expect(result[0].last[:name]).to eq("before-test")
+        expect(result[1].last[:name]).to eq("root-test")
+        expect(result[2].last[:name]).to eq("root2-test")
+        expect(result[3].last[:name]).to eq("after-test")
+      end
+    end
   end
 end

--- a/test/unit/vagrant/action/builtin/mixin_provisioners_test.rb
+++ b/test/unit/vagrant/action/builtin/mixin_provisioners_test.rb
@@ -188,9 +188,6 @@ describe Vagrant::Action::Builtin::MixinProvisioners do
 
       it "puts the each shortcut provisioners in place" do
         result = subject.provisioner_instances(env)
-        result.each do |p,o|
-          puts o[:name]
-        end
 
         expect(result[0].last[:name]).to eq("before-test")
         expect(result[1].last[:name]).to eq("root-test")

--- a/test/unit/vagrant/action/builtin/mixin_provisioners_test.rb
+++ b/test/unit/vagrant/action/builtin/mixin_provisioners_test.rb
@@ -42,6 +42,7 @@ describe Vagrant::Action::Builtin::MixinProvisioners do
 
   after do
     sandbox.close
+    described_class.reset!
   end
 
   describe "#provisioner_instances" do

--- a/website/source/docs/experimental/index.html.md
+++ b/website/source/docs/experimental/index.html.md
@@ -47,3 +47,10 @@ This is a list of all the valid experimental features that Vagrant recognizes:
 
 Enabling this feature allows triggers to recognize and execute `:type` triggers.
 More information about how these should be used can be found on the [trigger documentation page](/docs/triggers/configuration.html#trigger-types)
+
+### `dependency_provisioners`
+
+Enabling this feature allows all provisioners to specify `before` and `after`
+options. These options allow provisioners to be configured to run before or after
+any given "root" provisioner. more information about these options can be found
+on the [base provisioner documentation page](/docs/provisioning/basic_usage.html)

--- a/website/source/docs/provisioning/basic_usage.html.md
+++ b/website/source/docs/provisioning/basic_usage.html.md
@@ -28,12 +28,16 @@ option is what type a provisioner is:
   that _this_ provisioner should run before. If defined as a symbol, its only valid
   values are `:each` or `:all`, which makes the provisioner run before each and
   every root provisioner, or before all provisioners respectively.
+  __Note__: This option is currently experimental, so it needs to be explicitly
+  enabled to work. More info can be found [here](/docs/experimental/index.html).
 * `after` (string or symbol) - The exact name of an already defined provisioner
   that _this_ provisioner should run after. If defined as a symbol, its only valid
   values are `:each` or `:all`, which makes the provisioner run after each and
   every root provisioner, or before all provisioners respectively.
+  __Note__: This option is currently experimental, so it needs to be explicitly
+  enabled to work. More info can be found [here](/docs/experimental/index.html).
 
-More information about `before` and `after` options can be read [below](#dependency-provisioners).
+More information about how to use `before` and `after` options can be read [below](#dependency-provisioners).
 
 ## Configuration
 
@@ -250,10 +254,18 @@ end
 
 ## Dependency Provisioners
 
+<div class="alert alert-warning">
+  <strong>Warning: Advanced Topic!</strong> Dependency provisioners are
+  an advanced topic. If you are just getting started with Vagrant, you can
+  safely skip this.
+</div>
+
 If a provisioner has been configured using the `before` or `after` options, it
 is considered a _Dependency Provisioner_. This means it has been configured to
 run before or after a _Root Provisioner_, which does not have the `before` or
-`after` options configured. Dependency provisioners also have two valid shortcuts:
+`after` options configured.
+
+Dependency provisioners also have two valid shortcuts:
 `:each` and `:all`.
 
 **TODO: Add good real example here**

--- a/website/source/docs/provisioning/basic_usage.html.md
+++ b/website/source/docs/provisioning/basic_usage.html.md
@@ -268,8 +268,6 @@ run before or after a _Root Provisioner_, which does not have the `before` or
 Dependency provisioners also have two valid shortcuts:
 `:each` and `:all`.
 
-**TODO: Add good real example here**
-
 **Note**: As of 2.2.6, dependency provisioners cannot rely on other dependency
 provisioners and is considered a configuration state error in Vagrant. If you must
 order dependency provisioners, you can still order them by the order they are defined

--- a/website/source/docs/provisioning/basic_usage.html.md
+++ b/website/source/docs/provisioning/basic_usage.html.md
@@ -256,6 +256,13 @@ run before or after a _Root Provisioner_, which does not have the `before` or
 `after` options configured. Dependency provisioners also have two valid shortcuts:
 `:each` and `:all`.
 
+**TODO: Add good real example here**
+
+**Note**: As of 2.2.6, dependency provisioners cannot rely on other dependency
+provisioners and is considered a configuration state error in Vagrant. If you must
+order dependency provisioners, you can still order them by the order they are defined
+inside your Vagrantfile.
+
 An example of these dependency provisioners can be seen below:
 
 ```ruby

--- a/website/source/docs/provisioning/basic_usage.html.md
+++ b/website/source/docs/provisioning/basic_usage.html.md
@@ -260,6 +260,22 @@ end
   safely skip this.
 </div>
 
+<div class="alert alert-warning">
+  <strong>Warning!</strong> This feature is still experimental and may break or
+  change in between releases. Use at your own risk.
+
+  This feature currently reqiures the experimental flag to be used. To explicitly enable this feature, you can set the experimental flag to:
+
+  ```
+  VAGRANT_EXPERIMENTAL="dependency_provisioners"
+  ```
+
+  Please note that `VAGRANT_EXPERIMENTAL` is an environment variable. For more
+  information about this flag visit the [Experimental docs page](/docs/experimental/)
+  for more info. Without this flag enabled, provisioners with the `before` and
+  `after` option will be ignored.
+</div>
+
 If a provisioner has been configured using the `before` or `after` options, it
 is considered a _Dependency Provisioner_. This means it has been configured to
 run before or after a _Root Provisioner_, which does not have the `before` or


### PR DESCRIPTION
This pull request introduces two new experimental configuration options for all provisioners: `before` and `after`. Provisioners that specify one of these options are known as _dependency provisioners_, where as provisioners that don't specify these options are known as _root provisioners_. For a _dependency provisioner_ to run before or after a _root provisioner_, the _root provisioner_ must have a name.

These options allow a user to be explicit about _when_ a provisioner should run, before or after a **named** root provisioner. It also has two shortcut values: `:each` and `:all`.