### PR TITLE
Ensure proper paths are shown in config loading exceptions

### DIFF
--- a/lib/vagrant/config/loader.rb
+++ b/lib/vagrant/config/loader.rb
@@ -2,6 +2,8 @@ require "pathname"
 
 require "log4r"
 
+require "vagrant/util/platform"
+
 module Vagrant
   module Config
     # This class is responsible for loading Vagrant configuration,
@@ -129,7 +131,13 @@ module Vagrant
                 path = "(unknown)"
                 if e.backtrace && e.backtrace[0]
                   backtrace_tokens = e.backtrace[0].split(":")
-                  path = backtrace_tokens[0]
+                  if Vagrant::Util::Platform.windows?
+                    # path is split into two tokens on windows for some reason...
+                    # where 0th is drive letter, 1st is path
+                    path = backtrace_tokens[0] + ":" + backtrace_tokens[1]
+                  else
+                    path = backtrace_tokens[0]
+                  end
                   backtrace_tokens.each do |part|
                     if part =~ /\d+/
                       line = part.to_i

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -509,7 +509,13 @@ module VagrantPlugins
 
             line = "(unknown)"
             if e.backtrace && e.backtrace[0]
-              line = e.backtrace[0].split(":")[1]
+              if Vagrant::Util::Platform.windows?
+                # path is split into two tokens on windows for some reason...
+                # where 0th is drive letter, 1st is path, so line number is token 2
+                line = e.backtrace[0].split(":")[2]
+              else
+                line = e.backtrace[0].split(":")[1]
+              end
             end
 
             raise Vagrant::Errors::VagrantfileLoadError,


### PR DESCRIPTION
This PR fixes up some issues on Windows where Vagrant was not grabbing the proper path for Windows hosts when an exception occurred loading a config file.