### PR TITLE
FreeBSD: Update Ansible's package name

### DIFF
--- a/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
               if install_mode != :default
                 raise Ansible::Errors::AnsiblePipInstallIsNotSupported
               else
-                machine.communicate.sudo "yes | pkg install ansible"
+                machine.communicate.sudo "pkg install -qy py36-ansible"
               end
             end
 


### PR DESCRIPTION
The Ansible package in FreeBSD is now `py36-ansible`.

If `pkg` itself needs updating, passing only one 'yes' is not enough to confirm the installation of the package.  Use the `-y` option, specifically made for this purpose.  Also add `-q` to force a quiet output, inline with other guests.

References:

- [`pkg-install(8)`](https://www.freebsd.org/cgi/man.cgi?query=pkg-install&sektion=8)
- freebsd/freebsd-ports@cbf5576945e1582d1a4a8080c3c440addc73cd4e