### PR TITLE
Update nfs & service daemon names for suse based hosts

### DIFF
--- a/plugins/guests/suse/cap/nfs_client.rb
+++ b/plugins/guests/suse/cap/nfs_client.rb
@@ -5,8 +5,8 @@ module VagrantPlugins
         def self.nfs_client_install(machine)
           machine.communicate.sudo <<-EOH.gsub(/^ {12}/, '')
             zypper -n install nfs-client
-            /sbin/service rpcbind restart
-            /sbin/service nfs restart
+            /usr/bin/systemctl restart rpcbind
+            /usr/bin/systemctl restart nfs-client.target
           EOH
         end
       end

--- a/plugins/hosts/suse/cap/nfs.rb
+++ b/plugins/hosts/suse/cap/nfs.rb
@@ -7,11 +7,11 @@ module VagrantPlugins
         end
 
         def self.nfs_check_command(env)
-          "/sbin/service nfsserver status"
+          "systemctl status --no-pager nfs-server"
         end
 
         def self.nfs_start_command(env)
-          "/sbin/service nfsserver start"
+          "systemctl start --no-pager nfs-server"
         end
       end
     end

--- a/test/unit/plugins/guests/suse/cap/nfs_client_test.rb
+++ b/test/unit/plugins/guests/suse/cap/nfs_client_test.rb
@@ -24,8 +24,8 @@ describe "VagrantPlugins::GuestSUSE::Cap::NFSClient" do
     it "installs nfs client utilities" do
       cap.nfs_client_install(machine)
       expect(comm.received_commands[0]).to match(/zypper -n install nfs-client/)
-      expect(comm.received_commands[0]).to match(/service rpcbind restart/)
-      expect(comm.received_commands[0]).to match(/service nfs restart/)
+      expect(comm.received_commands[0]).to match(/systemctl restart rpcbind/)
+      expect(comm.received_commands[0]).to match(/systemctl restart nfs-client.target/)
     end
   end
 end


### PR DESCRIPTION
- `nfs.service` got recently removed in openSUSE Tumbleweed and calling `service restart nfs` errors out on Tumbleweed. `nfs.service` has been an alias to `nfs-client.target` for a very long time and can thus be safely substituted.
- all actively supported versions of openSUSE & SLE are using systemd now => no reason not to use `systemctl`

Something comparable has to be done for the corresponding files in `RedHat` to address #10838. cc @pvalena 