### PR TITLE
Fixes #10966: Ensure all subdirectory files are watched

### DIFF
--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -30,6 +30,10 @@ module VagrantPlugins
           exclude      = exclude[1..-1]
         end
 
+        exclude = "#{exclude}/" if !exclude.end_with?("/")
+        exclude = "^#{exclude}"
+        exclude += ".*" if !start_anchor
+
         # This is not an ideal solution, but it's a start. We can improve and
         # keep unit tests passing in the future.
         exclude = exclude.gsub("**", "|||GLOBAL|||")

--- a/test/unit/plugins/synced_folders/rsync/helper_test.rb
+++ b/test/unit/plugins/synced_folders/rsync/helper_test.rb
@@ -33,22 +33,22 @@ describe VagrantPlugins::SyncedFolderRSync::RsyncHelper do
 
     it "converts a directory match" do
       expect(described_class.exclude_to_regexp("foo/")).
-        to eq(/foo\//)
+        to eq(/^foo\/.[^\/]*/)
     end
 
     it "converts the start anchor" do
       expect(described_class.exclude_to_regexp("/foo")).
-        to eq(/foo/)
+        to eq(/^foo\//)
     end
 
     it "converts the **" do
       expect(described_class.exclude_to_regexp("fo**o")).
-        to eq(/fo.*o/)
+        to eq(/^fo.*o\/.[^\/]*/)
     end
 
     it "converts the *" do
       expect(described_class.exclude_to_regexp("fo*o")).
-        to eq(/fo[^\/]*o/)
+        to eq(/^fo[^\/]*o\/.[^\/]*/)
     end
   end
 


### PR DESCRIPTION
Prior to this commit, due to a fix that ignored `.vagrant` with rsync
helper, it broke the ability to watch for changes in subdirectories when
running the rsync-auto command. This commit puts back some of the helper
methods that were there previously for a given watcher path to ensure
that all files and subdirectories are properly watched and synced.