### PR TITLE
default pip_install_cmd value as empty string

### DIFF
--- a/plugins/provisioners/ansible/config/guest.rb
+++ b/plugins/provisioners/ansible/config/guest.rb
@@ -19,7 +19,7 @@ module VagrantPlugins
           @install           = UNSET_VALUE
           @install_mode      = UNSET_VALUE
           @pip_args          = UNSET_VALUE
-          @pip_install_cmd   = UNSET_VALUE          
+          @pip_install_cmd   = ""
           @provisioning_path = UNSET_VALUE
           @tmp_path          = UNSET_VALUE
         end


### PR DESCRIPTION
this fix #10950 

the logic seems in the `finalize!` method instead. Not went deeper to understand why has been coded in that why.

