### PR TITLE
Fixes #11027: Ensure VM id is passed to list snapshots

### DIFF
--- a/plugins/commands/snapshot/command/save.rb
+++ b/plugins/commands/snapshot/command/save.rb
@@ -31,7 +31,15 @@ module VagrantPlugins
               help: opts.help.chomp
           end
 
-          name = argv.pop
+          # If no snapshot name is given, the backup name is the same as the machine name.
+          # If there is a name given, we need to remove it and save it as `name`. Otherwise
+          # `with_target_vms` will treat the snapshot name as a guest name.
+          if argv.size < 2
+            name = argv.first
+          else
+            name = argv.pop
+          end
+
           with_target_vms(argv) do |vm|
             if !vm.provider.capability?(:snapshot_list)
               raise Vagrant::Errors::SnapshotNotSupported

--- a/test/unit/plugins/commands/snapshot/command/save_test.rb
+++ b/test/unit/plugins/commands/snapshot/command/save_test.rb
@@ -76,6 +76,29 @@ describe VagrantPlugins::CommandSnapshot::Command::Save do
       end
     end
 
+    context "with a snapshot guest and name given" do
+      let(:argv)     { ["foo", "backup"] }
+      it "calls snapshot_save with a snapshot name" do
+        machine.id = "foo"
+
+        expect(machine).to receive(:action) do |name, opts|
+          expect(name).to eq(:snapshot_save)
+          expect(opts[:snapshot_name]).to eq("backup")
+        end
+
+        expect(subject.execute).to eq(0)
+      end
+
+      it "doesn't snapshot a non-existent machine" do
+        machine.id = nil
+
+        expect(subject).to receive(:with_target_vms){}
+
+        expect(machine).to_not receive(:action)
+        expect(subject.execute).to eq(0)
+      end
+    end
+
     context "with a duplicate snapshot name given and no force flag" do
       let(:argv)     { ["test"] }
 


### PR DESCRIPTION
Prior to this commit, if you tried to save a snapshot without giving it
a name, the hyper-v driver would not properly obtain a vm id to save a
snapshot on, resulting in an error. This commit updates the command
snapshot save to hold onto the machines ID in argv rather than `pop` it
off, so that the hyperv driver can obtain the guests id when saving a
snapshot.