### PR TITLE
Fixes #10950: Ensure pip_install_cmd is finalized

### DIFF
--- a/plugins/provisioners/ansible/cap/guest/pip/pip.rb
+++ b/plugins/provisioners/ansible/cap/guest/pip/pip.rb
@@ -21,7 +21,6 @@ module VagrantPlugins
           end
 
           def self.get_pip(machine, pip_install_cmd=DEFAULT_PIP_INSTALL_CMD)
-
             # The objective here is to get pip either by default
             # or by the argument passed in. The objective is not 
             # to circumvent the pip setup by passing in nothing.

--- a/plugins/provisioners/ansible/config/guest.rb
+++ b/plugins/provisioners/ansible/config/guest.rb
@@ -19,7 +19,7 @@ module VagrantPlugins
           @install           = UNSET_VALUE
           @install_mode      = UNSET_VALUE
           @pip_args          = UNSET_VALUE
-          @pip_install_cmd   = UNSET_VALUE          
+          @pip_install_cmd   = UNSET_VALUE
           @provisioning_path = UNSET_VALUE
           @tmp_path          = UNSET_VALUE
         end
@@ -30,7 +30,7 @@ module VagrantPlugins
           @install           = true                   if @install           == UNSET_VALUE
           @install_mode      = :default               if @install_mode      == UNSET_VALUE
           @pip_args          = ""                     if @pip_args          == UNSET_VALUE
-          @pip_install_cmd   = ""                     if @pip_args          == UNSET_VALUE          
+          @pip_install_cmd   = ""                     if @pip_install_cmd   == UNSET_VALUE
           @provisioning_path = "/vagrant"             if provisioning_path  == UNSET_VALUE
           @tmp_path          = "/tmp/vagrant-ansible" if tmp_path           == UNSET_VALUE
         end

--- a/plugins/provisioners/ansible/provisioner/guest.rb
+++ b/plugins/provisioners/ansible/provisioner/guest.rb
@@ -33,7 +33,7 @@ module VagrantPlugins
         # Current limitations:
         #   - The installation of a specific Ansible version is only supported by
         #     the "pip" install_mode. Note that "pip" installation also takes place
-        #     via a default command. If pip needs to be installed differently then 
+        #     via a default command. If pip needs to be installed differently then
         #     the command can be overwritten by supplying "pip_install_cmd" in the
         #     config settings.
         #   - There is no absolute guarantee that the automated installation will replace

--- a/test/unit/plugins/provisioners/ansible/config/guest_test.rb
+++ b/test/unit/plugins/provisioners/ansible/config/guest_test.rb
@@ -61,6 +61,7 @@ describe VagrantPlugins::Ansible::Config::Guest do
       expect(subject.install_mode).to eql(:default)
       expect(subject.provisioning_path).to eql("/vagrant")
       expect(subject.tmp_path).to eql("/tmp/vagrant-ansible")
+      expect(subject.pip_install_cmd).to eql("")
     end
   end
 


### PR DESCRIPTION
Prior to this commit, the `pip_install_cmd` option for ansible guest
config was not properly finalized. This commit ensures that if that
value is still UNSET_VALUE, it gets set to empty string in the finalize!
method.