### PR TITLE
Ensure relative path for file provisioner is relative to machines cwd

### DIFF
--- a/plugins/provisioners/file/provisioner.rb
+++ b/plugins/provisioners/file/provisioner.rb
@@ -3,7 +3,7 @@ module VagrantPlugins
     class Provisioner < Vagrant.plugin("2", :provisioner)
       def provision
         @machine.communicate.tap do |comm|
-          source = File.expand_path(config.source)
+          source = File.expand_path(config.source, @machine.env.cwd)
           destination = expand_guest_path(config.destination)
 
           # If the source is a directory determine if any path modifications

--- a/test/unit/plugins/provisioners/file/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/file/provisioner_test.rb
@@ -65,7 +65,7 @@ describe VagrantPlugins::FileUpload::Provisioner do
       allow(config).to receive(:destination).and_return("/foo/bar")
 
       expect(communicator).to receive(:upload).with(
-        File.expand_path("source"), "/foo/bar")
+        File.expand_path("#{machine.env.cwd}/source"), "/foo/bar")
 
       subject.provision
     end


### PR DESCRIPTION
Prior to this commit, if you ran Vagrant in a different current working
directory other than where a current guest machines location is, the
file provisioner would not take into account the machines local dir, and
would instead use the path where Vagrant was invoked to expand the
`source` path option for a file provisioner. This commit fixes that by
passing the root path `machine.env.cwd` when expanding the source dir.