### PR TITLE
Use hostnamectl instead of hostname to set the hostname under SUSE

### DIFF
--- a/plugins/guests/suse/cap/change_host_name.rb
+++ b/plugins/guests/suse/cap/change_host_name.rb
@@ -5,11 +5,10 @@ module VagrantPlugins
         def self.change_host_name(machine, name)
           comm = machine.communicate
 
-          if !comm.test("hostname -f | grep '^#{name}$'", sudo: false)
+          if !comm.test("getent hosts '#{name}'", sudo: false)
             basename = name.split(".", 2)[0]
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
-              echo '#{basename}' > /etc/HOSTNAME
-              hostname '#{basename}'
+              hostnamectl set-hostname '#{basename}'
 
               # Prepend ourselves to /etc/hosts
               grep -w '#{name}' /etc/hosts || {

--- a/test/unit/plugins/guests/suse/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/suse/cap/change_host_name_test.rb
@@ -25,15 +25,15 @@ describe "VagrantPlugins::GuestSUSE::Cap::ChangeHostName" do
     let(:basename) { "banana-rama" }
 
     it "sets the hostname" do
-      comm.stub_command("hostname -f | grep '^#{name}$'", exit_code: 1)
+      comm.stub_command("getent hosts '#{name}'", exit_code: 1)
 
       cap.change_host_name(machine, name)
-      expect(comm.received_commands[1]).to match(/echo '#{basename}' > \/etc\/HOSTNAME/)
-      expect(comm.received_commands[1]).to match(/hostname '#{basename}'/)
+      expect(comm.received_commands[1]).to match(/hostnamectl set-hostname '#{basename}'/)
     end
 
     it "does not change the hostname if already set" do
-      comm.stub_command("hostname -f | grep '^#{name}$'", exit_code: 0)
+      comm.stub_command("getent hosts '#{name}'", exit_code: 0)
+
       cap.change_host_name(machine, name)
       expect(comm.received_commands.size).to eq(1)
     end


### PR DESCRIPTION
`hostname` isn't part of the boxes openSUSE currently provides. As openSUSE and SLE are using `systemd` quite a while, setting the hostname using `hostnamectl` should be fine.

Without this fix, the _transient hostname_ will stay on localhost until the VM is restarted.

I've tested this change against openSUSE Leap 15.0, Leap 15.1 and Tumbleweed using this Vagrantfile:

```ruby
Vagrant.configure("2") do |config|

  config.vm.define "Leap15-0" do |sut|
    sut.vm.box = "Leap-15.0.x86_64"
    sut.vm.box_url = "https://download.opensuse.org/repositories/Virtualization:/Appliances:/Images:/openSUSE-Leap-15.0/images/boxes/Leap-15.0.x86_64.json"
    sut.vm.hostname = "leap15-0.example.com"
  end

  config.vm.define "Leap15-1" do |sut|
    sut.vm.box = "Leap-15.1.x86_64"
    sut.vm.box_url = "https://download.opensuse.org/repositories/Virtualization:/Appliances:/Images:/openSUSE-Leap-15.1/images/boxes/Leap-15.1.x86_64.json"
    sut.vm.hostname = "leap15-1.example.com"
  end

  config.vm.define "Tumbleweed" do |sut|
    sut.vm.box = "opensuse/openSUSE-Tumbleweed-Vagrant.x86_64"
    sut.vm.hostname = "tumbleweed.example.com"
  end

end

```