### PR TITLE
Fix #10961 NFS sharing in macOS 10.15 host

### DIFF
--- a/plugins/hosts/bsd/cap/nfs.rb
+++ b/plugins/hosts/bsd/cap/nfs.rb
@@ -214,9 +214,9 @@ module VagrantPlugins
 
         def self.nfs_check_folders_for_apfs(folders)
           folders.each do |_, opts|
-            # check to see if this path is mounted in an APFS filesystem, and if it's in the
-            # firmlink which must be prefixed.
-            is_mounted_apfs_command = "df -t apfs #{opts[:hostpath]}"
+            # check to see if this path is mounted in an APFS filesystem, and if it's under the
+            # firmlink which must be prefixed. we need to use the OS X df — GNU won't notice.
+            is_mounted_apfs_command = "/bin/df -t apfs #{opts[:hostpath]}"
             result = Vagrant::Util::Subprocess.execute(*Shellwords.split(is_mounted_apfs_command))
             if (result.stdout.include? OSX_FIRMLINK_HACK)
               opts[:hostpath].prepend(OSX_FIRMLINK_HACK)

--- a/test/unit/plugins/hosts/bsd/cap/nfs_test.rb
+++ b/test/unit/plugins/hosts/bsd/cap/nfs_test.rb
@@ -1,0 +1,39 @@
+require_relative "../../../../base"
+require_relative "../../../../../../plugins/hosts/bsd/cap/nfs"
+require_relative "../../../../../../lib/vagrant/util"
+
+describe VagrantPlugins::HostBSD::Cap::NFS do
+
+  include_context "unit"
+
+  describe ".nfs_check_folders_for_apfs" do
+    it "should prefix host paths that are mounted in /System/Volumes/Data" do
+      output_from_df = <<-EOH
+Filesystem    512-blocks      Used Available Capacity iused      ifree %iused  Mounted on
+/dev/disk1s1   976490568 392813584 555082648    42% 1177049 4881275791    0%   /System/Volumes/Data
+EOH
+      expect(Vagrant::Util::Subprocess).to receive(:execute).and_return(
+        Vagrant::Util::Subprocess::Result.new(0, output_from_df, "")
+      )
+
+      folders = {"/vagrant"=>{:hostpath=>"/Users/johndoe/vagrant",:bsd__nfs_options=>["rw"]}}
+      described_class.nfs_check_folders_for_apfs(folders)
+      expect(folders["/vagrant"][:hostpath]).to eq("/System/Volumes/Data/Users/johndoe/vagrant")
+    end
+
+    it "should not prefix host paths that are mounted in elsewhere" do
+      output_from_df = <<-EOH
+Filesystem    512-blocks      Used Available Capacity iused      ifree %iused  Mounted on
+/dev/disk1s5   976490568  20634032 554201072     4%  481588 4881971252    0%   /
+EOH
+      expect(Vagrant::Util::Subprocess).to receive(:execute).and_return(
+        Vagrant::Util::Subprocess::Result.new(0, output_from_df, "")
+      )
+
+      folders = {"/vagrant"=>{:hostpath=>"/",:bsd__nfs_options=>["rw"]}}
+      described_class.nfs_check_folders_for_apfs(folders)
+      expect(folders["/vagrant"][:hostpath]).to eq("/")
+    end
+
+  end
+end


### PR DESCRIPTION
### Description

On macOS 10.15 (Catalina), `/` is read-only and paths inside of `/Users` (and elsewhere) are mounted via a "firmlink" (which is a new invention in APFS). These must be resolved to their full path to be shareable via NFS.

```
/Users/johnsmith/mycode  =>  /System/Volumes/Data/Users/johnsmith/mycode
```

This code tests each shared folder on the host, to see if it's 1) inside of an APFS filesystem, and 2) in this firmlink situation. Firmlinks are only createable by the OS, so this hardcoded path to check should be fine — at least until Apple adds more.

And this all was supposed to be visible to applications anyway. There's a useful intro to APFS changes in 10.15 here (linked to the right time)
https://developer.apple.com/videos/play/wwdc2019/710/?time=481

### Fixes

This fixes #10961 — and there were some helpful commenters in there who helped me track down where to begin.

### Tests

There weren't tests for the BSD NFS class, so I added one, but it's pretty isolated. This should also be testable by trying to share any folder below your home directory via NFS on 10.15. You'll see the side effects in `/etc/exports` on the host, which will have a `/System/Volumes/Data` prefix.

[Our team at Nutshell](https://github.com/nutshellcrm/) has been using vagrant for 6 years — thanks for making our lives easier, Mitchell & co!