### PR TITLE
Ensure build_args are passed into docker compose config file

### DIFF
--- a/plugins/providers/docker/action/build.rb
+++ b/plugins/providers/docker/action/build.rb
@@ -19,7 +19,7 @@ module VagrantPlugins
           build_dir ||= machine.provider_config.build_dir
           git_repo  = env[:git_repo]
           git_repo  ||= machine.provider_config.git_repo
-          
+
           # If we're not building a container, then just skip this step
           return @app.call(env) if (!build_dir && !git_repo)
 

--- a/plugins/providers/docker/driver/compose.rb
+++ b/plugins/providers/docker/driver/compose.rb
@@ -34,6 +34,12 @@ module VagrantPlugins
           @logger.debug("Data directory for composition file `#{@data_directory}`")
         end
 
+        # Updates the docker compose config file with the given arguments
+        #
+        # @param [String] dir - local directory or git repo URL
+        # @param [Hash] opts - valid key: extra_args
+        # @param [Block] block
+        # @return [Nil]
         def build(dir, **opts, &block)
           name = machine.name.to_s
           @logger.debug("Applying build for `#{name}` using `#{dir}` directory.")
@@ -47,26 +53,26 @@ module VagrantPlugins
                 services[name]["build"]["dockerfile"] = opts[:extra_args][opts[:extra_args].index("--file") + 1]
               end
               # Extract any build args that can be found
-              case opts[:build_args]
+              case opts[:extra_args]
               when Array
-                if opts[:build_args].include?("--build-arg")
+                if opts[:extra_args].include?("--build-arg")
                   idx = 0
-                  build_args = {}
-                  while(idx < opts[:build_args].size)
-                    arg_value = opts[:build_args][idx]
+                  extra_args = {}
+                  while(idx < opts[:extra_args].size)
+                    arg_value = opts[:extra_args][idx]
                     idx += 1
                     if arg_value.start_with?("--build-arg")
                       if !arg_value.include?("=")
-                        arg_value = opts[:build_args][idx]
+                        arg_value = opts[:extra_args][idx]
                         idx += 1
                       end
                       key, val = arg_value.to_s.split("=", 2).to_s.split("=")
-                      build_args[key] = val
+                      extra_args[key] = val
                     end
                   end
                 end
               when Hash
-                services[name]["build"]["args"] = opts[:build_args]
+                services[name]["build"]["args"] = opts[:extra_args]
               end
             end
           rescue => error

--- a/test/unit/plugins/providers/docker/driver_compose_test.rb
+++ b/test/unit/plugins/providers/docker/driver_compose_test.rb
@@ -54,6 +54,23 @@ describe VagrantPlugins::DockerProvider::Driver::Compose do
     end
   end
 
+  describe '#build' do
+    it 'creates a compose config with no extra options' do
+      expect(subject).to receive(:update_composition)
+      subject.build(composition_path)
+    end
+
+    it 'creates a compose config when given an array for build-arg' do
+      expect(subject).to receive(:update_composition)
+      subject.build(composition_path, extra_args: ["foo", "bar"])
+    end
+
+    it 'creates a compose config when given a hash for build-arg' do
+      expect(subject).to receive(:update_composition)
+      subject.build(composition_path, extra_args: {"foo"=>"bar"})
+    end
+  end
+
   describe '#create' do
     let(:params) { {
       image:      'jimi/hendrix:electric-ladyland',


### PR DESCRIPTION
Prior to this commit, the docker compose build method would not properly
set build_args if given in a Vagrantfile. This commit fixes that by
using the passed in key `extra_args` from the docker build action.