### PR TITLE
Fix NFS sharing in macOS 10.15 (based on #11105)

### DIFF
--- a/plugins/hosts/bsd/cap/nfs.rb
+++ b/plugins/hosts/bsd/cap/nfs.rb
@@ -214,9 +214,9 @@ module VagrantPlugins
 
         def self.nfs_check_folders_for_apfs(folders)
           folders.each do |_, opts|
-            # check to see if this path is mounted in an APFS filesystem, and if it's in the
-            # firmlink which must be prefixed.
-            is_mounted_apfs_command = "df -t apfs #{opts[:hostpath]}"
+            # check to see if this path is mounted in an APFS filesystem, and if it's under the
+            # firmlink which must be prefixed. we need to use the OS X df — GNU won't notice.
+            is_mounted_apfs_command = "/bin/df -t apfs #{opts[:hostpath]}"
             result = Vagrant::Util::Subprocess.execute(*Shellwords.split(is_mounted_apfs_command))
             if (result.stdout.include? OSX_FIRMLINK_HACK)
               opts[:hostpath].prepend(OSX_FIRMLINK_HACK)

--- a/plugins/hosts/bsd/cap/nfs.rb
+++ b/plugins/hosts/bsd/cap/nfs.rb
@@ -8,31 +8,12 @@ module VagrantPlugins
   module HostBSD
     module Cap
       class NFS
-        # On OS X 10.15, / is read-only and paths inside of /Users (and elsewhere) are mounted
-        # via a "firmlink" (which is a new invention in APFS). These must be resolved to their
-        # full path to be shareable via NFS.
-        # /Users/johnsmith/mycode   becomes   /System/Volumes/Data/Users/johnsmith/mycode
-        # we check to see if a path is mounted here with `df`, and prepend it.
-        #
-        # Firmlinks are only createable by the OS, so a hardcoded path should be fine, until
-        # Apple gets crazier. This wasn't supposed to be visible to applications anyway:
-        # https://developer.apple.com/videos/play/wwdc2019/710/?time=481
-        # see also https://github.com/hashicorp/vagrant/issues/10961
-        OSX_FIRMLINK_HACK = "/System/Volumes/Data"
-
         def self.nfs_export(environment, ui, id, ips, folders)
           nfs_exports_template = environment.host.capability(:nfs_exports_template)
           nfs_restart_command  = environment.host.capability(:nfs_restart_command)
           logger = Log4r::Logger.new("vagrant::hosts::bsd")
 
           nfs_checkexports! if File.file?("/etc/exports")
-
-          # Check to see if this folder is mounted 1) as APFS and 2) within the /System/Volumes/Data volume
-          # on OS X, which is a read-write "firmlink", and must be prepended so it can be shared via NFS
-          # we also need to directly mutate the :hostpath if we change it, so that it's mounted with the
-          # prefix.
-          logger.debug("Checking to see if NFS exports are in an APFS firmlink...")
-          nfs_check_folders_for_apfs folders
 
           # We need to build up mapping of directories that are enclosed
           # within each other because the exports file has to have subdirectories
@@ -45,8 +26,8 @@ module VagrantPlugins
           logger.debug("Compiling map of sub-directories for NFS exports...")
           dirmap = {}
           folders.sort_by { |_, opts| opts[:hostpath] }.each do |_, opts|
+            opts[:hostpath] = environment.host.capability(:resolve_host_path, opts[:hostpath].gsub('"', '\"'))
             hostpath = opts[:hostpath].dup
-            hostpath.gsub!('"', '\"')
 
             found = false
             dirmap.each do |dirs, diropts|
@@ -209,18 +190,6 @@ module VagrantPlugins
           r = Vagrant::Util::Subprocess.execute("nfsd", "checkexports")
           if r.exit_code != 0
             raise Vagrant::Errors::NFSBadExports, output: r.stderr
-          end
-        end
-
-        def self.nfs_check_folders_for_apfs(folders)
-          folders.each do |_, opts|
-            # check to see if this path is mounted in an APFS filesystem, and if it's under the
-            # firmlink which must be prefixed. we need to use the OS X df — GNU won't notice.
-            is_mounted_apfs_command = "/bin/df -t apfs #{opts[:hostpath]}"
-            result = Vagrant::Util::Subprocess.execute(*Shellwords.split(is_mounted_apfs_command))
-            if (result.stdout.include? OSX_FIRMLINK_HACK)
-              opts[:hostpath].prepend(OSX_FIRMLINK_HACK)
-            end
           end
         end
       end

--- a/plugins/hosts/bsd/cap/path.rb
+++ b/plugins/hosts/bsd/cap/path.rb
@@ -1,0 +1,11 @@
+module VagrantPlugins
+  module HostBSD
+    module Cap
+      class Path
+        def self.resolve_host_path(env, path)
+          path
+        end
+      end
+    end
+  end
+end

--- a/plugins/hosts/bsd/plugin.rb
+++ b/plugins/hosts/bsd/plugin.rb
@@ -36,6 +36,11 @@ module VagrantPlugins
         Cap::NFS
       end
 
+      host_capability("bsd", "resolve_host_path") do
+        require_relative "cap/path"
+        Cap::Path
+      end
+
       host_capability("bsd", "set_ssh_key_permissions") do
         require_relative "cap/ssh"
         Cap::SSH

--- a/plugins/hosts/darwin/cap/path.rb
+++ b/plugins/hosts/darwin/cap/path.rb
@@ -1,0 +1,58 @@
+module VagrantPlugins
+  module HostDarwin
+    module Cap
+      class Path
+        @@logger = Log4r::Logger.new("vagrant::host::darwin::path")
+
+        FIRMLINK_DEFS = "/usr/share/firmlinks".freeze
+        FIRMLINK_DATA_PATH = "/System/Volumes/Data".freeze
+
+        # Resolve the given host path to the actual
+        # usable system path by detecting firmlinks
+        # if available on the current system
+        #
+        # @param [String] path Host system path
+        # @return [String] resolved path
+        def self.resolve_host_path(env, path)
+          path = File.expand_path(path)
+          firmlink = firmlink_map.detect do |mount_path, data_path|
+            path.start_with?(mount_path)
+          end
+          return path if firmlink.nil?
+          current_prefix, new_suffix = firmlink
+          new_prefix = File.join(FIRMLINK_DATA_PATH, new_suffix)
+          new_path = path.sub(current_prefix, new_prefix)
+          @@logger.debug("Resolved given path `#{path}` to `#{new_path}`")
+          new_path
+        end
+
+        # Generate mapping of firmlinks if available on the host
+        #
+        # @return [Hash<String,String>]
+        def self.firmlink_map
+          if !@firmlink_map
+            return @firmlink_map = {} if !File.exist?(FIRMLINK_DEFS)
+            begin
+              @firmlink_map = Hash[
+                File.readlines(FIRMLINK_DEFS).map { |d|
+                  d.strip.split(/\s+/, 2)
+                }
+              ]
+            rescue => err
+              @@logger.warn("Failed to parse firmlink definitions: #{err}")
+              @firmlink_map = {}
+            end
+          end
+          @firmlink_map
+        end
+
+        # @private
+        # Reset the cached values for capability. This is not considered a public
+        # API and should only be used for testing.
+        def self.reset!
+          instance_variables.each(&method(:remove_instance_variable))
+        end
+      end
+    end
+  end
+end

--- a/plugins/hosts/darwin/plugin.rb
+++ b/plugins/hosts/darwin/plugin.rb
@@ -16,6 +16,11 @@ module VagrantPlugins
         Cap::ProviderInstallVirtualBox
       end
 
+      host_capability("darwin", "resolve_host_path") do
+        require_relative "cap/path"
+        Cap::Path
+      end
+
       host_capability("darwin", "rdp_client") do
         require_relative "cap/rdp"
         Cap::RDP

--- a/test/unit/plugins/hosts/bsd/cap/nfs_test.rb
+++ b/test/unit/plugins/hosts/bsd/cap/nfs_test.rb
@@ -1,0 +1,39 @@
+require_relative "../../../../base"
+require_relative "../../../../../../plugins/hosts/bsd/cap/nfs"
+require_relative "../../../../../../lib/vagrant/util"
+
+describe VagrantPlugins::HostBSD::Cap::NFS do
+
+  include_context "unit"
+
+  describe ".nfs_check_folders_for_apfs" do
+    it "should prefix host paths that are mounted in /System/Volumes/Data" do
+      output_from_df = <<-EOH
+Filesystem    512-blocks      Used Available Capacity iused      ifree %iused  Mounted on
+/dev/disk1s1   976490568 392813584 555082648    42% 1177049 4881275791    0%   /System/Volumes/Data
+EOH
+      expect(Vagrant::Util::Subprocess).to receive(:execute).and_return(
+        Vagrant::Util::Subprocess::Result.new(0, output_from_df, "")
+      )
+
+      folders = {"/vagrant"=>{:hostpath=>"/Users/johndoe/vagrant",:bsd__nfs_options=>["rw"]}}
+      described_class.nfs_check_folders_for_apfs(folders)
+      expect(folders["/vagrant"][:hostpath]).to eq("/System/Volumes/Data/Users/johndoe/vagrant")
+    end
+
+    it "should not prefix host paths that are mounted in elsewhere" do
+      output_from_df = <<-EOH
+Filesystem    512-blocks      Used Available Capacity iused      ifree %iused  Mounted on
+/dev/disk1s5   976490568  20634032 554201072     4%  481588 4881971252    0%   /
+EOH
+      expect(Vagrant::Util::Subprocess).to receive(:execute).and_return(
+        Vagrant::Util::Subprocess::Result.new(0, output_from_df, "")
+      )
+
+      folders = {"/vagrant"=>{:hostpath=>"/",:bsd__nfs_options=>["rw"]}}
+      described_class.nfs_check_folders_for_apfs(folders)
+      expect(folders["/vagrant"][:hostpath]).to eq("/")
+    end
+
+  end
+end

--- a/test/unit/plugins/hosts/bsd/cap/nfs_test.rb
+++ b/test/unit/plugins/hosts/bsd/cap/nfs_test.rb
@@ -1,39 +1,48 @@
 require_relative "../../../../base"
 require_relative "../../../../../../plugins/hosts/bsd/cap/nfs"
-require_relative "../../../../../../lib/vagrant/util"
 
 describe VagrantPlugins::HostBSD::Cap::NFS do
 
   include_context "unit"
 
-  describe ".nfs_check_folders_for_apfs" do
-    it "should prefix host paths that are mounted in /System/Volumes/Data" do
-      output_from_df = <<-EOH
-Filesystem    512-blocks      Used Available Capacity iused      ifree %iused  Mounted on
-/dev/disk1s1   976490568 392813584 555082648    42% 1177049 4881275791    0%   /System/Volumes/Data
-EOH
-      expect(Vagrant::Util::Subprocess).to receive(:execute).and_return(
-        Vagrant::Util::Subprocess::Result.new(0, output_from_df, "")
-      )
+  describe ".nfs_export" do
+    let(:environment) { double("environment", host: host) }
+    let(:host) { double("host") }
+    let(:ui) { double("ui") }
+    let(:id) { "UUID" }
+    let(:ips) { [] }
+    let(:folders) { {} }
 
-      folders = {"/vagrant"=>{:hostpath=>"/Users/johndoe/vagrant",:bsd__nfs_options=>["rw"]}}
-      described_class.nfs_check_folders_for_apfs(folders)
-      expect(folders["/vagrant"][:hostpath]).to eq("/System/Volumes/Data/Users/johndoe/vagrant")
+    before do
+      allow(host).to receive(:capability).and_return("")
+      allow(Vagrant::Util::TemplateRenderer).to receive(:render).and_return("")
+      allow(described_class).to receive(:sleep)
+      allow(described_class).to receive(:nfs_cleanup)
+      allow(described_class).to receive(:system)
+      allow(File).to receive(:writable?).with("/etc/exports")
+      allow(ui).to receive(:info)
     end
 
-    it "should not prefix host paths that are mounted in elsewhere" do
-      output_from_df = <<-EOH
-Filesystem    512-blocks      Used Available Capacity iused      ifree %iused  Mounted on
-/dev/disk1s5   976490568  20634032 554201072     4%  481588 4881971252    0%   /
-EOH
-      expect(Vagrant::Util::Subprocess).to receive(:execute).and_return(
-        Vagrant::Util::Subprocess::Result.new(0, output_from_df, "")
-      )
-
-      folders = {"/vagrant"=>{:hostpath=>"/",:bsd__nfs_options=>["rw"]}}
-      described_class.nfs_check_folders_for_apfs(folders)
-      expect(folders["/vagrant"][:hostpath]).to eq("/")
+    it "should execute successfully when no folders are defined" do
+      expect { described_class.nfs_export(environment, ui, id, ips, folders) }.
+        not_to raise_error
     end
 
+    context "with single folder defined" do
+      let(:folders) {
+        {"/vagrant" => {
+          type: :nfs, guestpath: "/vagrant", hostpath: "/Users/vagrant/paths", disabled: false}}
+      }
+
+      it "should execute successfully" do
+        expect { described_class.nfs_export(environment, ui, id, ips, folders) }.
+          not_to raise_error
+      end
+
+      it "should resolve the host path" do
+        expect(host).to receive(:capability).with(:resolve_host_path, folders["/vagrant"][:hostpath]).and_return("")
+        described_class.nfs_export(environment, ui, id, ips, folders)
+      end
+    end
   end
 end

--- a/test/unit/plugins/hosts/bsd/cap/path_test.rb
+++ b/test/unit/plugins/hosts/bsd/cap/path_test.rb
@@ -1,0 +1,13 @@
+require_relative "../../../../base"
+require_relative "../../../../../../plugins/hosts/bsd/cap/path"
+
+describe VagrantPlugins::HostBSD::Cap::Path do
+  describe ".resolve_host_path" do
+    let(:env) { double("environment") }
+    let(:path) { double("path") }
+
+    it "should return the path object provided" do
+      expect(described_class.resolve_host_path(env, path)).to eq(path)
+    end
+  end
+end

--- a/test/unit/plugins/hosts/darwin/cap/path_test.rb
+++ b/test/unit/plugins/hosts/darwin/cap/path_test.rb
@@ -1,0 +1,89 @@
+require_relative "../../../../base"
+require_relative "../../../../../../plugins/hosts/darwin/cap/path"
+
+describe VagrantPlugins::HostDarwin::Cap::Path do
+  describe ".resolve_host_path" do
+    let(:env) { double("environment") }
+    let(:path) { "/test/vagrant/path" }
+    let(:firmlink_map) { {} }
+
+    before { allow(described_class).to receive(:firmlink_map).and_return(firmlink_map) }
+
+    it "should not change the path when no firmlinks are defined" do
+      expect(described_class.resolve_host_path(env, path)).to eq(path)
+    end
+
+    context "when firmlink map contains non-matching values" do
+      let(:firmlink_map) { {"/users" => "users", "/system" => "system"} }
+
+      it "should not change the path" do
+        expect(described_class.resolve_host_path(env, path)).to eq(path)
+      end
+    end
+
+    context "when firmlink map contains matching value" do
+      let(:firmlink_map) { {"/users" => "users", "/test" => "test"} }
+
+      it "should update the path" do
+        expect(described_class.resolve_host_path(env, path)).not_to eq(path)
+      end
+
+      it "should prefix the path with the defined data path" do
+        expect(described_class.resolve_host_path(env, path)).to start_with(described_class.const_get(:FIRMLINK_DATA_PATH))
+      end
+    end
+
+    context "when firmlink map match points to different named target" do
+      let(:firmlink_map) { {"/users" => "users", "/test" => "other"} }
+
+      it "should update the path" do
+        expect(described_class.resolve_host_path(env, path)).not_to eq(path)
+      end
+
+      it "should prefix the path with the defined data path" do
+        expect(described_class.resolve_host_path(env, path)).to start_with(described_class.const_get(:FIRMLINK_DATA_PATH))
+      end
+
+      it "should include the updated path name" do
+        expect(described_class.resolve_host_path(env, path)).to include("other")
+      end
+    end
+  end
+
+  describe ".firmlink_map" do
+    before { described_class.reset! }
+
+    context "when firmlink definition file does not exist" do
+      before { expect(File).to receive(:exist?).with(described_class.const_get(:FIRMLINK_DEFS)).and_return(false) }
+
+      it "should return an empty hash" do
+        expect(described_class.firmlink_map).to eq({})
+      end
+    end
+
+    context "when firmlink definition file exists with values" do
+      before do
+        expect(File).to receive(:exist?).with(described_class.const_get(:FIRMLINK_DEFS)).and_return(true)
+        expect(File).to receive(:readlines).with.(described_class.const_get(:FIRMLINK_DEFS)).
+          and_return(["/System\tSystem\n", "/Users\tUsers\n", "/Library/Something\tLibrary/Somethingelse"])
+
+        it "should generate a non-empty hash" do
+          expect(described_class.firmlink_map).not_to be_empty
+        end
+
+        it "should properly create entries" do
+          result = described_class.firmlink_map
+          expect(result["/System"]).to eq("System")
+          expect(result["/Users"]).to eq("Users")
+          expect(result["/Library/Something"]).to eq("Library/Somethingelse")
+        end
+
+        it "should only load values once" do
+          result = describe_class.firmlink_app
+          expect(File).not_to receive(:readlines)
+          result = describe_class.firmlink_app
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a continuation of the work started in #11105

The firmlinks defined on the system can be located within
a system file (/usr/share/firmlinks). This can be read to
generate a simple map that can then be used for updating
paths as required.

Added a new host capability (resolve_host_path) which is
used by the bsd host nfs_export capability. The bsd host
implements this capability as a no-op, and the darwin
host implements this capability to handle firmlinks.