### PR TITLE
Update UI to properly retain newlines when adding prefix

### DIFF
--- a/lib/vagrant/ui.rb
+++ b/lib/vagrant/ui.rb
@@ -329,10 +329,12 @@ module Vagrant
         target = opts[:target] if opts.key?(:target)
         target = "#{target}:" if target != ""
 
-        # Get the lines. The first default is because if the message
-        # is an empty string, then we want to still use the empty string.
-        lines = [message]
-        lines = message.split("\n") if message != ""
+        lines = [].tap do |l|
+          message.scan(/(.*?)(\n|$)/).each do |m|
+            l << m.first if m.first != "" || (m.first == "" && m.last == "\n")
+          end
+        end
+        lines << "" if message.end_with?("\n")
 
         # Otherwise, make sure to prefix every line properly
         lines.map do |line|

--- a/lib/vagrant/ui.rb
+++ b/lib/vagrant/ui.rb
@@ -329,12 +329,15 @@ module Vagrant
         target = opts[:target] if opts.key?(:target)
         target = "#{target}:" if target != ""
 
-        lines = [].tap do |l|
-          message.scan(/(.*?)(\n|$)/).each do |m|
-            l << m.first if m.first != "" || (m.first == "" && m.last == "\n")
+        lines = [message]
+        if message != ""
+          lines = [].tap do |l|
+            message.scan(/(.*?)(\n|$)/).each do |m|
+              l << m.first if m.first != "" || (m.first == "" && m.last == "\n")
+            end
           end
+          lines << "" if message.end_with?("\n")
         end
-        lines << "" if message.end_with?("\n")
 
         # Otherwise, make sure to prefix every line properly
         lines.map do |line|

--- a/test/unit/vagrant/ui_test.rb
+++ b/test/unit/vagrant/ui_test.rb
@@ -413,5 +413,10 @@ describe Vagrant::UI::Prefixed do
         expect(subject.format_message(:detail, msg).count("\n")).to eq(msg.count("\n"))
       end
     end
+
+    it "should properly format a blank message" do
+      expect(subject.format_message(:detail, "", target: "default", prefix: true)).
+        to match(/\s+default:\s+/)
+    end
   end
 end

--- a/test/unit/vagrant/ui_test.rb
+++ b/test/unit/vagrant/ui_test.rb
@@ -406,4 +406,12 @@ describe Vagrant::UI::Prefixed do
       subject.output("foo", target: "bar")
     end
   end
+
+  describe "#format_message" do
+    it "should return the same number of new lines as given" do
+      ["no new line", "one\nnew line", "two\nnew lines\n", "three\nnew lines\n\n"].each do |msg|
+        expect(subject.format_message(:detail, msg).count("\n")).to eq(msg.count("\n"))
+      end
+    end
+  end
 end


### PR DESCRIPTION
When using a Prefixed UI instance prevent new line characters from
being removed when adding prefix formatting to output messages.

Fixes #11044