### PR TITLE
guest/redhat: fix nfs client installation

### DIFF
--- a/plugins/guests/redhat/cap/nfs_client.rb
+++ b/plugins/guests/redhat/cap/nfs_client.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
             fi
 
             if test $(ps -o comm= 1) == 'systemd'; then
-              /bin/systemctl restart rpcbind nfs
+              /bin/systemctl restart rpcbind nfs-server
             else
               /etc/init.d/rpcbind restart
               /etc/init.d/nfs restart


### PR DESCRIPTION
CentOS 8+ and Fedora 30+ no longer have the alias "nfs" for "nfs-server"
systemd service.

This shouldn't break backward compatibility, since "nfs-server" service
is available on all supported redhat systems that have systemctl binary.

Fixes #10838