### PR TITLE
Open i18n dependency up to `< 2.0`

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.add_dependency "childprocess", "~> 0.6.0"
   s.add_dependency "ed25519", "~> 1.2.4"
   s.add_dependency "erubis", "~> 2.7.0"
-  s.add_dependency "i18n", "~> 1.1.1"
+  s.add_dependency "i18n", ">= 1.1.1", "< 2.0"
   s.add_dependency "listen", "~> 3.1.5"
   s.add_dependency "hashicorp-checkpoint", "~> 0.1.5"
   s.add_dependency "log4r", "~> 1.1.9", "< 1.1.11"


### PR DESCRIPTION
As there should be no breaking changes.

I've not encountered any issues during testing.