### PR TITLE
FIX #11048, ansible_local provisioner, fails to install Ansible on an Arch Linux box

### DIFF
--- a/plugins/provisioners/ansible/cap/guest/arch/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/arch/ansible_install.rb
@@ -1,4 +1,5 @@
-require_relative "../../../errors"
+require_relative '../../../errors'
+require_relative '../pip/pip'
 
 module VagrantPlugins
   module Ansible
@@ -7,13 +8,27 @@ module VagrantPlugins
         module Arch
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
-              if install_mode != :default
-                raise Ansible::Errors::AnsiblePipInstallIsNotSupported
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd='')
+              case install_mode
+              when :pip
+                pip_setup machine, pip_install_cmd
+                Pip::pip_install machine, 'ansible', ansible_version, pip_args, true
+
+              when :pip_args_only
+                pip_setup machine, pip_install_cmd
+                Pip::pip_install machine, '', '', pip_args, false
+
               else
-                machine.communicate.sudo "pacman -Syy --noconfirm"
-                machine.communicate.sudo "pacman -S --noconfirm ansible"
+                machine.communicate.sudo 'pacman -Syy --noconfirm'
+                machine.communicate.sudo 'pacman -S --noconfirm ansible'
               end
+            end
+
+            def self.pip_setup(machine, pip_install_cmd='')
+              machine.communicate.sudo 'pacman -Syy --noconfirm'
+              machine.communicate.sudo 'pacman -S --noconfirm base-devel curl git'
+
+              Pip::get_pip machine, pip_install_cmd
             end
 
           end
@@ -22,3 +37,5 @@ module VagrantPlugins
     end
   end
 end
+
+


### PR DESCRIPTION
FIX #11048, add parameter `pip_install_cmd` to `ansible_install.rb` for arch guest.

ADD: Handling of `pip_install_cmd` in `ansible_install.rb` for arch guest.