### PR TITLE
Fixes #11139: Skip machines that haven't been created for snapshot save

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2053,6 +2053,9 @@ en:
           No pushed snapshot found!
 
           Use `vagrant snapshot push` to push a snapshot to restore to.
+        save:
+          vm_not_created: |-
+            Machine '%{name}' has not been created yet, and therefore cannot save snapshots. Skipping...
       status:
         aborted: |-
           The VM is in an aborted state. This means that it was abruptly

--- a/test/unit/plugins/commands/snapshot/command/save_test.rb
+++ b/test/unit/plugins/commands/snapshot/command/save_test.rb
@@ -92,8 +92,6 @@ describe VagrantPlugins::CommandSnapshot::Command::Save do
       it "doesn't snapshot a non-existent machine" do
         machine.id = nil
 
-        expect(subject).to receive(:with_target_vms){}
-
         expect(machine).to_not receive(:action)
         expect(subject.execute).to eq(0)
       end


### PR DESCRIPTION
This commit fixes the original #11027 fix, which assumed that the
hyper-v provider just wasn't properly getting a VM id when it listed
snapshots. In reality, it was just that if you invoke the
`with_target_vm` method with no arguments, it runs on the entire environment.
This meant that the capability snapshot_list attempted to be invoked on
machines that didn't exist yet, which is the original cause for why the
list_snapshot method did not recieve a vm ID. This commit fixes that by
simply skipping the machine if it does not yet exist.