### PR TITLE
Introduce disk management base config layer to core Vagrant

### DIFF
--- a/lib/vagrant/action.rb
+++ b/lib/vagrant/action.rb
@@ -15,6 +15,7 @@ module Vagrant
       autoload :Confirm, "vagrant/action/builtin/confirm"
       autoload :ConfigValidate, "vagrant/action/builtin/config_validate"
       autoload :DestroyConfirm, "vagrant/action/builtin/destroy_confirm"
+      autoload :Disk, "vagrant/action/builtin/disk"
       autoload :EnvSet,  "vagrant/action/builtin/env_set"
       autoload :GracefulHalt, "vagrant/action/builtin/graceful_halt"
       autoload :HandleBox, "vagrant/action/builtin/handle_box"

--- a/lib/vagrant/action/builtin/disk.rb
+++ b/lib/vagrant/action/builtin/disk.rb
@@ -12,6 +12,8 @@ module Vagrant
           defined_disks = get_disks(machine, env)
 
           # Call into providers machine implementation for disk management
+          #
+          # machine.provider.configure_disks(defined_disks)
 
           # Continue On
           @app.call(env)

--- a/lib/vagrant/action/builtin/disk.rb
+++ b/lib/vagrant/action/builtin/disk.rb
@@ -9,9 +9,24 @@ module Vagrant
 
         def call(env)
           machine = env[:machine]
+          defined_disks = get_disks(machine, env)
+
+          # Check that provider plugin is installed for disk
+          # If not, log warning or error to user that disks won't be managed
 
           # Continue On
           @app.call(env)
+        end
+
+        def get_disks(machine, env)
+          return @_disks if @_disks
+
+          @_disks = []
+          @_disks = machine.config.vm.disks.map do |disk|
+            # initialize the disk provider??
+          end
+
+          @_disks
         end
       end
     end

--- a/lib/vagrant/action/builtin/disk.rb
+++ b/lib/vagrant/action/builtin/disk.rb
@@ -1,0 +1,19 @@
+module Vagrant
+  module Action
+    module Builtin
+      class Disk
+        def initialize(app, env)
+          @app    = app
+          @logger = Log4r::Logger.new("vagrant::action::builtin::disk")
+        end
+
+        def call(env)
+          machine = env[:machine]
+
+          # Continue On
+          @app.call(env)
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant/action/builtin/disk.rb
+++ b/lib/vagrant/action/builtin/disk.rb
@@ -14,6 +14,8 @@ module Vagrant
           # Check that provider plugin is installed for disk
           # If not, log warning or error to user that disks won't be managed
 
+          # TODO: configure and attach disks for the machines providers implementation
+
           # Continue On
           @app.call(env)
         end

--- a/lib/vagrant/action/builtin/disk.rb
+++ b/lib/vagrant/action/builtin/disk.rb
@@ -12,8 +12,11 @@ module Vagrant
           defined_disks = get_disks(machine, env)
 
           # Call into providers machine implementation for disk management
-          #
-          # machine.provider.configure_disks(defined_disks)
+          if machine.provider.capability?(:configure_disks)
+           machine.provider.capability(:configure_disks, defined_disks)
+          else
+            @logger.warn(":configure_disks capability not defined for provider, cannot configure disks")
+          end
 
           # Continue On
           @app.call(env)

--- a/lib/vagrant/action/builtin/disk.rb
+++ b/lib/vagrant/action/builtin/disk.rb
@@ -15,7 +15,8 @@ module Vagrant
           if machine.provider.capability?(:configure_disks)
            machine.provider.capability(:configure_disks, defined_disks)
           else
-            @logger.warn(":configure_disks capability not defined for provider, cannot configure disks")
+            env[:ui].warn(I18n.t("vagrant.actions.disk.provider_unsupported",
+                               provider: machine.provider_name))
           end
 
           # Continue On

--- a/lib/vagrant/action/builtin/disk.rb
+++ b/lib/vagrant/action/builtin/disk.rb
@@ -11,10 +11,7 @@ module Vagrant
           machine = env[:machine]
           defined_disks = get_disks(machine, env)
 
-          # Check that provider plugin is installed for disk
-          # If not, log warning or error to user that disks won't be managed
-
-          # TODO: configure and attach disks for the machines providers implementation
+          # Call into providers machine implementation for disk management
 
           # Continue On
           @app.call(env)
@@ -24,9 +21,7 @@ module Vagrant
           return @_disks if @_disks
 
           @_disks = []
-          @_disks = machine.config.vm.disks.map do |disk|
-            # initialize the disk provider??
-          end
+          @_disks = machine.config.vm.disks
 
           @_disks
         end

--- a/lib/vagrant/util/numeric.rb
+++ b/lib/vagrant/util/numeric.rb
@@ -1,0 +1,37 @@
+module Vagrant
+  module Util
+    class Numeric
+      # Authors Note: This class has borrowed some code from the ActiveSupport Numeric class
+
+      # Conversion helper constants
+      KILOBYTE = 1024
+      MEGABYTE = KILOBYTE * 1024
+      GIGABYTE = MEGABYTE * 1024
+      TERABYTE = GIGABYTE * 1024
+      PETABYTE = TERABYTE * 1024
+      EXABYTE  = PETABYTE * 1024
+
+      class << self
+
+        # A helper that converts a shortcut string to its bytes representation.
+        # The expected format of `str` is essentially: "<Number>XX"
+        # Where `XX` is shorthand for KB, MB, GB, TB, PB, or EB. For example, 50 megabytes:
+        #
+        # str = "50MB"
+        #
+        # @param [String] - str
+        # @return [Integer] - bytes
+        def string_to_bytes(str)
+          str = str.to_s.strip
+        end
+
+        # @private
+        # Reset the cached values for platform. This is not considered a public
+        # API and should only be used for testing.
+        def reset!
+          instance_variables.each(&method(:remove_instance_variable))
+        end
+      end
+    end
+  end
+end

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -1,6 +1,8 @@
 require "log4r"
 require "securerandom"
 
+require "vagrant/util/numeric"
+
 module VagrantPlugins
   module Kernel_V2
     class VagrantConfigDisk < Vagrant.plugin("2", :config)
@@ -124,9 +126,12 @@ module VagrantPlugins
           errors << "Disk type '#{@type}' is not a valid type. Please pick one of the following supported disk types: #{DEFAULT_DISK_TYPES.join(', ')}"
         end
 
-        # TODO: Convert a string to int here?
         if @size && !@size.is_a?(Integer)
-          errors << "Config option size for disk is not an integer"
+          if @size.is_a?(String)
+            @size = Vagrant::Util::Numeric.string_to_bytes(@size)
+          else
+            errors << "Config option size for disk is not an integer"
+          end
         end
 
         if @file

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -34,6 +34,12 @@ module VagrantPlugins
       # @return [Integer]
       attr_accessor :size
 
+      # Path to the location of the disk file (Optional)
+      #
+      # @return [String]
+      attr_accessor :file
+
+
       # Determines if this disk is the _main_ disk, or an attachment.
       # Defaults to true.
       #
@@ -64,6 +70,7 @@ module VagrantPlugins
         @primary = UNSET_VALUE
         @config = nil
         @invalid = false
+        @file = UNSET_VALUE
 
         # Internal options
         @id = SecureRandom.uuid
@@ -101,6 +108,7 @@ module VagrantPlugins
         # by user
         @type = :disk if @type == UNSET_VALUE
         @size = nil if @size == UNSET_VALUE
+        @file = nil if @file == UNSET_VALUE
 
         if @primary == UNSET_VALUE
           @primary = true
@@ -128,6 +136,14 @@ module VagrantPlugins
         # TODO: Convert a string to int here?
         if @size && !@size.is_a?(Integer)
           errors << "Config option size for disk is not an integer"
+        end
+
+        if @file
+          if !@file.is_a?(String)
+            errors << "Config option `file` for #{machine.name} disk config is not a string"
+          else
+            # Validate that file exists
+          end
         end
 
         errors

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -39,6 +39,11 @@ module VagrantPlugins
       # @return [Integer]
       attr_accessor :size
 
+      # Determines if this disk is the _main_ disk, or an attachment. Defaults to true
+      #
+      # @return [Boolean]
+      attr_accessor :primary
+
       # Provider specific options
       #
       # This should work similar to how a "Provisioner" class works:
@@ -59,6 +64,7 @@ module VagrantPlugins
         @type = UNSET_VALUE
         @provider_type = UNSET_VALUE
         @size = UNSET_VALUE
+        @primary = UNSET_VALUE
         @config = nil
         @invalid = false
 
@@ -99,6 +105,7 @@ module VagrantPlugins
         @name = nil if @name == UNSET_VALUE
         @type = nil if @type == UNSET_VALUE
         @size = nil if @size == UNSET_VALUE
+        @primary = true if @primary == UNSET_VALUE
 
         @config = nil if @config == UNSET_VALUE
       end

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -101,7 +101,12 @@ module VagrantPlugins
         # by user
         @type = :disk if @type == UNSET_VALUE
         @size = nil if @size == UNSET_VALUE
-        @primary = true if @primary == UNSET_VALUE
+
+        if @primary == UNSET_VALUE
+          @primary = true
+        else
+          @primary = false
+        end
 
         # Give the disk a default name if unset
         # TODO: Name not required if primary?

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -84,7 +84,7 @@ module VagrantPlugins
 
         current = @config_class.new
         current.set_options(options) if options
-        block.call(current) if block
+        block.call(current) if block_given?
         current = @config.merge(current) if @config
         @config = current
       end
@@ -121,7 +121,7 @@ module VagrantPlugins
         end
 
         # TODO: Convert a string to int here?
-        if !@size.is_a?(Integer)
+        if @size && !@size.is_a?(Integer)
           errors << "Config option size for disk is not an integer"
         end
 

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -112,8 +112,9 @@ module VagrantPlugins
         @size = nil if @size == UNSET_VALUE
         @primary = true if @primary == UNSET_VALUE
 
-        # generate name instead of nil if unset_value
-        @name = nil if @name == UNSET_VALUE
+        # Give the disk a default name if unset
+        # TODO: Name not required if primray?
+        @name = "vagrant_#{@type.to_s}_#{@id.split("-").last}" if @name == UNSET_VALUE
 
         @config = nil if @config == UNSET_VALUE
       end

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -105,15 +105,13 @@ module VagrantPlugins
           @primary = false
         end
 
-        # Give the disk a default name if unset
-        # TODO: Name not required if primary?
-        if @primary
-          base_name = "vagrant_primary"
-        else
-          base_name = "vagrant"
+        if @name == UNSET_VALUE
+          if @primary
+            @name = "vagrant_primary"
+          else
+            @name = "name_#{@type.to_s}_#{@id.split("-").last}"
+          end
         end
-
-        @name = "#{base_name}_#{@type.to_s}_#{@id.split("-").last}" if @name == UNSET_VALUE
 
         @provider_config = nil if @provider_config == {}
       end

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -104,7 +104,7 @@ module VagrantPlugins
         @primary = true if @primary == UNSET_VALUE
 
         # Give the disk a default name if unset
-        # TODO: Name not required if primray?
+        # TODO: Name not required if primary?
         @name = "vagrant_#{@type.to_s}_#{@id.split("-").last}" if @name == UNSET_VALUE
 
         @config = nil if @config == UNSET_VALUE

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -13,9 +13,9 @@ module VagrantPlugins
       # @return [String]
       attr_reader :id
 
-      # Name for the given Disk. Defaults to nil.
+      # File name for the given disk. Defaults to nil.
       #
-      # TODO: Should probably default to a string+short integer id
+      # TODO: Should probably default to a string+short integer id in the finalize method
       #
       # @return [String]
       attr_accessor :name

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -31,9 +31,7 @@ module VagrantPlugins
 
       # Size of disk to create
       #
-      # TODO: Should we have shortcuts for GB???
-      #
-      # @return [Integer]
+      # @return [Integer,String]
       attr_accessor :size
 
       # Path to the location of the disk file (Optional)

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -15,18 +15,9 @@ module VagrantPlugins
       # @return [String]
       attr_reader :id
 
-      # File name for the given disk. Defaults to nil.
+      # File name for the given disk. Defaults to a generated name that is:
       #
-      # TODO: Should probably default to a string+short integer id in the finalize method
-      #
-      # Sometihng like:
-      #
-      # - `vagrant_short_id`
-      #
-      # Where short_id is calculated from the disks ID
-      #
-      # Finalize method in `Config#VM` might need to ensure there aren't colliding disk names?
-      # It might also depend on the provider
+      #  vagrant_<disk_type>_<short_uuid>
       #
       # @return [String]
       attr_accessor :name

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -135,8 +135,8 @@ module VagrantPlugins
         if @file
           if !@file.is_a?(String)
             errors << "Config option `file` for #{machine.name} disk config is not a string"
-          else
-            # Validate that file exists
+          elsif !File.file?(@file)
+            errors << "Disk file '#{@file}' for disk '#{@name}' on machine '#{machine.name}' does not exist."
           end
         end
 

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -60,7 +60,7 @@ module VagrantPlugins
       attr_accessor :config
 
       def initialize(type)
-        @logger = Log4r::Logger.new("vagrant::config::vm::trigger::config")
+        @logger = Log4r::Logger.new("vagrant::config::vm::disk")
 
         @type = type
 

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -109,7 +109,13 @@ module VagrantPlugins
 
         # Give the disk a default name if unset
         # TODO: Name not required if primary?
-        @name = "vagrant_#{@type.to_s}_#{@id.split("-").last}" if @name == UNSET_VALUE
+        if @primary
+          base_name = "vagrant_primary"
+        else
+          base_name = "vagrant"
+        end
+
+        @name = "#{base_name}_#{@type.to_s}_#{@id.split("-").last}" if @name == UNSET_VALUE
 
         @provider_config = nil if @provider_config == {}
       end

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -41,7 +41,13 @@ module VagrantPlugins
 
       # Provider specific options
       #
-      # TODO: INTERNAL??
+      # This should work similar to how a "Provisioner" class works:
+      #
+      # - This class is the base class where as this options value is actually a
+      #   provider specific class for the given options for that provider, if required
+      #
+      # - Hopefully in general the top-scope disk options are enough for the general
+      #   case that most people won't need provider specific options except for very specific cases
       #
       # @return [Hash]
       attr_accessor :options

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -66,6 +66,7 @@ module VagrantPlugins
         @id = SecureRandom.uuid
 
         # find disk provider plugin
+        # Need to pass in provider or figure out provider here
         @config_class = nil
         # @invalid = true if provider not found
         if !@config_class
@@ -99,7 +100,7 @@ module VagrantPlugins
         @type = nil if @type == UNSET_VALUE
         @size = nil if @size == UNSET_VALUE
 
-        @config = nil if @options == UNSET_VALUE
+        @config = nil if @config == UNSET_VALUE
       end
 
       # @return [Array] array of strings of error messages from config option validation

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -140,6 +140,12 @@ module VagrantPlugins
           end
         end
 
+        if @provider_config
+          if !@provider_config.keys.include?(machine.provider_name)
+            machine.env.ui.warn("Guest '#{machine.name}' using provider '#{machine.provider_name}' has provider specific config options for a provider other than '#{machine.provider_name}'. These provider config options will be ignored for this guest")
+          end
+        end
+
         errors
       end
 

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -121,28 +121,34 @@ module VagrantPlugins
         # validate type with list of known disk types
 
         if !DEFAULT_DISK_TYPES.include?(@type)
-          errors << "Disk type '#{@type}' is not a valid type. Please pick one of the following supported disk types: #{DEFAULT_DISK_TYPES.join(', ')}"
+          errors << I18n.t("vagrant.config.disk.invalid_type", type: @type,
+                           types: DEFAULT_DISK_TYPES.join(', '))
         end
 
         if @size && !@size.is_a?(Integer)
           if @size.is_a?(String)
             @size = Vagrant::Util::Numeric.string_to_bytes(@size)
-          else
-            errors << "Config option size for disk is not an integer"
+          end
+
+          if !@size
+            errors << I18n.t("vagrant.config.disk.invalid_size", name: @name, machine: machine.name)
           end
         end
 
         if @file
           if !@file.is_a?(String)
-            errors << "Config option `file` for #{machine.name} disk config is not a string"
+            errors << I18n.t("vagrant.config.disk.invalid_file_type", file: @file, machine: machine.name)
           elsif !File.file?(@file)
-            errors << "Disk file '#{@file}' for disk '#{@name}' on machine '#{machine.name}' does not exist."
+            errors << I18n.t("vagrant.config.disk.missing_file", file_path: @file,
+                             name: @name, machine: machine.name)
           end
         end
 
         if @provider_config
           if !@provider_config.keys.include?(machine.provider_name)
-            machine.env.ui.warn("Guest '#{machine.name}' using provider '#{machine.provider_name}' has provider specific config options for a provider other than '#{machine.provider_name}'. These provider config options will be ignored for this guest")
+            machine.env.ui.warn(I18n.t("vagrant.config.disk.missing_provider",
+                                       machine: machine.name,
+                                       provider_name: machine.provider_name))
           end
         end
 

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -39,7 +39,6 @@ module VagrantPlugins
       # @return [String]
       attr_accessor :file
 
-
       # Determines if this disk is the _main_ disk, or an attachment.
       # Defaults to true.
       #

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -103,8 +103,6 @@ module VagrantPlugins
 
         if @primary == UNSET_VALUE
           @primary = false
-        else
-          @primary = true
         end
 
         # Give the disk a default name if unset

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -102,9 +102,9 @@ module VagrantPlugins
         @file = nil if @file == UNSET_VALUE
 
         if @primary == UNSET_VALUE
-          @primary = true
-        else
           @primary = false
+        else
+          @primary = true
         end
 
         # Give the disk a default name if unset

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -1,0 +1,79 @@
+require "log4r"
+require "securerandom"
+
+module VagrantPlugins
+  module Kernel_V2
+    class VagrantConfigDisk < Vagrant.plugin("2", :config)
+      #-------------------------------------------------------------------
+      # Config class for a given Disk
+      #-------------------------------------------------------------------
+
+      # Note: This value is for internal use only
+      #
+      # @return [String]
+      attr_reader :id
+
+      # Name for the given Disk. Defaults to nil.
+      #
+      # TODO: Should probably default to a string+short integer id
+      #
+      # @return [String]
+      attr_accessor :name
+
+      # Type of disk to create
+      #
+      # @return [Symbol]
+      attr_accessor :type
+
+      # Size of disk to create
+      #
+      # @return [Integer]
+      attr_accessor :size
+
+      # Provider specific options
+      #
+      # TODO: INTERNAL??
+      #
+      # @return [Hash]
+      attr_accessor :options
+
+      def initialize(type)
+        @logger = Log4r::Logger.new("vagrant::config::vm::trigger::config")
+
+        @name = UNSET_VALUE
+        @type = UNSET_VALUE
+        @size = UNSET_VALUE
+        @options = UNSET_VALUE
+
+        # Internal options
+        @id = SecureRandom.uuid
+      end
+
+      def finalize!
+        # Ensure all config options are set to nil or default value if untouched
+        # by user
+        @name = nil if @name == UNSET_VALUE
+        @type = nil if @type == UNSET_VALUE
+        @size = nil if @size == UNSET_VALUE
+
+        @options = nil if @options == UNSET_VALUE
+      end
+
+      # @return [Array] array of strings of error messages from config option validation
+      def validate(machine)
+        errors = _detected_errors
+
+        # validate type with list of known disk types
+
+        errors
+      end
+
+      # The String representation of this Disk.
+      #
+      # @return [String]
+      def to_s
+        "disk config"
+      end
+    end
+  end
+end

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -66,18 +66,30 @@ module VagrantPlugins
         @id = SecureRandom.uuid
       end
 
+      # Helper method for storing provider specific config options
+      #
+      # Expected format is:
+      #
+      # - `provider__diskoption: value`
+      # - `{provider: {diskoption: value, otherdiskoption: value, ...}`
+      #
+      # Duplicates will be overriden
+      #
+      # @param [Hash] options
       def add_provider_config(**options, &block)
         current = {}
         options.each do |k,v|
           opts = k.to_s.split("__")
+
           if opts.size == 2
-            current[opts[0]] = opts[1]
+            current[opts[0].to_sym] = {opts[1].to_sym => v}
+          elsif v.is_a?(Hash)
+            current[k] = v
           else
-            @logger.warn("Disk option '#{k}' found that does not match expected schema")
+            @logger.warn("Disk option '#{k}' found that does not match expected provider disk config schema.")
           end
         end
 
-        #block.call(current) if block
         current = @provider_config.merge(current) if !@provider_config.empty?
         @provider_config = current
       end

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -17,6 +17,15 @@ module VagrantPlugins
       #
       # TODO: Should probably default to a string+short integer id in the finalize method
       #
+      # Sometihng like:
+      #
+      # - `vagrant_short_id`
+      #
+      # Where short_id is calculated from the disks ID
+      #
+      # Finalize method in `Config#VM` might need to ensure there aren't colliding disk names?
+      # It might also depend on the provider
+      #
       # @return [String]
       attr_accessor :name
 

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -80,7 +80,7 @@ module VagrantPlugins
         @__compiled_provider_configs   = {}
         @__defined_vm_keys             = []
         @__defined_vms                 = {}
-        @__drives                      = {}
+        @__drives                      = []
         @__finalized                   = false
         @__networks                    = {}
         @__providers                   = {}
@@ -400,7 +400,7 @@ module VagrantPlugins
           block.call(disk, VagrantConfigDisk)
         end
 
-        @__drives[disk[:id]] = disk
+        @__drives << disk
       end
 
       #-------------------------------------------------------------------

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -580,7 +580,6 @@ module VagrantPlugins
           end
         end
 
-        # TODO: This might need to be more complicated
         @__disks.each do |d|
           d.finalize!
         end
@@ -784,6 +783,17 @@ module VagrantPlugins
                 "vagrant.config.vm.network_ip_ends_in_one"))
             end
           end
+        end
+
+        # Validate disks
+        # Check if there is more than one primrary disk defined and throw an error
+        if @__disks.select { |d| d.primary && d.type == :disk }.size > 1
+          errors << "There is more than one disk defined for guest '#{machine.name}'. Please pick a `primary` disk."
+        end
+
+        @__disks.each do |d|
+          error = d.validate(machine)
+          errors.concat error if !error.empty?
         end
 
         # We're done with VM level errors so prepare the section

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -433,6 +433,11 @@ module VagrantPlugins
         # Add provider config
         disk_config.add_provider_config(provider_options, &block)
 
+        if !Vagrant::Util::Experimental.feature_enabled?("disk_base_config")
+          @logger.warn("Disk config defined, but experimental feature is not enabled. To use this feature, enable it with the experimental flag `disk_base_config`. Disk will not be added to internal config, and will be ignored.")
+          return
+        end
+
         @disks << disk_config
       end
 

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -400,7 +400,7 @@ module VagrantPlugins
           block.call(disk, VagrantConfigDisk)
         end
 
-        disk.add_config(options, block)
+        disk.add_config(options, &block)
 
         @__drives << disk
 

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -806,8 +806,10 @@ module VagrantPlugins
 
         # Validate disks
         # Check if there is more than one primrary disk defined and throw an error
-        if @disks.select { |d| d.primary && d.type == :disk }.size > 1
-          errors << "There is more than one disk defined for guest '#{machine.name}'. Please pick a `primary` disk."
+        primary_disks = @disks.select { |d| d.primary && d.type == :disk }
+        if primary_disks.size > 1
+          errors << I18n.t("vagrant.config.vm.multiple_primary_disks_error",
+                           name: machine.name)
         end
 
         # TODO: Check for duplicate disk names?

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -409,22 +409,26 @@ module VagrantPlugins
         @__defined_vms[name].config_procs << [options[:config_version], block] if block
       end
 
+      # Stores disk config options from Vagrantfile
+      #
+      # @param [Symbol] type
+      # @param [Hash]   options
+      # @param [Block]  block
       def disk(type, **options, &block)
         disk_config = VagrantConfigDisk.new(type)
 
         # Remove provider__option options before set_options, otherwise will
         # show up as missing setting
-        #
-        # We can probably combine this into a single method call...?
-        provider_options = options.select { |k,v| k.to_s.include?("__") }
-        options.delete_if { |k,v| k.to_s.include?("__") }
+        # Extract provider hash options as well
+        provider_options = {}
+        options.delete_if do |p,o|
+          if o.is_a?(Hash) || p.to_s.include?("__")
+            provider_options[p] = o
+            true
+          end
+        end
 
         disk_config.set_options(options)
-
-        # Can't use blocks if we use provider__option
-        #if block_given?
-        #  block.call(disk, VagrantConfigDisk)
-        #end
 
         # Add provider config
         disk_config.add_provider_config(provider_options, &block)

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -815,7 +815,8 @@ module VagrantPlugins
         disk_names = @disks.map { |d| d.name }
         duplicate_names = disk_names.detect{ |d| disk_names.count(d) > 1 }
         if duplicate_names && duplicate_names.size
-          errors << "Duplicate disk names found: #{duplicate_names}. Please use unique names"
+          errors << I18n.t("vagrant.config.vm.multiple_disk_names_error",
+                           name: duplicate_names)
         end
 
         @disks.each do |d|

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -392,7 +392,7 @@ module VagrantPlugins
         @__defined_vms[name].config_procs << [options[:config_version], block] if block
       end
 
-      def disk(type, &block)
+      def disk(type, **options, &block)
         disk = VagrantConfigDisk.new(type)
         if block.is_a?(Hash)
           disk.set_options(block)
@@ -400,7 +400,10 @@ module VagrantPlugins
           block.call(disk, VagrantConfigDisk)
         end
 
+        disk.add_config(options, block)
+
         @__drives << disk
+
       end
 
       #-------------------------------------------------------------------

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -210,7 +210,6 @@ module VagrantPlugins
 
           result.instance_variable_set(:@__defined_vm_keys, new_defined_vm_keys)
           result.instance_variable_set(:@__defined_vms, new_defined_vms)
-          result.instance_variable_set(:@disks, new_disks)
           result.instance_variable_set(:@__providers, new_providers)
           result.instance_variable_set(:@__provider_order, new_order)
           result.instance_variable_set(:@__provider_overrides, new_overrides)

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -410,18 +410,26 @@ module VagrantPlugins
       end
 
       def disk(type, **options, &block)
-        disk = VagrantConfigDisk.new(type)
+        disk_config = VagrantConfigDisk.new(type)
 
-        disk.set_options(options)
+        # Remove provider__option options before set_options, otherwise will
+        # show up as missing setting
+        #
+        # We can probably combine this into a single method call...?
+        provider_options = options.select { |k,v| k.to_s.include?("__") }
+        options.delete_if { |k,v| k.to_s.include?("__") }
 
-        if block_given?
-          block.call(disk, VagrantConfigDisk)
-        end
+        disk_config.set_options(options)
+
+        # Can't use blocks if we use provider__option
+        #if block_given?
+        #  block.call(disk, VagrantConfigDisk)
+        #end
 
         # Add provider config
-        disk.add_config(options, &block)
+        disk_config.add_provider_config(provider_options, &block)
 
-        @disks << disk
+        @disks << disk_config
       end
 
       #-------------------------------------------------------------------

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -812,7 +812,11 @@ module VagrantPlugins
                            name: machine.name)
         end
 
-        # TODO: Check for duplicate disk names?
+        disk_names = @disks.map { |d| d.name }
+        duplicate_names = disk_names.detect{ |d| disk_names.count(d) > 1 }
+        if duplicate_names && duplicate_names.size
+          errors << "Duplicate disk names found: #{duplicate_names}. Please use unique names"
+        end
 
         @disks.each do |d|
           error = d.validate(machine)

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -178,17 +178,17 @@ module VagrantPlugins
           @provisioners.each do |p|
             other_p = other_provs.find { |o| p.id == o.id }
             if other_p
-              # there is an override. take it.
+              # There is an override. Take it.
               other_p.config = p.config.merge(other_p.config)
               other_p.run    ||= p.run
               next if !other_p.preserve_order
 
-              # we're preserving order, delete from other
+              # We're preserving order, delete from other
               p = other_p
               other_provs.delete(other_p)
             end
 
-            # there is an override, merge it into the
+            # There is an override, merge it into the
             new_provs << p.dup
           end
           other_provs.each do |p|

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -134,10 +134,8 @@ module VagrantPlugins
             if other_p
               # there is an override. take it.
               other_p.config = p.config.merge(other_p.config)
-              #other_p.run    ||= p.run
-              #next if !other_p.preserve_order
 
-              # we're preserving order, delete from other
+              # Remove duplicate disk config from other
               p = other_p
               other_disks.delete(other_p)
             end

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -406,12 +406,14 @@ module VagrantPlugins
 
       def disk(type, **options, &block)
         disk = VagrantConfigDisk.new(type)
-        if block.is_a?(Hash)
-          disk.set_options(block)
-        else
+
+        disk.set_options(options)
+
+        if block_given?
           block.call(disk, VagrantConfigDisk)
         end
 
+        # Add provider config
         disk.add_config(options, &block)
 
         @__disks << disk

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -128,20 +128,27 @@ module VagrantPlugins
 
           # Merge defined disks
           other_disks = other.instance_variable_get(:@disks)
-          new_disks   = @disks.dup
-          @disks.each do |d|
-            other_d = other_disks.find { |o| d.id == o.id }
-            if other_d
-              # There is an override. Take it.
-              other_d.config = d.config.merge(other_p.config)
+          new_disks   = []
+          @disks.each do |p|
+            other_p = other_disks.find { |o| p.id == o.id }
+            if other_p
+              # there is an override. take it.
+              other_p.config = p.config.merge(other_p.config)
+              #other_p.run    ||= p.run
+              #next if !other_p.preserve_order
+
+              # we're preserving order, delete from other
+              p = other_p
+              other_disks.delete(other_p)
             end
 
-            # There is an override, merge it into the
-            new_disks << d.dup
+            # there is an override, merge it into the
+            new_disks << p.dup
           end
-          other_disks.each do |d|
-            new_disks << d.dup
+          other_disks.each do |p|
+            new_disks << p.dup
           end
+          result.instance_variable_set(:@disks, new_disks)
 
           # Merge the providers by prepending any configuration blocks we
           # have for providers onto the new configuration.
@@ -173,17 +180,17 @@ module VagrantPlugins
           @provisioners.each do |p|
             other_p = other_provs.find { |o| p.id == o.id }
             if other_p
-              # There is an override. Take it.
+              # there is an override. take it.
               other_p.config = p.config.merge(other_p.config)
               other_p.run    ||= p.run
               next if !other_p.preserve_order
 
-              # We're preserving order, delete from other
+              # we're preserving order, delete from other
               p = other_p
               other_provs.delete(other_p)
             end
 
-            # There is an override, merge it into the
+            # there is an override, merge it into the
             new_provs << p.dup
           end
           other_provs.each do |p|

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -791,6 +791,8 @@ module VagrantPlugins
           errors << "There is more than one disk defined for guest '#{machine.name}'. Please pick a `primary` disk."
         end
 
+        # TODO: Check for duplicate disk names?
+
         @__disks.each do |d|
           error = d.validate(machine)
           errors.concat error if !error.empty?

--- a/plugins/providers/virtualbox/action.rb
+++ b/plugins/providers/virtualbox/action.rb
@@ -79,6 +79,7 @@ module VagrantPlugins
           b.use ForwardPorts
           b.use SetHostname
           b.use SaneDefaults
+          b.use Disk
           b.use Customize, "pre-boot"
           b.use Boot
           b.use Customize, "post-boot"

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1792,6 +1792,17 @@ en:
 # Translations for config validation errors
 #-------------------------------------------------------------------------------
     config:
+      disk:
+        invalid_type: |-
+          Disk type '%{type}' is not a valid type. Please pick one of the following supported disk types: %{types}
+        invalid_size: |-
+          Config option 'size' for disk '%{name}' on guest '%{machine}' is not an integer
+        invalid_file_type: |-
+          Disk config option 'file' for '%{machine}' is not a string.
+        missing_file: |-
+          Disk file '%{file_path}' for disk '%{name}' on machine '%{machine}' does not exist.
+        missing_provider: |-
+          Guest '%{machine}' using provider '%{provider_name}' has provider specific config options for a provider other than '%{provider_name}'. These provider config options will be ignored for this guest
       common:
         bad_field: "The following settings shouldn't exist: %{fields}"
       chef:

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2153,6 +2153,9 @@ en:
       runner:
         waiting_cleanup: "Waiting for cleanup before exiting..."
         exit_immediately: "Exiting immediately, without cleanup!"
+      disk:
+        provider_unsupported: |-
+          Guest provider '%{provider}' does not support the disk feature, and will not use the disk configuration defined.
       vm:
         boot:
           booting: Booting VM...

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1892,6 +1892,8 @@ en:
           hyphens or dots. It cannot start with a hyphen or dot.
         ignore_provider_config: |-
           Ignoring provider config for validation...
+        multiple_primary_disks_error: |-
+          There are more than one primary disks defined for guest '%{name}'. Please ensure that only one disk has been defined as a primary disk.
         name_invalid: |-
           The sub-VM name '%{name}' is invalid. Please don't use special characters.
         network_ip_ends_in_one: |-

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1905,6 +1905,8 @@ en:
           Ignoring provider config for validation...
         multiple_primary_disks_error: |-
           There are more than one primary disks defined for guest '%{name}'. Please ensure that only one disk has been defined as a primary disk.
+        multiple_disk_names_error: |-
+          Duplicate disk names defined: '%{name}'. Disk names must be unique.
         name_invalid: |-
           The sub-VM name '%{name}' is invalid. Please don't use special characters.
         network_ip_ends_in_one: |-

--- a/test/unit/plugins/kernel_v2/config/disk_test.rb
+++ b/test/unit/plugins/kernel_v2/config/disk_test.rb
@@ -1,0 +1,56 @@
+require File.expand_path("../../../../base", __FILE__)
+
+require Vagrant.source_root.join("plugins/kernel_v2/config/disk")
+
+describe VagrantPlugins::Kernel_V2::VagrantConfigDisk do
+  include_context "unit"
+
+  let(:type) { :disk }
+
+  subject { described_class.new(type) }
+
+  let(:machine) { double("machine") }
+
+  def assert_invalid
+    errors = subject.validate(machine)
+    if !errors.empty? { |v| !v.empty? }
+      raise "No errors: #{errors.inspect}"
+    end
+  end
+
+  def assert_valid
+    errors = subject.validate(machine)
+    if !errors.empty? { |v| v.empty? }
+      raise "Errors: #{errors.inspect}"
+    end
+  end
+
+  before do
+    env = double("env")
+
+    subject.name = "foo"
+    subject.size = 100
+  end
+
+  describe "with defaults" do
+    it "is valid with test defaults" do
+      subject.finalize!
+      assert_valid
+    end
+
+    it "sets a command" do
+      subject.finalize!
+      expect(subject.type).to eq(type)
+    end
+
+    it "defaults to primray disk" do
+      subject.finalize!
+      expect(subject.primary).to eq(true)
+    end
+  end
+
+  describe "defining a new config that needs to match internal restraints" do
+    before do
+    end
+  end
+end

--- a/test/unit/plugins/kernel_v2/config/disk_test.rb
+++ b/test/unit/plugins/kernel_v2/config/disk_test.rb
@@ -43,9 +43,9 @@ describe VagrantPlugins::Kernel_V2::VagrantConfigDisk do
       expect(subject.type).to eq(type)
     end
 
-    it "defaults to primray disk" do
+    it "defaults to non-primray disk" do
       subject.finalize!
-      expect(subject.primary).to eq(true)
+      expect(subject.primary).to eq(false)
     end
   end
 

--- a/test/unit/plugins/kernel_v2/config/disk_test.rb
+++ b/test/unit/plugins/kernel_v2/config/disk_test.rb
@@ -38,7 +38,7 @@ describe VagrantPlugins::Kernel_V2::VagrantConfigDisk do
       assert_valid
     end
 
-    it "sets a command" do
+    it "sets a disk type" do
       subject.finalize!
       expect(subject.type).to eq(type)
     end

--- a/test/unit/plugins/kernel_v2/config/vm_test.rb
+++ b/test/unit/plugins/kernel_v2/config/vm_test.rb
@@ -549,6 +549,44 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
     end
   end
 
+  describe "#disk" do
+    it "stores the disks" do
+      subject.disk("disk", size: 100)
+      subject.disk("disk", size: 1000, primary: false, name: "storage")
+      subject.finalize!
+
+      d = subject.disks
+      expect(d.length).to eql(2)
+      expect(d[0].size).to eql(100)
+      expect(d[1].size).to eql(1000)
+      expect(d[1].name).to eql("storage")
+    end
+
+    it "does not merge duplicate disks" do
+      subject.disk("disk", size: 1000, primary: false, name: "storage")
+      subject.disk("disk", size: 1000, primary: false, name: "backup")
+
+      merged = subject.merge(subject)
+      merged_disks = merged.disks
+
+      expect(merged_disks.length).to eql(2)
+    end
+
+    it "ignores non-overriding runs" do
+      subject.disk("disk", name: "foo")
+
+      other = described_class.new
+      other.disk("disk", name: "bar", primary: false)
+
+      merged = subject.merge(other)
+      merged_disks = merged.disks
+
+      expect(merged_disks.length).to eql(2)
+      expect(merged_disks[0].name).to eq("foo")
+      expect(merged_disks[1].name).to eq("bar")
+    end
+  end
+
   describe "#synced_folder(s)" do
     it "defaults to sharing the current directory" do
       subject.finalize!

--- a/test/unit/plugins/kernel_v2/config/vm_test.rb
+++ b/test/unit/plugins/kernel_v2/config/vm_test.rb
@@ -551,9 +551,11 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
 
   describe "#disk" do
     it "stores the disks" do
-      subject.disk("disk", size: 100)
-      subject.disk("disk", size: 1000, primary: false, name: "storage")
+      subject.disk(:disk, size: 100)
+      subject.disk(:disk, size: 1000, primary: false, name: "storage")
       subject.finalize!
+
+      assert_valid
 
       d = subject.disks
       expect(d.length).to eql(2)
@@ -562,9 +564,16 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
       expect(d[1].name).to eql("storage")
     end
 
+    it "raises an error with duplicate names" do
+      subject.disk(:disk, size: 100, name: "foo")
+      subject.disk(:disk, size: 1000, name: "foo", primary: false)
+      subject.finalize!
+      assert_invalid
+    end
+
     it "does not merge duplicate disks" do
-      subject.disk("disk", size: 1000, primary: false, name: "storage")
-      subject.disk("disk", size: 1000, primary: false, name: "backup")
+      subject.disk(:disk, size: 1000, primary: false, name: "storage")
+      subject.disk(:disk, size: 1000, primary: false, name: "backup")
 
       merged = subject.merge(subject)
       merged_disks = merged.disks
@@ -573,10 +582,10 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
     end
 
     it "ignores non-overriding runs" do
-      subject.disk("disk", name: "foo")
+      subject.disk(:disk, name: "foo")
 
       other = described_class.new
-      other.disk("disk", name: "bar", primary: false)
+      other.disk(:disk, name: "bar", primary: false)
 
       merged = subject.merge(other)
       merged_disks = merged.disks

--- a/test/unit/plugins/kernel_v2/config/vm_test.rb
+++ b/test/unit/plugins/kernel_v2/config/vm_test.rb
@@ -550,6 +550,11 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
   end
 
   describe "#disk" do
+    before(:each) do
+      allow(Vagrant::Util::Experimental).to receive(:feature_enabled?).
+        with("disk_base_config").and_return("true")
+    end
+
     it "stores the disks" do
       subject.disk(:disk, size: 100)
       subject.disk(:disk, size: 1000, primary: false, name: "storage")

--- a/test/unit/vagrant/util/numeric_test.rb
+++ b/test/unit/vagrant/util/numeric_test.rb
@@ -1,0 +1,21 @@
+require File.expand_path("../../../base", __FILE__)
+
+require "vagrant/util/numeric"
+
+describe Vagrant::Util::Numeric do
+  include_context "unit"
+  before(:each) { described_class.reset! }
+  subject { described_class }
+
+  describe "#string_to_bytes" do
+    it "converts a string to the proper bytes" do
+      bytes = subject.string_to_bytes("10KB")
+      expect(bytes).to eq(10240)
+    end
+
+    it "returns nil if the given string is the wrong format" do
+      bytes = subject.string_to_bytes("10 Kilobytes")
+      expect(bytes).to eq(nil)
+    end
+  end
+end

--- a/website/source/docs/disks/configuration.html.md
+++ b/website/source/docs/disks/configuration.html.md
@@ -18,7 +18,14 @@ Vagrant Disks has several options that allow users to define and attach disks to
 * `primary` (boolean) - Optional argument that configures a given disk to be the "primary" disk to manage on the guest. There can only be one `primary` disk per guest.
 * `provider_config` (hash) - Additional provider specific options for managing a given disk.
 
-    **Note:** The `provider_config` option will depend on the provider you are using. Please read the provider specific documentation for disk management to learn about what options are available to use.
+    Generally, the disk option accepts two kinds of ways to define a provider config:
+
+    + `providername__diskoption = value`
+      - The provider name followed by a double underscore, and then the provider specific option for that disk
+    + `{providername: {diskoption: value}, otherprovidername: {diskoption: value}`
+      - A hash where the top level key(s) are one or more providers, and each provider keys values are a hash of options and their values.
+
+    **Note:** More specific examples of these can be found under the provider specific disk page. The `provider_config` option will depend on the provider you are using. Please read the provider specific documentation for disk management to learn about what options are available to use.
 
 ## Disk Types
 

--- a/website/source/docs/disks/configuration.html.md
+++ b/website/source/docs/disks/configuration.html.md
@@ -8,6 +8,23 @@ description: |-
 
 # Configuration
 
+<div class="alert alert-warning">
+  <strong>Warning!</strong> This feature is experimental and may break or
+  change in between releases. Use at your own risk. It currently is not officially
+  supported or functional.
+
+  This feature currently reqiures the experimental flag to be used. To explicitly enable this feature, you can set the experimental flag to:
+
+  ```
+  VAGRANT_EXPERIMENTAL="disk_base_config"
+  ```
+
+  Please note that `VAGRANT_EXPERIMENTAL` is an environment variable. For more
+  information about this flag visit the [Experimental docs page](/docs/experimental/)
+  for more info. Without this flag enabled, triggers with the `:type` option
+  will be ignored.
+</div>
+
 Vagrant Disks has several options that allow users to define and attach disks to guests.
 
 ## Disk Options
@@ -29,12 +46,31 @@ Vagrant Disks has several options that allow users to define and attach disks to
 
 ## Disk Types
 
+The disk config currently accepts three kinds of disk types:
+
+* `disk` (symbol)
+* `dvd` (symbol)
+* `floppy` (symbol)
+
+You can set a disk type with the first argument of a disk config in your Vagrantfile:
+
+```ruby
+config.vm.disk :disk, name: "backup", size: "10GB"
+config.vm.disk :floppy, name: "cool_files"
+```
+
 ## Provider Author Guide
 
 If you are a vagrant plugin author who maintains a provider for Vagrant, this short guide will hopefully give some information on how to use the internal disk config object.
 
-TODO: Fill out these main points
+<div class="alert alert-warning">
+  <strong>Warning!</strong> This guide is still being written as we develop this
+  new feature for Vagrant. Some points below are what we plan on covering once this
+  feature is more fully developed in Vagrant.
+</div>
 
 - Entry level builtin action `disk` and how to use it as a provider author
 - `id` is unique to each disk config object
 - `provider_config` and how to its structured and how to use/validate it
+
+More information should be coming once the disk feature is more functional.

--- a/website/source/docs/disks/configuration.html.md
+++ b/website/source/docs/disks/configuration.html.md
@@ -29,3 +29,6 @@ Vagrant Disks has several options that allow users to define and attach disks to
 
 ## Disk Types
 
+## Provider Author Guide
+
+If you are a vagrant plugin author who maintains a provider for Vagrant, this short guide will hopefully give some information on how to use the internal disk config object.

--- a/website/source/docs/disks/configuration.html.md
+++ b/website/source/docs/disks/configuration.html.md
@@ -1,0 +1,24 @@
+---
+layout: "docs"
+page_title: "Vagrant Disks Configuration"
+sidebar_current: "disks-configuration"
+description: |-
+  Documentation of various configuration options for Vagrant Disks
+---
+
+# Configuration
+
+Vagrant Disks has several options that allow users to define and attach disks to guests.
+
+## Disk Options
+
+* `name` (string) - Optional argument to give the disk a name
+* `type` (symbol) - The type of disk to manage. This option defaults to `:disk`. Please read the provider specific documentation for supported types.
+* `file` (string) - Optional argument that defines a path on disk pointing to the location of a disk file.
+* `primary` (boolean) - Optional argument that configures a given disk to be the "primary" disk to manage on the guest. There can only be one `primary` disk per guest.
+* `provider_config` (hash) - Additional provider specific options for managing a given disk.
+
+    **Note:** The `provider_config` option will depend on the provider you are using. Please read the provider specific documentation for disk management to learn about what options are available to use.
+
+## Disk Types
+

--- a/website/source/docs/disks/configuration.html.md
+++ b/website/source/docs/disks/configuration.html.md
@@ -20,7 +20,7 @@ Vagrant Disks has several options that allow users to define and attach disks to
 
     Generally, the disk option accepts two kinds of ways to define a provider config:
 
-    + `providername__diskoption = value`
+    + `providername__diskoption: value`
       - The provider name followed by a double underscore, and then the provider specific option for that disk
     + `{providername: {diskoption: value}, otherprovidername: {diskoption: value}`
       - A hash where the top level key(s) are one or more providers, and each provider keys values are a hash of options and their values.

--- a/website/source/docs/disks/configuration.html.md
+++ b/website/source/docs/disks/configuration.html.md
@@ -32,3 +32,9 @@ Vagrant Disks has several options that allow users to define and attach disks to
 ## Provider Author Guide
 
 If you are a vagrant plugin author who maintains a provider for Vagrant, this short guide will hopefully give some information on how to use the internal disk config object.
+
+TODO: Fill out these main points
+
+- Entry level builtin action `disk` and how to use it as a provider author
+- `id` is unique to each disk config object
+- `provider_config` and how to its structured and how to use/validate it

--- a/website/source/docs/disks/index.html.md
+++ b/website/source/docs/disks/index.html.md
@@ -10,5 +10,7 @@ description: |-
 
 As of version 2.3.0, Vagrant is capable managing what disks are available for a given guest.
 
+TODO: GIVE A HIGH LEVEL OVERVIEW HERE
+
 For more information about what options are available for configuring disks, see the
 [configuration section](/docs/disks/configuration.html).

--- a/website/source/docs/disks/index.html.md
+++ b/website/source/docs/disks/index.html.md
@@ -1,0 +1,14 @@
+---
+layout: "docs"
+page_title: "Vagrant Disks"
+sidebar_current: "disks"
+description: |-
+  Introduction to Vagrant Disks
+---
+
+# Vagrant Disks
+
+As of version 2.3.0, Vagrant is capable managing what disks are available for a given guest.
+
+For more information about what options are available for configuring disks, see the
+[configuration section](/docs/disks/configuration.html).

--- a/website/source/docs/disks/index.html.md
+++ b/website/source/docs/disks/index.html.md
@@ -8,9 +8,27 @@ description: |-
 
 # Vagrant Disks
 
-As of version 2.3.0, Vagrant is capable managing what disks are available for a given guest.
+<div class="alert alert-warning">
+  <strong>Warning!</strong> This feature is experimental and may break or
+  change in between releases. Use at your own risk. It currently is not officially
+  supported or functional.
 
-TODO: GIVE A HIGH LEVEL OVERVIEW HERE
+  This feature currently reqiures the experimental flag to be used. To explicitly enable this feature, you can set the experimental flag to:
+
+  ```
+  VAGRANT_EXPERIMENTAL="disk_base_config"
+  ```
+
+  Please note that `VAGRANT_EXPERIMENTAL` is an environment variable. For more
+  information about this flag visit the [Experimental docs page](/docs/experimental/)
+  for more info. Without this flag enabled, triggers with the `:type` option
+  will be ignored.
+
+  <strong>NOTE:</strong> Vagrant disks is currently a future feature for Vagrant that is not yet supported.
+  Some documentation exists here for future reference, however the Disk feature is
+  not yet functional. Please be patient for us to develop this new feature, and stay
+  tuned for a future release of Vagrant with this new functionality!
+</div>
 
 For more information about what options are available for configuring disks, see the
 [configuration section](/docs/disks/configuration.html).

--- a/website/source/docs/disks/usage.html.md
+++ b/website/source/docs/disks/usage.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "Vagrant Disk Usage"
-sidebar_current: "disk-usage"
+sidebar_current: "disks-usage"
 description: |-
   Various Vagrant Disk examples
 ---

--- a/website/source/docs/disks/usage.html.md
+++ b/website/source/docs/disks/usage.html.md
@@ -1,0 +1,13 @@
+---
+layout: "docs"
+page_title: "Vagrant Disk Usage"
+sidebar_current: "disk-usage"
+description: |-
+  Various Vagrant Disk examples
+---
+
+# Basic Usage
+
+Below are some very simple examples of how to use Vagrant Disks.
+
+## Examples

--- a/website/source/docs/disks/usage.html.md
+++ b/website/source/docs/disks/usage.html.md
@@ -11,3 +11,8 @@ description: |-
 Below are some very simple examples of how to use Vagrant Disks.
 
 ## Examples
+
+- Resizing a disk (primary)
+- Attaching a new disk
+- Using provider specific options
+- ???

--- a/website/source/docs/disks/usage.html.md
+++ b/website/source/docs/disks/usage.html.md
@@ -8,6 +8,23 @@ description: |-
 
 # Basic Usage
 
+<div class="alert alert-warning">
+  <strong>Warning!</strong> This feature is experimental and may break or
+  change in between releases. Use at your own risk. It currently is not officially
+  supported or functional.
+
+  This feature currently reqiures the experimental flag to be used. To explicitly enable this feature, you can set the experimental flag to:
+
+  ```
+  VAGRANT_EXPERIMENTAL="disk_base_config"
+  ```
+
+  Please note that `VAGRANT_EXPERIMENTAL` is an environment variable. For more
+  information about this flag visit the [Experimental docs page](/docs/experimental/)
+  for more info. Without this flag enabled, triggers with the `:type` option
+  will be ignored.
+</div>
+
 Below are some very simple examples of how to use Vagrant Disks.
 
 ## Examples
@@ -15,4 +32,3 @@ Below are some very simple examples of how to use Vagrant Disks.
 - Resizing a disk (primary)
 - Attaching a new disk
 - Using provider specific options
-- ???

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -128,6 +128,14 @@
         </ul>
       </li>
 
+      <li<%= sidebar_current("disks") %>>
+        <a href="/docs/disks/">Disks</a>
+        <ul class="nav">
+          <li<%= sidebar_current("disks-configuration") %>><a href="/docs/disks/configuration.html">Configuration</a></li>
+          <li<%= sidebar_current("disks-usage") %>><a href="/docs/disks/usage.html">Usage</a></li>
+        </ul>
+      </li>
+
       <li<%= sidebar_current("multimachine") %>>
         <a href="/docs/multi-machine/">Multi-Machine</a>
       </li>


### PR DESCRIPTION
This pull request adds a basic `disk` config option to Vagrant core that will allow providers to consume a config and manage a guests disk options. Similar to the provisioners, it has a few base options that all disks likely will need, but allows for more provider specific options with a `config` which will be implemented by each provider. Ideally in a Vagrantfile, a guests disk config block should be provider agnostic, unless there are some provider specific options that need to be set when configuring a disk.

By default, a new disk block is a non-primary disk that will be attached to the guest. If a user wishes to modify the primary disk attached to the guest, they can add the option `primary: true` to a disk config block.

```ruby
Vagrant.configure("2") do |config|
  config.vm.define "hashicorp" do |b|
    b.vm.box = "hashicorp/bionic64"

    b.vm.disk :disk, size: 1000,
      virtualbox__diskoption: "1234", libvirt__otheroption: true

    b.vm.disk :disk, size: 10000, name: "bigger_disk",
      virtualbox__diskoption: "1234"

  end
end
```

TODOs:

- [x] Define an entry action that all providers can call to configure their disks
- [x] We should provide "shortcuts" for defining disk size. Such as `size: "10GB"`
- [x] Better validation of disk config types in `validate`
- [x] Docs for website for new config option (and document how to use config class for provider authors)

Future TODOs after this PR:
- [x] Implement the disk provider for VirtualBox for "baseline" functionality. Should also reveal what is missing for the basic disk config layer. (Could be done in a different PR...)