### PR TITLE
explicitly test the hostname we'll be setting

### DIFF
--- a/plugins/guests/suse/cap/change_host_name.rb
+++ b/plugins/guests/suse/cap/change_host_name.rb
@@ -5,8 +5,8 @@ module VagrantPlugins
         def self.change_host_name(machine, name)
           comm = machine.communicate
 
-          if !comm.test("getent hosts '#{name}'", sudo: false)
-            basename = name.split(".", 2)[0]
+          basename = name.split(".", 2)[0]
+          if !comm.test('test "$(hostnamectl --static status)" = "#{basename}"', sudo: false)
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
               hostnamectl set-hostname '#{basename}'
 

--- a/test/unit/plugins/guests/suse/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/suse/cap/change_host_name_test.rb
@@ -25,14 +25,14 @@ describe "VagrantPlugins::GuestSUSE::Cap::ChangeHostName" do
     let(:basename) { "banana-rama" }
 
     it "sets the hostname" do
-      comm.stub_command("getent hosts '#{name}'", exit_code: 1)
+      comm.stub_command('test "$(hostnamectl --static status)" = "#{basename}"', exit_code: 1)
 
       cap.change_host_name(machine, name)
       expect(comm.received_commands[1]).to match(/hostnamectl set-hostname '#{basename}'/)
     end
 
     it "does not change the hostname if already set" do
-      comm.stub_command("getent hosts '#{name}'", exit_code: 0)
+      comm.stub_command('test "$(hostnamectl --static status)" = "#{basename}"', exit_code: 0)
 
       cap.change_host_name(machine, name)
       expect(comm.received_commands.size).to eq(1)


### PR DESCRIPTION
getent queries the system resolver for the hostname - but it's not
the resolver we're interested in. In fact, the hostname-to-be-set
may already exist in DNS (becuase DNS really is a nifty thing and
can do a lot of things which are not that possible with /etc/hosts
alone), in which case getent will "not fail" and vagrant will believe
the hostname had already been set.
Instead, query hostnamectl for the "static" hostname - that's the
one we will be setting, so we're ok IFF hostnamectl returns exactly
what we would be setting.