### PR TITLE
Fixes #11173: Show guest name in hostname error message

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -609,7 +609,7 @@ module VagrantPlugins
           errors << I18n.t("vagrant.config.vm.clone_and_box")
         end
 
-        errors << I18n.t("vagrant.config.vm.hostname_invalid_characters") if \
+        errors << I18n.t("vagrant.config.vm.hostname_invalid_characters", name: machine.name) if \
           @hostname && @hostname !~ /^[a-z0-9][-.a-z0-9]*$/i
 
         if @box_version

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1888,7 +1888,7 @@ en:
         box_missing: "A box must be specified."
         clone_and_box: "Only one of clone or box can be specified."
         hostname_invalid_characters: |-
-          The hostname set for the VM should only contain letters, numbers,
+          The hostname set for the VM '%{name}' should only contain letters, numbers,
           hyphens or dots. It cannot start with a hyphen or dot.
         ignore_provider_config: |-
           Ignoring provider config for validation...


### PR DESCRIPTION
This commit adds the machine guest name in the hostname validation error
message so that it's easier to see which guest in a Vagrantfile has the
validation error.