### PR TITLE
Fixes #10170: Check for modinfo in /sbin

### DIFF
--- a/plugins/hosts/linux/cap/nfs.rb
+++ b/plugins/hosts/linux/cap/nfs.rb
@@ -262,16 +262,25 @@ module VagrantPlugins
         end
 
         def self.modinfo_path
-          path = Vagrant::Util::Which.which("modinfo")
-          return path if path
+          if !defined?(@_modinfo_path)
+            @_modinfo_path = Vagrant::Util::Which.which("modinfo")
 
-          folders = ["/sbin"]
-          folders.each do |folder|
-            path = "#{folder}/modinfo"
-            return path if File.file?(path)
+            if @_modinfo_path.to_s.empty?
+              folders = ["/sbin"]
+              folders.each do |folder|
+                path = "#{folder}/modinfo"
+                if File.file?(path)
+                  @_modinfo_path = path
+                  break
+                end
+              end
+            end
+
+            if @_modinfo_path.to_s.empty?
+              @_modinfo_path = "modinfo"
+            end
           end
-
-          "modinfo"
+          @_modinfo_path
         end
 
         # @private

--- a/plugins/hosts/linux/cap/nfs.rb
+++ b/plugins/hosts/linux/cap/nfs.rb
@@ -270,6 +270,8 @@ module VagrantPlugins
             path = "#{folder}/modinfo"
             return path if File.file?(path)
           end
+
+          "modinfo"
         end
 
         # @private

--- a/plugins/hosts/linux/cap/nfs.rb
+++ b/plugins/hosts/linux/cap/nfs.rb
@@ -93,7 +93,7 @@ module VagrantPlugins
               "systemctl --no-pager --no-legend --plain list-unit-files --all --type=service " \
                 "| grep #{nfs_service_name_systemd}").exit_code == 0
           else
-            Vagrant::Util::Subprocess.execute("modinfo", "nfsd").exit_code == 0 ||
+            Vagrant::Util::Subprocess.execute(modinfo_path, "nfsd").exit_code == 0 ||
               Vagrant::Util::Subprocess.execute("grep", "nfsd", "/proc/filesystems").exit_code == 0
           end
         end
@@ -259,6 +259,17 @@ module VagrantPlugins
 
         def self.nfs_running?(check_command)
           Vagrant::Util::Subprocess.execute(*Shellwords.split(check_command)).exit_code == 0
+        end
+
+        def self.modinfo_path
+          path = Vagrant::Util::Which.which("modinfo")
+          return path if path
+
+          folders = ["/sbin"]
+          folders.each do |folder|
+            path = "#{folder}/modinfo"
+            return path if File.file?(path)
+          end
         end
 
         # @private

--- a/plugins/hosts/linux/cap/nfs.rb
+++ b/plugins/hosts/linux/cap/nfs.rb
@@ -266,13 +266,9 @@ module VagrantPlugins
             @_modinfo_path = Vagrant::Util::Which.which("modinfo")
 
             if @_modinfo_path.to_s.empty?
-              folders = ["/sbin"]
-              folders.each do |folder|
-                path = "#{folder}/modinfo"
-                if File.file?(path)
-                  @_modinfo_path = path
-                  break
-                end
+              path = "/sbin/modinfo"
+              if File.file?(path)
+                @_modinfo_path = path
               end
             end
 

--- a/test/unit/plugins/hosts/linux/cap/nfs_test.rb
+++ b/test/unit/plugins/hosts/linux/cap/nfs_test.rb
@@ -337,4 +337,40 @@ EOH
       end
     end
   end
+
+  describe ".modinfo_path" do
+    let(:cap){ VagrantPlugins::HostLinux::Cap::NFS }
+
+    context "with modinfo on PATH" do
+      before do
+        expect(Vagrant::Util::Which).to receive(:which).with("modinfo").and_return("/usr/bin/modinfo")
+      end
+
+      it "should use full path to modinfo" do
+        expect(cap.modinfo_path).to eq("/usr/bin/modinfo")
+      end
+    end
+
+    context "with modinfo at /sbin/modinfo" do
+      before do
+        expect(Vagrant::Util::Which).to receive(:which).with("modinfo").and_return(nil)
+        expect(File).to receive(:file?).with("/sbin/modinfo").and_return(true)
+      end
+
+      it "should use /sbin/modinfo" do
+        expect(cap.modinfo_path).to eq("/sbin/modinfo")
+      end
+    end
+
+    context "modinfo not found" do
+      before do
+        expect(Vagrant::Util::Which).to receive(:which).with("modinfo").and_return(nil)
+        expect(File).to receive(:file?).with("/sbin/modinfo").and_return(false)
+      end
+
+      it "should use modinfo" do
+        expect(cap.modinfo_path).to eq("modinfo")
+      end
+    end
+  end
 end

--- a/test/unit/plugins/hosts/linux/cap/nfs_test.rb
+++ b/test/unit/plugins/hosts/linux/cap/nfs_test.rb
@@ -372,5 +372,15 @@ EOH
         expect(cap.modinfo_path).to eq("modinfo")
       end
     end
+
+    context "with cached value for modinfo_path" do
+      before do
+        cap.instance_variable_set(:@_modinfo_path, "/usr/local/bin/modinfo")
+      end
+
+      it "should use cached value" do
+        expect(cap.modinfo_path).to eq("/usr/local/bin/modinfo")
+      end
+    end
   end
 end


### PR DESCRIPTION
Check for `modinfo` in /sbin if it doesn't appear on the PATH -- this could be expanded to scan other directories as well.

If it's not found on the PATH or in /sbin, the command will default back to `modinfo` so the user sees the error message about adding it to their PATH.