### PR TITLE
Bump rubyzip to v1.3.0 to fix CVE-2019-16892

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_dependency "net-scp", "~> 1.2.0"
   s.add_dependency "rb-kqueue", "~> 0.2.0"
   s.add_dependency "rest-client", ">= 1.6.0", "< 3.0"
-  s.add_dependency "rubyzip", "~> 1.2.2"
+  s.add_dependency "rubyzip", "~> 1.3"
   s.add_dependency "wdm", "~> 0.1.0"
   s.add_dependency "winrm", "~> 2.1"
   s.add_dependency "winrm-fs", "~> 1.0"


### PR DESCRIPTION
https://github.com/advisories/GHSA-5m2v-hc64-56h6

~~Perhaps we should bump it to v2.0.0 instead?~~ https://rubygems.org/gems/rubyzip