### PR TITLE
fix: allow vagrant up by name

### DIFF
--- a/lib/vagrant/machine_index.rb
+++ b/lib/vagrant/machine_index.rb
@@ -238,7 +238,7 @@ module Vagrant
     # @return [Hash]
     def find_by_prefix(prefix)
       @machines.each do |uuid, data|
-        return data.merge("id" => uuid) if uuid.start_with?(prefix)
+        return data.merge("id" => uuid) if uuid.start_with?(prefix) or data['name'] == prefix
       end
 
       nil


### PR DESCRIPTION
As stated in the [docs](https://github.com/hashicorp/vagrant/blob/master/website/source/docs/cli/up.html.md), one should be able to use the `vagrant up` command with either its name or uuid.

https://github.com/hashicorp/vagrant/blob/7560c7fdef59132bf80ab5e1ee0a085ed873fc5d/plugins/commands/up/command.rb#L87
https://github.com/hashicorp/vagrant/blob/7560c7fdef59132bf80ab5e1ee0a085ed873fc5d/lib/vagrant/plugin/v2/command.rb#L83-L107
https://github.com/hashicorp/vagrant/blob/7560c7fdef59132bf80ab5e1ee0a085ed873fc5d/lib/vagrant/machine_index.rb#L149-L156