### PR TITLE
Fixes #11179: Ensure Vagrant::Errors are loaded in file_checksum util

### DIFF
--- a/lib/vagrant/util/file_checksum.rb
+++ b/lib/vagrant/util/file_checksum.rb
@@ -2,6 +2,9 @@
 # passed into FileChecksum. Note that this isn't strictly enforced at
 # the moment, and this class isn't directly used. It is merely here for
 # documentation of structure of the class.
+
+require "vagrant/errors"
+
 class DigestClass
   def update(string); end
   def hexdigest; end
@@ -62,7 +65,7 @@ class FileChecksum
   def load_digest(type)
     digest = CHECKSUM_MAP[type.to_s.to_sym]
     if digest.nil?
-      raise Errors::BoxChecksumInvalidType,
+      raise Vagrant::Errors::BoxChecksumInvalidType,
         type: type.to_s
     end
     digest

--- a/test/unit/vagrant/util/file_checksum_test.rb
+++ b/test/unit/vagrant/util/file_checksum_test.rb
@@ -32,4 +32,15 @@ describe FileChecksum do
       expect(t_i.checksum).to eq(k_i.checksum)
     end
   end
+
+  context "with an invalid digest" do
+    let(:fake_digest) { :fake_digest }
+
+    it "should raise an exception if the box has an invalid checksum type" do
+      file = environment.workdir.join("file")
+      file.open("w+") { |f| f.write("HELLO!") }
+
+      expect{ described_class.new(file, fake_digest) }.to raise_error(Vagrant::Errors::BoxChecksumInvalidType)
+    end
+  end
 end


### PR DESCRIPTION
Prior to this commit, the file_checksum class used the `Vagrant::Errors`
class as if it were apart of the Vagrant module. However, since the
file_checksum class is an interface and not part of the Vagrant module,
it doesn't have access to that Error class like other Vagrant modules.
This commit fixes that by ensuring the `"vagrant/errors"` class is
loaded, and that the proper namespace is used.