### PR TITLE
Fixes #11137: Fixup how cloud publish handles its arguments

### DIFF
--- a/plugins/commands/cloud/publish.rb
+++ b/plugins/commands/cloud/publish.rb
@@ -55,7 +55,7 @@ module VagrantPlugins
           argv = parse_options(opts)
           return if !argv
 
-          if argv.empty? || argv.length > 4 || argv.length < 3
+          if argv.empty? || argv.length > 4 || argv.length < 3 || (argv.length == 3 && !options[:url])
             raise Vagrant::Errors::CLIInvalidUsage,
               help: opts.help.chomp
           end

--- a/test/unit/plugins/commands/cloud/publish_test.rb
+++ b/test/unit/plugins/commands/cloud/publish_test.rb
@@ -52,6 +52,15 @@ describe VagrantPlugins::CloudCommand::Command::Publish do
     let(:argv) { ["vagrant/box", "1.0.0", "virtualbox"] }
 
     it "shows help" do
+      expect { subject.execute }.
+        to raise_error(Vagrant::Errors::CLIInvalidUsage)
+    end
+  end
+
+  context "missing box file" do
+    let(:argv) { ["vagrant/box", "1.0.0", "virtualbox", "/notreal/file.box"] }
+
+    it "raises an exception" do
       allow(File).to receive(:file?).and_return(false)
       expect { subject.execute }.
         to raise_error(Vagrant::Errors::BoxFileNotExist)


### PR DESCRIPTION
Prior to this commit, if a user didn't supply a box file on disk or a
box url, Vagrant would crash and display a stacktrace with an invalid
file. This commit fixes that by adding some extra handling around the
arguments supplied to the publish command.