### PR TITLE
website - add -moz-osx-font-smoothing for smooth firefox osx fonts

### DIFF
--- a/website/source/assets/stylesheets/_global.scss
+++ b/website/source/assets/stylesheets/_global.scss
@@ -7,6 +7,7 @@ html {
 }
 
 body {
+  -moz-osx-font-smoothing: grayscale;
   -webkit-font-smoothing: antialiased;
   color: $body-font-color;
   background-color: $white;


### PR DESCRIPTION
Adding `-moz-osx-font-smoothing: grayscale;` to `<body>`  in `global-styles` to smooth out fonts in Firefox on OSX.

Note that we are already using `-webkit-font-smoothing: antialiased;`.

#### Before
![Screen Shot 2019-11-07 at 1 10 48 PM](https://user-images.githubusercontent.com/5368111/68424354-02e15a00-0161-11ea-80ae-3aca822eadc2.png)

---

### After
![Screen Shot 2019-11-07 at 1 10 32 PM](https://user-images.githubusercontent.com/5368111/68424353-02e15a00-0161-11ea-9143-f33c898fec29.png)

