### PR TITLE
Fixes #10741: Check if update is available locally

### DIFF
--- a/lib/vagrant/action/builtin/box_check_outdated.rb
+++ b/lib/vagrant/action/builtin/box_check_outdated.rb
@@ -70,15 +70,23 @@ module Vagrant
               message: e.message))
           end
           env[:box_outdated] = update != nil
-          if update
+          local_update = check_outdated_local(env)
+          if update and (local_update.nil? or local_update.version < update[1].version)
             env[:ui].warn(I18n.t(
               "vagrant.box_outdated_single",
               name: update[0].name,
               provider: box.provider,
               current: box.version,
               latest: update[1].version))
+          elsif local_update
+            env[:ui].warn(I18n.t(
+              "vagrant.box_outdated_local",
+              name: local_update.name,
+              old: box.version,
+              new: local_update.version))
+            env[:box_outdated] = true
           else
-            check_outdated_local(env)
+            env[:box_outdated] = false
           end
 
           @app.call(env)
@@ -93,19 +101,8 @@ module Vagrant
           version ||= ""
           version += "> #{machine.box.version}"
 
-          box = env[:box_collection].find(
+          env[:box_collection].find(
             machine.box.name, machine.box.provider, version)
-          if box
-            env[:ui].warn(I18n.t(
-              "vagrant.box_outdated_local",
-              name: box.name,
-              old: machine.box.version,
-              new: box.version))
-            env[:box_outdated] = true
-            return
-          end
-
-          env[:box_outdated] = false
         end
       end
     end

--- a/lib/vagrant/action/builtin/box_check_outdated.rb
+++ b/lib/vagrant/action/builtin/box_check_outdated.rb
@@ -71,7 +71,7 @@ module Vagrant
           end
           env[:box_outdated] = update != nil
           local_update = check_outdated_local(env)
-          if update and (local_update.nil? or local_update.version < update[1].version)
+          if update && (local_update.nil? || (local_update.version < update[1].version))
             env[:ui].warn(I18n.t(
               "vagrant.box_outdated_single",
               name: update[0].name,

--- a/test/unit/vagrant/action/builtin/box_check_outdated_test.rb
+++ b/test/unit/vagrant/action/builtin/box_check_outdated_test.rb
@@ -86,6 +86,8 @@ describe Vagrant::Action::Builtin::BoxCheckOutdated do
   end
 
   context "with a box" do
+    let(:warning) { "ALREADY INSTALLED" }
+
     it "sets env if no update" do
       expect(box).to receive(:has_update?).and_return(nil)
 
@@ -139,6 +141,41 @@ describe Vagrant::Action::Builtin::BoxCheckOutdated do
       subject.call(env)
 
       expect(env[:box_outdated]).to be(true)
+    end
+
+    context "both local and remote update exist" do
+      it "should prompt user to update" do
+        iso_env.box3("foo", "1.1", :virtualbox)
+
+        md = Vagrant::BoxMetadata.new(StringIO.new(<<-RAW))
+        {
+          "name": "foo",
+          "versions": [
+            {
+              "version": "1.2",
+              "providers": [
+                {
+                  "name": "virtualbox",
+                  "url": "bar"
+                }
+              ]
+            }
+          ]
+        }
+        RAW
+
+        expect(box).to receive(:has_update?).with(machine.config.vm.box_version,
+            {download_options:
+              {automatic_check: true, ca_cert: nil, ca_path: nil, client_cert: nil, insecure: false}}).
+          and_return([md, md.version("1.2"), md.version("1.2").provider("virtualbox")])
+
+        allow(I18n).to receive(:t) { :ok }
+        expect(I18n).to receive(:t).with(/box_outdated_single/, hash_including(latest: "1.2")).once
+
+        expect(app).to receive(:call).with(env).once
+
+        subject.call(env)
+      end
     end
 
     it "does not have a local update if not within constraints" do
@@ -225,6 +262,21 @@ describe Vagrant::Action::Builtin::BoxCheckOutdated do
 
         subject.call(env)
       end
+    end
+  end
+
+  describe ".check_outdated_local" do
+    let(:updated_box) do
+      box_dir = iso_env.box3("foo", "1.1", :virtualbox)
+      Vagrant::Box.new("foo", :virtualbox, "1.1", box_dir).tap do |b|
+        allow(b).to receive(:has_update?).and_return(nil)
+      end
+    end
+
+    it "should return the updated box if it is already installed" do
+      expect(subject).to receive(:check_outdated_local).with(env).and_return(updated_box)
+
+      subject.check_outdated_local(env)
     end
   end
 end

--- a/test/unit/vagrant/action/builtin/box_check_outdated_test.rb
+++ b/test/unit/vagrant/action/builtin/box_check_outdated_test.rb
@@ -86,8 +86,6 @@ describe Vagrant::Action::Builtin::BoxCheckOutdated do
   end
 
   context "with a box" do
-    let(:warning) { "ALREADY INSTALLED" }
-
     it "sets env if no update" do
       expect(box).to receive(:has_update?).and_return(nil)
 
@@ -274,9 +272,11 @@ describe Vagrant::Action::Builtin::BoxCheckOutdated do
     end
 
     it "should return the updated box if it is already installed" do
-      expect(subject).to receive(:check_outdated_local).with(env).and_return(updated_box)
+      expect(env[:box_collection]).to receive(:find).with("foo", :virtualbox, "> 1.0").and_return(updated_box)
 
-      subject.check_outdated_local(env)
+      local_update = subject.check_outdated_local(env)
+
+      expect(local_update).to eq(updated_box)
     end
   end
 end


### PR DESCRIPTION
Check the local box collection to see if the latest box update has already been downloaded.  If it has, don't show the "run vagrant update" message.