### PR TITLE
Update i18n dependency constraints

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "childprocess", "~> 0.6.0"
   s.add_dependency "ed25519", "~> 1.2.4"
   s.add_dependency "erubis", "~> 2.7.0"
-  s.add_dependency "i18n", "~> 1.1.1"
+  s.add_dependency "i18n", "~> 1.1"
   s.add_dependency "listen", "~> 3.1.5"
   s.add_dependency "hashicorp-checkpoint", "~> 0.1.5"
   s.add_dependency "log4r", "~> 1.1.9", "< 1.1.11"


### PR DESCRIPTION
Loosen dependency constraints on the i18n library to allow
versions under 2.0.