### PR TITLE
Don't prompt for input when installing Ansible

### DIFF
--- a/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
@@ -33,12 +33,12 @@ INLINE_CRIPT
 
               machine.communicate.sudo install_backports_if_wheezy_release
               machine.communicate.sudo "apt-get update -y -qq"
-              machine.communicate.sudo "apt-get install -y -qq ansible"
+              machine.communicate.sudo "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" ansible"
             end
 
             def self.pip_setup(machine, pip_install_cmd="")
               machine.communicate.sudo "apt-get update -y -qq"
-              machine.communicate.sudo "apt-get install -y -qq build-essential curl git libssl-dev libffi-dev python-dev"
+              machine.communicate.sudo "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev python-dev"
               Pip::get_pip machine, pip_install_cmd
             end
 

--- a/plugins/provisioners/ansible/cap/guest/ubuntu/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/ubuntu/ansible_install.rb
@@ -21,13 +21,13 @@ module VagrantPlugins
               unless machine.communicate.test("test -x \"$(which add-apt-repository)\"")
                 machine.communicate.sudo """
                   apt-get update -y -qq && \
-                  apt-get install -y -qq software-properties-common
+                  DEBIAN_FRONTEND=noninteractive apt-get install -y -qq software-properties-common --option \"Dpkg::Options::=--force-confold\"
                 """
               end
               machine.communicate.sudo """
                 add-apt-repository ppa:ansible/ansible -y && \
                 apt-get update -y -qq && \
-                apt-get install -y -qq ansible
+                DEBIAN_FRONTEND=noninteractive apt-get install -y -qq ansible --option \"Dpkg::Options::=--force-confold\"
               """
             end
 


### PR DESCRIPTION
Sets `DEBIAN_FRONTEND=noninteractive` and tells `dpkg` to take the old version of config files when installing Ansible, to prevent hangs waiting for user input.

Fixes #10914

I hope you don't mind my picking this up @gildegoma - I've had this branch sat around from a while ago when I happened to have some spare time and had figured out where the changes were