### PR TITLE
Fixup: Ensure Gem::Version.new does not receive nil value

### DIFF
--- a/plugins/commands/box/command/outdated.rb
+++ b/plugins/commands/box/command/outdated.rb
@@ -73,7 +73,15 @@ module VagrantPlugins
             end
 
             current = Gem::Version.new(box.version)
-            latest  = Gem::Version.new(md.versions(provider: box.provider).last)
+            box_versions = md.versions(provider: box.provider)
+
+            if box_versions.empty?
+              latest_box_version = box_versions.last.to_i
+            else
+              latest_box_version = box_versions.last
+            end
+
+            latest  = Gem::Version.new(latest_box_version)
             if latest <= current
               @env.ui.success(I18n.t(
                 "vagrant.box_up_to_date",


### PR DESCRIPTION
This commit fixes an issue where Gem::Version.new could recieve a nil
value if no addtional box updates are available. For some versions of
ruby, this is actually an error case. This commit fixes that by
converting it to an integer to prevent an exception.

Issue reference: https://github.com/rubygems/rubygems/issues/2359