### PR TITLE
Build quietly and capture the image hash from its output

### DIFF
--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -18,8 +18,8 @@ module VagrantPlugins
       def build(dir, **opts, &block)
         args   = Array(opts[:extra_args])
         args   << dir
-        result = execute('docker', 'build', *args, &block)
-        matches = result.scan(/Successfully built (.+)$/i)
+        result = execute('docker', 'build', '-q', *args, &block)
+        matches = result.scan(/^sha256:([0-9a-f]+)$/i)
         if matches.empty?
           # This will cause a stack trace in Vagrant, but it is a bug
           # if this happens anyways.

--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
         matches = result.scan(/Successfully built (.+)$/i)
         if matches.empty?
           # Check for the new output format 'writing image sha256...'
-          matches = result.scan(/writing image sha256:([0-9a-z]+) done$/i)
+          matches = result.scan(/writing image sha256:([0-9a-z]+) +$/i)
           if matches.empty?
             # This will cause a stack trace in Vagrant, but it is a bug
             # if this happens anyways.

--- a/plugins/providers/docker/executor/local.rb
+++ b/plugins/providers/docker/executor/local.rb
@@ -27,7 +27,12 @@ module VagrantPlugins
               stdout: result.stdout
           end
 
-          result.stdout
+          # If the new buildkit-based docker build is used, stdout is empty, and the output is in stderr
+          if result.stdout.to_s.strip.length == 0
+            result.stderr
+          else
+            result.stdout
+          end
         end
 
         def windows?


### PR DESCRIPTION
Consider the following combo:
- macOS Catalina
- Docker desktop 2.1.0.4
- Docker engine 19.03.4, experimental mode enabled
- Vagrant 2.2.6

With that combo the original line `matches = result.scan(/Successfully built (.+)$/i)` fails to generate a match, thus `up` fails because it doesn't find an image ID. With this change one can at least `vagrant up --provider=docker` successfully.

Downside may be the loss of output. Perhaps in the case where there is no `^sha256...` an exception could be raised and the user could be instructed to run `docker build` manually to see what exactly fails.