### PR TITLE
Fixes #11196: Add more examples for ruby heredoc shell scripts

### DIFF
--- a/website/source/docs/provisioning/shell.html.md
+++ b/website/source/docs/provisioning/shell.html.md
@@ -129,6 +129,33 @@ Vagrant.configure("2") do |config|
 end
 ```
 
+In the code block above, the script block starts with `<<-SCRIPT` and ends with `SCRIPT`.
+This is known as a _Here Document_ or a _heredoc_.  Additionally, if your script
+relies on quotes and you do not wish for Ruby to escape your quotes, you may
+want to use this style of _heredoc_ where `SCRIPT` is surrounded in single quotes:
+
+```ruby
+$script = <<-'SCRIPT'
+echo "These are my \"quotes\"! I am provisioning my guest."
+date > /etc/vagrant_provisioned_at
+SCRIPT
+
+Vagrant.configure("2") do |config|
+  config.vm.provision "shell", inline: $script
+end
+```
+
+Now that our _heredoc_ is quoted, our script will preserve the quotes in the string to `echo`:
+
+```
+==> default: Running provisioner: shell...
+    default: Running: inline script
+    default: These are my "quotes"! I am provisioning my guest.
+```
+
+For more examples of how to use _heredoc_ in Ruby, please refer to the
+[Ruby documentation](https://ruby-doc.org/core-2.5.0/doc/syntax/literals_rdoc.html#label-Here+Documents).
+
 It is understandable that if you are not familiar with Ruby, the above may seem very
 advanced or foreign. But do not fear, what it is doing is quite simple:
 the script is assigned to a global variable `$script`. This global variable

--- a/website/source/docs/provisioning/shell.html.md
+++ b/website/source/docs/provisioning/shell.html.md
@@ -130,9 +130,9 @@ end
 ```
 
 In the code block above, the script block starts with `<<-SCRIPT` and ends with `SCRIPT`.
-This is known as a _Here Document_ or a _heredoc_.  Additionally, if your script
+This is known as a `Here Document` or a `heredoc`.  Additionally, if your script
 relies on quotes and you do not wish for Ruby to escape your quotes, you may
-want to use this style of _heredoc_ where `SCRIPT` is surrounded in single quotes:
+want to use this style of heredoc where `SCRIPT` is surrounded in single quotes:
 
 ```ruby
 $script = <<-'SCRIPT'

--- a/website/source/docs/provisioning/shell.html.md
+++ b/website/source/docs/provisioning/shell.html.md
@@ -130,7 +130,7 @@ end
 ```
 
 In the code block above, the script block starts with `<<-SCRIPT` and ends with `SCRIPT`.
-This is known as a `Here Document` or a `heredoc`.  Additionally, if your script
+This is known as a "Here Document" or a "heredoc".  Additionally, if your script
 relies on quotes and you do not wish for Ruby to escape your quotes, you may
 want to use this style of heredoc where `SCRIPT` is surrounded in single quotes:
 
@@ -145,7 +145,7 @@ Vagrant.configure("2") do |config|
 end
 ```
 
-Now that our _heredoc_ is quoted, our script will preserve the quotes in the string to `echo`:
+Now that our "heredoc" is quoted, our script will preserve the quotes in the string to `echo`:
 
 ```
 ==> default: Running provisioner: shell...
@@ -153,7 +153,7 @@ Now that our _heredoc_ is quoted, our script will preserve the quotes in the str
     default: These are my "quotes"! I am provisioning my guest.
 ```
 
-For more examples of how to use _heredoc_ in Ruby, please refer to the
+For more examples of how to use "heredoc" in Ruby, please refer to the
 [Ruby documentation](https://ruby-doc.org/core-2.5.0/doc/syntax/literals_rdoc.html#label-Here+Documents).
 
 It is understandable that if you are not familiar with Ruby, the above may seem very


### PR DESCRIPTION
This commit adds an additional example for how to preserve quotes in a
script that uses heredocs.