### PR TITLE
nfs: avoid adding extra newlines to /etc/exports

### DIFF
--- a/plugins/hosts/linux/cap/nfs.rb
+++ b/plugins/hosts/linux/cap/nfs.rb
@@ -77,7 +77,7 @@ module VagrantPlugins
           sleep 0.5
 
           nfs_cleanup("#{Process.uid} #{id}")
-          output = "#{nfs_exports_content}\n#{output}"
+          output = nfs_exports_content + output
           nfs_write_exports(output)
 
           if nfs_running?(nfs_check_command)

--- a/test/unit/plugins/hosts/linux/cap/nfs_test.rb
+++ b/test/unit/plugins/hosts/linux/cap/nfs_test.rb
@@ -188,7 +188,7 @@ EOH
                   :linux__nfs_options=>["rw","all_squash"]}}
       valid_id = SecureRandom.uuid
       content =<<-EOH
-\n# VAGRANT-BEGIN: #{Process.uid} #{valid_id}
+# VAGRANT-BEGIN: #{Process.uid} #{valid_id}
 "/home/vagrant" 127.0.0.1(rw,all_squash,anonuid=,anongid=,fsid=)
 "/newhome/otherproject" 127.0.0.1(rw,all_squash,anonuid=,anongid=,fsid=)
 # VAGRANT-END: #{Process.uid} #{valid_id}


### PR DESCRIPTION
StringBlockEditor already adds the necessary newlines. That extra
newline was making /etc/exports longer and longer, full of empty lines,
because StringBlockEditor doesn't know about it and does not remove it.