### PR TITLE
Enhance docker build method for the Docker provider to include buildkit output

### DIFF
--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -20,9 +20,10 @@ module VagrantPlugins
       #
       # @return [String] id - ID matched from the docker build output.
       def build(dir, **opts, &block)
-        args   = Array(opts[:extra_args])
-        args   << dir
-        result = execute('docker', 'build', *args, &block)
+        args = Array(opts[:extra_args])
+        args << dir
+        opts = {with_stderr: true}
+        result = execute('docker', 'build', *args, opts, &block)
         matches = result.match(/Successfully built (?<id>.+)$/i)
         if !matches
           # Check for the new output format 'writing image sha256...'

--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -18,8 +18,8 @@ module VagrantPlugins
       def build(dir, **opts, &block)
         args   = Array(opts[:extra_args])
         args   << dir
-        result = execute('docker', 'build', *args, &block)
-        matches = result.scan(/Successfully built (.+)$/i)
+        result = execute('docker', 'build', '-q', *args, &block)
+        matches = result.scan(/^sha256:([0-9a-f]+)$/i)
         if matches.empty?
           # This will cause a stack trace in Vagrant, but it is a bug
           # if this happens anyways.

--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -15,23 +15,30 @@ module VagrantPlugins
         @executor = Executor::Local.new
       end
 
+      # Returns the id for a new container built from `docker build`. Raises
+      # an exception if the id was unable to be captured from the output
+      #
+      # @return [String] id - ID matched from the docker build output.
       def build(dir, **opts, &block)
         args   = Array(opts[:extra_args])
         args   << dir
-        result = execute('docker', 'build', '--progress', 'plain', *args, &block)
-        matches = result.scan(/Successfully built (.+)$/i)
-        if matches.empty?
+        result = execute('docker', 'build', *args, &block)
+        matches = result.match(/Successfully built (?<id>.+)$/i)
+        if !matches
           # Check for the new output format 'writing image sha256...'
-          matches = result.scan(/writing image sha256:([0-9a-z]+) +$/i)
-          if matches.empty?
+          # In this case, docker builtkit is enabled. Its format is different
+          # from standard docker
+          @logger.warn("Could not determine docker container ID. Scanning for buildkit output instead")
+          matches = result.match(/writing image .+:(?<id>[0-9a-z]+) done/i)
+          if !matches
             # This will cause a stack trace in Vagrant, but it is a bug
             # if this happens anyways.
-            raise "UNKNOWN OUTPUT: #{result}"
+            raise Errors::BuildError, result: result
           end
         end
 
-        # Return the last match, and the capture of it
-        matches[-1][0]
+        # Return the matched group `id`
+        matches[:id]
       end
 
       def create(params, **opts, &block)

--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
         matches = result.scan(/Successfully built (.+)$/i)
         if matches.empty?
           # Check for the new output format 'writing image sha256...'
-          matches = result.scan(/writing image sha256:([0-9a-z]+) done$/i)
+          matches = result.scan(/writing image sha256:([0-9a-z]+) +$/i)
           if matches.empty?
             # This will cause a stack trace in Vagrant, but it is a bug
             # if this happens anyways.

--- a/plugins/providers/docker/errors.rb
+++ b/plugins/providers/docker/errors.rb
@@ -5,6 +5,10 @@ module VagrantPlugins
         error_namespace("docker_provider.errors")
       end
 
+      class BuildError < DockerError
+        error_key(:build_error)
+      end
+
       class CommunicatorNonDocker < DockerError
         error_key(:communicator_non_docker)
       end

--- a/plugins/providers/docker/executor/local.rb
+++ b/plugins/providers/docker/executor/local.rb
@@ -27,7 +27,12 @@ module VagrantPlugins
               stdout: result.stdout
           end
 
-          result.stdout
+          # If the new buildkit-based docker build is used, stdout is empty, and the output is in stderr
+          if result.stdout.to_s.strip.length == 0
+            result.stderr
+          else
+            result.stdout
+          end
         end
 
         def windows?

--- a/plugins/providers/docker/executor/local.rb
+++ b/plugins/providers/docker/executor/local.rb
@@ -27,10 +27,12 @@ module VagrantPlugins
               stdout: result.stdout
           end
 
-          if result.stdout.to_s.strip.length == 0
-            result.stderr
-          else
-            result.stdout
+          if opts
+            if opts[:with_stderr]
+              return result.stdout + " " + result.stderr
+            else
+              return result.stdout
+            end
           end
         end
 

--- a/plugins/providers/docker/executor/local.rb
+++ b/plugins/providers/docker/executor/local.rb
@@ -27,7 +27,6 @@ module VagrantPlugins
               stdout: result.stdout
           end
 
-          # If the new buildkit-based docker build is used, stdout is empty, and the output is in stderr
           if result.stdout.to_s.strip.length == 0
             result.stderr
           else

--- a/templates/locales/providers_docker.yml
+++ b/templates/locales/providers_docker.yml
@@ -159,6 +159,8 @@ en:
         run exits and doesn't keep running.
 
     errors:
+      build_error: |-
+        Vagrant received unknown output from docker: %{result}
       compose_lock_timeout: |-
         Vagrant encountered a timeout waiting for the docker compose driver
         to become available. Please try to run your command again. If you

--- a/templates/locales/providers_docker.yml
+++ b/templates/locales/providers_docker.yml
@@ -160,7 +160,7 @@ en:
 
     errors:
       build_error: |-
-        Vagrant received unknown output from docker: %{result}
+        Vagrant received unknown output from `docker build` while building a container: %{result}
       compose_lock_timeout: |-
         Vagrant encountered a timeout waiting for the docker compose driver
         to become available. Please try to run your command again. If you

--- a/test/unit/plugins/providers/docker/driver_test.rb
+++ b/test/unit/plugins/providers/docker/driver_test.rb
@@ -152,6 +152,27 @@ describe VagrantPlugins::DockerProvider::Driver do
 ].to_json }
 
 
+  describe '#build' do
+    let(:result) { "Successfully built 1a2b3c4d" }
+    let(:buildkit_result) { "writing image sha256:1a2b3c4d done" }
+    let(:cid) { "1a2b3c4d" }
+
+    it "builds a container with standard docker" do
+      allow(subject).to receive(:execute).and_return(result)
+
+      container_id = subject.build("/tmp/fakedir")
+
+      expect(container_id).to eq(cid)
+    end
+
+    it "builds a container with buildkit docker" do
+      allow(subject).to receive(:execute).and_return(buildkit_result)
+
+      container_id = subject.build("/tmp/fakedir")
+
+      expect(container_id).to eq(cid)
+    end
+  end
 
   describe '#create' do
     let(:params) { {


### PR DESCRIPTION
Prior to this pull request, docker would look for a container ID based on
"Successfully built" string. This output does not exist if a user has
enabled the experimental feature `buildkit`. This commit updates the build
behavior to match against both kinds of outputs, and instead of using
`scan`, it uses MatchData and groups the container id with match group
name `:id` instead of making hard assumptions with the matches being
contained inside arrays from scan.

This is an enhancement based off of https://github.com/hashicorp/vagrant/pull/11197