### PR TITLE
Fixes #11207: Do not validate checksums if options are empty string

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -348,9 +348,15 @@ module Vagrant
             end
 
             if opts[:checksum] && opts[:checksum_type]
-              env[:ui].detail(I18n.t("vagrant.actions.box.add.checksumming"))
-              validate_checksum(
-                opts[:checksum_type], opts[:checksum], box_url)
+              if opts[:checksum].to_s.strip.empty?
+                @logger.warn("Given checksum is empty, cannot validate checksum for box")
+              elsif opts[:checksum_type].to_s.strip.empty?
+                @logger.warn("Given checksum type is empty, cannot validate checksum for box")
+              else
+                env[:ui].detail(I18n.t("vagrant.actions.box.add.checksumming"))
+                validate_checksum(
+                  opts[:checksum_type], opts[:checksum], box_url)
+              end
             end
 
             # Add the box!

--- a/lib/vagrant/util/file_checksum.rb
+++ b/lib/vagrant/util/file_checksum.rb
@@ -66,7 +66,8 @@ class FileChecksum
     digest = CHECKSUM_MAP[type.to_s.to_sym]
     if digest.nil?
       raise Vagrant::Errors::BoxChecksumInvalidType,
-        type: type.to_s
+        type: type.to_s,
+        types: CHECKSUM_MAP.keys.join(', ')
     end
     digest
   end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -578,7 +578,7 @@ en:
         The specified checksum type is not supported by Vagrant: %{type}.
         Vagrant supports the following checksum types:
 
-        md5, sha1, sha256
+        %{types}
       box_checksum_mismatch: |-
         The checksum of the downloaded box did not match the expected
         value. Please verify that you have the proper URL setup and that


### PR DESCRIPTION
Prior to this commit, if Vagrant received checksum options from Vagrant
Cloud that were simply empty strings, it would try to validate its
checksum with those options. This commit fixes that by ignoring empty
string values.