### PR TITLE
Ensure `nfs-server` is restarted when installing nfs client for redhat guests

### DIFF
--- a/plugins/guests/redhat/cap/nfs_client.rb
+++ b/plugins/guests/redhat/cap/nfs_client.rb
@@ -15,7 +15,7 @@ module VagrantPlugins
             fi
 
             if test $(ps -o comm= 1) == 'systemd'; then
-              /bin/systemctl restart rpcbind nfs
+              /bin/systemctl restart rpcbind nfs-server
             else
               /etc/init.d/rpcbind restart
               /etc/init.d/nfs restart

--- a/plugins/guests/redhat/cap/nfs_client.rb
+++ b/plugins/guests/redhat/cap/nfs_client.rb
@@ -5,7 +5,7 @@ module VagrantPlugins
         def self.nfs_client_install(machine)
           machine.communicate.sudo <<-EOH.gsub(/^ {12}/, '')
             if command -v dnf; then
-              if `dnf info -q libnfs-utils > /dev/null 2>&1` ; then 
+              if `dnf info -q libnfs-utils > /dev/null 2>&1` ; then
                 dnf -y install nfs-utils libnfs-utils portmap
               else
                 dnf -y install nfs-utils nfs-utils-lib portmap

--- a/test/unit/plugins/guests/redhat/cap/nfs_client_test.rb
+++ b/test/unit/plugins/guests/redhat/cap/nfs_client_test.rb
@@ -24,7 +24,7 @@ describe "VagrantPlugins::GuestRedHat::Cap:NFSClient" do
     it "installs nfs client" do
       cap.nfs_client_install(machine)
       expect(comm.received_commands[0]).to match(/install nfs-utils/)
-      expect(comm.received_commands[0]).to match(/\/bin\/systemctl restart rpcbind nfs/)
+      expect(comm.received_commands[0]).to match(/\/bin\/systemctl restart rpcbind nfs-server/)
     end
   end
 end


### PR DESCRIPTION
This pull request is a fixup of the original pull request https://github.com/hashicorp/vagrant/pull/11133, which ensures that `nfs-server` is restarted when installing the nfs client on redhat guests, rather than `nfs`, which is no longer valid for redhat guests that use systemd with systemctl.

Fixes #10838