### PR TITLE
Darwin: put each NFS export on its own line

### DIFF
--- a/plugins/hosts/darwin/cap/nfs.rb
+++ b/plugins/hosts/darwin/cap/nfs.rb
@@ -1,0 +1,11 @@
+module VagrantPlugins
+  module HostDarwin
+    module Cap
+      class NFS
+        def self.nfs_exports_template(environment)
+          "nfs/exports_darwin"
+        end
+      end
+    end
+  end
+end

--- a/plugins/hosts/darwin/plugin.rb
+++ b/plugins/hosts/darwin/plugin.rb
@@ -55,6 +55,11 @@ module VagrantPlugins
         require_relative "cap/configured_ip_addresses"
         Cap::ConfiguredIPAddresses
       end
+
+      host_capability("darwin", "nfs_exports_template") do
+        require_relative "cap/nfs"
+        Cap::NFS
+      end
     end
   end
 end

--- a/templates/nfs/exports_darwin.erb
+++ b/templates/nfs/exports_darwin.erb
@@ -1,0 +1,7 @@
+# VAGRANT-BEGIN: <%= user %> <%= uuid %>
+<% folders.each do |dirs, opts| %>
+<% dirs.each do |d| %>
+<%= d %> <%=opts[:bsd__compiled_nfs_options] %> <%= ips.join(" ") %>
+<% end %>
+<% end %>
+# VAGRANT-END: <%= user %> <%= uuid %>

--- a/test/unit/plugins/hosts/darwin/cap/nfs_test.rb
+++ b/test/unit/plugins/hosts/darwin/cap/nfs_test.rb
@@ -1,0 +1,17 @@
+require_relative "../../../../base"
+
+require_relative "../../../../../../plugins/hosts/darwin/cap/nfs"
+
+describe VagrantPlugins::HostDarwin::Cap::NFS do
+  include_context "unit"
+
+  let(:subject){ VagrantPlugins::HostDarwin::Cap::NFS }
+
+  it "exists" do
+    expect(subject).to_not be(nil)
+  end
+
+  it "should use nfs/exports_darwin as its template" do
+    expect(subject.nfs_exports_template(nil)).to eq("nfs/exports_darwin")
+  end
+end

--- a/test/unit/templates/nfs/exports_darwin_test.rb
+++ b/test/unit/templates/nfs/exports_darwin_test.rb
@@ -1,0 +1,68 @@
+require_relative "../../base"
+
+require "vagrant/util/template_renderer"
+
+describe "templates/nfs/exports_darwin" do
+  let(:template) { "nfs/exports_darwin" }
+  let(:user) { "501" }
+  let(:uuid) { "UUID" }
+  let(:opts) { {:bsd__compiled_nfs_options => "-alldirs -mapall=501:80"} }
+  let(:ips) { ["172.16.0.2"] }
+
+  it "renders the template" do
+    result = Vagrant::Util::TemplateRenderer.render(template, {
+      user:    user,
+      uuid:    uuid,
+      folders: []
+    })
+    expect(result).to eq <<-EOH.gsub(/^ {6}/, "")
+      # VAGRANT-BEGIN: 501 UUID
+      # VAGRANT-END: 501 UUID
+    EOH
+  end
+
+  context "one nfs mount" do
+    let(:folders) {
+      {
+        ["/vagrant"] => opts
+      }
+    }
+
+    it "renders the template" do
+      result = Vagrant::Util::TemplateRenderer.render(template, {
+        user:    user,
+        uuid:    uuid,
+        folders: folders,
+        ips:     ips
+      })
+      expect(result).to eq <<-EOH.gsub(/^ {8}/, "")
+        # VAGRANT-BEGIN: 501 UUID
+        /vagrant -alldirs -mapall=501:80 172.16.0.2
+        # VAGRANT-END: 501 UUID
+      EOH
+    end
+  end
+
+  context "subdirectory that should also be exported" do
+    let(:folders) {
+      {
+        ["/vagrant", "/vagrant/other"] => opts
+      }
+    }
+
+    it "puts each directory on its own line" do
+      result = Vagrant::Util::TemplateRenderer.render(template, {
+        user:    user,
+        uuid:    uuid,
+        folders: folders,
+        ips:     ips
+      })
+      expect(result).to eq <<-EOH.gsub(/^ {8}/, "")
+        # VAGRANT-BEGIN: 501 UUID
+        /vagrant -alldirs -mapall=501:80 172.16.0.2
+        /vagrant/other -alldirs -mapall=501:80 172.16.0.2
+        # VAGRANT-END: 501 UUID
+      EOH
+    end
+  end
+end


### PR DESCRIPTION
This PR implements the workaround for NFS issues with macOS Catalina mentioned here: https://github.com/hashicorp/vagrant/issues/11144#issuecomment-557085624.

Tested on macOS Mojave (10.14.6) and macOS Catalina (10.15.1).

It seems to resolve mount issues/timeouts in guests as well as `nfsd` service on host exiting due to SIGSEGV.