### PR TITLE
[WIP]Added support for PS Core to fix #11085powershell-fix

### DIFF
--- a/lib/vagrant/util/powershell.rb
+++ b/lib/vagrant/util/powershell.rb
@@ -15,6 +15,7 @@ module Vagrant
       # Number of seconds to wait while attempting to get powershell version
       DEFAULT_VERSION_DETECTION_TIMEOUT = 30
       LOGGER = Log4r::Logger.new("vagrant::util::powershell")
+      POWERSHELL_CORE_EXE = "pwsh"
 
       # @return [String|nil] a powershell executable, depending on environment
       def self.executable
@@ -34,6 +35,8 @@ module Vagrant
                   @_powershell_executable = nil
                 end
               end
+            elsif !Which.which(POWERSHELL_CORE_EXE).nil?
+              @_powershell_executable = POWERSHELL_CORE_EXE
             else
               @_powershell_executable = nil
             end


### PR DESCRIPTION
Added an additional path check for "pwsh" to detect versionf of PowerShell Core that may be on the user's PATH. This also opens up the possibility of removing Windows specific references in this file, as Core can be installed on Linux and mac OS, giving us the ability to expand Powershell into a cross-platform plugin.

This is a WIP right now because I have no ability to test. I have VMWare Workstation on my machine right now, and sadly cannot afford the $79 for the VMWare provider because I am unemployed right now. I was hoping someone else would be willing to run all of the acceptance tests to save me the hassle of setting up a new Windows VM for testing. I couldn't think of a way to easily write a unit test for this unfortunately.

If no one is able to help, I can set up a VM in a week or so when I get back from Thanksgiving.

Signed-off-by: Scott Simontis <yo@scottsimontis.io>