### PR TITLE
completion.sh: add more up options

### DIFF
--- a/contrib/bash/completion.sh
+++ b/contrib/bash/completion.sh
@@ -75,7 +75,19 @@ _vagrant() {
               then
                 local vm_list=$(find "${vagrant_state_file}/machines" -mindepth 1 -maxdepth 1 -type d -exec basename {} \;)
               fi
-              local up_commands="--no-provision"
+              local up_commands="\
+                --provision \
+                --no-provision \
+                --provision-with \
+                --destroy-on-error \
+                --no-destroy-on-error \
+                --parallel \
+                --no-parallel
+                --provider \
+                --install-provider \
+                --no-install-provider \
+                -h \
+                --help"
               COMPREPLY=($(compgen -W "${up_commands} ${vm_list}" -- ${cur}))
               return 0
             ;;


### PR DESCRIPTION
I noted the `--provision` option which I currently needed (to retry an Ansible playbook that had failed) was missing, so I added this along with all other options I could find. They are ordered in the same order as they are listed in the `--help` output.