### PR TITLE
ansible_local: Add `cap` bug fixes and related RSpec coverage

### DIFF
--- a/plugins/provisioners/ansible/cap/guest/arch/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/arch/ansible_install.rb
@@ -1,4 +1,5 @@
-require_relative "../../../errors"
+require_relative '../../../errors'
+require_relative '../pip/pip'
 
 module VagrantPlugins
   module Ansible
@@ -7,13 +8,27 @@ module VagrantPlugins
         module Arch
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
-              if install_mode != :default
-                raise Ansible::Errors::AnsiblePipInstallIsNotSupported
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd='')
+              case install_mode
+              when :pip
+                pip_setup machine, pip_install_cmd
+                Pip::pip_install machine, 'ansible', ansible_version, pip_args, true
+
+              when :pip_args_only
+                pip_setup machine, pip_install_cmd
+                Pip::pip_install machine, '', '', pip_args, false
+
               else
-                machine.communicate.sudo "pacman -Syy --noconfirm"
-                machine.communicate.sudo "pacman -S --noconfirm ansible"
+                machine.communicate.sudo 'pacman -Syy --noconfirm'
+                machine.communicate.sudo 'pacman -S --noconfirm ansible'
               end
+            end
+
+            def self.pip_setup(machine, pip_install_cmd='')
+              machine.communicate.sudo 'pacman -Syy --noconfirm'
+              machine.communicate.sudo 'pacman -S --noconfirm base-devel curl git'
+
+              Pip::get_pip machine, pip_install_cmd
             end
 
           end
@@ -22,3 +37,5 @@ module VagrantPlugins
     end
   end
 end
+
+

--- a/plugins/provisioners/ansible/cap/guest/arch/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/arch/ansible_install.rb
@@ -28,7 +28,7 @@ module VagrantPlugins
 
             def self.pip_setup(machine, pip_install_cmd = "")
               machine.communicate.sudo "pacman -Syy --noconfirm"
-              machine.communicate.sudo "pacman -S --noconfirm base-devel curl git"
+              machine.communicate.sudo "pacman -S --noconfirm base-devel curl git python"
 
               Pip::get_pip machine, pip_install_cmd
             end

--- a/plugins/provisioners/ansible/cap/guest/arch/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/arch/ansible_install.rb
@@ -1,5 +1,5 @@
-require_relative '../../../errors'
-require_relative '../pip/pip'
+require_relative "../../../errors"
+require_relative "../pip/pip"
 
 module VagrantPlugins
   module Ansible
@@ -8,25 +8,27 @@ module VagrantPlugins
         module Arch
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd='')
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd = "")
               case install_mode
               when :pip
                 pip_setup machine, pip_install_cmd
-                Pip::pip_install machine, 'ansible', ansible_version, pip_args, true
+                Pip::pip_install machine, "ansible", ansible_version, pip_args, true
 
               when :pip_args_only
                 pip_setup machine, pip_install_cmd
-                Pip::pip_install machine, '', '', pip_args, false
+                Pip::pip_install machine, "", "", pip_args, false
 
               else
-                machine.communicate.sudo 'pacman -Syy --noconfirm'
-                machine.communicate.sudo 'pacman -S --noconfirm ansible'
+                machine.communicate.sudo "pacman -Syy --noconfirm"
+                machine.communicate.sudo "pacman -S --noconfirm ansible"
               end
             end
 
-            def self.pip_setup(machine, pip_install_cmd='')
-              machine.communicate.sudo 'pacman -Syy --noconfirm'
-              machine.communicate.sudo 'pacman -S --noconfirm base-devel curl git'
+            private
+
+            def self.pip_setup(machine, pip_install_cmd = "")
+              machine.communicate.sudo "pacman -Syy --noconfirm"
+              machine.communicate.sudo "pacman -S --noconfirm base-devel curl git"
 
               Pip::get_pip machine, pip_install_cmd
             end
@@ -37,5 +39,3 @@ module VagrantPlugins
     end
   end
 end
-
-

--- a/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
@@ -7,8 +7,7 @@ module VagrantPlugins
         module Debian
           module AnsibleInstall
 
-
-            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd="")
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd = "")
               case install_mode
               when :pip
                 pip_setup machine, pip_install_cmd
@@ -36,7 +35,7 @@ INLINE_CRIPT
               machine.communicate.sudo "apt-get install -y -qq ansible"
             end
 
-            def self.pip_setup(machine, pip_install_cmd="")
+            def self.pip_setup(machine, pip_install_cmd = "")
               machine.communicate.sudo "apt-get update -y -qq"
               machine.communicate.sudo "apt-get install -y -qq build-essential curl git libssl-dev libffi-dev python-dev"
               Pip::get_pip machine, pip_install_cmd

--- a/plugins/provisioners/ansible/cap/guest/fedora/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/fedora/ansible_install.rb
@@ -8,7 +8,7 @@ module VagrantPlugins
         module Fedora
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd="")
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd = "")
               case install_mode
               when :pip
                 pip_setup machine, pip_install_cmd
@@ -25,7 +25,7 @@ module VagrantPlugins
 
             private
 
-            def self.pip_setup(machine, pip_install_cmd="")
+            def self.pip_setup(machine, pip_install_cmd = "")
               rpm_package_manager = Facts::rpm_package_manager(machine)
 
               machine.communicate.sudo "#{rpm_package_manager} install -y curl gcc gmp-devel libffi-devel openssl-devel python-crypto python-devel python-dnf python-setuptools redhat-rpm-config"

--- a/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
         module FreeBSD
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd = "")
               if install_mode != :default
                 raise Ansible::Errors::AnsiblePipInstallIsNotSupported
               else

--- a/plugins/provisioners/ansible/cap/guest/pip/pip.rb
+++ b/plugins/provisioners/ansible/cap/guest/pip/pip.rb
@@ -16,8 +16,12 @@ module VagrantPlugins
             end
 
             args_array = [pip_args, upgrade_arg, "#{package}#{version_arg}"]
+            args_array.reject! { |a| a.nil? || a.empty? }
 
-            machine.communicate.sudo "pip install #{args_array.join(' ')}"
+            pip_install = "pip install"
+            pip_install += " #{args_array.join(' ')}" unless args_array.empty?
+
+            machine.communicate.sudo pip_install
           end
 
           def self.get_pip(machine, pip_install_cmd=DEFAULT_PIP_INSTALL_CMD)

--- a/plugins/provisioners/ansible/cap/guest/pip/pip.rb
+++ b/plugins/provisioners/ansible/cap/guest/pip/pip.rb
@@ -24,15 +24,15 @@ module VagrantPlugins
             machine.communicate.sudo pip_install
           end
 
-          def self.get_pip(machine, pip_install_cmd=DEFAULT_PIP_INSTALL_CMD)
+          def self.get_pip(machine, pip_install_cmd = DEFAULT_PIP_INSTALL_CMD)
             # The objective here is to get pip either by default
-            # or by the argument passed in. The objective is not 
+            # or by the argument passed in. The objective is not
             # to circumvent the pip setup by passing in nothing.
             # Thus, we stick with the default on an empty string.
             # Typecast added in the check for safety.
 
             if pip_install_cmd.to_s.empty?
-              pip_install_cmd=DEFAULT_PIP_INSTALL_CMD
+              pip_install_cmd = DEFAULT_PIP_INSTALL_CMD
             end
 
             machine.ui.detail I18n.t("vagrant.provisioners.ansible.installing_pip")

--- a/plugins/provisioners/ansible/cap/guest/redhat/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/redhat/ansible_install.rb
@@ -8,7 +8,7 @@ module VagrantPlugins
         module RedHat
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd="")
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd = "")
               case install_mode
               when :pip
                 pip_setup machine, pip_install_cmd
@@ -33,7 +33,7 @@ module VagrantPlugins
               machine.communicate.sudo "#{rpm_package_manager} -y --enablerepo=epel install ansible"
             end
 
-            def self.pip_setup(machine, pip_install_cmd="")
+            def self.pip_setup(machine, pip_install_cmd = "")
               rpm_package_manager = Facts::rpm_package_manager(machine)
 
               machine.communicate.sudo("#{rpm_package_manager} -y install curl gcc libffi-devel openssl-devel python-crypto python-devel python-setuptools")

--- a/plugins/provisioners/ansible/cap/guest/suse/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/suse/ansible_install.rb
@@ -1,3 +1,4 @@
+require_relative "../../../errors"
 
 module VagrantPlugins
   module Ansible
@@ -6,7 +7,7 @@ module VagrantPlugins
         module SUSE
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd = "")
               if install_mode != :default
                 raise Ansible::Errors::AnsiblePipInstallIsNotSupported
               else

--- a/plugins/provisioners/ansible/cap/guest/ubuntu/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/ubuntu/ansible_install.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
         module Ubuntu
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd="")
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd = "")
               if install_mode != :default
                 Debian::AnsibleInstall::ansible_install machine, install_mode, ansible_version, pip_args, pip_install_cmd
               else

--- a/test/unit/plugins/provisioners/ansible/cap/guest/arch/ansible_install_test.rb
+++ b/test/unit/plugins/provisioners/ansible/cap/guest/arch/ansible_install_test.rb
@@ -1,9 +1,7 @@
 require_relative "../../../../../../base"
 require_relative "../shared/pip_ansible_install_examples"
 
-
 require Vagrant.source_root.join("plugins/provisioners/ansible/cap/guest/arch/ansible_install")
-
 
 describe VagrantPlugins::Ansible::Cap::Guest::Arch::AnsibleInstall do
   include_context "unit"

--- a/test/unit/plugins/provisioners/ansible/cap/guest/arch/ansible_install_test.rb
+++ b/test/unit/plugins/provisioners/ansible/cap/guest/arch/ansible_install_test.rb
@@ -1,0 +1,59 @@
+require_relative "../../../../../../base"
+require_relative "../shared/pip_ansible_install_examples"
+
+
+require Vagrant.source_root.join("plugins/provisioners/ansible/cap/guest/arch/ansible_install")
+
+
+describe VagrantPlugins::Ansible::Cap::Guest::Arch::AnsibleInstall do
+  include_context "unit"
+
+  subject { VagrantPlugins::Ansible::Cap::Guest::Arch::AnsibleInstall }
+
+  let(:iso_env) do
+    # We have to create a Vagrantfile so there is a root path
+    env = isolated_environment
+    env.vagrantfile("")
+    env.create_vagrant_env
+  end
+
+  let(:machine) { iso_env.machine(iso_env.machine_names[0], :dummy) }
+  let(:communicator) { double("comm") }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(communicator)
+    allow(communicator).to receive(:execute).and_return(true)
+  end
+
+  describe "#pip_setup" do
+    it "install required Arch packages and call Cap::Guest::Pip::get_pip" do
+      pip_install_cmd = "foo"
+
+      expect(communicator).to receive(:sudo).once.ordered.
+        with("pacman -Syy --noconfirm")
+      expect(communicator).to receive(:sudo).once.ordered.
+        with("pacman -S --noconfirm base-devel curl git")
+      expect(VagrantPlugins::Ansible::Cap::Guest::Pip).to receive(:get_pip).once.ordered.
+        with(machine, pip_install_cmd)
+
+      subject.pip_setup(machine, pip_install_cmd)
+    end
+  end
+
+  describe "#ansible_install" do
+
+    it_behaves_like "Ansible setup via pip"
+
+    describe "when install_mode is :default (or unknown)" do
+      it "installs ansible with 'pacman' package manager" do
+        expect(communicator).to receive(:sudo).once.ordered.
+          with("pacman -Syy --noconfirm")
+        expect(communicator).to receive(:sudo).once.ordered.
+          with("pacman -S --noconfirm ansible")
+
+        subject.ansible_install(machine, :default, "", "", "")
+      end
+    end
+  end
+
+end

--- a/test/unit/plugins/provisioners/ansible/cap/guest/arch/ansible_install_test.rb
+++ b/test/unit/plugins/provisioners/ansible/cap/guest/arch/ansible_install_test.rb
@@ -32,7 +32,7 @@ describe VagrantPlugins::Ansible::Cap::Guest::Arch::AnsibleInstall do
       expect(communicator).to receive(:sudo).once.ordered.
         with("pacman -Syy --noconfirm")
       expect(communicator).to receive(:sudo).once.ordered.
-        with("pacman -S --noconfirm base-devel curl git")
+        with("pacman -S --noconfirm base-devel curl git python")
       expect(VagrantPlugins::Ansible::Cap::Guest::Pip).to receive(:get_pip).once.ordered.
         with(machine, pip_install_cmd)
 

--- a/test/unit/plugins/provisioners/ansible/cap/guest/debian/ansible_install_test.rb
+++ b/test/unit/plugins/provisioners/ansible/cap/guest/debian/ansible_install_test.rb
@@ -1,0 +1,50 @@
+require_relative "../../../../../../base"
+require_relative "../shared/pip_ansible_install_examples"
+
+
+require Vagrant.source_root.join("plugins/provisioners/ansible/cap/guest/debian/ansible_install")
+
+
+describe VagrantPlugins::Ansible::Cap::Guest::Debian::AnsibleInstall do
+  include_context "unit"
+
+  subject { VagrantPlugins::Ansible::Cap::Guest::Debian::AnsibleInstall }
+
+  let(:iso_env) do
+    # We have to create a Vagrantfile so there is a root path
+    env = isolated_environment
+    env.vagrantfile("")
+    env.create_vagrant_env
+  end
+
+  let(:machine) { iso_env.machine(iso_env.machine_names[0], :dummy) }
+  let(:communicator) { double("comm") }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(communicator)
+    allow(communicator).to receive(:execute).and_return(true)
+  end
+
+  describe "#ansible_install" do
+
+    it_behaves_like "Ansible setup via pip on Debian-based systems"
+
+    describe "when install_mode is :default (or unknown)" do
+      it "installs ansible with apt package manager" do
+        install_backports_if_wheezy_release = <<INLINE_CRIPT
+CODENAME=`lsb_release -cs`
+if [ x$CODENAME == 'xwheezy' ]; then
+  echo 'deb http://http.debian.net/debian wheezy-backports main' > /etc/apt/sources.list.d/wheezy-backports.list
+fi
+INLINE_CRIPT
+
+        expect(communicator).to receive(:sudo).once.ordered.with(install_backports_if_wheezy_release)
+        expect(communicator).to receive(:sudo).once.ordered.with("apt-get update -y -qq")
+        expect(communicator).to receive(:sudo).once.ordered.with("apt-get install -y -qq ansible")
+
+        subject.ansible_install(machine, :default, "", "", "")
+      end
+    end
+  end
+
+end

--- a/test/unit/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install_test.rb
+++ b/test/unit/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install_test.rb
@@ -1,0 +1,41 @@
+require_relative "../../../../../../base"
+require_relative "../shared/pip_ansible_install_examples"
+
+
+require Vagrant.source_root.join("plugins/provisioners/ansible/cap/guest/freebsd/ansible_install")
+
+
+describe VagrantPlugins::Ansible::Cap::Guest::FreeBSD::AnsibleInstall do
+  include_context "unit"
+
+  subject { VagrantPlugins::Ansible::Cap::Guest::FreeBSD::AnsibleInstall }
+
+  let(:iso_env) do
+    # We have to create a Vagrantfile so there is a root path
+    env = isolated_environment
+    env.vagrantfile("")
+    env.create_vagrant_env
+  end
+
+  let(:machine) { iso_env.machine(iso_env.machine_names[0], :dummy) }
+  let(:communicator) { double("comm") }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(communicator)
+    allow(communicator).to receive(:execute).and_return(true)
+  end
+
+  describe "#ansible_install" do
+
+    it_behaves_like "Ansible setup via pip is not implemented"
+
+    describe "when install_mode is :default (or unknown)" do
+      it "installs ansible with 'pkg' package manager" do
+        expect(communicator).to receive(:sudo).with("yes | pkg install ansible")
+
+        subject.ansible_install(machine, :default, "", "", "")
+      end
+    end
+  end
+
+end

--- a/test/unit/plugins/provisioners/ansible/cap/guest/pip/pip_test.rb
+++ b/test/unit/plugins/provisioners/ansible/cap/guest/pip/pip_test.rb
@@ -23,30 +23,30 @@ describe VagrantPlugins::Ansible::Cap::Guest::Pip do
   end
 
   describe "#get_pip" do
-    describe 'when no pip_install_command argument is provided' do
+    describe 'when no pip_install_cmd argument is provided' do
       it "installs pip using the default command" do
         expect(communicator).to receive(:execute).with("curl https://bootstrap.pypa.io/get-pip.py | sudo python")
         subject.get_pip(machine)
       end
     end
 
-    describe 'when pip_install_command argument is provided' do
+    describe 'when pip_install_cmd argument is provided' do
       it "runs the supplied argument instead of default" do
-        pip_install_command = "foo"
-        expect(communicator).to receive(:execute).with(pip_install_command)
-        subject.get_pip(machine,pip_install_command)
+        pip_install_cmd = "foo"
+        expect(communicator).to receive(:execute).with(pip_install_cmd)
+        subject.get_pip(machine, pip_install_cmd)
       end
 
       it "installs pip using the default command if the argument is empty" do
-        pip_install_command = ""
+        pip_install_cmd = ""
         expect(communicator).to receive(:execute).with("curl https://bootstrap.pypa.io/get-pip.py | sudo python")
-        subject.get_pip(machine,pip_install_command)
-      end 
-        
+        subject.get_pip(machine, pip_install_cmd)
+      end
+
       it "installs pip using the default command if the argument is nil" do
         expect(communicator).to receive(:execute).with("curl https://bootstrap.pypa.io/get-pip.py | sudo python")
         subject.get_pip(machine, nil)
-      end         
-    end    
+      end
+    end
   end
 end

--- a/test/unit/plugins/provisioners/ansible/cap/guest/pip/pip_test.rb
+++ b/test/unit/plugins/provisioners/ansible/cap/guest/pip/pip_test.rb
@@ -23,28 +23,37 @@ describe VagrantPlugins::Ansible::Cap::Guest::Pip do
   end
 
   describe "#get_pip" do
-    describe 'when no pip_install_cmd argument is provided' do
+    describe "when no pip_install_cmd argument is provided" do
       it "installs pip using the default command" do
-        expect(communicator).to receive(:execute).with("curl https://bootstrap.pypa.io/get-pip.py | sudo python")
+        expect(communicator).to receive(:execute).
+          with("curl https://bootstrap.pypa.io/get-pip.py | sudo python")
+
         subject.get_pip(machine)
       end
     end
 
-    describe 'when pip_install_cmd argument is provided' do
+    describe "when pip_install_cmd argument is provided" do
       it "runs the supplied argument instead of default" do
         pip_install_cmd = "foo"
+
         expect(communicator).to receive(:execute).with(pip_install_cmd)
+
         subject.get_pip(machine, pip_install_cmd)
       end
 
       it "installs pip using the default command if the argument is empty" do
         pip_install_cmd = ""
-        expect(communicator).to receive(:execute).with("curl https://bootstrap.pypa.io/get-pip.py | sudo python")
+
+        expect(communicator).to receive(:execute).
+          with("curl https://bootstrap.pypa.io/get-pip.py | sudo python")
+
         subject.get_pip(machine, pip_install_cmd)
       end
 
       it "installs pip using the default command if the argument is nil" do
-        expect(communicator).to receive(:execute).with("curl https://bootstrap.pypa.io/get-pip.py | sudo python")
+        expect(communicator).to receive(:execute).
+          with("curl https://bootstrap.pypa.io/get-pip.py | sudo python")
+
         subject.get_pip(machine, nil)
       end
     end

--- a/test/unit/plugins/provisioners/ansible/cap/guest/shared/pip_ansible_install_examples.rb
+++ b/test/unit/plugins/provisioners/ansible/cap/guest/shared/pip_ansible_install_examples.rb
@@ -1,0 +1,68 @@
+
+shared_examples_for "Ansible setup via pip" do
+
+  describe "when install_mode is :pip" do
+    it "installs pip and calls Cap::Guest::Pip::pip_install" do
+      expect(communicator).to receive(:sudo).at_least(1).times.ordered
+      expect(VagrantPlugins::Ansible::Cap::Guest::Pip).to receive(:pip_install).once.ordered.
+        with(machine, "ansible", anything, anything, true)
+
+      subject.ansible_install(machine, :pip, "", "", "")
+    end
+  end
+
+  describe "when install_mode is :pip_args_only" do
+    it "installs pip and calls Cap::Guest::Pip::pip_install with 'pip_args' parameter" do
+      pip_args = "-r /vagrant/requirements.txt"
+
+      expect(communicator).to receive(:sudo).at_least(1).times.ordered
+      expect(VagrantPlugins::Ansible::Cap::Guest::Pip).to receive(:pip_install).with(machine, "", "", pip_args, false).ordered
+
+      subject.ansible_install(machine, :pip_args_only, "", pip_args, "")
+    end
+  end
+
+end
+
+shared_examples_for "Ansible setup via pip on Debian-based systems" do
+
+  describe "installs required Debian packages and..." do
+    pip_install_cmd = "foo"
+
+    it "calls Cap::Guest::Pip::get_pip with 'pip' install_mode" do
+      expect(communicator).to receive(:sudo).once.ordered.
+        with("apt-get update -y -qq")
+      expect(communicator).to receive(:sudo).once.ordered.
+        with("apt-get install -y -qq build-essential curl git libssl-dev libffi-dev python-dev")
+      expect(communicator).to receive(:sudo).once.ordered.
+        with("pip install --upgrade ansible")
+
+      subject.ansible_install(machine, :pip, "", "", pip_install_cmd)
+    end
+
+    it "calls Cap::Guest::Pip::get_pip with 'pip_args_only' install_mode" do
+      expect(communicator).to receive(:sudo).once.ordered.
+        with("apt-get update -y -qq")
+      expect(communicator).to receive(:sudo).once.ordered.
+        with("apt-get install -y -qq build-essential curl git libssl-dev libffi-dev python-dev")
+      expect(communicator).to receive(:sudo).once.ordered.
+        with("pip install")
+
+      subject.ansible_install(machine, :pip_args_only, "", "", pip_install_cmd)
+    end
+
+  end
+
+  it_behaves_like "Ansible setup via pip"
+
+end
+
+shared_examples_for "Ansible setup via pip is not implemented" do
+
+  describe "when install_mode is different from :default" do
+    it "raises an AnsiblePipInstallIsNotSupported error" do
+      expect { subject.ansible_install(machine, :ansible_the_hardway, "", "", "") }.to raise_error(VagrantPlugins::Ansible::Errors::AnsiblePipInstallIsNotSupported)
+    end
+  end
+
+end

--- a/test/unit/plugins/provisioners/ansible/cap/guest/suse/ansible_install_test.rb
+++ b/test/unit/plugins/provisioners/ansible/cap/guest/suse/ansible_install_test.rb
@@ -1,0 +1,41 @@
+require_relative "../../../../../../base"
+require_relative "../shared/pip_ansible_install_examples"
+
+
+require Vagrant.source_root.join("plugins/provisioners/ansible/cap/guest/suse/ansible_install")
+
+
+describe VagrantPlugins::Ansible::Cap::Guest::SUSE::AnsibleInstall do
+  include_context "unit"
+
+  subject { VagrantPlugins::Ansible::Cap::Guest::SUSE::AnsibleInstall }
+
+  let(:iso_env) do
+    # We have to create a Vagrantfile so there is a root path
+    env = isolated_environment
+    env.vagrantfile("")
+    env.create_vagrant_env
+  end
+
+  let(:machine) { iso_env.machine(iso_env.machine_names[0], :dummy) }
+  let(:communicator) { double("comm") }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(communicator)
+    allow(communicator).to receive(:execute).and_return(true)
+  end
+
+  describe "#ansible_install" do
+
+    it_behaves_like "Ansible setup via pip is not implemented"
+
+    describe "when install_mode is :default (or unknown)" do
+      it "installs ansible with 'zypper' package manager" do
+        expect(communicator).to receive(:sudo).with("zypper --non-interactive --quiet install ansible")
+
+        subject.ansible_install(machine, :default, "", "", "")
+      end
+    end
+  end
+
+end

--- a/test/unit/plugins/provisioners/ansible/cap/guest/ubuntu/ansible_install_test.rb
+++ b/test/unit/plugins/provisioners/ansible/cap/guest/ubuntu/ansible_install_test.rb
@@ -1,0 +1,76 @@
+require_relative "../../../../../../base"
+require_relative "../shared/pip_ansible_install_examples"
+
+
+require Vagrant.source_root.join("plugins/provisioners/ansible/cap/guest/ubuntu/ansible_install")
+
+
+describe VagrantPlugins::Ansible::Cap::Guest::Ubuntu::AnsibleInstall do
+  include_context "unit"
+
+  subject { VagrantPlugins::Ansible::Cap::Guest::Ubuntu::AnsibleInstall }
+
+  let(:iso_env) do
+    # We have to create a Vagrantfile so there is a root path
+    env = isolated_environment
+    env.vagrantfile("")
+    env.create_vagrant_env
+  end
+
+  let(:machine) { iso_env.machine(iso_env.machine_names[0], :dummy) }
+  let(:communicator) { double("comm") }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(communicator)
+    allow(communicator).to receive(:execute).and_return(true)
+  end
+
+  describe "#ansible_install" do
+
+    it_behaves_like "Ansible setup via pip on Debian-based systems"
+
+    describe "when install_mode is :default (or unknown)" do
+      describe "#ansible_apt_install" do
+        describe "installs ansible from ansible/ansible PPA repository" do
+
+          check_if_add_apt_repository_is_present="test -x \"$(which add-apt-repository)\""
+
+          it "first installs 'software-properties-common' package if add-apt-repository is not already present" do
+            allow(communicator).to receive(:test).
+              with(check_if_add_apt_repository_is_present).and_return(false)
+
+            expect(communicator).to receive(:sudo).once.ordered.
+              with("""
+                  apt-get update -y -qq && \
+                  apt-get install -y -qq software-properties-common
+                """)
+            expect(communicator).to receive(:sudo).once.ordered.
+              with("""
+                add-apt-repository ppa:ansible/ansible -y && \
+                apt-get update -y -qq && \
+                apt-get install -y -qq ansible
+              """)
+
+            subject.ansible_install(machine, :default, "", "", "")
+          end
+
+          it "adds 'ppa:ansible/ansible' and install 'ansible' package" do
+            allow(communicator).to receive(:test).
+              with(check_if_add_apt_repository_is_present).and_return(true)
+
+            expect(communicator).to receive(:sudo).
+              with("""
+                add-apt-repository ppa:ansible/ansible -y && \
+                apt-get update -y -qq && \
+                apt-get install -y -qq ansible
+              """)
+
+            subject.ansible_install(machine, :default, "", "", "")
+          end
+
+        end
+      end
+    end
+  end
+
+end


### PR DESCRIPTION

## Includes

**Bug Fixes:**
- [x] Review of #11148 (ArchLinux bug fix)
- [x] Fix method signature for FreeBSD and SuSE 

**Improvements:**
- [x] Trim the generated 'pip install' command in Ansible::Cap::Guest::Pip::pip_install

**RSpec Coverage:**
- [x] ArchLinux Guest
- [x] Debian Guest
- [x] Ubuntu Guest
- [x] FreeBSD Guest
- [x] SuSE Guest
- [ ]  Fedora Guest (will be implemented in a distinct PR)
- [ ]  RedHat/CentOS Guest (will be implemented in a distinct PR)

**Integration Tests:**
- [x] `archlinux/archlinux` -> caught  909cc20007bae1ead613c5f2c98c1508ba065a19
- [ ] `freebsd/FreeBSD-12.1-RELEASE` (will very likely be tested by @briancain for #11061/#11263)
- [ ] SuSE 

## References

- GH-6633
- GH-11048
- GH-11263