### PR TITLE
Fixes #11236: Windows port detection

### DIFF
--- a/lib/vagrant/util/is_port_open.rb
+++ b/lib/vagrant/util/is_port_open.rb
@@ -30,8 +30,7 @@ module Vagrant
           return true
         end
       rescue Timeout::Error, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, \
-             Errno::ENETUNREACH, Errno::EACCES, Errno::ENOTCONN, \
-             Errno::EADDRNOTAVAIL
+             Errno::ENETUNREACH, Errno::EACCES, Errno::ENOTCONN
         # Any of the above exceptions signal that the port is closed.
         return false
       end

--- a/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
+++ b/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
@@ -69,7 +69,7 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
     end
 
     context "with forwarded port defined" do
-      let(:port_options){ {guest: 80, host: 8080} }
+      let(:port_options){ {guest: 80, host: 52811} }
       before do
         expect(vm_config).to receive(:networks).and_return([[:forwarded_port, port_options]]).twice
       end
@@ -80,7 +80,7 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
       end
 
       context "with forwarded port already in use" do
-        let(:extra_in_use){ [8080] }
+        let(:extra_in_use){ [52811] }
 
         it "should raise a port collision error" do
           expect{ instance.call(env) }.to raise_error(Vagrant::Errors::ForwardPortCollision)
@@ -105,7 +105,7 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
 
       context "with custom port_check method" do
         let(:check_result){ [] }
-        let(:port_options){ {guest: 80, host: 8080, host_ip: "127.0.1.1"} }
+        let(:port_options){ {guest: 80, host: 52811, host_ip: "127.0.1.1"} }
 
         context "that accepts two parameters" do
           let(:collision_port_check) do
@@ -145,7 +145,7 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
 
   describe "#port_check" do
     let(:host_ip){ "127.0.0.1" }
-    let(:host_port){ 8080 }
+    let(:host_port){ 52811 }
 
     it "should check if the port is open" do
       expect(instance).to receive(:is_port_open?).with(host_ip, host_port).and_return true

--- a/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
+++ b/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
@@ -75,8 +75,8 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
       end
 
       it "should check if host port is in use" do
-        expect(instance).to receive(:is_forwarded_already).and_return false
-        expect(instance).to receive(:is_port_open?).and_return false
+        expect(instance).to receive(:is_forwarded_already).and_return(false)
+        expect(instance).to receive(:is_port_open?).and_return(false)
         instance.call(env)
       end
 
@@ -149,7 +149,7 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
     let(:host_port){ 8080 }
 
     it "should check if the port is open" do
-      expect(instance).to receive(:is_port_open?).with(host_ip, host_port).and_return true
+      expect(instance).to receive(:is_port_open?).with(host_ip, host_port).and_return(true)
       instance.send(:port_check, host_ip, host_port)
     end
 
@@ -157,13 +157,13 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
       let(:host_ip){ nil }
 
       it "should set host_ip to 0.0.0.0 when unset" do
-        expect(instance).to receive(:is_port_open?).with("0.0.0.0", host_port).and_return true
+        expect(instance).to receive(:is_port_open?).with("0.0.0.0", host_port).and_return(true)
         instance.send(:port_check, host_ip, host_port)
       end
 
       it "should set host_ip to 127.0.0.1 when 0.0.0.0 is not available" do
-        expect(instance).to receive(:is_port_open?).with("0.0.0.0", host_port).and_raise Errno::EADDRNOTAVAIL
-        expect(instance).to receive(:is_port_open?).with("127.0.0.1", host_port).and_return true
+        expect(instance).to receive(:is_port_open?).with("0.0.0.0", host_port).and_raise(Errno::EADDRNOTAVAIL)
+        expect(instance).to receive(:is_port_open?).with("127.0.0.1", host_port).and_return(true)
         instance.send(:port_check, host_ip, host_port)
       end
     end

--- a/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
+++ b/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
@@ -69,18 +69,19 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
     end
 
     context "with forwarded port defined" do
-      let(:port_options){ {guest: 80, host: 52811} }
+      let(:port_options){ {guest: 80, host: 8080} }
       before do
         expect(vm_config).to receive(:networks).and_return([[:forwarded_port, port_options]]).twice
       end
 
       it "should check if host port is in use" do
         expect(instance).to receive(:is_forwarded_already).and_return false
+        expect(instance).to receive(:is_port_open?).and_return false
         instance.call(env)
       end
 
       context "with forwarded port already in use" do
-        let(:extra_in_use){ [52811] }
+        let(:extra_in_use){ [8080] }
 
         it "should raise a port collision error" do
           expect{ instance.call(env) }.to raise_error(Vagrant::Errors::ForwardPortCollision)
@@ -105,7 +106,7 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
 
       context "with custom port_check method" do
         let(:check_result){ [] }
-        let(:port_options){ {guest: 80, host: 52811, host_ip: "127.0.1.1"} }
+        let(:port_options){ {guest: 80, host: 8080, host_ip: "127.0.1.1"} }
 
         context "that accepts two parameters" do
           let(:collision_port_check) do
@@ -145,7 +146,7 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
 
   describe "#port_check" do
     let(:host_ip){ "127.0.0.1" }
-    let(:host_port){ 52811 }
+    let(:host_port){ 8080 }
 
     it "should check if the port is open" do
       expect(instance).to receive(:is_port_open?).with(host_ip, host_port).and_return true

--- a/test/unit/vagrant/util/is_port_open_test.rb
+++ b/test/unit/vagrant/util/is_port_open_test.rb
@@ -49,5 +49,15 @@ describe Vagrant::Util::IsPortOpen do
     # best, really.
     expect(klass.is_port_open?("127.0.0.1", closed_port)).not_to be
   end
+
+  it "should handle connection refused" do
+    expect(TCPSocket).to receive(:new).with("0.0.0.0", closed_port).and_raise Errno::ECONNREFUSED
+    expect(klass.is_port_open?("0.0.0.0", closed_port)).to be(false)
+  end
+
+  it "should raise an error if cannot assign requested address" do
+    expect(TCPSocket).to receive(:new).with("0.0.0.0", open_port).and_raise Errno::EADDRNOTAVAIL
+    expect { klass.is_port_open?("0.0.0.0", open_port) }.to raise_error Errno::EADDRNOTAVAIL
+  end
 end
 

--- a/test/unit/vagrant/util/is_port_open_test.rb
+++ b/test/unit/vagrant/util/is_port_open_test.rb
@@ -51,13 +51,13 @@ describe Vagrant::Util::IsPortOpen do
   end
 
   it "should handle connection refused" do
-    expect(TCPSocket).to receive(:new).with("0.0.0.0", closed_port).and_raise Errno::ECONNREFUSED
+    expect(TCPSocket).to receive(:new).with("0.0.0.0", closed_port).and_raise(Errno::ECONNREFUSED)
     expect(klass.is_port_open?("0.0.0.0", closed_port)).to be(false)
   end
 
   it "should raise an error if cannot assign requested address" do
-    expect(TCPSocket).to receive(:new).with("0.0.0.0", open_port).and_raise Errno::EADDRNOTAVAIL
-    expect { klass.is_port_open?("0.0.0.0", open_port) }.to raise_error Errno::EADDRNOTAVAIL
+    expect(TCPSocket).to receive(:new).with("0.0.0.0", open_port).and_raise(Errno::EADDRNOTAVAIL)
+    expect { klass.is_port_open?("0.0.0.0", open_port) }.to raise_error(Errno::EADDRNOTAVAIL)
   end
 end
 


### PR DESCRIPTION
This reverts commit 81553263ab812a7fd0a2ab0f627bee139ad6397c.

This fixes a regression with Windows port detection which led to port
collisions not being fixed on `vagrant up`.

PR #8517 changed `IsPortOpen#is_port_open?` to rescue
Errno::EADDRNOTAVAIL, but there is code
in `HandleForwardedPortCollisions#port_check` that depends on that
error bubbling up.

This PR also changes the port number in the HandleForwardedPortCollisions
tests to be a less common port number -- some of these tests will fail
if there is a local process running on port 8080.