### PR TITLE
Fixes #11249: Add VirtualBox provider support for version 6.1.x

### DIFF
--- a/plugins/providers/virtualbox/driver/meta.rb
+++ b/plugins/providers/virtualbox/driver/meta.rb
@@ -64,6 +64,7 @@ module VagrantPlugins
             "5.1" => Version_5_1,
             "5.2" => Version_5_2,
             "6.0" => Version_6_0,
+            "6.1" => Version_6_1,
           }
 
           if @@version.start_with?("4.2.14")

--- a/plugins/providers/virtualbox/driver/version_6_1.rb
+++ b/plugins/providers/virtualbox/driver/version_6_1.rb
@@ -1,0 +1,16 @@
+require File.expand_path("../version_6_0", __FILE__)
+
+module VagrantPlugins
+  module ProviderVirtualBox
+    module Driver
+      # Driver for VirtualBox 6.1.x
+      class Version_6_1 < Version_6_0
+        def initialize(uuid)
+          super
+
+          @logger = Log4r::Logger.new("vagrant::provider::virtualbox_6_1")
+        end
+      end
+    end
+  end
+end

--- a/plugins/providers/virtualbox/plugin.rb
+++ b/plugins/providers/virtualbox/plugin.rb
@@ -59,6 +59,7 @@ module VagrantPlugins
       autoload :Version_5_1, File.expand_path("../driver/version_5_1", __FILE__)
       autoload :Version_5_2, File.expand_path("../driver/version_5_2", __FILE__)
       autoload :Version_6_0, File.expand_path("../driver/version_6_0", __FILE__)
+      autoload :Version_6_1, File.expand_path("../driver/version_6_1", __FILE__)
     end
 
     module Model

--- a/website/source/docs/virtualbox/index.html.md
+++ b/website/source/docs/virtualbox/index.html.md
@@ -13,7 +13,7 @@ Vagrant comes with support out of the box for [VirtualBox](https://www.virtualbo
 a free, cross-platform consumer virtualization product.
 
 The VirtualBox provider is compatible with VirtualBox versions 4.0.x, 4.1.x,
-4.2.x, 4.3.x, 5.0.x, 5.1.x, 5.2.x, and 6.0.x. Other versions are unsupported and the provider
+4.2.x, 4.3.x, 5.0.x, 5.1.x, 5.2.x, 6.0.x, and 6.1.x. Other versions are unsupported and the provider
 will display an error message. Please note that beta and pre-release versions
 of VirtualBox are not supported and may not be well-behaved.
 


### PR DESCRIPTION
This commit adds support for VirtualBox version 6.1.x. It simply
inherits from the base 6.0.x provider class.