### PR TITLE
Alphabiztize the Website and template

### DIFF
--- a/templates/commands/init/Vagrantfile.erb
+++ b/templates/commands/init/Vagrantfile.erb
@@ -70,7 +70,7 @@ Vagrant.configure("2") do |config|
   # information on available options.
 
   # Enable provisioning with a shell script. Additional provisioners such as
-  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # Ansible, Chef, Docker, Puppet and Salt are also available. Please see the
   # documentation for more information about their specific syntax and use.
   # config.vm.provision "shell", inline: <<-SHELL
   #   apt-get update

--- a/website/source/index.html.erb
+++ b/website/source/index.html.erb
@@ -74,7 +74,7 @@ description: |-
           providing the same operating system, packages, users, and
           configurations, all while giving users the flexibility to use their
           favorite editor, IDE, and browser. Vagrant also integrates with your
-          existing configuration management tooling like Chef, Puppet, Ansible,
+          existing configuration management tooling like Ansible, Chef, Docker, Puppet
           or Salt, so you can use the same scripts to configure Vagrant as
           production.
         </p>


### PR DESCRIPTION
Having these provisioners not alphabitized on the website and
Vagrantfile, seemed odd. This reorders them to be consistent.

Signed-off-by: JJ Asghar <jjasghar@gmail.com>