### PR TITLE
Use WinSSH shell for `vagrant ssh -c`

### DIFF
--- a/lib/vagrant/action/builtin/ssh_run.rb
+++ b/lib/vagrant/action/builtin/ssh_run.rb
@@ -36,7 +36,17 @@ module Vagrant
 
           # Get the command and wrap it in a login shell
           command = ShellQuote.escape(env[:ssh_run_command], "'")
-          command = "#{env[:machine].config.ssh.shell} -c '#{command}'"
+
+          # This will always default to 'bash -l' unless it is explicitly set in
+          # the Vagrantfile, because the base SSHConfig object has already been
+          # finalized.
+          shell = env[:machine].config.ssh.shell
+
+          if env[:machine].config.vm.communicator == :winssh && shell == "cmd"
+            command = "#{shell} /C #{command}"
+          else
+            command = "#{shell} -c '#{command}'"
+          end
 
           # Execute!
           opts = env[:ssh_opts] || {}

--- a/lib/vagrant/action/builtin/ssh_run.rb
+++ b/lib/vagrant/action/builtin/ssh_run.rb
@@ -37,13 +37,17 @@ module Vagrant
           # Get the command and wrap it in a login shell
           command = ShellQuote.escape(env[:ssh_run_command], "'")
 
-          # This will always default to 'bash -l' unless it is explicitly set in
-          # the Vagrantfile, because the base SSHConfig object has already been
-          # finalized.
-          shell = env[:machine].config.ssh.shell
+          if env[:machine].config.vm.communicator == :winssh
+            shell = env[:machine].config.winssh.shell
+          else
+            shell = env[:machine].config.ssh.shell
+          end
 
-          if env[:machine].config.vm.communicator == :winssh && shell == "cmd"
-            command = "#{shell} /C #{command}"
+          if shell == "cmd"
+            # Add an extra space to the command so cmd.exe quoting works
+            # properly
+            command = "#{shell} /C #{command} "
+            env[:tty] = false
           else
             command = "#{shell} -c '#{command}'"
           end

--- a/website/source/docs/vagrantfile/ssh_settings.html.md
+++ b/website/source/docs/vagrantfile/ssh_settings.html.md
@@ -126,9 +126,7 @@ net-ssh library (ignored by the `ssh` executable) and should not be used in gene
 This defaults to the value of `config.ssh.username`.
 
 * `config.ssh.shell` (string) - The shell to use when executing SSH commands from
-Vagrant. By default this is `bash -l`. Note that this has no effect on
-the shell you get when you run `vagrant ssh`. This configuration option
-only affects the shell to use when executing commands internally in Vagrant.
+Vagrant. By default this is `bash -l`.
 
 * `config.ssh.sudo_command` (string) - The command to use when executing a command
 with `sudo`. This defaults to `sudo -E -H %c`. The `%c` will be replaced by

--- a/website/source/docs/vagrantfile/winssh_settings.html.md
+++ b/website/source/docs/vagrantfile/winssh_settings.html.md
@@ -48,9 +48,7 @@ packets every 5 seconds by default to keep connections alive.
 
 * `config.winssh.shell` (string) - The shell to use when executing SSH commands from
 Vagrant. By default this is `cmd`. Valid values are `"cmd"` or `"powershell"`.
-Note that this has no effect on the shell you get when you run `vagrant ssh`.
-This configuration option only affects the shell to use when executing commands
-internally in Vagrant.
+When the WinSSH provider is enabled, this shell will be used when you run `vagrant ssh`.
 
 * `config.winssh.export_command_template` (string) - The template used to generate
 exported environment variables in the active session. This can be useful


### PR DESCRIPTION
This PR changes the behavior of the builtin `SSHRun` action to use a Windows shell if the WinSSH communicator is active.

By default, this will be `cmd`, but it can be overridden by setting the `config.winssh.shell` setting in a Vagrantfile.

Example usage:

```
vagrant ssh -c dir
```

```
vagrant ssh -c 'dir "c:\program files"'
```