### PR TITLE
Return if no disk config

### DIFF
--- a/lib/vagrant/action/builtin/disk.rb
+++ b/lib/vagrant/action/builtin/disk.rb
@@ -12,11 +12,13 @@ module Vagrant
           defined_disks = get_disks(machine, env)
 
           # Call into providers machine implementation for disk management
-          if machine.provider.capability?(:configure_disks)
-           machine.provider.capability(:configure_disks, defined_disks)
-          else
-            env[:ui].warn(I18n.t("vagrant.actions.disk.provider_unsupported",
-                               provider: machine.provider_name))
+          if !defined_disks.empty?
+            if machine.provider.capability?(:configure_disks)
+             machine.provider.capability(:configure_disks, defined_disks)
+            else
+              env[:ui].warn(I18n.t("vagrant.actions.disk.provider_unsupported",
+                                 provider: machine.provider_name))
+            end
           end
 
           # Continue On

--- a/test/unit/vagrant/action/builtin/disk_test.rb
+++ b/test/unit/vagrant/action/builtin/disk_test.rb
@@ -1,0 +1,50 @@
+require File.expand_path("../../../../base", __FILE__)
+
+describe Vagrant::Action::Builtin::Disk do
+  let(:app) { lambda { |env| } }
+  let(:vm) { double("vm") }
+  let(:config) { double("config", vm: vm) }
+  let(:provider) { double("provider") }
+  let(:machine) { double("machine", config: config, provider: provider, provider_name: "provider") }
+  let(:env) { { ui: ui, machine: machine} }
+
+  let(:disks) { [double("disk")] }
+
+  let(:ui)  { double("ui") }
+
+  describe "#call" do
+    it "calls configure_disks if disk config present" do
+      allow(vm).to receive(:disks).and_return(disks)
+      allow(machine).to receive(:disks).and_return(disks)
+      allow(machine.provider).to receive(:capability?).with(:configure_disks).and_return(true)
+      subject = described_class.new(app, env)
+
+      expect(app).to receive(:call).with(env).ordered
+      expect(machine.provider).to receive(:capability).with(:configure_disks, disks)
+
+      subject.call(env)
+    end
+
+    it "continues on if no disk config present" do
+      allow(vm).to receive(:disks).and_return([])
+      subject = described_class.new(app, env)
+
+      expect(app).to receive(:call).with(env).ordered
+      expect(machine.provider).not_to receive(:capability).with(:configure_disks, disks)
+
+      subject.call(env)
+    end
+
+    it "prints a warning if disk config capability is unsupported" do
+      allow(vm).to receive(:disks).and_return(disks)
+      allow(machine.provider).to receive(:capability?).with(:configure_disks).and_return(false)
+      subject = described_class.new(app, env)
+
+      expect(app).to receive(:call).with(env).ordered
+      expect(machine.provider).not_to receive(:capability).with(:configure_disks, disks)
+      expect(ui).to receive(:warn)
+
+      subject.call(env)
+    end
+  end
+end


### PR DESCRIPTION
Prior to this commit, even if a machine had no disk config, the disk action would print a warning saying the feature is unsupported. This commit fixes that by only checking the configure_disk capability if there are any disks to configure. Otherwise, it continues on the action stack and ignores any disk configuring steps.