### PR TITLE
Fix ansible_install for several guest caps

### DIFF
--- a/plugins/provisioners/ansible/cap/guest/arch/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/arch/ansible_install.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
         module Arch
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd="")
               if install_mode != :default
                 raise Ansible::Errors::AnsiblePipInstallIsNotSupported
               else

--- a/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
               if install_mode != :default
                 raise Ansible::Errors::AnsiblePipInstallIsNotSupported
               else
-                machine.communicate.sudo "yes | pkg install ansible"
+                machine.communicate.sudo "pkg install -qy py36-ansible"
               end
             end
 

--- a/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
         module FreeBSD
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd="")
               if install_mode != :default
                 raise Ansible::Errors::AnsiblePipInstallIsNotSupported
               else

--- a/plugins/provisioners/ansible/cap/guest/suse/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/suse/ansible_install.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
         module SUSE
           module AnsibleInstall
 
-            def self.ansible_install(machine, install_mode, ansible_version, pip_args)
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd="")
               if install_mode != :default
                 raise Ansible::Errors::AnsiblePipInstallIsNotSupported
               else


### PR DESCRIPTION
Prior to this commit, several guests were not updated to support the additional parameter `pip_install_cmd`. This commit includes that param, even if it goes unused in the guests. Without this param, Vagrant would crash expecting 4 params on the guest capability, rather than the passed in 5.

This pull request also brings in the PR https://github.com/hashicorp/vagrant/pull/11061, which updates the package used on FreeBSD for installing ansible.