### PR TITLE
depreciated item

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -425,7 +425,7 @@ module Vagrant
         runtime_dependencies.each { |d| gem d.name, *d.requirement.as_list }
       # discover all the gems we have available
       list = {}
-      directories = [Gem::Specification.default_specifications_dir]
+      directories = [Gem.default_specifications_dir]
       Gem::Specification.find_all{true}.each do |spec|
         list[spec.full_name] = spec
       end


### PR DESCRIPTION
I followed the instructions to build vagrant from source so I could get vagrant to work with the latest version of Virtualbox since the new version which has this functionality has not been released yet.  So I cloned the repo, ran "bundle install", and configured the local vagrant executable to run by running "bundle --binstubs exec".  I then attempt to use the local vagrant executable to validate a vagrantfile, and, while the command ultimately succeeds, I see a warning:

```
ruby C:/users/john/documents/github/vagrant/exec/vagrant validate
NOTE: Gem::Specification.default_specifications_dir is deprecated; use Gem.default_specifications_dir instead. It will be removed on or after 2020-02-01.
Gem::Specification.default_specifications_dir called from C:/Users/john/Documents/Github/vagrant/lib/vagrant/bundler.rb:428.
NOTE: Gem::Specification.default_specifications_dir is deprecated; use Gem.default_specifications_dir instead. It will be removed on or after 2020-02-01.
Gem::Specification.default_specifications_dir called from C:/Users/john/Documents/Github/vagrant/lib/vagrant/bundler.rb:428.
```

So I modified the referenced bundler.rb file with the new object and re-ran the validate command and the warning did not appear again.