### PR TITLE
Check name config option with respond_to?

### DIFF
--- a/lib/vagrant/action/builtin/mixin_provisioners.rb
+++ b/lib/vagrant/action/builtin/mixin_provisioners.rb
@@ -35,7 +35,8 @@ module Vagrant
             # Note: `name` is set to a symbol, since it is converted to one via #Config::VM.provision
             provisioner_name = provisioner.name
             if !provisioner_name
-              if provisioner.config.name
+              if provisioner.config.respond_to?(:name) &&
+                  provisioner.config.name
                 provisioner_name = provisioner.config.name.to_sym
               end
             else


### PR DESCRIPTION
Prior to this commit, the check used to look for the config option
`name` in a provisioner config would accidentally create a "DummyConfig"
based on how vagrant handles missing config options. This commit fixes
that by instead using the `respond_to?` method to check for the
existance of the config option name.