### PR TITLE
Remove Windows GEMRC fix/workaround

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -40,20 +40,6 @@ module Vagrant
     def initialize
       @plugin_gem_path = Vagrant.user_data_path.join("gems", RUBY_VERSION).freeze
       @logger = Log4r::Logger.new("vagrant::bundler")
-
-      # TODO: Remove fix when https://github.com/rubygems/rubygems/pull/2735
-      # gets merged and released
-      #
-      # Because of a rubygems bug, we need to set the gemrc file path
-      # through this method rather than relying on the environment varible
-      # GEMRC. On windows, that path gets split on `:`: and `;`, which means
-      # the drive letter gets treated as its own path. If that path exists locally,
-      # (like having a random folder called `c` where the library was invoked),
-      # it fails thinking the folder `c` is a gemrc file.
-      gemrc_val = ENV["GEMRC"]
-      ENV["GEMRC"] = ""
-      Gem.configuration = Gem::ConfigFile.new(["--config-file", gemrc_val])
-      ENV["GEMRC"] = gemrc_val
     end
 
     # Enable Vagrant environment specific plugins at given data path


### PR DESCRIPTION
The RubyGems pull-request (https://github.com/rubygems/rubygems/pull/2735) this temporary fix/workaround was waiting for to land, got merged in April of 2019.

The workaround is causing Vagrant to crash for many of our Windows users when they try to run `vagrant up` through a NPM-script. Removing the workaround code appears to solve their issue.