### PR TITLE
remove warning about deprecated function

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -425,7 +425,7 @@ module Vagrant
         runtime_dependencies.each { |d| gem d.name, *d.requirement.as_list }
       # discover all the gems we have available
       list = {}
-      directories = [Gem::Specification.default_specifications_dir]
+      directories = [Gem.default_specifications_dir]
       Gem::Specification.find_all{true}.each do |spec|
         list[spec.full_name] = spec
       end


### PR DESCRIPTION
remove this warning:
NOTE: Gem::Specification.default_specifications_dir is deprecated; use Gem.default_specifications_dir instead. It will be removed on or after 2020-02-01.
Gem::Specification.default_specifications_dir called from /opt/vagrant/embedded/gems/gems/vagrant-2.2.6/lib/vagrant/bundler.rb:428.

Happens on ruby 2.6.5