### PR TITLE
Fix issues with Windows SSH provisioner

### DIFF
--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -213,11 +213,18 @@ module Vagrant
           return path if !cygwin?
 
           # Replace all "\" with "/", otherwise cygpath doesn't work.
-          path = path.gsub("\\", "/")
+          path = unix_windows_path(path)
 
           # Call out to cygpath and gather the result
           process = Subprocess.execute("cygpath", "-w", "-l", "-a", path.to_s)
           return process.stdout.chomp
+        end
+
+        # This takes any path and converts Windows-style path separators
+        # to Unix-like path separators.
+        # @return [String]
+        def unix_windows_path(path)
+          path.gsub("\\", "/")
         end
 
         # This checks if the filesystem is case sensitive. This is not a

--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -20,6 +20,7 @@ module VagrantPlugins
   module CommunicatorSSH
     # This class provides communication with the VM via SSH.
     class Communicator < Vagrant.plugin("2", :communicator)
+      READY_COMMAND=""
       # Marker for start of PTY enabled command output
       PTY_DELIM_START = "bccbb768c119429488cfd109aacea6b5-pty"
       # Marker for end of PTY enabled command output
@@ -155,7 +156,7 @@ module VagrantPlugins
         end
 
         # Verify the shell is valid
-        if execute("", error_check: false) != 0
+        if execute(self.class.const_get(:READY_COMMAND), error_check: false) != 0
           raise Vagrant::Errors::SSHInvalidShell
         end
 
@@ -168,6 +169,7 @@ module VagrantPlugins
 
         # If we used a password, then insert the insecure key
         ssh_info = @machine.ssh_info
+        return if ssh_info.nil?
         insert   = ssh_info[:password] && ssh_info[:private_key_path].empty?
         ssh_info[:private_key_path].each do |pk|
           if insecure_key?(pk)

--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -227,6 +227,7 @@ module VagrantPlugins
           command:     command,
           shell:       nil,
           sudo:        false,
+          force_raw:   false
         }.merge(opts || {})
 
         opts[:good_exit] = Array(opts[:good_exit])
@@ -238,6 +239,7 @@ module VagrantPlugins
           shell_opts = {
             sudo: opts[:sudo],
             shell: opts[:shell],
+            force_raw: opts[:force_raw]
           }
 
           shell_execute(connection, command, **shell_opts) do |type, data|

--- a/plugins/communicators/winssh/communicator.rb
+++ b/plugins/communicators/winssh/communicator.rb
@@ -48,28 +48,27 @@ module VagrantPlugins
             remote_name = "#{machine_config_ssh.upload_directory}/#{File.basename(tfile.path)}.#{remote_ext}"
 
             if shell == "powershell"
-              base_cmd = "powershell -File #{remote_name}"
               tfile.puts <<-SCRIPT.force_encoding('ASCII-8BIT')
 Remove-Item #{remote_name}
 Write-Host #{CMD_GARBAGE_MARKER}
 [Console]::Error.WriteLine("#{CMD_GARBAGE_MARKER}")
 #{command}
 SCRIPT
+              base_cmd = "powershell -file #{remote_name}"
             else
-              base_cmd = remote_name
               tfile.puts <<-SCRIPT.force_encoding('ASCII-8BIT')
+DEL #{remote_name}
 ECHO OFF
 ECHO #{CMD_GARBAGE_MARKER}
 ECHO #{CMD_GARBAGE_MARKER} 1>&2
 #{command}
 SCRIPT
+              base_cmd = "cmd /q /c #{remote_name}"
             end
 
             tfile.close
             upload(tfile.path, remote_name)
             tfile.delete
-
-            base_cmd = shell_cmd(opts.merge(shell: base_cmd))
           end
 
           @logger.debug("Base SSH exec command: #{base_cmd}")

--- a/plugins/communicators/winssh/communicator.rb
+++ b/plugins/communicators/winssh/communicator.rb
@@ -45,7 +45,7 @@ module VagrantPlugins
           else
             tfile = Tempfile.new('vagrant-ssh')
             remote_ext = shell == "powershell" ? "ps1" : "bat"
-            remote_name = "#{machine_config_ssh.upload_directory}\\#{File.basename(tfile.path)}.#{remote_ext}"
+            remote_name = "#{machine_config_ssh.upload_directory}/#{File.basename(tfile.path)}.#{remote_ext}"
 
             if shell == "powershell"
               base_cmd = "powershell -File #{remote_name}"

--- a/plugins/communicators/winssh/communicator.rb
+++ b/plugins/communicators/winssh/communicator.rb
@@ -35,9 +35,12 @@ module VagrantPlugins
 
           if force_raw
             if shell == "powershell"
-              base_cmd = "powershell \"Write-Host #{CMD_GARBAGE_MARKER}; [Console]::Error.WriteLine('#{CMD_GARBAGE_MARKER}'); #{command}\""
+              command = "Write-Host #{CMD_GARBAGE_MARKER}; [Console]::Error.WriteLine('#{CMD_GARBAGE_MARKER}'); #{command}"
+              command = Base64.strict_encode64(command.encode("UTF-16LE", "UTF-8"))
+              base_cmd = "powershell -encodedCommand #{command}"
             else
-              base_cmd = "cmd /q /c \"ECHO #{CMD_GARBAGE_MARKER} && ECHO #{CMD_GARBAGE_MARKER} 1>&2 && #{command}\""
+              command = "ECHO #{CMD_GARBAGE_MARKER} && ECHO #{CMD_GARBAGE_MARKER} 1>&2 && #{command}"
+              base_cmd = "cmd /q /c \"#{command}\""
             end
           else
             tfile = Tempfile.new('vagrant-ssh')
@@ -227,7 +230,7 @@ SCRIPT
       end
 
       def create_remote_directory(dir, force_raw=false)
-        execute("if not exist \"#{dir}\" mkdir \"#{dir}\"", shell: "cmd", force_raw: force_raw)
+        execute("md -Force \"#{dir}\"", shell: "powershell", force_raw: force_raw)
       end
     end
   end

--- a/plugins/communicators/winssh/config.rb
+++ b/plugins/communicators/winssh/config.rb
@@ -12,15 +12,11 @@ module VagrantPlugins
       end
 
       def finalize!
-        @shell = "cmd" if @shell == UNSET_VALUE
+        @shell = "powershell" if @shell == UNSET_VALUE
         @sudo_command = "%c" if @sudo_command == UNSET_VALUE
         @upload_directory = "C:/Windows/Temp" if @upload_directory == UNSET_VALUE
         if @export_command_template == UNSET_VALUE
-          if @shell == "cmd"
-            @export_command_template = 'set %ENV_KEY%="%ENV_VALUE%"'
-          else
-            @export_command_template = '$env:%ENV_KEY%="%ENV_VALUE%"'
-          end
+          @export_command_template = '$env:%ENV_KEY%="%ENV_VALUE%"'
         end
         super
       end

--- a/plugins/communicators/winssh/config.rb
+++ b/plugins/communicators/winssh/config.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
       def finalize!
         @shell = "cmd" if @shell == UNSET_VALUE
         @sudo_command = "%c" if @sudo_command == UNSET_VALUE
-        @upload_directory = "C:\\Windows\\Temp" if @upload_directory == UNSET_VALUE
+        @upload_directory = "C:/Windows/Temp" if @upload_directory == UNSET_VALUE
         if @export_command_template == UNSET_VALUE
           if @shell == "cmd"
             @export_command_template = 'set %ENV_KEY%="%ENV_VALUE%"'

--- a/plugins/guests/windows/cap/public_key.rb
+++ b/plugins/guests/windows/cap/public_key.rb
@@ -37,7 +37,7 @@ module VagrantPlugins
 
           # Ensure the user's ssh directory exists
           remote_ssh_dir = "#{home_dir}\\.ssh"
-          comm.execute("dir \"#{remote_ssh_dir}\"\n if errorlevel 1 (mkdir \"#{remote_ssh_dir}\")", shell: "cmd")
+          comm.create_remote_directory(remote_ssh_dir)
           remote_upload_path = "#{temp_dir}\\vagrant-insert-pubkey-#{Time.now.to_i}"
           remote_authkeys_path = "#{remote_ssh_dir}\\authorized_keys"
 
@@ -55,7 +55,7 @@ module VagrantPlugins
           File.write(keys_file.path, keys.join("\r\n") + "\r\n")
           comm.upload(keys_file.path, remote_upload_path)
           keys_file.delete
-          comm.execute <<-EOC.gsub(/^\s*/, ""), shell: "powershell"
+          comm.execute(<<-EOC.gsub(/^\s*/, ""), shell: "powershell")
             Set-Acl "#{remote_upload_path}" (Get-Acl "#{remote_authkeys_path}")
             Move-Item -Force "#{remote_upload_path}" "#{remote_authkeys_path}"
           EOC

--- a/plugins/provisioners/shell/config.rb
+++ b/plugins/provisioners/shell/config.rb
@@ -55,7 +55,7 @@ module VagrantPlugins
         @sha384               = nil if @sha384 == UNSET_VALUE
         @sha512               = nil if @sha512 == UNSET_VALUE
         @env                  = {}  if @env == UNSET_VALUE
-        @upload_path          = "/tmp/vagrant-shell" if @upload_path == UNSET_VALUE
+        @upload_path          = nil if @upload_path == UNSET_VALUE
         @privileged           = true if @privileged == UNSET_VALUE
         @binary               = false if @binary == UNSET_VALUE
         @keep_color           = false if @keep_color == UNSET_VALUE
@@ -107,11 +107,6 @@ module VagrantPlugins
 
         if !env.is_a?(Hash)
           errors << I18n.t("vagrant.provisioners.shell.env_must_be_a_hash")
-        end
-
-        # There needs to be a path to upload the script to
-        if !upload_path
-          errors << I18n.t("vagrant.provisioners.shell.upload_path_not_set")
         end
 
         if !args_valid?

--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -194,19 +194,20 @@ module VagrantPlugins
           @machine.communicate.tap do |comm|
             # Make sure that the upload path has an extension, since
             # having an extension is critical for Windows execution
-            if File.extname(upload_path) == ""
-              upload_path += File.extname(path.to_s)
+            winrm_upload_path = upload_path
+            if File.extname(winrm_upload_path) == ""
+              winrm_upload_path += File.extname(path.to_s)
             end
 
             # Upload it
-            comm.upload(path.to_s, upload_path)
+            comm.upload(path.to_s, winrm_upload_path)
 
             # Build the environment
             env = config.env.map { |k,v| "$env:#{k} = #{quote_and_escape(v.to_s)}" }
             env = env.join("; ")
 
             # Calculate the path that we'll be executing
-            exec_path = upload_path
+            exec_path = winrm_upload_path
             exec_path.gsub!('/', '\\')
             exec_path = "c:#{exec_path}" if exec_path.start_with?("\\")
 

--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -43,9 +43,9 @@ module VagrantPlugins
           @_upload_path = config.upload_path.to_s
 
           if @_upload_path.empty?
-            case @machine.config.vm.communicator
-            when :winssh
-              @_upload_path = "C:\\Windows\\Temp\\vagrant-shell"
+            case @machine.config.vm.guest
+            when :windows
+              @_upload_path = "C:\\tmp\\vagrant-shell"
             else
               @_upload_path = "/tmp/vagrant-shell"
             end

--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -40,12 +40,17 @@ module VagrantPlugins
 
       def upload_path
         if !defined?(@_upload_path)
-          @_upload_path = config.upload_path.to_s
+          case @machine.config.vm.guest
+          when :windows
+            @_upload_path = Vagrant::Util::Platform.unix_windows_path(config.upload_path.to_s)
+          else
+            @_upload_path = config.upload_path.to_s
+          end
 
           if @_upload_path.empty?
             case @machine.config.vm.guest
             when :windows
-              @_upload_path = "C:\\tmp\\vagrant-shell"
+              @_upload_path = "C:/tmp/vagrant-shell"
             else
               @_upload_path = "/tmp/vagrant-shell"
             end

--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -136,7 +136,7 @@ module VagrantPlugins
           @machine.communicate.tap do |comm|
             env = config.env.map{|k,v| comm.generate_environment_export(k, v)}.join
             if File.extname(upload_path).empty?
-              remote_ext = @machine.config.winssh.shell == "powershell" ? "ps1" : "bat"
+              remote_ext = File.extname(path)[1..-1]
               upload_path << ".#{remote_ext}"
             end
             if remote_ext == "ps1"

--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -38,6 +38,22 @@ module VagrantPlugins
         end
       end
 
+      def upload_path
+        if !defined?(@_upload_path)
+          @_upload_path = config.upload_path.to_s
+
+          if @_upload_path.empty?
+            case @machine.config.vm.communicator
+            when :winssh
+              @_upload_path = "C:\\Windows\\Temp\\vagrant-shell"
+            else
+              @_upload_path = "/tmp/vagrant-shell"
+            end
+          end
+        end
+        @_upload_path
+      end
+
       protected
 
       # This handles outputting the communication data back to the UI
@@ -63,10 +79,10 @@ module VagrantPlugins
         env = config.env.map { |k,v| "#{k}=#{quote_and_escape(v.to_s)}" }
         env = env.join(" ")
 
-        command =  "chmod +x '#{config.upload_path}'"
+        command =  "chmod +x '#{upload_path}'"
         command << " &&"
         command << " #{env}" if !env.empty?
-        command << " #{config.upload_path}#{args}"
+        command << " #{upload_path}#{args}"
 
         with_script_file do |path|
           # Upload the script to the machine
@@ -79,10 +95,10 @@ module VagrantPlugins
             end
 
             user = info[:username]
-            comm.sudo("chown -R #{user} #{config.upload_path}",
+            comm.sudo("chown -R #{user} #{upload_path}",
                       error_check: false)
 
-            comm.upload(path.to_s, config.upload_path)
+            comm.upload(path.to_s, upload_path)
 
             if config.name
               @machine.ui.detail(I18n.t("vagrant.provisioners.shell.running",
@@ -114,7 +130,6 @@ module VagrantPlugins
           # Upload the script to the machine
           @machine.communicate.tap do |comm|
             env = config.env.map{|k,v| comm.generate_environment_export(k, v)}.join
-            upload_path = config.upload_path.to_s
             if File.extname(upload_path).empty?
               remote_ext = @machine.config.winssh.shell == "powershell" ? "ps1" : "bat"
               upload_path << ".#{remote_ext}"
@@ -174,7 +189,6 @@ module VagrantPlugins
           @machine.communicate.tap do |comm|
             # Make sure that the upload path has an extension, since
             # having an extension is critical for Windows execution
-            upload_path = config.upload_path.to_s
             if File.extname(upload_path) == ""
               upload_path += File.extname(path.to_s)
             end

--- a/test/unit/plugins/communicators/winssh/communicator_test.rb
+++ b/test/unit/plugins/communicators/winssh/communicator_test.rb
@@ -207,16 +207,22 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
     context "with force_raw set to true" do
       it "does not write to a temp file" do
         expect(ssh_cmd_file).to_not receive(:puts)
-        communicator.execute("dir", force_raw: true)
+        expect(communicator.execute("dir", force_raw: true)).to eq(0)
       end
 
       it "does not upload a wrapper script" do
         expect(communicator).to_not receive(:upload)
-        communicator.execute("dir", force_raw: true)
+        expect(communicator.execute("dir", force_raw: true)).to eq(0)
       end
 
       it "executes the base command" do
         expect(channel).to receive(:exec).with(/dir/)
+        expect(communicator.execute("dir", force_raw: true)).to eq(0)
+      end
+
+      it "prepends UUID output to command for garbage removal" do
+        expect(channel).to receive(:exec).
+          with(/ECHO #{command_garbage_marker} && ECHO #{command_garbage_marker}.*/)
         expect(communicator.execute("dir", force_raw: true)).to eq(0)
       end
     end

--- a/test/unit/plugins/communicators/winssh/communicator_test.rb
+++ b/test/unit/plugins/communicators/winssh/communicator_test.rb
@@ -203,6 +203,23 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
         expect(stderr).to eq("Dir1\nDir2\n")
       end
     end
+
+    context "with force_raw set to true" do
+      it "does not write to a temp file" do
+        expect(ssh_cmd_file).to_not receive(:puts)
+        communicator.execute("dir", force_raw: true)
+      end
+
+      it "does not upload a wrapper script" do
+        expect(communicator).to_not receive(:upload)
+        communicator.execute("dir", force_raw: true)
+      end
+
+      it "executes the base command" do
+        expect(channel).to receive(:exec).with(/dir/)
+        expect(communicator.execute("dir", force_raw: true)).to eq(0)
+      end
+    end
   end
 
   describe ".test" do
@@ -525,14 +542,6 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
       it "should generate custom export based on template" do
         expect(communicator.send(:generate_environment_export, "TEST", "value")).to eq("setenv TEST value\n")
       end
-    end
-  end
-
-  describe "#shell_execute" do
-    before(&connection_setup)
-    it "should not create a directory for the command wrapper script" do
-      expect(communicator).to receive(:upload).with(anything, anything, hash_including(mkdir: false))
-      communicator.shell_execute(connection, "dir")
     end
   end
 end

--- a/test/unit/plugins/guests/windows/cap/insert_public_key_test.rb
+++ b/test/unit/plugins/guests/windows/cap/insert_public_key_test.rb
@@ -22,6 +22,7 @@ describe "VagrantPlugins::GuestWindows::Cap::InsertPublicKey" do
     allow(comm).to receive(:execute).with(/echo .+/, shell: "cmd").and_yield(:stdout, "TEMP\r\nHOME\r\n")
     allow(comm).to receive(:execute).with(/dir .+\.ssh/, shell: "cmd")
     allow(comm).to receive(:execute).with(/dir .+authorized_keys/, shell: "cmd", error_check: false).and_return(auth_keys_check_result)
+    allow(comm).to receive(:create_remote_directory)
   end
 
   after do

--- a/test/unit/plugins/guests/windows/cap/remove_public_key_test.rb
+++ b/test/unit/plugins/guests/windows/cap/remove_public_key_test.rb
@@ -29,6 +29,7 @@ describe "VagrantPlugins::GuestWindows::Cap::RemovePublicKey" do
     allow(comm).to receive(:execute).with(/echo .+/, shell: "cmd").and_yield(:stdout, "TEMP\r\nHOME\r\n")
     allow(comm).to receive(:execute).with(/dir .+\.ssh/, shell: "cmd")
     allow(comm).to receive(:execute).with(/dir .+authorized_keys/, shell: "cmd", error_check: false).and_return(auth_keys_check_result)
+    allow(comm).to receive(:create_remote_directory)
   end
 
   after do

--- a/test/unit/plugins/provisioners/shell/config_test.rb
+++ b/test/unit/plugins/provisioners/shell/config_test.rb
@@ -7,6 +7,7 @@ describe "VagrantPlugins::Shell::Config" do
 
   let(:machine)          { double('machine', env: Vagrant::Environment.new) }
   let(:file_that_exists) { File.expand_path(__FILE__)                       }
+  let(:unset_value)      { Vagrant::Plugin::V2::Config::UNSET_VALUE         }
 
   subject { described_class.new }
 
@@ -142,6 +143,15 @@ describe "VagrantPlugins::Shell::Config" do
       result = subject.validate(machine)
       expect(result["shell provisioner"]).to be_empty
     end
+
+    it "returns no error if upload_path is unset" do
+      subject.inline = "script"
+      subject.upload_path = unset_value
+      subject.finalize!
+
+      result = subject.validate(machine)
+      expect(result["shell provisioner"]).to be_empty
+    end
   end
 
   describe 'finalize!' do
@@ -150,7 +160,7 @@ describe "VagrantPlugins::Shell::Config" do
       subject.args = 1
       subject.finalize!
 
-      expect(subject.args).to eq '1'
+      expect(subject.args).to eq('1')
     end
 
     it 'changes integer args in arrays into strings' do
@@ -158,7 +168,14 @@ describe "VagrantPlugins::Shell::Config" do
       subject.args = ["string", 1, 2]
       subject.finalize!
 
-      expect(subject.args).to eq ["string", '1', '2']
+      expect(subject.args).to eq(["string", '1', '2'])
+    end
+
+    it "no longer sets a default for upload_path" do
+      subject.upload_path = unset_value
+      subject.finalize!
+
+      expect(subject.upload_path).to eq(nil)
     end
 
     context "with sensitive option enabled" do

--- a/test/unit/plugins/provisioners/shell/config_test.rb
+++ b/test/unit/plugins/provisioners/shell/config_test.rb
@@ -7,7 +7,6 @@ describe "VagrantPlugins::Shell::Config" do
 
   let(:machine)          { double('machine', env: Vagrant::Environment.new) }
   let(:file_that_exists) { File.expand_path(__FILE__)                       }
-  let(:unset_value)      { Vagrant::Plugin::V2::Config::UNSET_VALUE         }
 
   subject { described_class.new }
 
@@ -146,7 +145,6 @@ describe "VagrantPlugins::Shell::Config" do
 
     it "returns no error if upload_path is unset" do
       subject.inline = "script"
-      subject.upload_path = unset_value
       subject.finalize!
 
       result = subject.validate(machine)
@@ -172,7 +170,6 @@ describe "VagrantPlugins::Shell::Config" do
     end
 
     it "no longer sets a default for upload_path" do
-      subject.upload_path = unset_value
       subject.finalize!
 
       expect(subject.upload_path).to eq(nil)

--- a/test/unit/plugins/provisioners/shell/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/shell/provisioner_test.rb
@@ -355,19 +355,21 @@ describe "Vagrant::Shell::Provisioner" do
           allow(machine).to receive_message_chain(:config, :vm, :guest).and_return(:windows)
         end
 
-        it "should default to C:\\tmp\\vagrant-shell" do
-          expect(vsp.upload_path).to eq("C:\\tmp\\vagrant-shell")
+        it "should default to C:/tmp/vagrant-shell" do
+          expect(vsp.upload_path).to eq("C:/tmp/vagrant-shell")
         end
       end
     end
 
     context "when upload_path is set" do
+      let(:upload_path) { "arbitrary" }
+
       let(:config) {
         double(
           :config,
           :args        => "doesn't matter",
           :env         => {},
-          :upload_path => "arbitrary",
+          :upload_path => upload_path,
           :remote?     => false,
           :path        => "doesn't matter",
           :inline      => "doesn't matter",
@@ -383,6 +385,18 @@ describe "Vagrant::Shell::Provisioner" do
 
       it "should use the value from from config" do
         expect(vsp.upload_path).to eq("arbitrary")
+      end
+
+      context "windows" do
+        let(:upload_path) { "C:\\Windows\\Temp" }
+
+        before do
+          allow(machine).to receive_message_chain(:config, :vm, :guest).and_return(:windows)
+        end
+
+        it "should normalize the slashes" do
+          expect(vsp.upload_path).to eq("C:/Windows/Temp")
+        end
       end
     end
 

--- a/test/unit/plugins/provisioners/shell/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/shell/provisioner_test.rb
@@ -323,4 +323,82 @@ describe "Vagrant::Shell::Provisioner" do
       end
     end
   end
+
+  describe "#upload_path" do
+    context "when upload path is not set" do
+      let(:vsp) {
+        VagrantPlugins::Shell::Provisioner.new(machine, config)
+      }
+
+      let(:config) {
+        double(
+          :config,
+          :args        => "doesn't matter",
+          :env         => {},
+          :upload_path => nil,
+          :remote?     => false,
+          :path        => "doesn't matter",
+          :inline      => "doesn't matter",
+          :binary      => false,
+          :reset       => true,
+          :reboot      => false,
+        )
+      }
+
+      it "should default to /tmp/vagrant-shell" do
+        expect(vsp.upload_path).to eq("/tmp/vagrant-shell")
+      end
+
+      context "with winssh provisioner" do
+        before do
+          allow(machine).to receive_message_chain(:config, :vm, :communicator).and_return(:winssh)
+        end
+
+        it "should default to C:\\Windows\\Temp\\vagrant-shell" do
+          expect(vsp.upload_path).to eq("C:\\Windows\\Temp\\vagrant-shell")
+        end
+      end
+    end
+
+    context "when upload_path is set" do
+      let(:config) {
+        double(
+          :config,
+          :args        => "doesn't matter",
+          :env         => {},
+          :upload_path => "arbitrary",
+          :remote?     => false,
+          :path        => "doesn't matter",
+          :inline      => "doesn't matter",
+          :binary      => false,
+          :reset       => true,
+          :reboot      => false,
+        )
+      }
+
+      let(:vsp) {
+        VagrantPlugins::Shell::Provisioner.new(machine, config)
+      }
+
+      it "should use the value from from config" do
+        expect(vsp.upload_path).to eq("arbitrary")
+      end
+    end
+
+    context "with cached value" do
+      let(:config) { double(:config) }
+
+      let(:vsp) {
+        VagrantPlugins::Shell::Provisioner.new(machine, config)
+      }
+
+      before do
+        vsp.instance_variable_set(:@_upload_path, "anything")
+      end
+
+      it "should use cached value" do
+        expect(vsp.upload_path).to eq("anything")
+      end
+    end
+  end
 end

--- a/test/unit/plugins/provisioners/shell/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/shell/provisioner_test.rb
@@ -8,6 +8,7 @@ describe "Vagrant::Shell::Provisioner" do
   let(:machine) {
     double(:machine, env: env, id: "ID").tap { |machine|
       allow(machine).to receive_message_chain(:config, :vm, :communicator).and_return(:not_winrm)
+      allow(machine).to receive_message_chain(:config, :vm, :guest).and_return(:linux)
       allow(machine).to receive_message_chain(:communicate, :tap) {}
     }
   }
@@ -349,13 +350,13 @@ describe "Vagrant::Shell::Provisioner" do
         expect(vsp.upload_path).to eq("/tmp/vagrant-shell")
       end
 
-      context "with winssh provisioner" do
+      context "windows" do
         before do
-          allow(machine).to receive_message_chain(:config, :vm, :communicator).and_return(:winssh)
+          allow(machine).to receive_message_chain(:config, :vm, :guest).and_return(:windows)
         end
 
-        it "should default to C:\\Windows\\Temp\\vagrant-shell" do
-          expect(vsp.upload_path).to eq("C:\\Windows\\Temp\\vagrant-shell")
+        it "should default to C:\\tmp\\vagrant-shell" do
+          expect(vsp.upload_path).to eq("C:\\tmp\\vagrant-shell")
         end
       end
     end

--- a/test/unit/vagrant/util/platform_test.rb
+++ b/test/unit/vagrant/util/platform_test.rb
@@ -533,11 +533,11 @@ EOF
         expect(subject.wsl_drvfs_path?("/home/vagrant/some/path")).to be_falsey
       end
     end
+  end
 
-    describe ".unix_windows_path" do
-      it "takes a windows path and returns a unixy path" do
-        expect(subject.unix_windows_path("C:\\Temp\\Windows")).to eq("C:/Temp/Windows")
-      end
+  describe ".unix_windows_path" do
+    it "takes a windows path and returns a POSIX-like path" do
+      expect(subject.unix_windows_path("C:\\Temp\\Windows")).to eq("C:/Temp/Windows")
     end
   end
 end

--- a/test/unit/vagrant/util/platform_test.rb
+++ b/test/unit/vagrant/util/platform_test.rb
@@ -280,7 +280,7 @@ describe Vagrant::Util::Platform do
       end
 
       it "should return false when path is within /mnt" do
-        expect(subject.wsl_path?("/mnt/c")).to be false
+        expect(subject.wsl_path?("/mnt/c")).to be(false)
       end
     end
 
@@ -531,6 +531,12 @@ EOF
 
       it "should return false when path prefix is not found" do
         expect(subject.wsl_drvfs_path?("/home/vagrant/some/path")).to be_falsey
+      end
+    end
+
+    describe ".unix_windows_path" do
+      it "takes a windows path and returns a unixy path" do
+        expect(subject.unix_windows_path("C:\\Temp\\Windows")).to eq("C:/Temp/Windows")
       end
     end
   end

--- a/website/source/docs/vagrantfile/winssh_settings.html.md
+++ b/website/source/docs/vagrantfile/winssh_settings.html.md
@@ -74,5 +74,3 @@ being executed.
 
 * `config.winssh.upload_directory` (string) - The upload directory used on the guest
 to store scripts for execute. This is set to `C:\Windows\Temp` by default.
-Vagrant will not attempt to create this directory, so it must already exist on
-the guest.

--- a/website/source/docs/vagrantfile/winssh_settings.html.md
+++ b/website/source/docs/vagrantfile/winssh_settings.html.md
@@ -74,3 +74,5 @@ being executed.
 
 * `config.winssh.upload_directory` (string) - The upload directory used on the guest
 to store scripts for execute. This is set to `C:\Windows\Temp` by default.
+Vagrant will not attempt to create this directory, so it must already exist on
+the guest.


### PR DESCRIPTION
Windows commands that run over SSH are wrapped in a script that writes a
special marker to the two output streams (stdout and stderr).  This
allows Vagrant to consume the output streams.

Unfortunately, this leads to a sort of chicken-and-egg problem where no
commands can be run before a wrapper script exists. For example, you
can't make a destination directory to upload the wrapper script without
first creating a wrapper script to make the directory. :)

This PR adds the ability to create "raw" commands with the WinSSH 
communicator (i.e. not wrapped in a shell script). This way we can 
create the `config.winssh.upload_directory` for our wrapper scripts 
without needing to make any assumptions 
about the existing directory structure on the guest.

It also moves the default `upload_path` from the shell provisioner
config so we can have OS-specific defaults.

What remains:
- [x] When `config.winssh.shell = "cmd"`, `.ps1` files should be run 
through PowerShell
- [x] Uploading files with spaces in them -- invoke the `scp.exe` command as an encoded powershell command.
- [ ] Currently the [docs](https://www.vagrantup.com/docs/provisioning/shell.html#inline-scripts) say "For Windows guest machines, the inline 
script must be PowerShell. Batch scripts are not allowed as inline 
scripts." -- for the WinSSH communicator we could assume inline scripts 
to be written in the language of `config.winssh.shell`. Not sure if 
would be more valuable to standardize this across communicators.

Fixes #11232.