### PR TITLE
Fix missing quoting for `VagrantFile`

### DIFF
--- a/website/source/docs/provisioning/ansible_intro.html.md
+++ b/website/source/docs/provisioning/ansible_intro.html.md
@@ -44,7 +44,7 @@ You can of course target other operating systems that do not have YUM by changin
 
 ### Running Ansible
 
-The `playbook` option is strictly required by both Ansible provisioners ([`ansible`](/docs/provisioning/ansible.html) and [`ansible_local`](/docs/provisioning/ansible_local.html)), as illustrated in this basic Vagrantfile` configuration:
+The `playbook` option is strictly required by both Ansible provisioners ([`ansible`](/docs/provisioning/ansible.html) and [`ansible_local`](/docs/provisioning/ansible_local.html)), as illustrated in this basic `Vagrantfile` configuration:
 
 ```ruby
 Vagrant.configure("2") do |config|


### PR DESCRIPTION
VagrantFile\` -> \`VagrantFile\`

Signed-off-by: 林博仁(Buo-ren, Lin) <Buo.Ren.Lin@gmail.com>