### PR TITLE
Lock closed issues after 30 days

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -1,0 +1,17 @@
+behavior "remove_labels_on_reply" "remove_stale" {
+    labels = ["waiting-reply"]
+    only_non_maintainers = true
+}
+
+poll "closed_issue_locker" "locker" {
+  schedule             = "0 50 1 * * *"
+  closed_for           = "720h" # 30 days
+  max_issues           = 500
+  sleep_between_issues = "5s"
+
+  message = <<-EOF
+    I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
+
+    If you have found a problem that seems similar to this, please open a new issue and complete the issue template so we can capture all the details necessary to investigate further.
+  EOF
+}

--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -1,8 +1,3 @@
-behavior "remove_labels_on_reply" "remove_stale" {
-    labels = ["waiting-reply"]
-    only_non_maintainers = true
-}
-
 poll "closed_issue_locker" "locker" {
   schedule             = "0 50 1 * * *"
   closed_for           = "720h" # 30 days


### PR DESCRIPTION
This commit adds Hashibot support to lock closed issues after 30 days.
~It also will automatically remove the `waiting-reply` tag if a user
replies to an issue with that tag.~