### PR TITLE
Not possible to add/override CFLAGS for plugin install/update

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -272,6 +272,26 @@ module Vagrant
       end
     end
   end
+
+  # This helper provides temporary environmental variable changes.
+  def self.with_temp_env(environment)
+    # Build up the new environment, preserving the old values so we
+    # can replace them back in later.
+    old_env = {}
+    environment.each do |key, value|
+      key          = key.to_s
+      old_env[key] = ENV[key]
+      ENV[key]     = value
+    end
+
+    # Call the block, returning its return value
+    return yield
+  ensure
+    # Reset the environment no matter what
+    old_env.each do |key, value|
+      ENV[key] = value
+    end
+  end
 end
 
 # Default I18n to load the en locale

--- a/lib/vagrant/plugin/manager.rb
+++ b/lib/vagrant/plugin/manager.rb
@@ -135,7 +135,7 @@ module Vagrant
         if local_spec.nil?
           result = nil
           install_lambda = lambda do
-            Vagrant::Bundler.instance.install(plugins, opts[:env_local]).each do |spec|
+            Vagrant::Bundler.instance.install(plugins, opts[:env_vars], opts[:env_local]).each do |spec|
               next if spec.name != name
               next if result && result.version >= spec.version
               result = spec
@@ -158,6 +158,7 @@ module Vagrant
           require: opts[:require],
           sources: opts[:sources],
           env_local: !!opts[:env_local],
+          env_vars: opts[:env_vars],
           installed_gem_version: result.version.to_s
         )
 

--- a/lib/vagrant/plugin/state_file.rb
+++ b/lib/vagrant/plugin/state_file.rb
@@ -41,6 +41,7 @@ module Vagrant
           "require"               => opts[:require] || "",
           "sources"               => opts[:sources] || [],
           "installed_gem_version" => opts[:installed_gem_version],
+          "env_vars"              => opts[:env_vars],
           "env_local"             => !!opts[:env_local]
         }
 

--- a/plugins/commands/plugin/action/install_gem.rb
+++ b/plugins/commands/plugin/action/install_gem.rb
@@ -18,6 +18,7 @@ module VagrantPlugins
           plugin_name = env[:plugin_name]
           sources     = env[:plugin_sources]
           version     = env[:plugin_version]
+          env_vars    = env[:env_vars]
           env_local   = env[:plugin_env_local]
 
           # Install the gem
@@ -33,6 +34,7 @@ module VagrantPlugins
             require:   entrypoint,
             sources:   sources,
             verbose:   !!env[:plugin_verbose],
+            env_vars:  env_vars,
             env_local: env_local
           )
 

--- a/plugins/commands/plugin/command/install.rb
+++ b/plugins/commands/plugin/command/install.rb
@@ -12,12 +12,20 @@ module VagrantPlugins
         LOCAL_INSTALL_PAUSE = 3
 
         def execute
-          options = { verbose: false }
+          options = {
+            verbose: false,
+            env_vars: {},
+          }
 
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant plugin install <name>... [-h]"
             o.separator ""
             build_install_opts(o, options)
+
+            o.on("-D VARIABLE=VALUE", "--define VARIABLE=VALUE", "Set environment variable") do |e|
+              name, value = e.split('=', 2)
+              options[:env_vars][name] = value
+            end
 
             o.on("--local", "Install plugin for local project only") do |l|
               options[:env_local] = l
@@ -61,6 +69,7 @@ module VagrantPlugins
                 plugin_version:     info[:version],
                 plugin_sources:     info[:sources] || Vagrant::Bundler::DEFAULT_GEM_SOURCES.dup,
                 plugin_name:        name,
+                env_vars:           options[:env_vars],
                 plugin_env_local:   true
               )
             end
@@ -73,6 +82,7 @@ module VagrantPlugins
                 plugin_sources:     options[:plugin_sources],
                 plugin_name:        name,
                 plugin_verbose:     options[:verbose],
+                env_vars:           options[:env_vars],
                 plugin_env_local:   options[:env_local]
               )
             end

--- a/test/unit/support/shared/base_context.rb
+++ b/test/unit/support/shared/base_context.rb
@@ -110,23 +110,8 @@ shared_context "unit" do
   end
 
   # This helper provides temporary environmental variable changes.
-  def with_temp_env(environment)
-    # Build up the new environment, preserving the old values so we
-    # can replace them back in later.
-    old_env = {}
-    environment.each do |key, value|
-      key          = key.to_s
-      old_env[key] = ENV[key]
-      ENV[key]     = value
-    end
-
-    # Call the block, returning its return value
-    return yield
-  ensure
-    # Reset the environment no matter what
-    old_env.each do |key, value|
-      ENV[key] = value
-    end
+  def with_temp_env(environment, &block)
+    Vagrant::with_temp_env(environment, &block)
   end
 
   # This helper provides a randomly available port(s) for each argument to the


### PR DESCRIPTION
### Vagrant version

```console
$ vagrant -v
Vagrant 2.2.6
```

### Host operating system

```console
$ cat /etc/*release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu Focal Fossa (development branch)"
NAME="Ubuntu"
VERSION="20.04 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu Focal Fossa (development branch)"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
```

### Guest operating system

N/A

### Vagrantfile

N/A

### Debug output

N/A

### Expected behavior

Attempting to install Vagrant plugins that depend on native modules often requires the user to specify additional environment variables (`CFLAGS`, `CXXFLAGS`) to get the module to build. When specified as part of the environment as follows:

```console
$ CFLAGS="-DHAVE_VIRDOMAINQEMUMONITORCOMMAND" CONFIGURE_ARGS='with-ldflags=-L/opt/vagrant/embedded/lib with-libvirt-include=/usr/include/libvirt with-libvirt-lib=/usr/lib' GEM_HOME=~/.vagrant.d/gems GEM_PATH=$GEM_HOME:/opt/vagrant/embedded/gems PATH=/opt/vagrant/embedded/bin:$PATH VAGRANT_LOG=debug vagrant plugin install vagrant-libvirt
```

I'd expect them to be available to any rake tasks executed as part of the build/installation process of the `vagrant-libvirt` gem and any of its dependencies.

### Actual behavior

The environment variable mangling changed the name of the `CFLAGS` environment variable to `VAGRANT_OLD_ENV_CFLAGS`. You can observe this by dumping `ENV.inspect` at around https://github.com/hashicorp/vagrant/blob/a1abc177bd3776bbd72a6d84b3e0b7c01661ee08/lib/vagrant/bundler.rb#L381.

I was unable to discern where this mangling takes place, though I can see the string `VAGRANT_OLD_ENV` exists in the `/opt/vagrant/bin/vagrant` binary... :cry: 

### Steps to reproduce

1. Apply patch to `bundler.rb`. 
2. Run `CFLAGS="-DHAVE_VIRDOMAINQEMUMONITORCOMMAND" vagrant plugin install vagrant-libvirt`
3. Observe that the `ENV` output includes an empty `CFLAGS` value.

### References

N/A