### PR TITLE
avoid ruby constant complaining about keyword parameters being deprec…

### DIFF
--- a/lib/vagrant/box.rb
+++ b/lib/vagrant/box.rb
@@ -165,7 +165,7 @@ module Vagrant
       version += ", " if version
       version ||= ""
       version += "> #{@version}"
-      md      = self.load_metadata(download_options)
+      md      = self.load_metadata(**download_options)
       newer   = md.version(version, provider: @provider)
       return nil if !newer
 

--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -100,7 +100,7 @@ module Vagrant
 
       def translate_error(opts)
         return nil if !opts[:_key]
-        I18n.t("#{opts[:_namespace]}.#{opts[:_key]}", opts)
+        I18n.t("#{opts[:_namespace]}.#{opts[:_key]}", **opts)
       end
     end
 

--- a/lib/vagrant/ui.rb
+++ b/lib/vagrant/ui.rb
@@ -148,9 +148,9 @@ module Vagrant
       # to `say`.
       [:detail, :info, :warn, :error, :output, :success].each do |method|
         class_eval <<-CODE
-          def #{method}(message, *args)
+          def #{method}(message, **args)
             super(message)
-            say(#{method.inspect}, message, *args)
+            say(#{method.inspect}, message, **args)
           end
         CODE
       end
@@ -168,7 +168,7 @@ module Vagrant
         opts[:prefix]   = false if !opts.key?(:prefix)
 
         # Output the data
-        say(:info, message, opts)
+        say(:info, message, **opts)
 
         input = nil
         if opts[:echo] || !@stdin.respond_to?(:noecho)
@@ -179,10 +179,10 @@ module Vagrant
 
             # Output a newline because without echo, the newline isn't
             # echoed either.
-            say(:info, "\n", opts)
+            say(:info, "\n", **opts)
           rescue Errno::EBADF
             # This means that stdin doesn't support echoless input.
-            say(:info, "\n#{I18n.t("vagrant.stdin_cant_hide_input")}\n ", opts)
+            say(:info, "\n#{I18n.t("vagrant.stdin_cant_hide_input")}\n ", **opts)
 
             # Ask again, with echo enabled
             input = ask(message, opts.merge(echo: true))

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -376,7 +376,7 @@ module VagrantPlugins
         prov.preserve_order = !!options.delete(:preserve_order) if \
           options.key?(:preserve_order)
         prov.run = options.delete(:run) if options.key?(:run)
-        prov.add_config(options, &block)
+        prov.add_config(**options, &block)
         nil
       end
 

--- a/plugins/providers/virtualbox/action/forward_ports.rb
+++ b/plugins/providers/virtualbox/action/forward_ports.rb
@@ -48,7 +48,7 @@ module VagrantPlugins
             # bridged networking don't require port-forwarding and establishing
             # forwarded ports on these attachment types has uncertain behaviour.
             @env[:ui].detail(I18n.t("vagrant.actions.vm.forward_ports.forwarding_entry",
-                                    message_attributes))
+                                    **message_attributes))
 
             # Verify we have the network interface to attach to
             if !interfaces[fp.adapter]

--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -53,7 +53,7 @@ module VagrantPlugins
           options = {}
           options[:color] = color if !config.keep_color
 
-          @machine.ui.detail(data.chomp, options)
+          @machine.ui.detail(data.chomp, **options)
         end
       end
 


### PR DESCRIPTION
…ated

avoid constant repeation of:

```
warning: Using the last argument as keyword parameters is deprecated;
  maybe ** should be added to the call
```

Signed-off-by: BlackEagle <ike.devolder@gmail.com>