### PR TITLE
Add support up to TLS 1.2 for Powershell

### DIFF
--- a/plugins/provisioners/salt/bootstrap-salt.ps1
+++ b/plugins/provisioners/salt/bootstrap-salt.ps1
@@ -54,6 +54,9 @@ If ([IntPtr]::Size -eq 4) {
   $arch = "AMD64"
 }
 
+# Powershell supports only TLS 1.0 by default. Add support up to TLS 1.2
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls,Tls11,Tls12'
+
 # Download minion setup file
 $minionFilename = "Salt-Minion-$version-$arch-Setup.exe"
 $versionYear = [regex]::Match($version, "\d+").Value


### PR DESCRIPTION
Powershell supports only TLS 1.0 by default. The bootstrap uses $webclient.DownloadFile($url, $file). This intends to resolve the following issue when fetching the minion package. 

```
Stdout from the command:

Service defaulting to run.
Downloading Salt minion installer
WARNING: Retrying download in 2 seconds. Retry # 1
WARNING: Retrying download in 2 seconds. Retry # 2
WARNING: Retrying download in 2 seconds. Retry # 3
WARNING: Retrying download in 2 seconds. Retry # 4
The request was aborted: Could not create SSL/TLS secure channel.
At C:\tmp\bootstrap_salt.ps1:74 char:5
+     $webclient.DownloadFile($url, $file)
+     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : NotSpecified: (:) [], WebException
    + FullyQualifiedErrorId : WebException


IsPublic IsSerial Name                                     BaseType
-------- -------- ----                                     --------
True     True     ErrorRecord                              System.Object
The request was aborted: Could not create SSL/TLS secure channel.
   at System.Net.WebClient.DownloadFile(Uri address, String fileName)
   at CallSite.Target(Closure , CallSite , Object , Object , Object )
```