### PR TITLE
Include important Ansible docs in side navbar

### DIFF
--- a/website/source/docs/provisioning/ansible.html.md
+++ b/website/source/docs/provisioning/ansible.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "Ansible - Provisioning"
-sidebar_current: "provisioning-ansible"
+sidebar_current: "provisioning-ansible-provisioner"
 description: |-
   The Vagrant Ansible provisioner allows you to provision the guest using
   Ansible playbooks by executing "ansible-playbook" from the Vagrant host.

--- a/website/source/docs/provisioning/ansible_intro.html.md
+++ b/website/source/docs/provisioning/ansible_intro.html.md
@@ -1,7 +1,7 @@
 ---
 layout: "docs"
 page_title: "Ansible - Short Introduction"
-sidebar_current: "provisioning-ansible-intro"
+sidebar_current: "provisioning-ansible"
 description: |-
   This page includes options and information that is applicable to both Vagrant
   Ansible provisioners.

--- a/website/source/layouts/docs.erb
+++ b/website/source/layouts/docs.erb
@@ -92,8 +92,14 @@
           <li<%= sidebar_current("provisioning-basic") %>><a href="/docs/provisioning/basic_usage.html">Basic Usage</a></li>
           <li<%= sidebar_current("provisioning-file") %>><a href="/docs/provisioning/file.html">File</a></li>
           <li<%= sidebar_current("provisioning-shell") %>><a href="/docs/provisioning/shell.html">Shell</a></li>
-          <li<%= sidebar_current("provisioning-ansible") %>><a href="/docs/provisioning/ansible.html">Ansible</a></li>
-          <li<%= sidebar_current("provisioning-ansible-local") %>><a href="/docs/provisioning/ansible_local.html">Ansible Local</a></li>
+          <li<%= sidebar_current("provisioning-ansible") %>>
+            <a href="/docs/provisioning/ansible_intro.html">Ansible Intro</a>
+            <ul class="nav">
+              <li<%= sidebar_current("provisioning-ansible-provisioner") %>><a href="/docs/provisioning/ansible.html">Ansible</a></li>
+              <li<%= sidebar_current("provisioning-ansible-local") %>><a href="/docs/provisioning/ansible_local.html">Ansible Local</a></li>
+              <li<%= sidebar_current("provisioning-ansible-common") %>><a href="/docs/provisioning/ansible_common.html">Common Ansible Options</a></li>
+            </ul>
+          </li>
           <li<%= sidebar_current("provisioning-cfengine") %>><a href="/docs/provisioning/cfengine.html">CFEngine</a></li>
           <li<%= sidebar_current("provisioning-chefcommon") %>><a href="/docs/provisioning/chef_common.html">Chef Common Configuration</a></li>
           <li<%= sidebar_current("provisioning-chefsolo") %>><a href="/docs/provisioning/chef_solo.html">Chef Solo</a></li>


### PR DESCRIPTION
This commit adds some extra nav links for important Ansible
documentation that was burried in the other doc pages.

/cc @Lin-Buo-Ren

![Peek 2020-01-29 11-42](https://user-images.githubusercontent.com/810277/73391467-e6028180-428c-11ea-9892-a6a2d6e4afe5.gif)
