### PR TITLE
Don't build gem on Vagrant forks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build-gem:
+    if: github.repository == 'hashicorp/vagrant'
     name: Build Vagrant RubyGem
     runs-on: ubuntu-18.04
     steps:


### PR DESCRIPTION
This commit adds a check to see if push is happening against the main
Vagrant repo. If not, it will skip the build-gem job.  This prevents
people from getting failure notifications when they push to the master
branch of their Vagrant fork.