### PR TITLE
docker provider: Don't explode when removing an image if it is in use

### DIFF
--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -166,6 +166,7 @@ module VagrantPlugins
         return true
       rescue => e
         return false if e.to_s.include?("is using it")
+        return false if e.to_s.include?("is being used")
         raise if !e.to_s.include?("No such image")
       end
 

--- a/test/unit/plugins/providers/docker/driver_test.rb
+++ b/test/unit/plugins/providers/docker/driver_test.rb
@@ -389,8 +389,17 @@ describe VagrantPlugins::DockerProvider::Driver do
       end
     end
 
-    context 'image is being used' do
+    context 'image is being used by running container' do
       before { allow(subject).to receive(:execute).and_raise("image is being used by running container") }
+
+      it 'does not remove the image' do
+        expect(subject.rmi(id)).to eq(false)
+        subject.rmi(id)
+      end
+    end
+
+    context 'image is being used by stopped container' do
+      before { allow(subject).to receive(:execute).and_raise("image is being used by stopped container") }
 
       it 'does not remove the image' do
         expect(subject.rmi(id)).to eq(false)


### PR DESCRIPTION
Output from recent Docker has changed:

    Stderr: Error response from daemon: conflict: unable to delete 0ba49dd235e5 (cannot be forced) - image is being used by running container 250bbe980448

Fixes #7245