### PR TITLE
Fixes #11358: Actually validate synced_folder type options

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -755,9 +755,14 @@ module VagrantPlugins
             errors << I18n.t("vagrant.config.vm.shared_folder_mount_options_array")
           end
 
-          # One day remove this probably.
-          if options[:extra]
-            errors << "The 'extra' flag on synced folders is now 'mount_options'"
+          if options[:type]
+            plugins = Vagrant.plugin("2").manager.synced_folders
+            impl_class = plugins[options[:type]]
+            if !impl_class
+              errors << I18n.t("vagrant.config.vm.shared_folder_invalid_option_type",
+                              type: options[:type],
+                              options: plugins.keys.join(', '))
+            end
           end
         end
 

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1946,7 +1946,7 @@ en:
         shared_folder_invalid_option_type: |-
           The type '%{type}' is not a valid synced folder type. If 'type' is not
             specified, Vagrant will automatically choose the best synced folder
-            option for your guest. Otherwise, please pick from the following valid options:
+            option for your guest. Otherwise, please pick from the following available options:
 
               %{options}
         shared_folder_nfs_owner_group: |-

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1943,6 +1943,12 @@ en:
           The shared folder guest path must be absolute: %{path}
         shared_folder_hostpath_missing: |-
           The host path of the shared folder is missing: %{path}
+        shared_folder_invalid_option_type: |-
+          The type '%{type}' is not a valid synced folder type. If 'type' is not
+            specified, Vagrant will automatically choose the best synced folder
+            option for your guest. Otherwise, please pick from the following valid options:
+
+              %{options}
         shared_folder_nfs_owner_group: |-
           Shared folders that have NFS enabled do not support owner/group
           attributes. Host path: %{path}


### PR DESCRIPTION
Prior to this commit, Vagrant wouldn't validate the `type` option for
any synced_folder configs defined. This commit updates that behavior to
look at the current list of installed synced_folder plugins, and ensure
if a type is defined, it's a valid plugin in that list.