### PR TITLE
Fix use of -q option in curl invocation

### DIFF
--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -183,6 +183,7 @@ module Vagrant
 
       def execute_curl(options, subprocess_options, &data_proc)
         options = options.dup
+        options.unshift("-q")
         options << subprocess_options
 
         # Create the callback that is called if we are interrupted
@@ -230,7 +231,6 @@ module Vagrant
       def options
         # Build the list of parameters to execute with cURL
         options = [
-          "-q",
           "--fail",
           "--location",
           "--max-redirs", "10", "--verbose",

--- a/test/unit/vagrant/util/downloader_test.rb
+++ b/test/unit/vagrant/util/downloader_test.rb
@@ -261,17 +261,16 @@ describe Vagrant::Util::Downloader do
 
   describe "#head" do
     let(:curl_options) {
-      ["-q", "--fail", "--location", "--max-redirs", "10", "--verbose", "--user-agent", described_class::USER_AGENT, source, {}]
+      ["-q", "-I", "--fail", "--location", "--max-redirs", "10",
+       "--verbose", "--user-agent", described_class::USER_AGENT,
+       source, {}]
     }
 
     it "returns the output" do
       allow(subprocess_result).to receive(:stdout).and_return("foo")
 
-      options = curl_options.dup
-      options.unshift("-I")
-
       expect(Vagrant::Util::Subprocess).to receive(:execute).
-        with("curl", *options).and_return(subprocess_result)
+        with("curl", *curl_options).and_return(subprocess_result)
 
       expect(subject.head).to eq("foo")
     end


### PR DESCRIPTION
curl ignores -q if it's not the first option.  Thus, prior to this
change, curl configuration file is used while performing HEAD request.