### PR TITLE
Website: bump middleman version

### DIFF
--- a/website/Gemfile
+++ b/website/Gemfile
@@ -1,3 +1,3 @@
 source "https://rubygems.org"
 
-gem "middleman-hashicorp", "0.3.41"
+gem "middleman-hashicorp", "0.3.43"

--- a/website/Gemfile.lock
+++ b/website/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
       rack (>= 1.4.5, < 2.0)
       thor (>= 0.15.2, < 2.0)
       tilt (~> 1.4.1, < 2.0)
-    middleman-hashicorp (0.3.41)
+    middleman-hashicorp (0.3.43)
       bootstrap-sass (~> 3.3)
       builder (~> 3.2)
       middleman (~> 3.4)
@@ -155,7 +155,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  middleman-hashicorp (= 0.3.41)
+  middleman-hashicorp (= 0.3.43)
 
 BUNDLED WITH
    1.17.3

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,4 +1,4 @@
-VERSION?="0.3.41"
+VERSION?="0.3.43"
 
 build:
 	@echo "==> Starting build in Docker..."


### PR DESCRIPTION
Update middleman-hashicorp@0.3.43 to deploy copy change - “HashiCorp Suite” -> “HashiCorp Stack”

