### PR TITLE
Detail other valid values for `config.ssh.verify_host_key`.

### DIFF
--- a/website/source/docs/vagrantfile/ssh_settings.html.md
+++ b/website/source/docs/vagrantfile/ssh_settings.html.md
@@ -138,4 +138,6 @@ appropriate user. By default this is "vagrant", since that is what most
 public boxes are made as.
 
 * `config.ssh.verify_host_key` (string, symbol) - Perform strict host-key verification. The
-default value is `:never`.
+default value is `:never`. The other options are `:accept_new_or_local_tunnel`,
+`:accept_new`, or `:always`, which each refer to one of
+[net-ssh](https://net-ssh.github.io/net-ssh/)'s `Net::SSH::Verifiers` subclasses.


### PR DESCRIPTION
This commit adds more detail to the documentation for `config.ssh.verify_host_key`. Currently, the documentation only mentions the default value but does not provide any hints as to what valid values exist, or where this value is being passed to. As I'm sure you know, this is ultimately passed to the `net-ssh` library. It would have saved me some time doing searches to have read this fact in the Vagrant docs directly.

Thanks for considering this expansion.