### PR TITLE
Update exit code value used for retry check - ArgumentException

### DIFF
--- a/plugins/communicators/winrm/shell.rb
+++ b/plugins/communicators/winrm/shell.rb
@@ -19,7 +19,7 @@ module VagrantPlugins
 
       # Exit code generated when user is invalid. Can occur
       # after a hostname update
-      INVALID_USERID_EXITCODE = -196608
+      INVALID_USERID_EXITCODE = -2147024809
 
       # These are the exceptions that we retry because they represent
       # errors that are generally fixed from a retry and don't

--- a/test/unit/plugins/communicators/winrm/shell_test.rb
+++ b/test/unit/plugins/communicators/winrm/shell_test.rb
@@ -103,7 +103,7 @@ describe VagrantPlugins::CommunicatorWinRM::WinRMShell do
     let(:eusername) { double("elevatedusername") }
     let(:username) { double("username") }
     let(:failed_output) { WinRM::Output.new.tap { |out|
-        out.exitcode = -196608
+        out.exitcode = described_class.const_get(:INVALID_USERID_EXITCODE)
         out << {stderr: "(10,8):UserId:"}
         out << {stderr: "At line:72 char:1"}
       } }

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -28,11 +28,11 @@ Gem::Specification.new do |s|
   s.add_dependency "net-scp", "~> 1.2.0"
   s.add_dependency "rb-kqueue", "~> 0.2.0"
   s.add_dependency "rest-client", ">= 1.6.0", "< 3.0"
-  s.add_dependency "rubyzip", "~> 1.3"
+  s.add_dependency "rubyzip", "~> 2.0"
   s.add_dependency "wdm", "~> 0.1.0"
-  s.add_dependency "winrm", "~> 2.1"
-  s.add_dependency "winrm-fs", "~> 1.0"
-  s.add_dependency "winrm-elevated", "~> 1.1"
+  s.add_dependency "winrm", ">= 2.3.4", "< 3.0"
+  s.add_dependency "winrm-fs", ">= 1.3.4", "< 2.0"
+  s.add_dependency "winrm-elevated", ">= 1.2.1", "< 2.0"
   s.add_dependency "vagrant_cloud", "~> 2.0.3"
 
   # NOTE: The ruby_dep gem is an implicit dependency from the listen gem. Later versions


### PR DESCRIPTION
Fixes hangs encountered when running elevated commands and updates
the exit code to match with ArgumentException.

Relies on: winrb/winrm-elevated#33