### PR TITLE
Fix #11396: Use sudo to detect if systemd in use

### DIFF
--- a/lib/vagrant/util/guest_inspection.rb
+++ b/lib/vagrant/util/guest_inspection.rb
@@ -12,7 +12,7 @@ module Vagrant
         #
         # @return [Boolean]
         def systemd?(comm)
-          comm.test("ps -o comm= 1 | grep systemd")
+          comm.test("ps -o comm= 1 | grep systemd", sudo: true)
         end
 
         # systemd-networkd.service is in use

--- a/test/unit/plugins/guests/debian/cap/configure_networks_test.rb
+++ b/test/unit/plugins/guests/debian/cap/configure_networks_test.rb
@@ -67,7 +67,7 @@ describe "VagrantPlugins::GuestDebian::Cap::ConfigureNetworks" do
     before do
       allow(comm).to receive(:test).with("nmcli -t d show eth1").and_return(false)
       allow(comm).to receive(:test).with("nmcli -t d show eth2").and_return(false)
-      allow(comm).to receive(:test).with("ps -o comm= 1 | grep systemd").and_return(false)
+      allow(comm).to receive(:test).with("ps -o comm= 1 | grep systemd", {sudo: true}).and_return(false)
       allow(comm).to receive(:test).with("systemctl -q is-active systemd-networkd.service", anything).and_return(false)
       allow(comm).to receive(:test).with("command -v netplan").and_return(false)
     end
@@ -85,7 +85,7 @@ describe "VagrantPlugins::GuestDebian::Cap::ConfigureNetworks" do
 
     context "with systemd" do
       before do
-        expect(comm).to receive(:test).with("ps -o comm= 1 | grep systemd").and_return(true)
+        expect(comm).to receive(:test).with("ps -o comm= 1 | grep systemd", {sudo: true}).and_return(true)
         allow(comm).to receive(:test).with("command -v netplan").and_return(false)
       end
 

--- a/test/unit/vagrant/util/guest_inspection_test.rb
+++ b/test/unit/vagrant/util/guest_inspection_test.rb
@@ -1,0 +1,18 @@
+require File.expand_path("../../../base", __FILE__)
+
+require "vagrant/util/guest_inspection"
+
+describe Vagrant::Util::GuestInspection::Linux do
+  include_context "unit"
+
+  let(:comm) { double("comm") }
+
+  subject{ Class.new { extend Vagrant::Util::GuestInspection::Linux } }
+
+  describe "#systemd?" do
+    it "should execute the command with sudo" do
+      expect(comm).to receive(:test).with(/ps/, {sudo: true}).and_return(true)
+      expect(subject.systemd?(comm)).to be(true)
+    end
+  end
+end


### PR DESCRIPTION
This change allows the vagrant user to see the systemd process in the
event that the hidepid mount option is enabled.