### PR TITLE
Alpine capability for Ansbile support

### DIFF
--- a/plugins/provisioners/ansible/cap/guest/alpine/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/alpine/ansible_install.rb
@@ -24,13 +24,12 @@ module VagrantPlugins
             private
 
             def self.ansible_apk_install(machine)
-              machine.communicate.sudo "apk add --update --no-cache python3 ansible"
+              machine.communicate.sudo "apk add --update --no-cache python ansible"
             end
 
             def self.pip_setup(machine, pip_install_cmd = "")
-              machine.communicate.sudo "apk add --update --no-cache python3"
-              machine.communicate.sudo "if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi"
-              machine.communicate.sudo "apk add --update --no-cache --virtual .build-deps python3-dev libffi-dev openssl-dev build-base"
+              machine.communicate.sudo "apk add --update --no-cache python"
+              machine.communicate.sudo "apk add --update --no-cache --virtual .build-deps python-dev libffi-dev openssl-dev build-base"
               Pip::get_pip machine, pip_install_cmd
             end
 

--- a/plugins/provisioners/ansible/cap/guest/alpine/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/alpine/ansible_install.rb
@@ -24,12 +24,15 @@ module VagrantPlugins
             private
 
             def self.ansible_apk_install(machine)
-              machine.communicate.sudo "apk add --update --no-cache python ansible"
+              machine.communicate.sudo "apk add --update --no-cache python3 ansible"
+              machine.communicate.sudo "if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi"
+              machine.communicate.sudo "if [ ! -e /usr/bin/pip ]; then ln -sf pip3 /usr/bin/pip ; fi"
             end
 
             def self.pip_setup(machine, pip_install_cmd = "")
-              machine.communicate.sudo "apk add --update --no-cache python"
-              machine.communicate.sudo "apk add --update --no-cache --virtual .build-deps python-dev libffi-dev openssl-dev build-base"
+              machine.communicate.sudo "apk add --update --no-cache python3"
+              machine.communicate.sudo "if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi"
+              machine.communicate.sudo "apk add --update --no-cache --virtual .build-deps python3-dev libffi-dev openssl-dev build-base"
               Pip::get_pip machine, pip_install_cmd
             end
 

--- a/plugins/provisioners/ansible/cap/guest/alpine/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/alpine/ansible_install.rb
@@ -8,30 +8,32 @@ module VagrantPlugins
         module Alpine
           module AnsibleInstall
 
-            DEV_PACKAGES = "python3-dev libffi-dev openssl-dev build-base".freeze
-
             def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd = "")
+              python_setup machine
               case install_mode
-              when :pip
-                pip_setup machine, pip_install_cmd
-                Pip::pip_install machine, "ansible", ansible_version, pip_args, true
-              when :pip_args_only
-                pip_setup machine, pip_install_cmd
-                Pip::pip_install machine, "", "", pip_args, false
-              else
-                ansible_apk_install machine
+                when :pip
+                  pip_setup machine
+                  Pip::pip_install machine, "ansible", ansible_version, pip_args, true
+                when :pip_args_only
+                  pip_setup machine
+                  Pip::pip_install machine, "", "", pip_args, false
+                else
+                  ansible_apk_install machine
               end
             end
 
             private
 
-            def self.ansible_apk_install(machine)
-              machine.communicate.sudo "apk add --update python ansible"
+            def self.python_setup(machine)
+              machine.communicate.sudo "apk add --update --no-cache python3"
+              machine.communicate.sudo "if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi"
             end
 
-            def self.pip_setup(machine, pip_install_cmd = "")
-              machine.communicate.sudo "apk add --update python3"
-              machine.communicate.sudo "apk add --update #{DEV_PACKAGES}"
+            def self.ansible_apk_install(machine)
+              machine.communicate.sudo "apk add --update --no-cache ansible"
+            end
+
+            def self.pip_setup(machine)
               machine.communicate.sudo "pip3 install --upgrade pip"
             end
 

--- a/plugins/provisioners/ansible/cap/guest/alpine/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/alpine/ansible_install.rb
@@ -1,0 +1,44 @@
+require_relative "../facts"
+require_relative "../pip/pip"
+
+module VagrantPlugins
+  module Ansible
+    module Cap
+      module Guest
+        module Alpine
+          module AnsibleInstall
+
+            DEV_PACKAGES = "python3-dev libffi-dev openssl-dev build-base".freeze
+
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd = "")
+              case install_mode
+              when :pip
+                pip_setup machine, pip_install_cmd
+                Pip::pip_install machine, "ansible", ansible_version, pip_args, true
+              when :pip_args_only
+                pip_setup machine, pip_install_cmd
+                Pip::pip_install machine, "", "", pip_args, false
+              else
+                ansible_apk_install machine
+              end
+            end
+
+            private
+
+            def self.ansible_apk_install(machine)
+              machine.communicate.sudo "apk add --update python ansible"
+            end
+
+            def self.pip_setup(machine, pip_install_cmd = "")
+              machine.communicate.sudo "apk add --update python3"
+              machine.communicate.sudo "apk add --update #{DEV_PACKAGES}"
+              machine.communicate.sudo "pip3 install --upgrade pip"
+              # Pip::get_pip machine, pip_install_cmd
+            end
+
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/provisioners/ansible/cap/guest/alpine/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/alpine/ansible_install.rb
@@ -9,13 +9,12 @@ module VagrantPlugins
           module AnsibleInstall
 
             def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd = "")
-              python_setup machine
               case install_mode
                 when :pip
-                  pip_setup machine
+                  pip_setup machine, pip_install_cmd
                   Pip::pip_install machine, "ansible", ansible_version, pip_args, true
                 when :pip_args_only
-                  pip_setup machine
+                  pip_setup machine, pip_install_cmd
                   Pip::pip_install machine, "", "", pip_args, false
                 else
                   ansible_apk_install machine
@@ -24,17 +23,15 @@ module VagrantPlugins
 
             private
 
-            def self.python_setup(machine)
+            def self.ansible_apk_install(machine)
+              machine.communicate.sudo "apk add --update --no-cache python3 ansible"
+            end
+
+            def self.pip_setup(machine, pip_install_cmd = "")
               machine.communicate.sudo "apk add --update --no-cache python3"
               machine.communicate.sudo "if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi"
-            end
-
-            def self.ansible_apk_install(machine)
-              machine.communicate.sudo "apk add --update --no-cache ansible"
-            end
-
-            def self.pip_setup(machine)
-              machine.communicate.sudo "pip3 install --upgrade pip"
+              machine.communicate.sudo "apk add --update --no-cache --virtual .build-deps python3-dev libffi-dev openssl-dev build-base"
+              Pip::get_pip machine, pip_install_cmd
             end
 
           end

--- a/plugins/provisioners/ansible/cap/guest/alpine/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/alpine/ansible_install.rb
@@ -33,7 +33,6 @@ module VagrantPlugins
               machine.communicate.sudo "apk add --update python3"
               machine.communicate.sudo "apk add --update #{DEV_PACKAGES}"
               machine.communicate.sudo "pip3 install --upgrade pip"
-              # Pip::get_pip machine, pip_install_cmd
             end
 
           end

--- a/plugins/provisioners/ansible/plugin.rb
+++ b/plugins/provisioners/ansible/plugin.rb
@@ -45,6 +45,11 @@ module VagrantPlugins
         Cap::Guest::Arch::AnsibleInstall
       end
 
+      guest_capability(:alpine, :ansible_install) do
+        require_relative "cap/guest/alpine/ansible_install"
+        Cap::Guest::Alpine::AnsibleInstall
+      end
+
       guest_capability(:debian, :ansible_install) do
         require_relative "cap/guest/debian/ansible_install"
         Cap::Guest::Debian::AnsibleInstall

--- a/test/unit/plugins/provisioners/ansible/cap/guest/alpine/ansible_install_test.rb
+++ b/test/unit/plugins/provisioners/ansible/cap/guest/alpine/ansible_install_test.rb
@@ -26,11 +26,9 @@ describe VagrantPlugins::Ansible::Cap::Guest::Alpine::AnsibleInstall do
   describe "#pip_setup" do
     it "install required alpine packages for pip" do
       expect(communicator).to receive(:sudo).once.ordered.
-        with("apk add --update --no-cache python3")
+        with("apk add --update --no-cache python")
       expect(communicator).to receive(:sudo).once.ordered.
-        with("if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi")
-      expect(communicator).to receive(:sudo).once.ordered.
-        with("apk add --update --no-cache --virtual .build-deps python3-dev libffi-dev openssl-dev build-base")
+        with("apk add --update --no-cache --virtual .build-deps python-dev libffi-dev openssl-dev build-base")
 
       subject.pip_setup(machine)
     end
@@ -43,7 +41,7 @@ describe VagrantPlugins::Ansible::Cap::Guest::Alpine::AnsibleInstall do
     describe "when install_mode is :default (or unknown)" do
       it "installs ansible with 'apk' package manager" do
         expect(communicator).to receive(:sudo).once.ordered.
-            with("apk add --update --no-cache python3 ansible")
+            with("apk add --update --no-cache python ansible")
 
         subject.ansible_install(machine, :default, "", "", "")
       end

--- a/test/unit/plugins/provisioners/ansible/cap/guest/alpine/ansible_install_test.rb
+++ b/test/unit/plugins/provisioners/ansible/cap/guest/alpine/ansible_install_test.rb
@@ -26,34 +26,24 @@ describe VagrantPlugins::Ansible::Cap::Guest::Alpine::AnsibleInstall do
   describe "#pip_setup" do
     it "install required alpine packages for pip" do
       expect(communicator).to receive(:sudo).once.ordered.
-        with("pip3 install --upgrade pip")
+        with("apk add --update --no-cache python3")
+      expect(communicator).to receive(:sudo).once.ordered.
+        with("if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi")
+      expect(communicator).to receive(:sudo).once.ordered.
+        with("apk add --update --no-cache --virtual .build-deps python3-dev libffi-dev openssl-dev build-base")
 
       subject.pip_setup(machine)
     end
   end
 
   describe "#ansible_install" do
-    describe "install python3 for any mode" do
-      it "installs python3 and set default symlinks" do
-        expect(communicator).to receive(:sudo).once.ordered.
-            with("apk add --update --no-cache python3")
-        expect(communicator).to receive(:sudo).once.ordered.
-            with("if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi")
-
-        subject.python_setup(machine)
-      end
-    end
 
     it_behaves_like "Ansible setup via pip"
 
     describe "when install_mode is :default (or unknown)" do
       it "installs ansible with 'apk' package manager" do
         expect(communicator).to receive(:sudo).once.ordered.
-            with("apk add --update --no-cache python3")
-        expect(communicator).to receive(:sudo).once.ordered.
-            with("if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi")
-        expect(communicator).to receive(:sudo).once.ordered.
-            with("apk add --update --no-cache ansible")
+            with("apk add --update --no-cache python3 ansible")
 
         subject.ansible_install(machine, :default, "", "", "")
       end

--- a/test/unit/plugins/provisioners/ansible/cap/guest/alpine/ansible_install_test.rb
+++ b/test/unit/plugins/provisioners/ansible/cap/guest/alpine/ansible_install_test.rb
@@ -1,0 +1,63 @@
+require_relative "../../../../../../base"
+require_relative "../shared/pip_ansible_install_examples"
+
+require Vagrant.source_root.join("plugins/provisioners/ansible/cap/guest/alpine/ansible_install")
+
+describe VagrantPlugins::Ansible::Cap::Guest::Alpine::AnsibleInstall do
+  include_context "unit"
+
+  subject { VagrantPlugins::Ansible::Cap::Guest::Alpine::AnsibleInstall }
+
+  let(:iso_env) do
+    # We have to create a Vagrantfile so there is a root path
+    env = isolated_environment
+    env.vagrantfile("")
+    env.create_vagrant_env
+  end
+
+  let(:machine) { iso_env.machine(iso_env.machine_names[0], :dummy) }
+  let(:communicator) { double("comm") }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(communicator)
+    allow(communicator).to receive(:execute).and_return(true)
+  end
+
+  describe "#pip_setup" do
+    it "install required alpine packages for pip" do
+      expect(communicator).to receive(:sudo).once.ordered.
+        with("pip3 install --upgrade pip")
+
+      subject.pip_setup(machine)
+    end
+  end
+
+  describe "#ansible_install" do
+    describe "install python3 for any mode" do
+      it "installs python3 and set default symlinks" do
+        expect(communicator).to receive(:sudo).once.ordered.
+            with("apk add --update --no-cache python3")
+        expect(communicator).to receive(:sudo).once.ordered.
+            with("if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi")
+
+        subject.python_setup(machine)
+      end
+    end
+
+    it_behaves_like "Ansible setup via pip"
+
+    describe "when install_mode is :default (or unknown)" do
+      it "installs ansible with 'apk' package manager" do
+        expect(communicator).to receive(:sudo).once.ordered.
+            with("apk add --update --no-cache python3")
+        expect(communicator).to receive(:sudo).once.ordered.
+            with("if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi")
+        expect(communicator).to receive(:sudo).once.ordered.
+            with("apk add --update --no-cache ansible")
+
+        subject.ansible_install(machine, :default, "", "", "")
+      end
+    end
+  end
+
+end

--- a/test/unit/plugins/provisioners/ansible/cap/guest/alpine/ansible_install_test.rb
+++ b/test/unit/plugins/provisioners/ansible/cap/guest/alpine/ansible_install_test.rb
@@ -26,9 +26,11 @@ describe VagrantPlugins::Ansible::Cap::Guest::Alpine::AnsibleInstall do
   describe "#pip_setup" do
     it "install required alpine packages for pip" do
       expect(communicator).to receive(:sudo).once.ordered.
-        with("apk add --update --no-cache python")
+        with("apk add --update --no-cache python3")
       expect(communicator).to receive(:sudo).once.ordered.
-        with("apk add --update --no-cache --virtual .build-deps python-dev libffi-dev openssl-dev build-base")
+        with("if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi")
+      expect(communicator).to receive(:sudo).once.ordered.
+        with("apk add --update --no-cache --virtual .build-deps python3-dev libffi-dev openssl-dev build-base")
 
       subject.pip_setup(machine)
     end
@@ -41,7 +43,11 @@ describe VagrantPlugins::Ansible::Cap::Guest::Alpine::AnsibleInstall do
     describe "when install_mode is :default (or unknown)" do
       it "installs ansible with 'apk' package manager" do
         expect(communicator).to receive(:sudo).once.ordered.
-            with("apk add --update --no-cache python ansible")
+            with("apk add --update --no-cache python3 ansible")
+        expect(communicator).to receive(:sudo).once.ordered.
+            with("if [ ! -e /usr/bin/python ]; then ln -sf python3 /usr/bin/python ; fi")
+        expect(communicator).to receive(:sudo).once.ordered.
+            with("if [ ! -e /usr/bin/pip ]; then ln -sf pip3 /usr/bin/pip ; fi")
 
         subject.ansible_install(machine, :default, "", "", "")
       end


### PR DESCRIPTION
This PR adds capability for Alpine guest for Ansible provisioner installation.

Some notes:
* Ansible version installed via Package manager depends on Alpine guest version
* Use Python3 for any installation mode