### PR TITLE
save the mountpoint within virtualbox folder share

### DIFF
--- a/plugins/providers/virtualbox/driver/version_6_0.rb
+++ b/plugins/providers/virtualbox/driver/version_6_0.rb
@@ -119,7 +119,7 @@ module VagrantPlugins
 
             args << "--automount" if folder.key?(:automount) && folder[:automount]
 
-            args << "--auto-mount-point" if folder.key?(:guestpath) && folder[:guestpath]
+            args << "--auto-mount-point" << folder[:guestpath] if folder.key?(:guestpath)
 
             if folder[:SharedFoldersEnableSymlinksCreate]
               # Enable symlinks on the shared folder

--- a/plugins/providers/virtualbox/driver/version_6_0.rb
+++ b/plugins/providers/virtualbox/driver/version_6_0.rb
@@ -113,13 +113,13 @@ module VagrantPlugins
             args = ["--name",
               folder[:name],
               "--hostpath",
-              hostpath,
-              "--auto-mount-point",
-              folder[:guestpath]]
+              hostpath]
 
             args << "--transient" if folder.key?(:transient) && folder[:transient]
 
             args << "--automount" if folder.key?(:automount) && folder[:automount]
+
+            args << "--auto-mount-point" if folder.key?(:guestpath) && folder[:guestpath]
 
             if folder[:SharedFoldersEnableSymlinksCreate]
               # Enable symlinks on the shared folder

--- a/plugins/providers/virtualbox/synced_folder.rb
+++ b/plugins/providers/virtualbox/synced_folder.rb
@@ -106,6 +106,8 @@ module VagrantPlugins
             hostpath = Vagrant::Util::Platform.cygwin_windows_path(hostpath)
           end
 
+          guestpath = data[:guestpath]
+
           enable_symlink_create = true
 
           if ENV['VAGRANT_DISABLE_VBOXSYMLINKCREATE']
@@ -123,6 +125,7 @@ module VagrantPlugins
             defs << {
               name: os_friendly_id(id),
               hostpath: hostpath.to_s,
+              guestpath: guestpath.to_s,
               transient: transient,
               SharedFoldersEnableSymlinksCreate: enable_symlink_create,
               automount: !!data[:automount]

--- a/test/unit/plugins/providers/virtualbox/synced_folder_test.rb
+++ b/test/unit/plugins/providers/virtualbox/synced_folder_test.rb
@@ -78,31 +78,31 @@ describe VagrantPlugins::ProviderVirtualBox::SyncedFolder do
     end
 
     it "should prepare and share the folders" do
-      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :transient=>false, :automount=>false, :SharedFoldersEnableSymlinksCreate=>true}])
+      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :guestpath=>"/folder", :transient=>false, :automount=>false, :SharedFoldersEnableSymlinksCreate=>true}])
       subject.prepare(machine, folders, nil)
     end
 
     it "should prepare and share the folders without symlinks enabled" do
-      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :transient=>false, :automount=>false, :SharedFoldersEnableSymlinksCreate=>false}])
+      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :guestpath=>"/folder", :transient=>false, :automount=>false, :SharedFoldersEnableSymlinksCreate=>false}])
       subject.prepare(machine, folders_disabled, nil)
     end
 
     it "should prepare and share the folders without symlinks enabled with env var set" do
       stub_env('VAGRANT_DISABLE_VBOXSYMLINKCREATE'=>'1')
 
-      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :transient=>false, :automount=>false, :SharedFoldersEnableSymlinksCreate=>false}])
+      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :guestpath=>"/folder", :transient=>false, :automount=>false, :SharedFoldersEnableSymlinksCreate=>false}])
       subject.prepare(machine, folders_nosymvar, nil)
     end
 
     it "should prepare and share the folders and override symlink setting" do
       stub_env('VAGRANT_DISABLE_VBOXSYMLINKCREATE'=>'1')
 
-      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :transient=>false, :automount=>false, :SharedFoldersEnableSymlinksCreate=>true}])
+      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :guestpath=>"/folder", :transient=>false, :automount=>false, :SharedFoldersEnableSymlinksCreate=>true}])
       subject.prepare(machine, folders, nil)
     end
 
     it "should prepare and share the folders with automount enabled" do
-      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :transient=>false, :SharedFoldersEnableSymlinksCreate=>true, :automount=>true}])
+      expect(driver).to receive(:share_folders).with([{:name=>"folder", :hostpath=>"/Users/brian/vagrant-folder", :guestpath=>"/folder", :transient=>false, :SharedFoldersEnableSymlinksCreate=>true, :automount=>true}])
       subject.prepare(machine, folders_automount, nil)
     end
   end


### PR DESCRIPTION
As of version 6.0 VBoxManage accepts the commandline argument "--auto-mount-point" (even though it is still missing in their documentation) which can be used to define the guestpath for a folder share. This has the advantage that mountpoints stay consistent,  say throughout a reboot procedure initiated from within the virtual machine or when starting the VM not via "vagrant up" but from within the VirtualBox Manager.
fixes hashicorp/vagrant#11415