### PR TITLE
Fix #11271: catch IdentityNotMappedException

### DIFF
--- a/plugins/providers/hyperv/scripts/utils/VagrantVM/VagrantVM.psm1
+++ b/plugins/providers/hyperv/scripts/utils/VagrantVM/VagrantVM.psm1
@@ -722,7 +722,7 @@ function Check-VagrantHyperVAccess {
     )
     $acl = Get-ACL -Path $Path
     $systemACL = $acl.Access | where {
-        $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value -eq "S-1-5-18" -and
+        try { return $_.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier]).Value -eq "S-1-5-18" } catch { return $false } -and
         $_.FileSystemRights -eq "FullControl" -and
         $_.AccessControlType -eq "Allow" -and
         $_.IsInherited -eq $true}


### PR DESCRIPTION
Some IdentityReferences cannot be translated to
[System.Security.Principal.SecurityIdentifier] because they don't map to
a SecurityIdentifier.

An example is:
`IdentityReference : APPLICATION PACKAGE AUTHORITY\ALL APPLICATION PACKAGES`

In such case, it is better to catch the exception and treat it as `$false.`