### PR TITLE
Missed comma in configuration file

### DIFF
--- a/website/source/docs/docker/networking.html.md
+++ b/website/source/docs/docker/networking.html.md
@@ -199,7 +199,7 @@ $ docker network create my-custom-network --subnet=172.20.0.0/16
 ```ruby
 Vagrant.configure("2") do |config|
   config.vm.define "docker"  do |docker|
-    docker.vm.network :private_network, type: "dhcp" name: "my-custom-network"
+    docker.vm.network :private_network, type: "dhcp", name: "my-custom-network"
     docker.vm.provider "docker" do |d|
       d.build_dir = "docker_build_dir"
     end


### PR DESCRIPTION
Vagrant throws this error when I tried to run this block of code.
```
syntax error, unexpected tIDENTIFIER, expecting keyword_endate_network, type: "dhcp" name: "my-custom-network"
```

After I added a comma, all starts to work correctly.
