### PR TITLE
Update dynamic action hooks implementation

### DIFF
--- a/lib/vagrant/action.rb
+++ b/lib/vagrant/action.rb
@@ -2,6 +2,7 @@ require 'vagrant/action/builder'
 
 module Vagrant
   module Action
+    autoload :Hook,        'vagrant/action/hook'
     autoload :Runner,      'vagrant/action/runner'
     autoload :Warden,      'vagrant/action/warden'
 

--- a/lib/vagrant/plugin/v2/manager.rb
+++ b/lib/vagrant/plugin/v2/manager.rb
@@ -28,6 +28,55 @@ module Vagrant
           result
         end
 
+        # Find all hooks that are applicable for the given key. This
+        # lookup does not include hooks which are defined for ALL_ACTIONS.
+        # Key lookups will match on either string or symbol values. The
+        # provided keys is broken down into multiple parts for lookups,
+        # which allows defining hooks with an entire namespaced name,
+        # or a short suffx. For example:
+        #
+        #  Assume we are given an action class
+        #    key = Vagrant::Action::Builtin::SyncedFolders
+        #
+        #  The list of keys that will be checked for hooks:
+        #    ["Vagrant::Action::Builtin::SyncedFolders", "vagrant_action_builtin_synced_folders",
+        #     "Action::Builtin::SyncedFolders", "action_builtin_synced_folders",
+        #     "Builtin::SyncedFolders", "builtin_synced_folders",
+        #     "SyncedFolders", "synced_folders"]
+        #
+        # @param key [Class, String] key Key for hook lookups
+        # @return [Array<Proc>]
+        def find_action_hooks(key)
+          result = []
+
+          generate_hook_keys(key).each do |k|
+            @registered.each do |plugin|
+              result += plugin.components.action_hooks[k]
+              result += plugin.components.action_hooks[k.to_sym]
+            end
+          end
+
+          result
+        end
+
+        # Generate all valid lookup keys for given key
+        #
+        # @param [Class, String] key Base key for generation
+        # @return [Array<String>] all valid keys
+        def generate_hook_keys(key)
+          key = key.is_a?(Class) ? key.name : key.to_s
+          parts = key.split("::")
+          [].tap do |keys|
+            until parts.empty?
+              x = parts.join("::")
+              keys << x
+              y = x.gsub(/([a-z])([A-Z])/, '\1_\2').gsub('::', '_').downcase
+              keys << y if x != y
+              parts.shift
+            end
+          end
+        end
+
         # This returns all the registered commands.
         #
         # @return [Registry<Symbol, Array<Proc, Hash>>]

--- a/plugins/guests/darwin/plugin.rb
+++ b/plugins/guests/darwin/plugin.rb
@@ -6,6 +6,11 @@ module VagrantPlugins
       name "Darwin guest"
       description "Darwin guest support."
 
+      action_hook(:apfs_firmlinks, :synced_folders) do |hook|
+        require_relative "cap/mount_vmware_shared_folder"
+        hook.append(Cap::MountVmwareSharedFolder.method(:write_apfs_firmlinks))
+      end
+
       guest(:darwin, :bsd)  do
         require_relative "guest"
         Guest

--- a/test/unit/plugins/guests/darwin/cap/mount_vmware_shared_folder_test.rb
+++ b/test/unit/plugins/guests/darwin/cap/mount_vmware_shared_folder_test.rb
@@ -39,10 +39,6 @@ describe "VagrantPlugins::GuestDarwin::Cap::MountVmwareSharedFolder" do
         expect(communicator).to receive(:test).with(/synthetic\.conf/)
       end
 
-      it "should register an action hook" do
-        expect(VagrantPlugins::GuestDarwin::Plugin).to receive(:action_hook).with(:apfs_firmlinks, :after_synced_folders)
-      end
-
       context "with guest path within existing directory" do
         let(:guestpath) { "/Users/vagrant/workspace" }
 
@@ -75,10 +71,6 @@ describe "VagrantPlugins::GuestDarwin::Cap::MountVmwareSharedFolder" do
 
         it "should create the symlink within the writable APFS container" do
           expect(communicator).to receive(:sudo).with(%r{ln -s .+/System/Volumes/Data.+})
-        end
-
-        it "should register an action hook" do
-          expect(VagrantPlugins::GuestDarwin::Plugin).to receive(:action_hook).with(:apfs_firmlinks, :after_synced_folders)
         end
 
         context "when firmlink is provided by the system" do

--- a/test/unit/plugins/guests/darwin/cap/mount_vmware_shared_folder_test.rb
+++ b/test/unit/plugins/guests/darwin/cap/mount_vmware_shared_folder_test.rb
@@ -156,4 +156,55 @@ describe "VagrantPlugins::GuestDarwin::Cap::MountVmwareSharedFolder" do
       end
     end
   end
+
+  describe ".write_apfs_firmlinks" do
+    let(:env) { nil }
+    let(:action) { double("action", call: nil) }
+    let(:machine) { double("machine", id: machine_id) }
+    let(:machine_id) { double("machine_id") }
+    let(:delayed) { {} }
+
+    context "when env is nil" do
+      it "should be a no-op" do
+        expect(described_class).not_to receive(:apfs_firmlinks_delayed)
+        described_class.write_apfs_firmlinks(env)
+      end
+    end
+
+    context "when env is empty hash" do
+      let(:env) { {} }
+
+      it "should be a no-op" do
+        expect(described_class).not_to receive(:apfs_firmlinks_delayed)
+        described_class.write_apfs_firmlinks(env)
+      end
+    end
+
+    context "when machine is defined within env" do
+      let(:env) { {machine: machine} }
+
+      it "should request the stored delayed actions" do
+        expect(described_class).to receive(:apfs_firmlinks_delayed).and_return(delayed)
+        described_class.write_apfs_firmlinks(env)
+      end
+    end
+
+    context "when delayed action is stored for machine" do
+      let(:env) { {machine: machine} }
+
+      before { described_class.apfs_firmlinks_delayed[machine_id] = action }
+      after { described_class.apfs_firmlinks_delayed.clear }
+
+      it "should call the delayed action" do
+        expect(action).to receive(:call)
+        described_class.write_apfs_firmlinks(env)
+      end
+
+      it "should remove the action after calling" do
+        expect(action).to receive(:call)
+        described_class.write_apfs_firmlinks(env)
+        expect(delayed).to be_empty
+      end
+    end
+  end
 end

--- a/test/unit/vagrant/plugin/v2/manager_test.rb
+++ b/test/unit/vagrant/plugin/v2/manager_test.rb
@@ -11,6 +11,122 @@ describe Vagrant::Plugin::V2::Manager do
     p
   end
 
+  describe "#generate_hook_keys" do
+    it "should return array with one value" do
+      expect(subject.generate_hook_keys(:test_value)).to eq(["test_value"])
+    end
+
+    it "should return array with two values when key is camel cased" do
+      result = subject.generate_hook_keys("TestValue")
+      expect(result.size).to eq(2)
+      expect(result).to include("TestValue")
+      expect(result).to include("test_value")
+    end
+
+    it "should handle class/module value" do
+      result = subject.generate_hook_keys(Vagrant)
+      expect(result.size).to eq(2)
+      expect(result).to include("Vagrant")
+      expect(result).to include("vagrant")
+    end
+
+    it "should handle namespaced value" do
+      result = subject.generate_hook_keys(Vagrant::Plugin)
+      expect(result.size).to eq(4)
+      expect(result).to include("Vagrant::Plugin")
+      expect(result).to include("Plugin")
+      expect(result).to include("vagrant_plugin")
+      expect(result).to include("plugin")
+    end
+  end
+
+  describe "#find_action_hooks" do
+    let(:hook_name) { "Vagrant::Plugin" }
+
+    before do
+      h_name = hook_name
+      pA = plugin do |p|
+        p.action_hook(:test, h_name) { "hook_called" }
+      end
+      subject.register(pA)
+    end
+
+    it "should find hook with full namespace" do
+      hooks = subject.find_action_hooks(Vagrant::Plugin)
+      expect(hooks).not_to be_empty
+      expect(hooks.first.call).to eq("hook_called")
+    end
+
+    it "should not find hook with short class name" do
+      hooks = subject.find_action_hooks("Plugin")
+      expect(hooks).to be_empty
+    end
+
+    it "should not find hook with full snake cased name" do
+      hooks = subject.find_action_hooks(:vagrant_plugin)
+      expect(hooks).to be_empty
+    end
+
+    it "should not find hook with short snake cased name" do
+      hooks = subject.find_action_hooks("plugin")
+      expect(hooks).to be_empty
+    end
+
+    context "when hook uses full snake cased name" do
+      let(:hook_name) { :vagrant_plugin }
+
+      it "should find hook with full namespace" do
+        hooks = subject.find_action_hooks(Vagrant::Plugin)
+        expect(hooks).not_to be_empty
+        expect(hooks.first.call).to eq("hook_called")
+      end
+
+      it "should find hook with full snake cased name" do
+        hooks = subject.find_action_hooks(:vagrant_plugin)
+        expect(hooks).not_to be_empty
+        expect(hooks.first.call).to eq("hook_called")
+      end
+
+      it "should not find hook with short class name" do
+        hooks = subject.find_action_hooks("Plugin")
+        expect(hooks).to be_empty
+      end
+
+      it "should not find hook with short snake cased name" do
+        hooks = subject.find_action_hooks("plugin")
+        expect(hooks).to be_empty
+      end
+    end
+
+    context "when hook uses short snake cased name" do
+      let(:hook_name) { :plugin }
+
+      it "should find hook with full namespace" do
+        hooks = subject.find_action_hooks(Vagrant::Plugin)
+        expect(hooks).not_to be_empty
+        expect(hooks.first.call).to eq("hook_called")
+      end
+
+      it "should find hook with short class name" do
+        hooks = subject.find_action_hooks("Plugin")
+        expect(hooks).not_to be_empty
+        expect(hooks.first.call).to eq("hook_called")
+      end
+
+      it "should find hook with short snake cased name" do
+        hooks = subject.find_action_hooks("plugin")
+        expect(hooks).not_to be_empty
+        expect(hooks.first.call).to eq("hook_called")
+      end
+
+      it "should not find hook with full snake cased name" do
+        hooks = subject.find_action_hooks(:vagrant_plugin)
+        expect(hooks).to be_empty
+      end
+    end
+
+  end
+
   describe "#action_hooks" do
     it "should contain globally registered hooks" do
       pA = plugin do |p|


### PR DESCRIPTION
Updates dynamic action hooks implementation to fetch
defined action hooks and properly apply them to an
action which is to be run. This prevents the generation of
new actions and allows proper injection via the Hook
class.

Fixes #11401