### PR TITLE
Catch any StandardError exception while waiting for Windows reboot

### DIFF
--- a/plugins/guests/windows/cap/reboot.rb
+++ b/plugins/guests/windows/cap/reboot.rb
@@ -28,8 +28,9 @@ module VagrantPlugins
           wait_remaining = MAX_REBOOT_RETRY_DURATION
           begin
             wait_for_reboot(machine)
-          rescue HTTPClient::ConnectTimeoutError, Vagrant::Errors::MachineGuestNotReady, WinRM::WinRMHTTPTransportError => e
+          rescue => err
             raise if wait_remaining < 0
+            @logger.debug("Exception caught while waiting for reboot: #{err}")
             @logger.warn("Machine not ready, cannot start reboot yet. Trying again")
             sleep(5)
             wait_remaining -= 5


### PR DESCRIPTION
This prevents any unexpected connection related error from breaking
the wait loop while windows reboots. If an underlying problem unrelated
to the guest is causing exceptions, the exception will still be raised
to the user, simply after the loop has exceeded the defined maximum
wait time.

Fixes #11238