### PR TITLE
Document ability to specify which host-only network.

### DIFF
--- a/website/source/docs/virtualbox/networking.html.md
+++ b/website/source/docs/virtualbox/networking.html.md
@@ -16,7 +16,7 @@ By default, private networks are [host-only networks](https://www.virtualbox.org
 because those are the easiest to work with. In VirtualBox, since you can
 create multiple host-only networks, it is also possible to specify which
 host-only network you want the Vagrant VirtualBox provider to use for
-a given interface. To do this, use the `:name` symbol with the name of
+a given interface. To do this, use the `name` argument with the name of
 the host-only interface to use.
 
 ```ruby

--- a/website/source/docs/virtualbox/networking.html.md
+++ b/website/source/docs/virtualbox/networking.html.md
@@ -22,7 +22,7 @@ the host-only interface to use.
 ```ruby
 Vagrant.configure("2") do |config|
   config.vm.network "private_network", type: "dhcp",
-    name: => "vboxnet3"
+    name: "vboxnet3"
 end
 ```
 

--- a/website/source/docs/virtualbox/networking.html.md
+++ b/website/source/docs/virtualbox/networking.html.md
@@ -10,6 +10,22 @@ description: |-
 
 # Networking
 
+## VirtualBox Host-Only Networks
+
+By default, private networks are [host-only networks](https://www.virtualbox.org/manual/ch06.html#network_hostonly),
+because those are the easiest to work with. In VirtualBox, since you can
+create multiple host-only networks, it is also possible to specify which
+host-only network you want to the Vagrant Virtualbox provider to use for
+a given interface. To do this, use the `:name` symbol with the name of
+the host-only interface to use.
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.network "private_network", type: "dhcp",
+    :name => "vboxnet3"
+end
+```
+
 ## VirtualBox Internal Network
 
 The Vagrant VirtualBox provider supports using the private network as a

--- a/website/source/docs/virtualbox/networking.html.md
+++ b/website/source/docs/virtualbox/networking.html.md
@@ -15,14 +15,14 @@ description: |-
 By default, private networks are [host-only networks](https://www.virtualbox.org/manual/ch06.html#network_hostonly),
 because those are the easiest to work with. In VirtualBox, since you can
 create multiple host-only networks, it is also possible to specify which
-host-only network you want to the Vagrant Virtualbox provider to use for
+host-only network you want the Vagrant VirtualBox provider to use for
 a given interface. To do this, use the `:name` symbol with the name of
 the host-only interface to use.
 
 ```ruby
 Vagrant.configure("2") do |config|
   config.vm.network "private_network", type: "dhcp",
-    :name => "vboxnet3"
+    name: => "vboxnet3"
 end
 ```
 


### PR DESCRIPTION
Although it has been possible to specify a specific VirtualBox host-only network
to attach a machine's NIC to, this was never mentioned by the documentation in
the VirtualBox provider's networking section. I had to spelunk through the issue
tracker to find an example of this.

This patch adds a code example along with a short description of the ability in
human language prose, and a link to the relevant section in the VirtualBox User
Manual about "Host-Only Networking."