### PR TITLE
Fix warnings and errors for ruby 2.7

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -2,6 +2,7 @@ require "digest/sha1"
 require "log4r"
 require "pathname"
 require "uri"
+require "cgi"
 
 require "vagrant/box_metadata"
 require "vagrant/util/downloader"
@@ -44,7 +45,7 @@ module Vagrant
             u = u.gsub("\\", "/")
             if Util::Platform.windows? && u =~ /^[a-z]:/i
               # On Windows, we need to be careful about drive letters
-              u = "file:///#{URI.escape(u)}"
+              u = "file:///#{CGI::escape(u)}"
             end
 
             if u =~ /^[a-z0-9]+:.*$/i && !u.start_with?("file://")
@@ -53,9 +54,9 @@ module Vagrant
             end
 
             # Expand the path and try to use that, if possible
-            p = File.expand_path(URI.unescape(u.gsub(/^file:\/\//, "")))
+            p = File.expand_path(CGI::unescape(u.gsub(/^file:\/\//, "")))
             p = Util::Platform.cygwin_windows_path(p)
-            next "file://#{URI.escape(p.gsub("\\", "/"))}" if File.file?(p)
+            next "file://#{p.gsub("\\", "/")}" if File.file?(p)
 
             u
           end
@@ -495,7 +496,7 @@ module Vagrant
             url ||= uri.opaque
             #7570 Strip leading slash left in front of drive letter by uri.path
             Util::Platform.windows? && url.gsub!(/^\/([a-zA-Z]:)/, '\1')
-            url = URI.unescape(url)
+            url = CGI::unescape(url)
 
             begin
               File.open(url, "r") do |f|

--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -632,7 +632,11 @@ module Vagrant
       self_spec.runtime_dependencies.each { |d| gem d.name, *d.requirement.as_list }
       # discover all the gems we have available
       list = {}
-      directories = [Gem::Specification.default_specifications_dir]
+      if(Gem::Version.create(RUBY_VERSION) >= Gem::Version.create("2.7"))
+        directories = [Gem.default_specifications_dir]
+      else
+        directories = [Gem::Specification.default_specifications_dir]
+      end
       Gem::Specification.find_all{true}.each do |spec|
         list[spec.full_name] = spec
       end

--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -1,4 +1,5 @@
 require "uri"
+require "cgi"
 
 require "log4r"
 require "digest"
@@ -42,8 +43,8 @@ module Vagrant
         begin
           url = URI.parse(@source)
           if url.scheme && url.scheme.start_with?("http") && url.user
-            auth = "#{URI.unescape(url.user)}"
-            auth += ":#{URI.unescape(url.password)}" if url.password
+            auth = "#{CGI::unescape(url.user)}"
+            auth += ":#{CGI::unescape(url.password)}" if url.password
             url.user = nil
             url.password = nil
             options[:auth] ||= auth

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary       = "Build and distribute virtualized development environments."
   s.description   = "Vagrant is a tool for building and distributing virtualized development environments."
 
-  s.required_ruby_version     = "~> 2.4", "< 2.7"
+  s.required_ruby_version     = "~> 2.4"
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "bcrypt_pbkdf", "~> 1.0.0"


### PR DESCRIPTION
Ruby 2.7 causes many depreciation warnings. I tried to remove the majority of them.

I still get some tests failing in `test/unit/plugins/providers/docker/driver_compose_test.rb`. One example of a test failing:
```
$ bundle exec rspec test/unit/plugins/providers/docker/driver_compose_test.rb -e "sets container name"
Run options:
  include {:full_description=>/sets\ container\ name/}
  exclude {:windows=>true}

VagrantPlugins::DockerProvider::Driver::Compose
  #create
    sets container name (FAILED - 1)

Failures:

  1) VagrantPlugins::DockerProvider::Driver::Compose#create sets container name
     Failure/Error: before { expect(subject).to receive(:execute).with(*compose_execute_up) }

       #<VagrantPlugins::DockerProvider::Driver::Compose:0x000056416b3e4ba0 @logger=#<Log4r::Logger:0x000056416b2dd748 @fullname="vagrant::docker::driver::compose", @outputters=[], @additive=true, @name="compose", @path="vagrant::docker::driver", @parent=#<Log4r::Logger:0x000056416b3d2658 @fullname="vagrant::docker::driver", @outputters=[], @additive=true, @name="driver", @path="vagrant::docker", @parent=#<Log4r::RootLogger:0x000056416a3297c0 @level=0, @outputters=[]>, @level=0, @trace=false>, @level=0, @trace=false>, @executor=#<VagrantPlugins::DockerProvider::Executor::Local:0x000056416b325598>, @machine=#<Double "machine">, @data_directory=#<Double "data-directory">, @compose_lock=#<Thread::Mutex:0x000056416b2396c0>> received :execute with unexpected arguments
         expected: ("docker-compose", "-f", "docker-compose.yml", "-p", "cwd", "up", "--remove-orphans", "-d", {})
              got: ("docker-compose", "-f", "docker-compose.yml", "-p", "cwd", "up", "--remove-orphans", "-d") (1 time)
                   ("docker-compose", "-f", "docker-compose.yml", "-p", "cwd", "ps", "-q", "docker_1") (1 time)
     # ./test/unit/plugins/providers/docker/driver_compose_test.rb:88:in `block (3 levels) in <top (required)>'

Finished in 2.02 seconds (files took 0.47252 seconds to load)
1 example, 1 failure
```
I do not know how to fix this. Does someone who is more fluent in Ruby could help? 