### PR TITLE
Fix #11439: Quote each exported directory

### DIFF
--- a/templates/nfs/exports_darwin.erb
+++ b/templates/nfs/exports_darwin.erb
@@ -1,7 +1,7 @@
 # VAGRANT-BEGIN: <%= user %> <%= uuid %>
 <% folders.each do |dirs, opts| %>
 <% dirs.each do |d| %>
-<%= d %> <%=opts[:bsd__compiled_nfs_options] %> <%= ips.join(" ") %>
+"<%= d %>" <%=opts[:bsd__compiled_nfs_options] %> <%= ips.join(" ") %>
 <% end %>
 <% end %>
 # VAGRANT-END: <%= user %> <%= uuid %>

--- a/test/unit/templates/nfs/exports_darwin_test.rb
+++ b/test/unit/templates/nfs/exports_darwin_test.rb
@@ -37,7 +37,7 @@ describe "templates/nfs/exports_darwin" do
       })
       expect(result).to eq <<-EOH.gsub(/^ {8}/, "")
         # VAGRANT-BEGIN: 501 UUID
-        /vagrant -alldirs -mapall=501:80 172.16.0.2
+        "/vagrant" -alldirs -mapall=501:80 172.16.0.2
         # VAGRANT-END: 501 UUID
       EOH
     end
@@ -59,8 +59,8 @@ describe "templates/nfs/exports_darwin" do
       })
       expect(result).to eq <<-EOH.gsub(/^ {8}/, "")
         # VAGRANT-BEGIN: 501 UUID
-        /vagrant -alldirs -mapall=501:80 172.16.0.2
-        /vagrant/other -alldirs -mapall=501:80 172.16.0.2
+        "/vagrant" -alldirs -mapall=501:80 172.16.0.2
+        "/vagrant/other" -alldirs -mapall=501:80 172.16.0.2
         # VAGRANT-END: 501 UUID
       EOH
     end


### PR DESCRIPTION
This commit changes the Darwin NFS template for /etc/exports to put each
exported directory in quotes.

This fixes an issue with directory names that have spaces in them.
Quotes were chosen (rather than escaping the spaces) in order to match
the template for Linux NFS exports.