### PR TITLE
Explicitly activate vagrant specification when not activated

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -248,6 +248,10 @@ module Vagrant
       error_key(:bundler_error)
     end
 
+    class SourceSpecNotFound < BundlerError
+      error_key(:source_spec_not_found)
+    end
+
     class CantReadMACAddresses < VagrantError
       error_key(:cant_read_mac_addresses)
     end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -711,6 +711,10 @@ en:
         or transient network issues. The reported error is:
 
         %{message}
+      source_spec_not_found: |-
+        Vagrant failed to properly initialize its internal library
+        dependencies. Please try running the command again. If this
+        error persists, please report a bug.
       cant_read_mac_addresses: |-
         The provider you are using  ('%{provider}') doesn't support the
         "nic_mac_addresses" provider capability which is required


### PR DESCRIPTION
This fixes an issue where the vagrant specification may not be
activated in certain cases (like using `github:` option for
gem entry in a Gemfile). When no vagrant specification is
currently activated, activate before loading runtime dependencies.

Fixes #10945