### PR TITLE
When not running as a pre-release version, disable verbose output

### DIFF
--- a/bin/vagrant
+++ b/bin/vagrant
@@ -94,6 +94,11 @@ begin
   # Schedule the cleanup of things
   at_exit(&Vagrant::Bundler.instance.method(:deinit))
 
+  # If this is not a pre-release disable verbose output
+  if !Vagrant.prerelease?
+    $VERBOSE = nil
+  end
+
   # Create a logger right away
   logger = Log4r::Logger.new("vagrant::bin::vagrant")
   logger.info("`vagrant` invoked: #{ARGV.inspect}")


### PR DESCRIPTION
This will restrict output of warnings for things like method
deprections to only being visble while running a pre-release
version of Vagrant (typically in development)