### PR TITLE
Add RHEL/CentOS 8 to list of RHEL flavors

### DIFF
--- a/plugins/guests/redhat/cap/flavor.rb
+++ b/plugins/guests/redhat/cap/flavor.rb
@@ -10,7 +10,9 @@ module VagrantPlugins
           end
 
           # Detect various flavors we care about
-          if output =~ /(CentOS|Red Hat Enterprise|Scientific|Cloud|Virtuozzo)\s*Linux( .+)? release 7/i
+          if output =~ /(CentOS|Red Hat Enterprise|Scientific|Cloud|Virtuozzo)\s*Linux( .+)? release 8/i
+            return :rhel_8
+          elsif output =~ /(CentOS|Red Hat Enterprise|Scientific|Cloud|Virtuozzo)\s*Linux( .+)? release 7/i
             return :rhel_7
           else
             return :rhel


### PR DESCRIPTION
This will make it so that `:rhel_8` will be returned on el8
guests.