### PR TITLE
Fix #11373: Check all interfaces for port collisions

### DIFF
--- a/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
+++ b/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
@@ -271,7 +271,11 @@ module Vagrant
             end
           else
             # Do a regular check
-            is_port_open?(host_ip, host_port)
+            if test_host_ip == "0.0.0.0" || ipv4_addresses.include?(test_host_ip)
+              is_port_open?(test_host_ip, host_port)
+            else
+              raise Errors::ForwardPortHostIPNotFound
+            end
           end
         end
 

--- a/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
+++ b/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
@@ -254,7 +254,7 @@ module Vagrant
         def port_check(host_ip, host_port)
           # If no host_ip is specified, intention taken to be listen on all interfaces.
           test_host_ip = host_ip || "0.0.0.0"
-          if @machine.config.vm.guest == :windows && test_host_ip == "0.0.0.0"
+          if Util::Platform.windows? && test_host_ip == "0.0.0.0"
             @logger.debug("Testing port #{host_port} on all IPv4 interfaces...")
             available_interfaces = ipv4_interfaces.select do |interface|
               @logger.debug("Testing #{interface[0]} with IP address #{interface[1]}")

--- a/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
+++ b/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
@@ -1,7 +1,7 @@
 require "set"
 
 require "log4r"
-require 'socket'
+require "socket"
 
 require "vagrant/util/is_port_open"
 
@@ -246,7 +246,7 @@ module Vagrant
         def ipv4_addresses
           ip_addresses = []
           Socket.getifaddrs.each do |ifaddr|
-            if ifaddr.addr.ipv4?
+            if ifaddr.addr && ifaddr.addr.ipv4?
               ip_addresses << ifaddr.addr.ip_address
             end
           end

--- a/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
+++ b/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
@@ -272,7 +272,7 @@ module Vagrant
             if test_host_ip == "0.0.0.0" || ipv4_interfaces.detect { |iface| iface[1] == test_host_ip }
               is_port_open?(test_host_ip, host_port)
             else
-              raise Errors::ForwardPortHostIPNotFound
+              raise Errors::ForwardPortHostIPNotFound, name: @machine.name, host_ip: host_ip
             end
           end
         end

--- a/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
+++ b/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
@@ -255,7 +255,8 @@ module Vagrant
 
         def port_check(host_ip, host_port)
           # If no host_ip is specified, intention taken to be listen on all interfaces.
-          if host_ip.nil? || host_ip == "0.0.0.0"
+          test_host_ip = host_ip || "0.0.0.0"
+          if @machine.config.vm.guest == :windows && test_host_ip == "0.0.0.0"
             @logger.debug("Checking port #{host_port} on all IPv4 addresses...")
             available_ips = ipv4_addresses.select do |test_host_ip|
               @logger.debug("Host IP: #{test_host_ip}, port: #{host_port}")

--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -400,6 +400,10 @@ module Vagrant
       error_key(:auto_empty, "vagrant.actions.vm.forward_ports")
     end
 
+    class ForwardPortHostIPNotFound < VagrantError
+      error_key(:host_ip_not_found, "vagrant.actions.vm.forward_ports")
+    end
+
     class ForwardPortCollision < VagrantError
       error_key(:collision_error, "vagrant.actions.vm.forward_ports")
     end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2321,6 +2321,10 @@ en:
           forwarding: Forwarding ports...
           forwarding_entry: |-
             %{guest_port} (guest) => %{host_port} (host) (adapter %{adapter})
+          host_ip_not_found:
+            You are trying to forward a host IP that does not exist. Please set `host_ip`
+            to the address of an existing IPv4 network interface, or remove the option
+            from your port forward configuration.
           non_nat: |-
             VirtualBox adapter #%{adapter} not configured as "NAT". Skipping port
             forwards on this adapter.

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2321,10 +2321,13 @@ en:
           forwarding: Forwarding ports...
           forwarding_entry: |-
             %{guest_port} (guest) => %{host_port} (host) (adapter %{adapter})
-          host_ip_not_found:
+          host_ip_not_found: |-
             You are trying to forward a host IP that does not exist. Please set `host_ip`
             to the address of an existing IPv4 network interface, or remove the option
             from your port forward configuration.
+
+            VM: %{name}
+            Host IP: %{host_ip}
           non_nat: |-
             VirtualBox adapter #%{adapter} not configured as "NAT". Skipping port
             forwards on this adapter.

--- a/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
+++ b/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
@@ -39,13 +39,10 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
     end
   end
 
-  let(:guest) { }
-
   let(:vm_config) do
     double("machine_vm_config").tap do |config|
       allow(config).to receive(:usable_port_range).and_return(1000..2000)
       allow(config).to receive(:networks).and_return([])
-      allow(config).to receive(:guest).and_return(guest)
     end
   end
 
@@ -206,7 +203,9 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
       let(:host_ip) { "0.0.0.0" }
 
       context "on windows" do
-        let(:guest) { :windows }
+        before do
+          expect(Vagrant::Util::Platform).to receive(:windows?).and_return(true)
+        end
 
         it "should check the port on every IPv4 interface" do
           expect(instance).to receive(:is_port_open?).with(interfaces[0][1], host_port)

--- a/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
+++ b/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
@@ -233,9 +233,11 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
 
     context "when host ip does not exist" do
       let(:host_ip) { "127.0.0.2" }
+      let(:name) { "default" }
 
-      it "should raise an error" do
-        expect{ instance.send(:port_check, host_ip, host_port) }.to raise_error(Vagrant::Errors::ForwardPortHostIPNotFound)
+      it "should raise an error including the machine name" do
+        allow(machine).to receive(:name).and_return(name)
+        expect{ instance.send(:port_check, host_ip, host_port) }.to raise_error(Vagrant::Errors::ForwardPortHostIPNotFound, /#{name}/)
       end
     end
   end

--- a/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
+++ b/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
@@ -148,20 +148,33 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
   describe "#recover" do
   end
 
-  describe "#ipv4_addresses" do
-    let(:ipv4_ifaddr) { double("ipv4_ifaddr") }
-    let(:ipv6_ifaddr) { double("ipv6_ifaddr") }
+  describe "#ipv4_interfaces" do
+    let(:name) { double("name") }
+    let(:address) { double("address") }
+
+    let(:ipv4_ifaddr) do
+      double("ipv4_ifaddr").tap do |ifaddr|
+        allow(ifaddr).to receive(:name).and_return(name)
+        allow(ifaddr).to receive_message_chain(:addr, :ipv4?).and_return(true)
+        allow(ifaddr).to receive_message_chain(:addr, :ip_address).and_return(address)
+      end
+    end
+
+    let(:ipv6_ifaddr) do
+      double("ipv6_ifaddr").tap do |ifaddr|
+        allow(ifaddr).to receive(:name)
+        allow(ifaddr).to receive_message_chain(:addr, :ipv4?).and_return(false)
+      end
+    end
+
     let(:ifaddrs) { [ ipv4_ifaddr, ipv6_ifaddr ] }
 
     before do
-      allow(ipv4_ifaddr).to receive_message_chain(:addr, :ipv4?).and_return(true)
-      allow(ipv4_ifaddr).to receive_message_chain(:addr, :ip_address).and_return("127.0.0.1")
-      allow(ipv6_ifaddr).to receive_message_chain(:addr, :ipv4?).and_return(false)
       allow(Socket).to receive(:getifaddrs).and_return(ifaddrs)
     end
 
-    it "returns a list of all IPv4 addresses" do
-      expect(instance.send(:ipv4_addresses)).to eq([ "127.0.0.1" ])
+    it "returns a list of IPv4 interfaces with their names and addresses" do
+      expect(instance.send(:ipv4_interfaces)).to eq([ [name, address] ])
     end
 
     context "with nil interface address" do
@@ -169,7 +182,7 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
       let(:ifaddrs) { [ ipv4_ifaddr, ipv6_ifaddr, nil_ifaddr ] }
 
       it "filters out nil addr info" do
-        expect(instance.send(:ipv4_addresses)).to eq([ "127.0.0.1" ])
+        expect(instance.send(:ipv4_interfaces)).to eq([ [name, address] ])
       end
     end
   end
@@ -177,11 +190,11 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
   describe "#port_check" do
     let(:host_ip){ "127.0.0.1" }
     let(:host_port){ 8080 }
-    let(:test_ips) { [ "127.0.0.1", "192.168.1.7" ] }
+    let(:interfaces) { [ ["lo0", "127.0.0.1"], ["eth0", "192.168.1.7"] ] }
 
     before do
       instance.instance_variable_set(:@machine, machine)
-      allow(instance).to receive(:ipv4_addresses).and_return(test_ips)
+      allow(instance).to receive(:ipv4_interfaces).and_return(interfaces)
     end
 
     it "should check if the port is open" do
@@ -196,23 +209,23 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
         let(:guest) { :windows }
 
         it "should check the port on every IPv4 interface" do
-          expect(instance).to receive(:is_port_open?).with(test_ips.first, host_port)
-          expect(instance).to receive(:is_port_open?).with(test_ips.last, host_port)
+          expect(instance).to receive(:is_port_open?).with(interfaces[0][1], host_port)
+          expect(instance).to receive(:is_port_open?).with(interfaces[1][1], host_port)
           instance.send(:port_check, host_ip, host_port)
         end
 
         it "should return false if the port is closed on any IPv4 interfaces" do
-          expect(instance).to receive(:is_port_open?).with(test_ips.first, host_port).
+          expect(instance).to receive(:is_port_open?).with(interfaces[0][1], host_port).
             and_return(true)
-          expect(instance).to receive(:is_port_open?).with(test_ips.last, host_port).
+          expect(instance).to receive(:is_port_open?).with(interfaces[1][1], host_port).
             and_return(false)
           expect(instance.send(:port_check, host_ip, host_port)).to be(false)
         end
 
         it "should return true if the port is open on all IPv4 interfaces" do
-          expect(instance).to receive(:is_port_open?).with(test_ips.first, host_port).
+          expect(instance).to receive(:is_port_open?).with(interfaces[0][1], host_port).
             and_return(true)
-          expect(instance).to receive(:is_port_open?).with(test_ips.last, host_port).
+          expect(instance).to receive(:is_port_open?).with(interfaces[1][1], host_port).
             and_return(true)
           expect(instance.send(:port_check, host_ip, host_port)).to be(true)
         end

--- a/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
+++ b/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
@@ -154,11 +154,20 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
       allow(ipv4_ifaddr).to receive_message_chain(:addr, :ipv4?).and_return(true)
       allow(ipv4_ifaddr).to receive_message_chain(:addr, :ip_address).and_return("127.0.0.1")
       allow(ipv6_ifaddr).to receive_message_chain(:addr, :ipv4?).and_return(false)
+      allow(Socket).to receive(:getifaddrs).and_return(ifaddrs)
     end
 
     it "returns a list of all IPv4 addresses" do
-      allow(Socket).to receive(:getifaddrs).and_return(ifaddrs)
       expect(instance.send(:ipv4_addresses)).to eq([ "127.0.0.1" ])
+    end
+
+    context "on windows" do
+      let(:nil_ifaddr) { double("nil_ifaddr", addr: nil ) }
+      let(:ifaddrs) { [ ipv4_ifaddr, ipv6_ifaddr, nil_ifaddr ] }
+
+      it "filters out nil addr info" do
+        expect(instance.send(:ipv4_addresses)).to eq([ "127.0.0.1" ])
+      end
     end
   end
 

--- a/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
+++ b/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
@@ -177,9 +177,11 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
   describe "#port_check" do
     let(:host_ip){ "127.0.0.1" }
     let(:host_port){ 8080 }
+    let(:test_ips) { [ "127.0.0.1", "192.168.1.7" ] }
 
     before do
       instance.instance_variable_set(:@machine, machine)
+      allow(instance).to receive(:ipv4_addresses).and_return(test_ips)
     end
 
     it "should check if the port is open" do
@@ -187,13 +189,8 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
       instance.send(:port_check, host_ip, host_port)
     end
 
-    context "when host_ip is 0.0.0.0" do
+    context "when host ip is 0.0.0.0" do
       let(:host_ip) { "0.0.0.0" }
-      let(:test_ips) { [ "127.0.0.1", "192.168.1.7" ] }
-
-      before do
-        allow(instance).to receive(:ipv4_addresses).and_return(test_ips)
-      end
 
       context "on windows" do
         let(:guest) { :windows }
@@ -219,6 +216,14 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
             and_return(true)
           expect(instance.send(:port_check, host_ip, host_port)).to be(true)
         end
+      end
+    end
+
+    context "when host ip does not exist" do
+      let(:host_ip) { "127.0.0.2" }
+
+      it "should raise an error" do
+        expect{ instance.send(:port_check, host_ip, host_port) }.to raise_error(Vagrant::Errors::ForwardPortHostIPNotFound)
       end
     end
   end


### PR DESCRIPTION
This commit changes the behavior of the port check to check all possible
IPv4 network interfaces on a Windows host when the host IP is unset or
`0.0.0.0`.  This means that if the desired port is available on any
network interfaces, a forward from 0.0.0.0 will use that interface.

If the port is open (in use) on all interfaces, then it's treated as a
collision and will either throw an error or auto-correct the port, based
on the Vagrantfile configuration.