### PR TITLE
Quiet cli option

### DIFF
--- a/bin/vagrant
+++ b/bin/vagrant
@@ -78,12 +78,6 @@ if argv.include?("--debug-timestamp")
   ENV["VAGRANT_LOG_TIMESTAMP"] = "1"
 end
 
-# Setting to enable/disable showing progress bars
-if argv.include?("--quiet-progress")
-  argv.delete("--quiet-progress")
-  ENV["VAGRANT_QUIET_PROGRESS"] = "1"
-end
-
 # Stdout/stderr should not buffer output
 $stdout.sync = true
 $stderr.sync = true
@@ -114,6 +108,7 @@ begin
     o.on("--debug", "Enable debug output")
     o.on("--timestamp", "Enable timestamps on log output")
     o.on("--debug-timestamp", "Enable debug output with timestamps")
+    o.on("--no-tty", "Enable non-interactive output")
   })
 
   # Create a logger right away
@@ -150,6 +145,12 @@ begin
   if argv.include?("--machine-readable")
     argv.delete("--machine-readable")
     opts[:ui_class] = Vagrant::UI::MachineReadable
+  end
+
+  # Setting to enable/disable showing progress bars
+  if argv.include?("--no-tty")
+    argv.delete("--no-tty")
+    opts[:ui_class] = Vagrant::UI::NonInteractive
   end
 
   # Default to colored output

--- a/bin/vagrant
+++ b/bin/vagrant
@@ -78,6 +78,12 @@ if argv.include?("--debug-timestamp")
   ENV["VAGRANT_LOG_TIMESTAMP"] = "1"
 end
 
+# Setting to enable/disable showing progress bars
+if argv.include?("--quiet-progress")
+  argv.delete("--quiet-progress")
+  ENV["VAGRANT_QUIET_PROGRESS"] = "1"
+end
+
 # Stdout/stderr should not buffer output
 $stdout.sync = true
 $stderr.sync = true

--- a/lib/vagrant/ui.rb
+++ b/lib/vagrant/ui.rb
@@ -31,9 +31,14 @@ module Vagrant
       attr_accessor :stderr
 
       def initialize
-        @logger   = Log4r::Logger.new("vagrant::ui::interface")
-        @opts     = { :show_progress => true }
+        if ENV["VAGRANT_QUIET_PROGRESS"]
+          show_progress = false
+        else
+          show_progress = true
+        end
 
+        @logger   = Log4r::Logger.new("vagrant::ui::interface")
+        @opts     = { :show_progress => show_progress }
         @stdin  = $stdin
         @stdout = $stdout
         @stderr = $stderr

--- a/lib/vagrant/ui.rb
+++ b/lib/vagrant/ui.rb
@@ -31,14 +31,8 @@ module Vagrant
       attr_accessor :stderr
 
       def initialize
-        if ENV["VAGRANT_QUIET_PROGRESS"]
-          show_progress = false
-        else
-          show_progress = true
-        end
-
         @logger   = Log4r::Logger.new("vagrant::ui::interface")
-        @opts     = { :show_progress => show_progress }
+        @opts     = {}
         @stdin  = $stdin
         @stdout = $stdout
         @stderr = $stderr

--- a/lib/vagrant/ui.rb
+++ b/lib/vagrant/ui.rb
@@ -32,7 +32,7 @@ module Vagrant
 
       def initialize
         @logger   = Log4r::Logger.new("vagrant::ui::interface")
-        @opts     = {}
+        @opts     = { :show_progress => true }
 
         @stdin  = $stdin
         @stdout = $stdout
@@ -74,6 +74,12 @@ module Vagrant
       # @param [Array] data The data associated with the type
       def machine(type, *data)
         @logger.info("Machine: #{type} #{data.inspect}")
+      end
+
+      def output_if_showing_progress
+        if @opts[:show_progress] == true
+          yield self
+        end
       end
     end
 

--- a/lib/vagrant/ui.rb
+++ b/lib/vagrant/ui.rb
@@ -76,6 +76,9 @@ module Vagrant
         @logger.info("Machine: #{type} #{data.inspect}")
       end
 
+      # Yields self (UI)
+      # Provides a way for selectively displaying or not displaying
+      # updating content like download progress.
       def rewriting
         yield self
       end

--- a/lib/vagrant/ui.rb
+++ b/lib/vagrant/ui.rb
@@ -265,6 +265,19 @@ module Vagrant
       end
     end
 
+
+    class NonInteractive < Basic
+      def initialize
+        super
+        @opts = { :show_progress => false }
+      end
+
+      def ask(*args)
+        # Non interactive can't ask for input
+        raise Errors::UIExpectsTTY
+      end
+    end
+
     # Prefixed wraps an existing UI and adds a prefix to it.
     class Prefixed < Interface
       # The prefix for `output` messages.

--- a/lib/vagrant/ui.rb
+++ b/lib/vagrant/ui.rb
@@ -211,15 +211,17 @@ module Vagrant
       # to the UI. Send `clear_line` to clear the line to show
       # a continuous progress meter.
       def report_progress(progress, total, show_parts=true)
-        if total && total > 0
-          percent = (progress.to_f / total.to_f) * 100
-          line    = "Progress: #{percent.to_i}%"
-          line   << " (#{progress} / #{total})" if show_parts
-        else
-          line    = "Progress: #{progress}"
-        end
+        if @opts[:show_progress] == true
+          if total && total > 0
+            percent = (progress.to_f / total.to_f) * 100
+            line    = "Progress: #{percent.to_i}%"
+            line   << " (#{progress} / #{total})" if show_parts
+          else
+            line    = "Progress: #{progress}"
+          end
 
-        info(line, new_line: false)
+          info(line, new_line: false)
+        end
       end
 
       def clear_line
@@ -301,7 +303,11 @@ module Vagrant
 
       [:clear_line, :report_progress].each do |method|
         # By default do nothing, these aren't formatted
-        define_method(method) { |*args| @ui.send(method, *args) }
+        define_method(method) do |*args|
+          @ui.output_if_showing_progress do |ui|
+            ui.send(method, *args)
+          end
+        end
       end
 
       # For machine-readable output, set the prefix in the

--- a/lib/vagrant/util/curl_helper.rb
+++ b/lib/vagrant/util/curl_helper.rb
@@ -82,10 +82,11 @@ module Vagrant
             # 9 - Time spent
             # 10 - Time left
             # 11 - Current speed
-
             output = "Progress: #{columns[0]}% (Rate: #{columns[11]}/s, Estimated time remaining: #{columns[10]})"
-            ui.clear_line
-            ui.detail(output, new_line: false)
+            ui.output_if_showing_progress do |ui|
+              ui.clear_line
+              ui.detail(output, new_line: false)
+            end
           end
         end
 

--- a/lib/vagrant/util/curl_helper.rb
+++ b/lib/vagrant/util/curl_helper.rb
@@ -37,8 +37,10 @@ module Vagrant
                   source_host = source_uri.host.to_s.split(".", 2).last
                   location_host = location_uri.host.to_s.split(".", 2).last
                   if !redirect_notify && location_host != source_host && !SILENCED_HOSTS.include?(location_host)
-                    ui.clear_line
-                    ui.detail "Download redirected to host: #{location_uri.host}"
+                    ui.rewriting do |ui|
+                      ui.clear_line
+                      ui.detail "Download redirected to host: #{location_uri.host}"
+                    end
                   end
                   redirect_notify = true
                 end

--- a/lib/vagrant/util/curl_helper.rb
+++ b/lib/vagrant/util/curl_helper.rb
@@ -83,7 +83,7 @@ module Vagrant
             # 10 - Time left
             # 11 - Current speed
             output = "Progress: #{columns[0]}% (Rate: #{columns[11]}/s, Estimated time remaining: #{columns[10]})"
-            ui.output_if_showing_progress do |ui|
+            ui.rewriting do |ui|
               ui.clear_line
               ui.detail(output, new_line: false)
             end

--- a/plugins/providers/hyperv/action/export.rb
+++ b/plugins/providers/hyperv/action/export.rb
@@ -25,8 +25,10 @@ module VagrantPlugins
           @env[:ui].info I18n.t("vagrant.actions.vm.export.exporting")
           export_tmp_dir = Vagrant::Util::Platform.wsl_to_windows_path(@env["export.temp_dir"])
           @env[:machine].provider.driver.export(export_tmp_dir) do |progress|
-            @env[:ui].clear_line
-            @env[:ui].report_progress(progress.percent, 100, false)
+            @env[:ui].rewriting do |ui|
+              ui.clear_line
+              ui.report_progress(progress.percent, 100, false)
+            end
           end
 
           # Clear the line a final time so the next data can appear

--- a/plugins/providers/virtualbox/action/export.rb
+++ b/plugins/providers/virtualbox/action/export.rb
@@ -23,8 +23,10 @@ module VagrantPlugins
         def export
           @env[:ui].info I18n.t("vagrant.actions.vm.export.exporting")
           @env[:machine].provider.driver.export(ovf_path) do |progress|
-            @env[:ui].clear_line
-            @env[:ui].report_progress(progress.percent, 100, false)
+            @env[:ui].rewriting do |ui|
+              ui.clear_line
+              ui.report_progress(progress.percent, 100, false)
+            end
           end
 
           # Clear the line a final time so the next data can appear

--- a/plugins/providers/virtualbox/action/import.rb
+++ b/plugins/providers/virtualbox/action/import.rb
@@ -19,8 +19,10 @@ module VagrantPlugins
           env[:ui].info I18n.t("vagrant.actions.vm.clone.creating")
           env[:machine].id = env[:machine].provider.driver.clonevm(
             env[:clone_id], env[:clone_snapshot]) do |progress|
-            env[:ui].clear_line
-            env[:ui].report_progress(progress, 100, false)
+            env[:ui].rewriting do |ui|
+              ui.clear_line
+              ui.report_progress(progress, 100, false)
+            end
           end
 
           # Clear the line one last time since the progress meter doesn't
@@ -51,8 +53,10 @@ module VagrantPlugins
           # Import the virtual machine
           ovf_file = env[:machine].box.directory.join("box.ovf").to_s
           id = env[:machine].provider.driver.import(ovf_file) do |progress|
-            env[:ui].clear_line
-            env[:ui].report_progress(progress, 100, false)
+            env[:ui].rewriting do |ui|
+              ui.clear_line
+              ui.report_progress(progress, 100, false)
+            end
           end
 
           # Set the machine ID

--- a/plugins/providers/virtualbox/action/prepare_clone_snapshot.rb
+++ b/plugins/providers/virtualbox/action/prepare_clone_snapshot.rb
@@ -55,8 +55,10 @@ module VagrantPlugins
           @logger.info("Creating base snapshot for master VM.")
           env[:machine].provider.driver.create_snapshot(
             env[:clone_id], name) do |progress|
-              env[:ui].clear_line
-              env[:ui].report_progress(progress, 100, false)
+              env[:ui].rewriting do |ui|
+                ui.clear_line
+                ui.report_progress(progress, 100, false)
+              end
           end
         end
       end

--- a/plugins/providers/virtualbox/action/snapshot_delete.rb
+++ b/plugins/providers/virtualbox/action/snapshot_delete.rb
@@ -12,8 +12,10 @@ module VagrantPlugins
             name: env[:snapshot_name]))
           env[:machine].provider.driver.delete_snapshot(
             env[:machine].id, env[:snapshot_name]) do |progress|
-            env[:ui].clear_line
-            env[:ui].report_progress(progress, 100, false)
+            env[:ui].rewriting do |ui|
+              ui.clear_line
+              ui.report_progress(progress, 100, false)
+            end
           end
 
           # Clear the line one last time since the progress meter doesn't disappear

--- a/plugins/providers/virtualbox/action/snapshot_restore.rb
+++ b/plugins/providers/virtualbox/action/snapshot_restore.rb
@@ -12,8 +12,10 @@ module VagrantPlugins
             name: env[:snapshot_name]))
           env[:machine].provider.driver.restore_snapshot(
             env[:machine].id, env[:snapshot_name]) do |progress|
-            env[:ui].clear_line
-            env[:ui].report_progress(progress, 100, false)
+            env[:ui].rewriting do |ui|
+              ui.clear_line
+              ui.report_progress(progress, 100, false)
+            end
           end
 
           # Clear the line one last time since the progress meter doesn't disappear

--- a/test/unit/bin/vagrant_test.rb
+++ b/test/unit/bin/vagrant_test.rb
@@ -91,6 +91,14 @@ describe "vagrant bin" do
           with(hash_including(ui_class: Vagrant::UI::Colored))
       end
     end
+
+    describe "--quiet-progress" do
+      let(:argv) { ["--quiet-progress"] }
+
+      it "should enable less verbose progress output" do
+        expect(ENV).to receive(:[]=).with("VAGRANT_QUIET_PROGRESS", "1")
+      end
+    end
   end
 
   context "default CLI flags" do

--- a/test/unit/bin/vagrant_test.rb
+++ b/test/unit/bin/vagrant_test.rb
@@ -92,11 +92,12 @@ describe "vagrant bin" do
       end
     end
 
-    describe "--quiet-progress" do
-      let(:argv) { ["--quiet-progress"] }
+    describe "--no-tty" do
+      let(:argv) { ["--no-tty"] }
 
       it "should enable less verbose progress output" do
-        expect(ENV).to receive(:[]=).with("VAGRANT_QUIET_PROGRESS", "1")
+        expect(Vagrant::Environment).to receive(:new).
+          with(hash_including(ui_class: Vagrant::UI::NonInteractive))
       end
     end
   end

--- a/test/unit/vagrant/ui_test.rb
+++ b/test/unit/vagrant/ui_test.rb
@@ -111,22 +111,14 @@ describe Vagrant::UI::Basic do
     end
   end
 
-  context "#output_if_showing_progress" do
-    it "yields an output" do
-      subject.opts[:show_progress] = true
-      expect { |b| subject.output_if_showing_progress(&b) }.to yield_control
-    end
-
-    it "does not yield an output" do
-      subject.opts[:show_progress] = false
-      expect { |b| subject.output_if_showing_progress(&b) }.to_not yield_control
+  context "#rewriting" do
+    it "does output progress" do
+      expect { |b| subject.rewriting(&b) }.to yield_control
     end
   end
 end
 
 describe Vagrant::UI::NonInteractive do
-  # let(:ui)     { Vagrant::UI::NonInteractive.new }
-
   describe "#ask" do
     it "raises an exception" do
       expect{subject.ask("foo")}.to raise_error(Vagrant::Errors::UIExpectsTTY)
@@ -137,6 +129,12 @@ describe Vagrant::UI::NonInteractive do
     it "does not output progress" do
       expect(subject).to_not receive(:info)
       subject.report_progress(1, 1)
+    end
+  end
+
+  describe "#rewriting" do
+    it "does not output progress" do
+      expect { |b| subject.rewriting(&b) }.to_not yield_control
     end
   end
 end

--- a/test/unit/vagrant/ui_test.rb
+++ b/test/unit/vagrant/ui_test.rb
@@ -124,6 +124,23 @@ describe Vagrant::UI::Basic do
   end
 end
 
+describe Vagrant::UI::NonInteractive do
+  # let(:ui)     { Vagrant::UI::NonInteractive.new }
+
+  describe "#ask" do
+    it "raises an exception" do
+      expect{subject.ask("foo")}.to raise_error(Vagrant::Errors::UIExpectsTTY)
+    end
+  end
+
+  describe "#report_progress" do
+    it "does not output progress" do
+      expect(subject).to_not receive(:info)
+      subject.report_progress(1, 1)
+    end
+  end
+end
+
 describe Vagrant::UI::Colored do
   include_context "unit"
 

--- a/test/unit/vagrant/ui_test.rb
+++ b/test/unit/vagrant/ui_test.rb
@@ -110,6 +110,18 @@ describe Vagrant::UI::Basic do
       subject.detail(output)
     end
   end
+
+  context "#output_if_showing_progress" do
+    it "yields an output" do
+      subject.opts[:show_progress] = true
+      expect { |b| subject.output_if_showing_progress(&b) }.to yield_control
+    end
+
+    it "does not yield an output" do
+      subject.opts[:show_progress] = false
+      expect { |b| subject.output_if_showing_progress(&b) }.to_not yield_control
+    end
+  end
 end
 
 describe Vagrant::UI::Colored do

--- a/test/unit/vagrant/util/downloader_test.rb
+++ b/test/unit/vagrant/util/downloader_test.rb
@@ -38,6 +38,7 @@ describe Vagrant::Util::Downloader do
       before do
         allow(ui).to receive(:clear_line)
         allow(ui).to receive(:detail)
+        allow(ui).to receive(:rewriting).and_yield(ui)
       end
 
       after do


### PR DESCRIPTION
fixes https://github.com/hashicorp/vagrant/issues/11414

Putting this up as an idea. Not sure if I really like the implementation. A couple of questions:
- should vagrant just throw out the whole output when the `--quiet` flag is used?
- are there any instances where the output should be "quiet" but there still needs to be information returned to the user?
- should the `--quiet` flag exist globally, or does it make sense for only some commands to have a quiet option