### PR TITLE
Add static route support for debian guests

### DIFF
--- a/templates/guests/debian/network_static.erb
+++ b/templates/guests/debian/network_static.erb
@@ -7,4 +7,9 @@ iface <%= options[:device] %> inet static
 <% if options[:gateway] %>
       gateway <%= options[:gateway] %>
 <% end %>
+<% if options[:route] %>
+<% options[:route].split(';').each do |route| %>
+      post-up ip -4 route add <%= route %>
+<% end %>
+<% end %>
 #VAGRANT-END


### PR DESCRIPTION
It should be possible to confgure static routes for debian guests.
There is an existing implementation to perform static route configuration inside funtoo linux guest systems. This implementation assumes a route property to be existent inside the network options.

The route property is interpreted like the following:
> route
> Specify a semi-colon delimited list of IPv4 routes to apply when this interface is brought up. Will be appended to ip -4 route add.

According to funtoo documentation: [funtoo linux - Networking Documentation](https://www.funtoo.org/Networking#Server_Network_Configuration
)

Currently route configurations aren't passed along from the libvirt provider.
There is a filed pull request: https://github.com/vagrant-libvirt/vagrant-libvirt/pull/1086

