### PR TITLE
Update childprocess gem

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "bcrypt_pbkdf", "~> 1.0.0"
-  s.add_dependency "childprocess", "~> 0.6.0"
+  s.add_dependency "childprocess", "~> 3.0.0"
   s.add_dependency "ed25519", "~> 1.2.4"
   s.add_dependency "erubis", "~> 2.7.0"
   s.add_dependency "i18n", "~> 1.1"


### PR DESCRIPTION
childprocess v 1.x includes a fix for encoding on Windows
https://github.com/enkessler/childprocess/pull/134
This was previously causing errors on Windows hosts