### PR TITLE
Do not comment when locking really old issues

### DIFF
--- a/.hashibot.hcl
+++ b/.hashibot.hcl
@@ -4,6 +4,8 @@ poll "closed_issue_locker" "locker" {
   max_issues           = 500
   sleep_between_issues = "5s"
 
+  no_comment_if_no_activity_for = "4320h" # 180 days
+
   message = <<-EOF
     I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
 


### PR DESCRIPTION
If the last activity on the issue is more than 180 days,
only lock the issue and do not leave comment.