### PR TITLE
Fix #8704: Raise an exception if the guest IP ends with .1

### DIFF
--- a/plugins/providers/virtualbox/driver/version_5_0.rb
+++ b/plugins/providers/virtualbox/driver/version_5_0.rb
@@ -587,6 +587,10 @@ module VagrantPlugins
 
         def read_guest_ip(adapter_number)
           ip = read_guest_property("/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP")
+          if ip.end_with?(".1")
+            @logger.warn("VBoxManage guest property returned: #{ip}. Result resembles IP of DHCP server. Retrying IP lookup.")
+            ip = read_guest_property("/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP")
+          end
           if !valid_ip_address?(ip)
             raise Vagrant::Errors::VirtualBoxGuestPropertyNotFound,
               guest_property: "/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP"

--- a/plugins/providers/virtualbox/driver/version_5_0.rb
+++ b/plugins/providers/virtualbox/driver/version_5_0.rb
@@ -928,7 +928,7 @@ module VagrantPlugins
         def valid_ip_address?(ip)
           # Filter out invalid IP addresses
           # GH-4658 VirtualBox can report an IP address of 0.0.0.0 for FreeBSD guests.
-          if ip == "0.0.0.0"
+          if ip == "0.0.0.0" || ip.nil?
             return false
           else
             return true

--- a/plugins/providers/virtualbox/driver/version_5_0.rb
+++ b/plugins/providers/virtualbox/driver/version_5_0.rb
@@ -481,7 +481,7 @@ module VagrantPlugins
             end
           end
 
-          return get_machine_id specified_name
+          return get_machine_id(specified_name)
         end
 
         def max_network_adapters
@@ -588,9 +588,10 @@ module VagrantPlugins
         def read_guest_ip(adapter_number)
           ip = read_guest_property("/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP")
           if ip.end_with?(".1")
-            @logger.warn("VBoxManage guest property returned: #{ip}. Result resembles IP of DHCP server. Retrying IP lookup.")
-            ip = read_guest_property("/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP")
+            @logger.warn("VBoxManage guest property returned: #{ip}. Result resembles IP of DHCP server and is being ignored.")
+            ip = nil
           end
+
           if !valid_ip_address?(ip)
             raise Vagrant::Errors::VirtualBoxGuestPropertyNotFound,
               guest_property: "/VirtualBox/GuestInfo/Net/#{adapter_number}/V4/IP"

--- a/test/unit/plugins/providers/virtualbox/support/shared/virtualbox_driver_version_5_x_examples.rb
+++ b/test/unit/plugins/providers/virtualbox/support/shared/virtualbox_driver_version_5_x_examples.rb
@@ -127,20 +127,20 @@ shared_examples "a version 5.x virtualbox driver" do |options|
   end
 
   describe "#read_guest_ip" do
-    it "retries reading the guest ip if the resulting value ends in .1" do
-      key = "/VirtualBox/GuestInfo/Net/1/V4/IP"
+    context "when guest ip ends in .1" do
+      before do
+        key = "/VirtualBox/GuestInfo/Net/1/V4/IP"
 
-      expect(subprocess).to receive(:execute).
-        with("VBoxManage", "guestproperty", "get", uuid, key, an_instance_of(Hash)).
-        and_return(subprocess_result(stdout: "Value: 172.28.128.1"))
+        expect(subprocess).to receive(:execute).
+          with("VBoxManage", "guestproperty", "get", uuid, key, an_instance_of(Hash)).
+          and_return(subprocess_result(stdout: "Value: 172.28.128.1"))
+      end
 
-      expect(subprocess).to receive(:execute).
-        with("VBoxManage", "guestproperty", "get", uuid, key, an_instance_of(Hash)).
-        and_return(subprocess_result(stdout: "Value: 172.28.128.11"))
+      it "should set the ip value to nil" do
+        value = subject.read_guest_ip(1)
 
-      value = subject.read_guest_ip(1)
-
-      expect(value).to eq("172.28.128.11")
+        expect(value).to be_nil
+      end
     end
   end
 end

--- a/test/unit/plugins/providers/virtualbox/support/shared/virtualbox_driver_version_5_x_examples.rb
+++ b/test/unit/plugins/providers/virtualbox/support/shared/virtualbox_driver_version_5_x_examples.rb
@@ -125,4 +125,22 @@ shared_examples "a version 5.x virtualbox driver" do |options|
       end
     end
   end
+
+  describe "#read_guest_ip" do
+    it "retries reading the guest ip if the resulting value ends in .1" do
+      key = "/VirtualBox/GuestInfo/Net/1/V4/IP"
+
+      expect(subprocess).to receive(:execute).
+        with("VBoxManage", "guestproperty", "get", uuid, key, an_instance_of(Hash)).
+        and_return(subprocess_result(stdout: "Value: 172.28.128.1"))
+
+      expect(subprocess).to receive(:execute).
+        with("VBoxManage", "guestproperty", "get", uuid, key, an_instance_of(Hash)).
+        and_return(subprocess_result(stdout: "Value: 172.28.128.11"))
+
+      value = subject.read_guest_ip(1)
+
+      expect(value).to eq("172.28.128.11")
+    end
+  end
 end

--- a/test/unit/plugins/providers/virtualbox/support/shared/virtualbox_driver_version_5_x_examples.rb
+++ b/test/unit/plugins/providers/virtualbox/support/shared/virtualbox_driver_version_5_x_examples.rb
@@ -136,10 +136,28 @@ shared_examples "a version 5.x virtualbox driver" do |options|
           and_return(subprocess_result(stdout: "Value: 172.28.128.1"))
       end
 
-      it "should set the ip value to nil" do
-        value = subject.read_guest_ip(1)
+      it "should raise an error" do
+        expect { subject.read_guest_ip(1) }.to raise_error(Vagrant::Errors::VirtualBoxGuestPropertyNotFound)
+      end
+    end
+  end
 
-        expect(value).to be_nil
+  describe "#valid_ip_address?" do
+    context "when ip is 0.0.0.0" do
+      let(:ip) { "0.0.0.0" }
+
+      it "should be false" do
+        result = subject.send(:valid_ip_address?, ip)
+        expect(result).to be(false)
+      end
+    end
+
+    context "when ip address is nil" do
+      let(:ip) { nil }
+
+      it "should be false" do
+        result = subject.send(:valid_ip_address?, ip)
+        expect(result).to be(false)
       end
     end
   end


### PR DESCRIPTION
If the VirtualBox guest property `/VirtualBox/GuestInfo/Net/1/V4/IP`
returns an IP address ending in .1, raise an exception.

This addresses an issue that was revealed as an NFS error, where Vagrant
was creating an exports file with the wrong IP address. This was thought
to be caused by the presence of a docker0 interface, but it manifested
itself even without Docker installed.

This issue is difficult to reproduce, but hopefully this PR will get us
closer to the root cause.