### PR TITLE
Adjust when the hook action is performed

### DIFF
--- a/plugins/guests/darwin/plugin.rb
+++ b/plugins/guests/darwin/plugin.rb
@@ -8,7 +8,7 @@ module VagrantPlugins
 
       action_hook(:apfs_firmlinks, :synced_folders) do |hook|
         require_relative "cap/mount_vmware_shared_folder"
-        hook.append(Cap::MountVmwareSharedFolder.method(:write_apfs_firmlinks))
+        hook.prepend(Vagrant::Action::Builtin::Delayed, Cap::MountVmwareSharedFolder.method(:write_apfs_firmlinks))
       end
 
       guest(:darwin, :bsd)  do


### PR DESCRIPTION
With the adjustments provided in #11455 the location of injecting
within the call stack has been changed slightly. With the entire
stack now being generated before execution instead of dynamic
hooks being wrapped around actions at run time, this update
ensures that the method is called correctly after the entirety of
the synced folders action has completed.