### PR TITLE
Use VBox VM's MAC address to find the IP address for NFS mounts

### DIFF
--- a/plugins/providers/virtualbox/driver/meta.rb
+++ b/plugins/providers/virtualbox/driver/meta.rb
@@ -126,6 +126,7 @@ module VagrantPlugins
           :read_dhcp_servers,
           :read_guest_additions_version,
           :read_guest_ip,
+          :read_guest_ip_by_mac_address,
           :read_guest_property,
           :read_host_only_interfaces,
           :read_mac_address,


### PR DESCRIPTION
The network adapter numbers used by Vagrant is not a reliable method of
finding guest-side IP addresses. This is because any virtual network
interface created inside the VM by the guest will affect the order of
in which the network adapters are listed.

We now use a network adapter's MAC address to uniquely identify it,
since it's guaranteed to not change after VM starts.

Following is the error that prompted troubleshooting and this fix:

    ==> default: Configuring and enabling network interfaces...
    NFS requires a host-only network to be created.
    Please add a host-only network to the machine (with either DHCP or a
    static IP) for NFS to work.

This prevented the shared-folders feature to stop mounting my
host-directories.

I frequently noticed this error in my development VBox VMs, but not very
reliably. Restarting the VM about 5 times would make the problem go
away.

After significant troubleshooting I noticed this was caused by Docker
daemon installed in the VM. Disabling Docker's auto-start-on-boot would
resolve this problem for good.

The following is the minimal Vagrantfile that reproduces the problem.
When trying to reproduce this problem, remember that you _may_ not see
the error message once in a while since this error is sensitive to when
Docker creates its virtual NIC.

    Vagrant.configure("2") do |config|
      config.vm.box = "ubuntu/xenial64"
      config.vm.network "private_network", type: "dhcp"
      config.vm.synced_folder ".", "/vagrant_data", type: "nfs"

      config.vm.provision "shell", privileged: false, inline: <<-SHELL
    sudo apt-get install -y apt-transport-https ca-certificates curl software-properties-common
    curl -sSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
    sudo add-apt-repository \
    "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
    $(lsb_release -cs) \
    stable"
    sudo apt-get update
    sudo apt-get install -y docker-ce
    sudo docker run hello-world

    # Uncomment the following line to fix the problem
    #sudo systemctl disable docker
    SHELL
    end

I discovered this bug early last year on VBox version 5.0, and developed
a fix and have been using the fix for a while. I have now tested this
fix on versions 5.2 and 6.0 as well.