### PR TITLE
Shell provisioner: Change double-quoted values of environment variables to single-quotes

### DIFF
--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -83,7 +83,7 @@ module VagrantPlugins
       # This is the provision method called if SSH is what is running
       # on the remote end, which assumes a POSIX-style host.
       def provision_ssh(args)
-        env = config.env.map { |k,v| "#{k}=#{quote_and_escape(v.to_s)}" }
+        env = config.env.map { |k,v| "#{k}=#{quote_and_escape(v.to_s, "'")}" }
         env = env.join(" ")
 
         command =  "chmod +x '#{upload_path}'"


### PR DESCRIPTION
Please refer to: https://discuss.hashicorp.com/t/shell-provisioner-how-to-pass-env-var-containing-dollar-sign/7924/3