### PR TITLE
Updated default provider variable to use latest

### DIFF
--- a/website/source/docs/providers/default.html.md
+++ b/website/source/docs/providers/default.html.md
@@ -26,4 +26,4 @@ variable.
 
 Just set `VAGRANT_DEFAULT_PROVIDER` to the provider you wish to be the
 default. For example, if you use Vagrant with VMware Fusion, you can set
-the environmental variable to `vmware_fusion` and it will be your default.
+the environmental variable to `vmware_desktop` and it will be your default.


### PR DESCRIPTION
The docs state that `vmware_desktop` is the common provider name when using the latest VMWare plugin. Updating this entry to match.