### PR TITLE
Use #systemd_networkd? guest check for renderer

### DIFF
--- a/plugins/guests/debian/cap/configure_networks.rb
+++ b/plugins/guests/debian/cap/configure_networks.rb
@@ -60,7 +60,7 @@ module VagrantPlugins
           # By default, netplan expects the renderer to be systemd-networkd,
           # but if any device is managed by NetworkManager, then we use that renderer
           # ref: https://netplan.io/reference
-          if networkd?(comm)
+          if systemd_networkd?(comm)
             renderer = "networkd"
             ethernets.keys.each do |k|
               if nm_controlled?(comm, k)

--- a/test/unit/plugins/guests/debian/cap/configure_networks_test.rb
+++ b/test/unit/plugins/guests/debian/cap/configure_networks_test.rb
@@ -140,7 +140,7 @@ describe "VagrantPlugins::GuestDebian::Cap::ConfigureNetworks" do
         let(:networkd_yml) { "---\nnetwork:\n  version: 2\n  renderer: networkd\n  ethernets:\n    eth1:\n      dhcp4: true\n    eth2:\n      addresses:\n      - 33.33.33.10/16\n      gateway4: 33.33.0.1\n" }
 
         it "uses NetworkManager if detected on device" do
-          allow(cap).to receive(:networkd?).and_return(false)
+          allow(cap).to receive(:systemd_networkd?).and_return(false)
           allow(cap).to receive(:nmcli?).and_return(true)
           allow(cap).to receive(:nm_controlled?).and_return(true)
           allow(comm).to receive(:test).with("nmcli -t d show eth1").and_return(true)
@@ -159,7 +159,7 @@ describe "VagrantPlugins::GuestDebian::Cap::ConfigureNetworks" do
         end
 
         it "raises and error if NetworkManager is detected on device but nmcli is not installed" do
-          allow(cap).to receive(:networkd?).and_return(true)
+          allow(cap).to receive(:systemd_networkd?).and_return(true)
           allow(cap).to receive(:nmcli?).and_return(false)
           allow(cap).to receive(:nm_controlled?).and_return(true)
           allow(comm).to receive(:test).with("nmcli -t d show eth1").and_return(true)
@@ -169,7 +169,7 @@ describe "VagrantPlugins::GuestDebian::Cap::ConfigureNetworks" do
         end
 
         it "creates and starts the networks for systemd with netplan" do
-          allow(cap).to receive(:networkd?).and_return(true)
+          allow(cap).to receive(:systemd_networkd?).and_return(true)
           expect(cap).to receive(:upload_tmp_file).with(comm, networkd_yml)
             .and_return("/tmp/vagrant-network-entry.1234")
 


### PR DESCRIPTION
This checks that systemd_networkd service is active and
in use when setting the renderer instead of checking for
the networkd executable availability.