### PR TITLE
Fix issues with inline provisioner when WinSSH shell is set to cmd

### DIFF
--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -137,13 +137,18 @@ module VagrantPlugins
           # Upload the script to the machine
           @machine.communicate.tap do |comm|
             env = config.env.map{|k,v| comm.generate_environment_export(k, v)}.join(';')
-            remote_ext = File.extname(path)
+
+            remote_ext = File.extname(upload_path.to_s)
             if remote_ext.empty?
-              remote_ext = @machine.config.winssh.shell == "cmd" ? ".bat" : ".ps1"
+              remote_ext = File.extname(path.to_s)
+              if remote_ext.empty?
+                remote_ext = @machine.config.winssh.shell == "cmd" ? ".bat" : ".ps1"
+              end
             end
 
             remote_path = add_extension(upload_path, remote_ext)
-            if remote_ext == "bat"
+
+            if remote_ext == ".bat"
               command = "#{env}\n cmd.exe /c \"#{remote_path}\" #{args}"
             else
               # Copy powershell_args from configuration

--- a/test/unit/plugins/provisioners/shell/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/shell/provisioner_test.rb
@@ -583,7 +583,7 @@ describe "Vagrant::Shell::Provisioner" do
 
         it "executes the remote script with powershell" do
           expect(communicator).to receive(:upload).with(anything, config.upload_path)
-          expect(communicator).to receive(:execute).with(/powershell/, anything)
+          expect(communicator).to receive(:execute).with(/powershell.*\.ps1/, anything)
           vsp.send(:provision_winssh, "")
         end
       end
@@ -595,7 +595,7 @@ describe "Vagrant::Shell::Provisioner" do
 
         it "executes the remote script with cmd" do
           expect(communicator).to receive(:upload).with(anything, config.upload_path)
-          expect(communicator).to receive(:execute).with(/cmd/, anything)
+          expect(communicator).to receive(:execute).with(/cmd.*\.bat/, anything)
           vsp.send(:provision_winssh, "")
         end
       end


### PR DESCRIPTION
This commit fixes a couple of issues when the WinSSH shell is set to
cmd:

- A check for the .bat extension returned by File.extname
- Execute inline scripts with PowerShell when upload_path ends with .ps1