### PR TITLE
Add :hostname option to network config

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -849,7 +849,17 @@ module VagrantPlugins
         valid_network_types = [:forwarded_port, :private_network, :public_network]
 
         port_range=(1..65535)
+        has_hostname_config = false
         networks.each do |type, options|
+          if options[:hostname]
+            if has_hostname_config
+              errors << I18n.t("vagrant.config.vm.multiple_networks_set_hostname")
+            end
+            if options[:ip] == nil
+              errors << I18n.t("vagrant.config.vm.network_with_hostname_must_set_ip")
+            end
+            has_hostname_config = true
+          end
           if !valid_network_types.include?(type)
             errors << I18n.t("vagrant.config.vm.network_type_invalid",
                             type: type.to_s)

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1957,6 +1957,7 @@ en:
           There are more than one primary disks defined for guest '%{name}'. Please ensure that only one disk has been defined as a primary disk.
         multiple_disk_names_error: |-
           Duplicate disk names defined: '%{name}'. Disk names must be unique.
+        multiple_networks_set_hostname: "Multiple networks have set `:hostname`"
         name_invalid: |-
           The sub-VM name '%{name}' is invalid. Please don't use special characters.
         network_ip_ends_in_one: |-
@@ -1975,6 +1976,7 @@ en:
           Forwarded port definitions require a "host" and "guest" value
         network_type_invalid: |-
           Network type '%{type}' is invalid. Please use a valid network type.
+        network_with_hostname_must_set_ip: "Network specified with `:hostname` must provide a static ip"
         provisioner_not_found: |-
           The '%{name}' provisioner could not be found.
         shared_folder_guestpath_duplicate: |-

--- a/test/unit/plugins/kernel_v2/config/vm_test.rb
+++ b/test/unit/plugins/kernel_v2/config/vm_test.rb
@@ -303,6 +303,32 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
       subject.finalize!
       assert_invalid
     end
+
+    it "is an error if multiple networks set hostname" do
+      subject.network "public_network", ip: "192.168.0.1", hostname: true
+      subject.network "public_network", ip: "192.168.0.2", hostname: true
+      subject.finalize!
+      assert_invalid
+    end
+
+    it "is an error if networks set hostname without ip" do
+      subject.network "public_network", hostname: true
+      subject.finalize!
+      assert_invalid
+    end
+
+    it "is not an error if hostname non-bool" do
+      subject.network "public_network",  ip: "192.168.0.1", hostname: "true"
+      subject.finalize!
+      assert_valid
+    end
+
+    it "is not an error if one hostname is true" do
+      subject.network "public_network",  ip: "192.168.0.1", hostname: true
+      subject.network "public_network",  ip: "192.168.0.2", hostname: false
+      subject.finalize!
+      assert_valid
+    end
   end
 
   describe "#post_up_message" do

--- a/website/pages/docs/networking/basic_usage.mdx
+++ b/website/pages/docs/networking/basic_usage.mdx
@@ -46,3 +46,34 @@ the order in which the networks are enabled.
 
 Networks are automatically configured and enabled after they've been defined
 in the Vagrantfile as part of the `vagrant up` or `vagrant reload` process.
+
+## Setting Hostname
+
+A hostname may be defined for a Vagrant VM using the `config.vm.hostname`
+setting. By default, this will modify `/etc/hosts`, adding the hostname
+on a loopback interface that is not in use.  For example:
+
+```ruby
+Vagrant.configure("2") do |config|
+  # ...
+  config.vm.hostname = "myhost.local"
+end
+```
+
+will add the entry `127.0.X.1  myhost myhost.local` to `/etc/hosts`. 
+
+A public or private network with an assigned IP may be flagged for hostname.
+In this case, the hostname will be added to the flagged network. Note, that
+if there are multiple networks only one may be flagged for hostname. For
+example:
+
+```ruby
+Vagrant.configure("2") do |config|
+  # ...
+  config.vm.hostname = "myhost.local"
+  config.vm.network "public_network", ip: "192.168.0.1", hostname: true
+  config.vm.network "public_network", ip: "192.168.0.2"
+end
+```
+
+will add the entry `192.168.0.1  myhost myhost.local` to `/etc/hosts`.


### PR DESCRIPTION
addresses adding hostname option to network config as per https://github.com/hashicorp/vagrant/issues/11508 

* hostname is a boolean
* a network that sets hostname should have a static ip address
* only one network may set hostname

can be set at `config.vm.network :public_network, hostname: true, ip: "192.168.0.1"`