### PR TITLE
Docker provider: bridge_inhibitipv4 option to prevent IP assignment

### DIFF
--- a/plugins/providers/docker/action/prepare_networks.rb
+++ b/plugins/providers/docker/action/prepare_networks.rb
@@ -25,6 +25,10 @@ module VagrantPlugins
           options.map do |key, value|
             # If value is false, option is not set
             next if value.to_s == "false"
+            # If key is bridge_inhibitipv4 then pass option to bridge driver via -o
+            if key.to_s == "bridge_inhibitipv4"
+              next ["-o","com.docker.network.bridge.inhibit_ipv4=#{value.to_s}"]
+            end
             # If value is true, consider feature flag with no value
             opt = value.to_s == "true" ? [] : [value]
             opt.unshift("--#{key.to_s.tr("_", "-")}")

--- a/test/unit/plugins/providers/docker/action/prepare_networks_test.rb
+++ b/test/unit/plugins/providers/docker/action/prepare_networks_test.rb
@@ -235,6 +235,14 @@ describe VagrantPlugins::DockerProvider::Action::PrepareNetworks do
              :protocol=>"tcp",
              :id=>"80e017d5-388f-4a2f-a3de-f8dce8156a58"} }
 
+    let(:inhibitipv4_network_options) {
+            {:bridge_inhibitipv4=>"true",
+             :subnet=>"172.20.0.0/16",
+             :driver=>"bridge",
+             :alias=>"mynetwork",
+             :protocol=>"tcp",
+             :id=>"80e017d5-388f-4a2f-a3de-f8dce8156a58"} }
+
     it "returns an array of cli arguments" do
       cli_args = subject.generate_create_cli_arguments(network_options)
       expect(cli_args).to eq( ["--ip", "172.20.128.2", "--subnet", "172.20.0.0/16", "--driver", "bridge", "--internal", "--alias", "mynetwork", "--protocol", "tcp", "--id", "80e017d5-388f-4a2f-a3de-f8dce8156a58"])
@@ -243,6 +251,11 @@ describe VagrantPlugins::DockerProvider::Action::PrepareNetworks do
     it "removes option if set to false" do
       cli_args = subject.generate_create_cli_arguments(false_network_options)
       expect(cli_args).to eq( ["--ip", "172.20.128.2", "--subnet", "172.20.0.0/16", "--driver", "bridge", "--alias", "mynetwork", "--protocol", "tcp", "--id", "80e017d5-388f-4a2f-a3de-f8dce8156a58"])
+    end
+
+    it "passes inhibitipv4 to the bridge driver via -o com.docker.network.bridge.inhibit_ipv4" do
+      cli_args = subject.generate_create_cli_arguments(inhibitipv4_network_options)
+      expect(cli_args).to eq( ["-o","com.docker.network.bridge.inhibit_ipv4=true","--subnet", "172.20.0.0/16", "--driver", "bridge", "--alias", "mynetwork", "--protocol", "tcp", "--id", "80e017d5-388f-4a2f-a3de-f8dce8156a58"])
     end
   end
 


### PR DESCRIPTION
Make the scoped option `docker_network__bridge_inhibitipv4` pass an argument to
`docker network create` that inhibits IP address assignemnt to the bridge:

    -o com.docker.network.bridge.inhibit_ipv4=true

This patch allows the upcoming Docker functionality to be access using a
network option. In future there might be a case for switching this to true by
default for private: networks for parity with other providers.

Rationale and context is provided in issue #11577.