### PR TITLE
Fixes #11606: Mock out guest capabilities instead of running them

### DIFF
--- a/test/unit/plugins/provisioners/docker/installer_test.rb
+++ b/test/unit/plugins/provisioners/docker/installer_test.rb
@@ -36,9 +36,10 @@ describe VagrantPlugins::DockerProvisioner::Installer do
     end
 
     it "installs docker if not present" do
-      expect(communicator).to receive(:test).with(/docker/, {:sudo=>true}).and_return(false).at_least(:twice)
-      # Will execute sudo commands to install
-      expect(communicator).to receive(:sudo).at_least(:once)
+      allow(machine).to receive_message_chain(:guest, :capability?).with(:docker_installed).and_return(true)
+      allow(machine).to receive_message_chain(:guest, :capability).with(:docker_install).and_return(false)
+      allow(machine).to receive_message_chain(:guest, :capability).with(:docker_installed).and_return(false)
+
       # Expect to raise error since we are mocking out the test for docker install to return false
       expect {subject.ensure_installed()}.to raise_error(VagrantPlugins::DockerProvisioner::DockerError)
     end


### PR DESCRIPTION
This commit fixes a test that only fails on certain users machines where
Vagrant ends up trying to run real guest capabilities to test if the
docker provisioner raises an error if the provisioner install failed. It
fixes it by mocking out the expected return values for those
capabilities rather than relying on them actually running for this
specific unit test.