### PR TITLE
Require missing Vagrant::Util::MapCommandOptions

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -8,6 +8,7 @@ require "vagrant/config/v2/util"
 require "vagrant/util/platform"
 require "vagrant/util/presence"
 require "vagrant/util/experimental"
+require "vagrant/util/map_command_options"
 
 require File.expand_path("../vm_provisioner", __FILE__)
 require File.expand_path("../vm_subvm", __FILE__)


### PR DESCRIPTION
as it is later used in plugins/kernel_v2/config/vm.rb:475.
_ _ _ _
Without it it fails on Fedora since Vagrant 2.2.8:
```console
$ vagrant
Traceback (most recent call last):
        14: from /usr/share/vagrant/gems/bin/vagrant:23:in `<main>'
        13: from /usr/share/vagrant/gems/bin/vagrant:23:in `load'
        12: from /usr/share/vagrant/gems/gems/vagrant-2.2.8/bin/vagrant:168:in `<top (required)>'
        11: from /usr/share/vagrant/gems/gems/vagrant-2.2.8/bin/vagrant:168:in `new'
        10: from /usr/share/vagrant/gems/gems/vagrant-2.2.8/lib/vagrant/environment.rb:178:in `initialize'
         9: from /usr/share/vagrant/gems/gems/vagrant-2.2.8/lib/vagrant/environment.rb:973:in `process_configured_plugins'
         8: from /usr/share/vagrant/gems/gems/vagrant-2.2.8/lib/vagrant/environment.rb:792:in `vagrantfile'
         7: from /usr/share/vagrant/gems/gems/vagrant-2.2.8/lib/vagrant/environment.rb:792:in `new'
         6: from /usr/share/vagrant/gems/gems/vagrant-2.2.8/lib/vagrant/vagrantfile.rb:29:in `initialize'
         5: from /usr/share/vagrant/gems/gems/vagrant-2.2.8/lib/vagrant/config/loader.rb:200:in `load'
         4: from /usr/share/vagrant/gems/gems/vagrant-2.2.8/lib/vagrant/config/v2/loader.rb:21:in `finalize'
         3: from /usr/share/vagrant/gems/gems/vagrant-2.2.8/lib/vagrant/config/v2/root.rb:51:in `finalize!'
         2: from /usr/share/vagrant/gems/gems/vagrant-2.2.8/lib/vagrant/config/v2/root.rb:51:in `each'
         1: from /usr/share/vagrant/gems/gems/vagrant-2.2.8/lib/vagrant/config/v2/root.rb:52:in `block in finalize!'
/usr/share/vagrant/gems/gems/vagrant-2.2.8/plugins/kernel_v2/config/vm.rb:475:in `finalize!': uninitialized constant Vagrant::Util::MapCommandOptions (NameError)
```