### PR TITLE
Fix #9552: Install rsync on Haiku guests

### DIFF
--- a/plugins/guests/haiku/cap/rsync.rb
+++ b/plugins/guests/haiku/cap/rsync.rb
@@ -1,0 +1,15 @@
+module VagrantPlugins
+  module GuestHaiku
+    module Cap
+      class RSync
+        def self.rsync_installed(machine)
+          machine.communicate.test("test -f /bin/rsync")
+        end
+
+        def self.rsync_install(machine)
+          machine.communicate.execute("pkgman install -y rsync")
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/haiku/cap/rsync.rb
+++ b/plugins/guests/haiku/cap/rsync.rb
@@ -9,6 +9,10 @@ module VagrantPlugins
         def self.rsync_install(machine)
           machine.communicate.execute("pkgman install -y rsync")
         end
+
+        def self.rsync_command(machine)
+          "rsync -zz"
+        end
       end
     end
   end

--- a/plugins/guests/haiku/plugin.rb
+++ b/plugins/guests/haiku/plugin.rb
@@ -40,6 +40,11 @@ module VagrantPlugins
         require_relative "cap/rsync"
         Cap::RSync
       end
+
+      guest_capability(:haiku, :rsync_command) do
+        require_relative "cap/rsync"
+        Cap::RSync
+      end
     end
   end
 end

--- a/plugins/guests/haiku/plugin.rb
+++ b/plugins/guests/haiku/plugin.rb
@@ -30,6 +30,16 @@ module VagrantPlugins
         require_relative "cap/remove_public_key"
         Cap::RemovePublicKey
       end
+
+      guest_capability(:haiku, :rsync_install) do
+        require_relative "cap/rsync"
+        Cap::RSync
+      end
+
+      guest_capability(:haiku, :rsync_installed) do
+        require_relative "cap/rsync"
+        Cap::RSync
+      end
     end
   end
 end

--- a/test/unit/plugins/guests/haiku/cap/rsync_test.rb
+++ b/test/unit/plugins/guests/haiku/cap/rsync_test.rb
@@ -1,0 +1,38 @@
+require_relative "../../../../base"
+
+describe "VagrantPlugins::GuestHaiku::Cap::RSync" do
+  let(:caps) do
+    VagrantPlugins::GuestHaiku::Plugin
+      .components
+      .guest_capabilities[:haiku]
+  end
+
+  let(:machine) { double("machine") }
+  let(:comm) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(comm)
+  end
+
+  after do
+    comm.verify_expectations!
+  end
+
+  describe ".rsync_install" do
+    let(:cap) { caps.get(:rsync_install) }
+
+    it "installs rsync" do
+      comm.expect_command("pkgman install -y rsync")
+      cap.rsync_install(machine)
+    end
+  end
+
+  describe ".rsync_installed" do
+    let(:cap) { caps.get(:rsync_installed) }
+
+    it "checks if rsync is installed" do
+      comm.expect_command("test -f /bin/rsync")
+      cap.rsync_installed(machine)
+    end
+  end
+end

--- a/test/unit/plugins/guests/haiku/cap/rsync_test.rb
+++ b/test/unit/plugins/guests/haiku/cap/rsync_test.rb
@@ -35,4 +35,12 @@ describe "VagrantPlugins::GuestHaiku::Cap::RSync" do
       cap.rsync_installed(machine)
     end
   end
+
+  describe ".rsync_command" do
+    let(:cap) { caps.get(:rsync_command) }
+
+    it "defaults to 'rsync -zz'" do
+      expect(cap.rsync_command(machine)).to eq("rsync -zz")
+    end
+  end
 end


### PR DESCRIPTION
This PR creates guest capabilities for HaikuOS to install rsync and perform basic synchronization. I created a Vagrant box for testing here: https://app.vagrantup.com/jbonhag/boxes/haiku-x86_64

Caveat:
Running rsync against a destination under the root directory (`/vagrant`)will create directories but not files, so you will see errors like this:

```
rsync: open "/vagrant/Vagrantfile" failed: Invalid Argument (-2147483643)
```

As a workaround, we can create a symlink to e.g. `/boot/home/vagrant` from `/vagrant` using a similar design to the way we create synthetic firmlinks for macOS 10.15 guests. This can be done under a different PR.

Update: Testing box has been updated with the following default synced folder:

```ruby
config.vm.synced_folder ".", "/boot/home/vagrant", type: "rsync"
```