### PR TITLE
Treat an empty box value as invalid

### DIFF
--- a/lib/vagrant/action/builtin/handle_box.rb
+++ b/lib/vagrant/action/builtin/handle_box.rb
@@ -20,7 +20,7 @@ module Vagrant
         def call(env)
           machine = env[:machine]
 
-          if !machine.config.vm.box
+          if !machine.config.vm.box || machine.config.vm.box.to_s.empty?
             @logger.info("Skipping HandleBox because no box is set")
             return @app.call(env)
           end

--- a/lib/vagrant/vagrantfile.rb
+++ b/lib/vagrant/vagrantfile.rb
@@ -197,7 +197,7 @@ module Vagrant
         local_keys = keys.dup
 
         # Load the box Vagrantfile, if there is one
-        if config.vm.box && boxes
+        if !config.vm.box.to_s.empty? && boxes
           box = boxes.find(config.vm.box, box_formats, config.vm.box_version)
           if box
             box_vagrantfile = find_vagrantfile(box.directory)

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -511,7 +511,7 @@ module VagrantPlugins
         @base_mac = nil if @base_mac == UNSET_VALUE
         @base_address = nil if @base_address == UNSET_VALUE
         @boot_timeout = 300 if @boot_timeout == UNSET_VALUE
-        @box = nil if @box == UNSET_VALUE
+        @box = nil if @box == UNSET_VALUE || @box.to_s.empty?
         @ignore_box_vagrantfile = false if @ignore_box_vagrantfile == UNSET_VALUE
 
         if @box_check_update == UNSET_VALUE

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -733,7 +733,7 @@ module VagrantPlugins
         end
 
         if box && box.empty?
-          errors << I18n.t("vagrant.config.vm.box_empty")
+          errors << I18n.t("vagrant.config.vm.box_empty", machine_name: machine.name)
         end
 
         errors << I18n.t("vagrant.config.vm.hostname_invalid_characters", name: machine.name) if \

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -511,7 +511,7 @@ module VagrantPlugins
         @base_mac = nil if @base_mac == UNSET_VALUE
         @base_address = nil if @base_address == UNSET_VALUE
         @boot_timeout = 300 if @boot_timeout == UNSET_VALUE
-        @box = nil if @box == UNSET_VALUE || @box.to_s.empty?
+        @box = nil if @box == UNSET_VALUE
         @ignore_box_vagrantfile = false if @ignore_box_vagrantfile == UNSET_VALUE
 
         if @box_check_update == UNSET_VALUE
@@ -730,6 +730,10 @@ module VagrantPlugins
 
         if box && clone
           errors << I18n.t("vagrant.config.vm.clone_and_box")
+        end
+
+        if box && box.empty?
+          errors << I18n.t("vagrant.config.vm.box_empty")
         end
 
         errors << I18n.t("vagrant.config.vm.hostname_invalid_characters", name: machine.name) if \

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1980,7 +1980,7 @@ en:
           Checksum type specified but "box_download_checksum" is blank
         box_download_checksum_notblank: |-
           Checksum specified but must also specify "box_download_checksum_type"
-        box_empty: "Box value is an empty string."
+        box_empty: "Box value for guest '%{machine_name}' is an empty string."
         box_missing: "A box must be specified."
         box_download_options_type: |-
           Found "box_download_options" specified as type '%{type}', should be a Hash

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1980,6 +1980,7 @@ en:
           Checksum type specified but "box_download_checksum" is blank
         box_download_checksum_notblank: |-
           Checksum specified but must also specify "box_download_checksum_type"
+        box_empty: "Box value is an empty string."
         box_missing: "A box must be specified."
         box_download_options_type: |-
           Found "box_download_options" specified as type '%{type}', should be a Hash

--- a/test/unit/plugins/kernel_v2/config/vm_test.rb
+++ b/test/unit/plugins/kernel_v2/config/vm_test.rb
@@ -86,6 +86,12 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
       assert_invalid
     end
 
+    it "cannot be an empty string" do
+      subject.box = ""
+      subject.finalize!
+      assert_invalid
+    end
+
     it "is not required if the provider says so" do
       machine.provider_options[:box_optional] = true
       subject.box = nil

--- a/test/unit/vagrant/action/builtin/handle_box_test.rb
+++ b/test/unit/vagrant/action/builtin/handle_box_test.rb
@@ -37,6 +37,15 @@ describe Vagrant::Action::Builtin::HandleBox do
     subject.call(env)
   end
 
+  it "works if box is empty string" do
+    machine.config.vm.box = ""
+    machine.config.vm.box_url = nil
+
+    expect(app).to receive(:call).with(env)
+
+    subject.call(env)
+  end
+
   it "doesn't do anything if a box exists" do
     allow(machine).to receive(:box).and_return(box)
 

--- a/test/unit/vagrant/vagrantfile_test.rb
+++ b/test/unit/vagrant/vagrantfile_test.rb
@@ -368,6 +368,17 @@ describe Vagrant::Vagrantfile do
         to raise_error(Vagrant::Errors::ProviderNotUsable)
     end
 
+    it "does not try to load the box if the box is empty" do
+      provider_cls = register_provider("foo")
+
+      configure do |config|
+        config.vm.box = ""
+      end
+
+      expect(boxes).not_to receive(:find)
+      results = subject.machine_config(:default, :foo, boxes)
+    end
+
     context "when provider validation is ignored" do
       before do
         configure do |config|


### PR DESCRIPTION
This fixes an issue where having a box name set to an empty string will
cause all Vagrant commands to fail with an error like:

> ArgumentError: Malformed version number string (random box name)

This may be related to #10663.