### PR TITLE
Option to forcefully/gracefully destroy virtualbox vm

### DIFF
--- a/plugins/commands/destroy/command.rb
+++ b/plugins/commands/destroy/command.rb
@@ -8,6 +8,7 @@ module VagrantPlugins
       def execute
         options = {}
         options[:force] = false
+        options[:force_halt] = true
 
         opts = OptionParser.new do |o|
           o.banner = "Usage: vagrant destroy [options] [name|id]"
@@ -22,6 +23,10 @@ module VagrantPlugins
           o.on("--[no-]parallel",
                "Enable or disable parallelism if provider supports it (automatically enables force)") do |p|
             options[:parallel] = p
+          end
+
+          o.on("-g", "--graceful", "Gracefully poweroff of VM") do |f|
+            options[:force_halt] = false
           end
         end
 
@@ -46,8 +51,7 @@ module VagrantPlugins
             # gather states to be checked after destroy
             init_states[vm.name] = vm.state.id
             machines << vm
-
-            batch.action(vm, :destroy, force_confirm_destroy: options[:force])
+            batch.action(vm, :destroy, force_confirm_destroy: options[:force], force_halt: options[:force_halt])
           end
         end
 

--- a/plugins/providers/virtualbox/action.rb
+++ b/plugins/providers/virtualbox/action.rb
@@ -106,7 +106,7 @@ module VagrantPlugins
                 b3.use ConfigValidate
                 b3.use ProvisionerCleanup, :before
                 b3.use CheckAccessible
-                b3.use EnvSet, force_halt: true
+                b3.use EnvSet, force_halt: env2[:force_halt]
                 b3.use action_halt
                 b3.use Destroy
                 b3.use CleanMachineFolder

--- a/test/unit/plugins/commands/destroy/command_test.rb
+++ b/test/unit/plugins/commands/destroy/command_test.rb
@@ -44,7 +44,7 @@ describe VagrantPlugins::CommandDestroy::Command do
     end
 
     it "should destroy the default box" do
-      allow_any_instance_of(Vagrant::BatchAction).to receive(:action) .with(machine, :destroy, anything)
+      allow_any_instance_of(Vagrant::BatchAction).to receive(:action) .with(machine, :destroy, force_confirm_destroy: false, force_halt: true)
 
       expect(machine.state).to receive(:id).and_return(:running)
       expect(machine.state).to receive(:id).and_return(:dead)
@@ -98,6 +98,17 @@ describe VagrantPlugins::CommandDestroy::Command do
         expect(machine).to be_kind_of(Vagrant::Machine)
         expect(action).to eq(:destroy)
       end
+      subject.execute
+    end
+  end
+
+  context "with --graceful set" do
+    let(:argv){ ["--graceful", "--force"] }
+
+    it "passes in true to batch" do
+      batch = double("environment_batch")
+      expect(iso_env).to receive(:batch).and_yield(batch)
+      expect(batch).to receive(:action).with(anything, :destroy, force_confirm_destroy: true, force_halt: false)
       subject.execute
     end
   end

--- a/website/pages/docs/cli/destroy.mdx
+++ b/website/pages/docs/cli/destroy.mdx
@@ -28,6 +28,7 @@ directory containing the `shutdown` command.
 - `--[no-]parallel` - Destroys multiple machines in parallel if the provider
   supports it. Please consult the provider documentation to see if this feature
   is supported.
+- `-g` or `--graceful` - Shuts down the machine gracefully. 
 
 -> The `destroy` command does not remove a box that may have been installed on
 your computer during `vagrant up`. Thus, even if you run `vagrant destroy`,


### PR DESCRIPTION
fixes virtual box part of https://github.com/hashicorp/vagrant/issues/10292

docker does not halt the machine before destroying.