### PR TITLE
Ensure MapCommandOptions is required

### DIFF
--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -9,7 +9,6 @@ require "vagrant/util/platform"
 require "vagrant/util/subprocess"
 require "vagrant/util/curl_helper"
 require "vagrant/util/file_checksum"
-require "vagrant/util/map_command_options"
 
 module Vagrant
   module Util

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -726,7 +726,7 @@ module VagrantPlugins
         end
 
         box_download_options.each do |k, v|
-          # If the value is truthy and 
+          # If the value is truthy and
           # if `box_extra_download_options` does not include the key
           # then the conversion to extra download options produced an error
           if v && !box_extra_download_options.include?("--#{k}")

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -8,6 +8,7 @@ require "vagrant/config/v2/util"
 require "vagrant/util/platform"
 require "vagrant/util/presence"
 require "vagrant/util/experimental"
+require "vagrant/util/map_command_options"
 
 require File.expand_path("../vm_provisioner", __FILE__)
 require File.expand_path("../vm_subvm", __FILE__)


### PR DESCRIPTION
This pull request ensures the util class MapCommandOptions is required. It was previously used in the downloader class, but the require was not moved over. This change just ensures the class is loaded prior to use for the config vm class.