### PR TITLE
Ensure example domain is used rather than potentially real domain

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2673,7 +2673,7 @@ en:
         server_url_required: |-
           Chef server provisioning requires that the `config.chef.chef_server_url` be set to the
           URL of your chef server. Examples include "http://12.12.12.12:4000" and
-          "http://myserver.com:4000" (the port of course can be different, but 4000 is the default)
+          "http://example.com:4000" (the port of course can be different, but 4000 is the default)
         server_validation_key_required: |-
           Chef server provisioning requires that the `config.chef.validation_key_path` configuration
           be set to a path on your local machine of the validation key used to register the

--- a/test/unit/plugins/commands/cloud/auth/middleware/add_authentication_test.rb
+++ b/test/unit/plugins/commands/cloud/auth/middleware/add_authentication_test.rb
@@ -50,7 +50,7 @@ describe VagrantPlugins::CloudCommand::AddAuthentication do
       VagrantPlugins::CloudCommand::Client.new(iso_env).store_token(token)
 
       original = [
-        "http://google.com/box.box",
+        "http://example.com/box.box",
         "#{server_url}/foo.box",
         "#{server_url}/bar.box?arg=true",
       ]
@@ -74,7 +74,7 @@ describe VagrantPlugins::CloudCommand::AddAuthentication do
       VagrantPlugins::CloudCommand::Client.new(iso_env).store_token(token)
 
       original = [
-        "http://google.com/box.box",
+        "http://example.com/box.box",
         "http://vagrantcloud.com/foo.box",
         "http://vagrantcloud.com/bar.box?arg=true",
       ]
@@ -95,7 +95,7 @@ describe VagrantPlugins::CloudCommand::AddAuthentication do
       VagrantPlugins::CloudCommand::Client.new(iso_env).store_token(token)
 
       original = [
-        "http://google.com/box.box",
+        "http://example.org/box.box",
         "http://vagrantcloud.com/foo.box",
         "http://example.com/bar.box",
         "http://example.com/foo.box"

--- a/test/unit/plugins/commands/cloud/provider/create_test.rb
+++ b/test/unit/plugins/commands/cloud/provider/create_test.rb
@@ -69,11 +69,11 @@ describe VagrantPlugins::CloudCommand::ProviderCommand::Command::Create do
   end
 
   context "with arguments and a remote url" do
-    let (:argv) { ["vagrant/box-name", "virtualbox", "1.0.0", "https://box.com/box"] }
+    let (:argv) { ["vagrant/box-name", "virtualbox", "1.0.0", "https://example.com/box"] }
 
     it "creates a provider" do
       allow(VagrantCloud::Provider).to receive(:new).
-        with(version, "virtualbox", nil, "https://box.com/box", "vagrant", "box-name", client.token, nil, nil, nil).
+        with(version, "virtualbox", nil, "https://example.com/box", "vagrant", "box-name", client.token, nil, nil, nil).
         and_return(provider)
 
       expect(VagrantPlugins::CloudCommand::Util).to receive(:format_box_results)

--- a/test/unit/plugins/commands/cloud/provider/update_test.rb
+++ b/test/unit/plugins/commands/cloud/provider/update_test.rb
@@ -69,11 +69,11 @@ describe VagrantPlugins::CloudCommand::ProviderCommand::Command::Update do
   end
 
   context "with arguments and a remote url" do
-    let (:argv) { ["vagrant/box-name", "virtualbox", "1.0.0", "https://box.com/box"] }
+    let (:argv) { ["vagrant/box-name", "virtualbox", "1.0.0", "https://example.com/box"] }
 
     it "creates a provider" do
       allow(VagrantCloud::Provider).to receive(:new).
-        with(version, "virtualbox", nil, "https://box.com/box", "vagrant", "box-name", client.token, nil, nil, nil).
+        with(version, "virtualbox", nil, "https://example.com/box", "vagrant", "box-name", client.token, nil, nil, nil).
         and_return(provider)
 
       expect(VagrantPlugins::CloudCommand::Util).to receive(:format_box_results)

--- a/test/unit/plugins/commands/cloud/provider/upload_test.rb
+++ b/test/unit/plugins/commands/cloud/provider/upload_test.rb
@@ -52,9 +52,9 @@ describe VagrantPlugins::CloudCommand::ProviderCommand::Command::Upload do
         with(version, "virtualbox", nil, nil, "vagrant", "box-name", client.token).
         and_return(provider)
       allow(provider).to receive(:upload_url).
-        and_return("http://upload.here/there")
+        and_return("http://example.com/there")
       allow(Vagrant::Util::Uploader).to receive(:new).
-        with("http://upload.here/there", "path/to/box.box", {ui: anything}).
+        with("http://example.com/there", "path/to/box.box", {ui: anything}).
         and_return(uploader)
 
       expect(uploader).to receive(:upload!)
@@ -66,9 +66,9 @@ describe VagrantPlugins::CloudCommand::ProviderCommand::Command::Upload do
         with(version, "virtualbox", nil, nil, "vagrant", "box-name", client.token).
         and_return(provider)
       allow(provider).to receive(:upload_url).
-        and_return("http://upload.here/there")
+        and_return("http://example.com/there")
       allow(Vagrant::Util::Uploader).to receive(:new).
-        with("http://upload.here/there", "path/to/box.box", {ui: anything}).
+        with("http://example.com/there", "path/to/box.box", {ui: anything}).
         and_return(uploader)
 
       allow(uploader).to receive(:upload!).

--- a/test/unit/plugins/commands/cloud/publish_test.rb
+++ b/test/unit/plugins/commands/cloud/publish_test.rb
@@ -71,9 +71,9 @@ describe VagrantPlugins::CloudCommand::Command::Publish do
     let(:argv) { ["vagrant/box", "1.0.0", "virtualbox", box_path] }
 
     it "publishes a box given options" do
-      allow(provider).to receive(:upload_url).and_return("http://upload.here/there")
+      allow(provider).to receive(:upload_url).and_return("http://example.com/there")
       allow(Vagrant::Util::Uploader).to receive(:new).
-        with("http://upload.here/there", "/full/path/to/the/virtualbox.box", {ui: anything}).
+        with("http://example.com/there", "/full/path/to/the/virtualbox.box", {ui: anything}).
         and_return(uploader)
       allow(uploader).to receive(:upload!)
       expect(VagrantPlugins::CloudCommand::Util).to receive(:format_box_results)
@@ -81,9 +81,9 @@ describe VagrantPlugins::CloudCommand::Command::Publish do
     end
 
     it "catches a ClientError if something goes wrong" do
-      allow(provider).to receive(:upload_url).and_return("http://upload.here/there")
+      allow(provider).to receive(:upload_url).and_return("http://example.com/there")
       allow(Vagrant::Util::Uploader).to receive(:new).
-        with("http://upload.here/there", "/full/path/to/the/virtualbox.box", {ui: anything}).
+        with("http://example.com/there", "/full/path/to/the/virtualbox.box", {ui: anything}).
         and_return(uploader)
       allow(uploader).to receive(:upload!)
       allow(box).to receive(:create).
@@ -92,9 +92,9 @@ describe VagrantPlugins::CloudCommand::Command::Publish do
     end
 
     it "calls update if entity already exists" do
-      allow(provider).to receive(:upload_url).and_return("http://upload.here/there")
+      allow(provider).to receive(:upload_url).and_return("http://example.com/there")
       allow(Vagrant::Util::Uploader).to receive(:new).
-        with("http://upload.here/there", "/full/path/to/the/virtualbox.box", {ui: anything}).
+        with("http://example.com/there", "/full/path/to/the/virtualbox.box", {ui: anything}).
         and_return(uploader)
       allow(uploader).to receive(:upload!)
       allow(box).to receive(:create).
@@ -108,9 +108,9 @@ describe VagrantPlugins::CloudCommand::Command::Publish do
     let(:argv) { ["vagrant/box", "1.0.0", "virtualbox", box_path, "--release"] }
 
     it "releases the box" do
-      allow(provider).to receive(:upload_url).and_return("http://upload.here/there")
+      allow(provider).to receive(:upload_url).and_return("http://example.com/there")
       allow(Vagrant::Util::Uploader).to receive(:new).
-        with("http://upload.here/there", "/full/path/to/the/virtualbox.box", {ui: anything}).
+        with("http://example.com/there", "/full/path/to/the/virtualbox.box", {ui: anything}).
         and_return(uploader)
       allow(uploader).to receive(:upload!)
       expect(VagrantPlugins::CloudCommand::Util).to receive(:format_box_results)
@@ -120,7 +120,7 @@ describe VagrantPlugins::CloudCommand::Command::Publish do
   end
 
   context "with arguments and a remote url" do
-    let(:argv) { ["vagrant/box", "1.0.0", "virtualbox", "--url", "https://www.boxes.com/path/to/the/virtualbox.box"] }
+    let(:argv) { ["vagrant/box", "1.0.0", "virtualbox", "--url", "https://www.example.com/path/to/the/virtualbox.box"] }
 
     it "does not upload a file" do
       expect(VagrantPlugins::CloudCommand::Util).to receive(:format_box_results)

--- a/test/unit/plugins/commands/init/command_test.rb
+++ b/test/unit/plugins/commands/init/command_test.rb
@@ -111,10 +111,10 @@ describe VagrantPlugins::CommandInit::Command do
     end
 
     it "creates a Vagrantfile with a box and box_url" do
-      described_class.new(["hashicorp/precise64", "http://mybox.com"], env).execute
+      described_class.new(["hashicorp/precise64", "http://example.com"], env).execute
       contents = File.read(vagrantfile_path)
       expect(contents).to match(/config.vm.box = "hashicorp\/precise64"/)
-      expect(contents).to match(/config.vm.box_url = "http:\/\/mybox.com"/)
+      expect(contents).to match(/config.vm.box_url = "http:\/\/example.com"/)
     end
 
     it "creates a Vagrantfile with a box and box version" do

--- a/test/unit/plugins/providers/docker/config_test.rb
+++ b/test/unit/plugins/providers/docker/config_test.rb
@@ -76,26 +76,26 @@ describe VagrantPlugins::DockerProvider::Config do
       subject.finalize!
       assert_invalid
     end
-    
+
     it "build dir and git repo" do
       subject.build_dir = build_dir
-      subject.git_repo = "http://someone.com/something.git#branch:dir"
+      subject.git_repo = "http://example.com/something.git#branch:dir"
       subject.image = nil
       subject.finalize!
       assert_invalid
     end
-    
+
     it "git repo dir and image" do
       subject.build_dir = nil
-      subject.git_repo = "http://someone.com/something.git#branch:dir"
+      subject.git_repo = "http://example.com/something.git#branch:dir"
       subject.image = "foo"
       subject.finalize!
       assert_invalid
     end
-    
+
     it "build dir, git repo and image" do
       subject.build_dir = build_dir
-      subject.git_repo = "http://someone.com/something.git#branch:dir"
+      subject.git_repo = "http://example.com/something.git#branch:dir"
       subject.image = "foo"
       subject.finalize!
       assert_invalid
@@ -117,46 +117,46 @@ describe VagrantPlugins::DockerProvider::Config do
       assert_valid
     end
   end
-  
+
   describe "#git_repo" do
     it "should be valid if not set with image or build dir" do
       subject.build_dir = nil
-      subject.git_repo = "http://someone.com/something.git#branch:dir"
+      subject.git_repo = "http://example.com/something.git#branch:dir"
       subject.image = nil
       subject.finalize!
       assert_valid
     end
 
     it "should be valid with a http git url" do
-      subject.git_repo = "http://someone.com/something.git#branch:dir"
+      subject.git_repo = "http://example.com/something.git#branch:dir"
       subject.finalize!
       assert_valid
     end
-    
+
     it "should be valid with a git@ url" do
-      subject.git_repo = "git@someone.com:somebody/something"
+      subject.git_repo = "git@example.com:somebody/something"
       subject.finalize!
       assert_valid
     end
-    
+
     it "should be valid with a git:// url" do
-      subject.git_repo = "git://someone.com/something"
+      subject.git_repo = "git://example.com/something"
       subject.finalize!
       assert_valid
     end
-    
+
     it "should be valid with a short url beginning with github.com url" do
       subject.git_repo = "github.com/somebody/something"
       subject.finalize!
       assert_valid
     end
-    
+
     it "should be invalid with an non-git url" do
       subject.git_repo = "http://foo.bar.com"
       subject.finalize!
       assert_invalid
     end
-    
+
     it "should be invalid with an non url" do
       subject.git_repo = "http||://foo.bar.com sdfs"
       subject.finalize!
@@ -262,7 +262,7 @@ describe VagrantPlugins::DockerProvider::Config do
         expect(subject.build_dir).to be_nil
         expect(subject.image).to eq("bar")
       end
-      
+
       it "overrides image if git_repo is set previously" do
         one.git_repo = "foo"
         two.image = "bar"
@@ -278,15 +278,15 @@ describe VagrantPlugins::DockerProvider::Config do
         expect(subject.build_dir).to eq("bar")
         expect(subject.image).to be_nil
       end
-      
+
       it "overrides build_dir if git_repo is set previously" do
         one.git_repo = "foo"
         two.build_dir = "bar"
-       
+
         expect(subject.build_dir).to eq("bar")
         expect(subject.git_repo).to be_nil
       end
-      
+
       it "overrides git_repo if build_dir is set previously" do
         one.build_dir = "foo"
         two.git_repo = "bar"
@@ -294,7 +294,7 @@ describe VagrantPlugins::DockerProvider::Config do
         expect(subject.build_dir).to be_nil
         expect(subject.git_repo).to eq("bar")
       end
-      
+
       it "overrides git_repo if image is set previously" do
         one.image = "foo"
         two.git_repo = "bar"
@@ -311,7 +311,7 @@ describe VagrantPlugins::DockerProvider::Config do
         expect(subject.build_dir).to eq("bar")
         expect(subject.image).to eq("baz")
       end
-      
+
       it "preserves if both image and git_repo are set" do
         one.image = "foo"
         two.image = "baz"
@@ -320,7 +320,7 @@ describe VagrantPlugins::DockerProvider::Config do
         expect(subject.image).to eq("baz")
         expect(subject.git_repo).to eq("bar")
       end
-      
+
       it "preserves if both build_dir and git_repo are set" do
         one.build_dir = "foo"
         two.build_dir = "baz"

--- a/test/unit/vagrant/util/downloader_test.rb
+++ b/test/unit/vagrant/util/downloader_test.rb
@@ -134,11 +134,11 @@ describe Vagrant::Util::Downloader do
     context "with a username and password" do
       it "downloads the file with the proper flags" do
         original_source = source
-        source  = "http://foo:bar@baz.com/box.box"
+        source  = "http://foo:bar@example.com/box.box"
         subject = described_class.new(source, destination)
 
         i = curl_options.index(original_source)
-        curl_options[i] = "http://baz.com/box.box"
+        curl_options[i] = "http://example.com/box.box"
 
         i = curl_options.index("--output")
         curl_options.insert(i, "foo:bar")
@@ -155,11 +155,11 @@ describe Vagrant::Util::Downloader do
     context "with an urlescaped username and password" do
       it "downloads the file with unescaped credentials" do
         original_source = source
-        source  = "http://fo%5Eo:b%40r@baz.com/box.box"
+        source  = "http://fo%5Eo:b%40r@example.com/box.box"
         subject = described_class.new(source, destination)
 
         i = curl_options.index(original_source)
-        curl_options[i] = "http://baz.com/box.box"
+        curl_options[i] = "http://example.com/box.box"
 
         i = curl_options.index("--output")
         curl_options.insert(i, "fo^o:b@r")

--- a/website/source/docs/boxes/format.html.md
+++ b/website/source/docs/boxes/format.html.md
@@ -103,7 +103,7 @@ It is a JSON document, structured in the following way:
       "providers": [
         {
           "name": "virtualbox",
-          "url": "http://somewhere.com/bionic64_010_virtualbox.box",
+          "url": "http://example.com/bionic64_010_virtualbox.box",
           "checksum_type": "sha1",
           "checksum": "foo"
         }

--- a/website/source/docs/cli/init.html.md
+++ b/website/source/docs/cli/init.html.md
@@ -61,7 +61,7 @@ $ vagrant init -f hashicorp/bionic64
 Create a Vagrantfile with the specific box, from the specific box URL:
 
 ```sh
-$ vagrant init my-company-box https://boxes.company.com/my-company.box
+$ vagrant init my-company-box https://example.com/my-company.box
 ```
 
 Create a Vagrantfile, locking the box to a version constraint:

--- a/website/source/docs/provisioning/chef_client.html.md
+++ b/website/source/docs/provisioning/chef_client.html.md
@@ -36,7 +36,7 @@ that the node can register with the Chef Server:
 ```ruby
 Vagrant.configure("2") do |config|
   config.vm.provision "chef_client" do |chef|
-    chef.chef_server_url = "http://mychefserver.com"
+    chef.chef_server_url = "http://example.com"
     chef.validation_key_path = "validation.pem"
   end
 end

--- a/website/source/docs/push/ftp.html.md
+++ b/website/source/docs/push/ftp.html.md
@@ -51,7 +51,7 @@ The Vagrant Push FTP and SFTP strategy is defined in the `Vagrantfile` using the
 
 ```ruby
 config.push.define "ftp" do |push|
-  push.host = "ftp.company.com"
+  push.host = "ftp.example.com"
   push.username = "username"
   push.password = "password"
 end

--- a/website/source/docs/push/index.html.md
+++ b/website/source/docs/push/index.html.md
@@ -20,7 +20,7 @@ Push configuration section in a `Vagrantfile`:
 
 ```ruby
 config.push.define "ftp" do |push|
-  push.host = "ftp.company.com"
+  push.host = "ftp.example.com"
   push.username = "..."
   # ...
 end


### PR DESCRIPTION
This pull request replaces what could be potentially real domains and replaces them with `example.com`. For tests, this hopefully prevents any accidental requests actually being made to what could be real domains, and instead uses the example domain.