### PR TITLE
Fixed error in bootstrap.sh

### DIFF
--- a/website/source/intro/getting-started/provisioning.html.md
+++ b/website/source/intro/getting-started/provisioning.html.md
@@ -33,7 +33,7 @@ apt-get update
 apt-get install -y apache2
 if ! [ -L /var/www ]; then
   rm -rf /var/www
-  ln -fs /vagrant /var/www
+  ln -fs /vagrant/html /var/www
 fi
 ```
 


### PR DESCRIPTION
The previous version of the provisioning instructions linked to the `/vagrant` directory, but
the current version of Apache uses a default `DocumentRoot` setting of `/var/www`, not
`/var/www/html`, as assumed by the previous version of the documentation. The current version
of this tutorial results in the `/vagrant` directory being completely wiped out and replaced
by a new -and empty- `/vagrant` directory, by virtue of the `--force` flag specified by the
documentation.

This pull request fixes issue #11594 