### PR TITLE
Fix #11640: Check port of loopback address

### DIFF
--- a/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
+++ b/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
@@ -269,7 +269,8 @@ module Vagrant
             end
           else
             # Do a regular check
-            if test_host_ip == "0.0.0.0" || Vagrant::Util::IPv4Interfaces.ipv4_interfaces.detect { |iface| iface[1] == test_host_ip }
+            if test_host_ip == "0.0.0.0" || Addrinfo.ip(test_host_ip).ipv4_loopback? ||
+                ipv4_interfaces.detect { |iface| iface[1] == test_host_ip }
               Vagrant::Util::IsPortOpen.is_port_open?(test_host_ip, host_port)
             else
               raise Errors::ForwardPortHostIPNotFound, name: machine.name, host_ip: host_ip

--- a/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
+++ b/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
@@ -270,7 +270,7 @@ module Vagrant
           else
             # Do a regular check
             if test_host_ip == "0.0.0.0" || Addrinfo.ip(test_host_ip).ipv4_loopback? ||
-                ipv4_interfaces.detect { |iface| iface[1] == test_host_ip }
+                Vagrant::Util::IPv4Interfaces.ipv4_interfaces.detect { |iface| iface[1] == test_host_ip }
               Vagrant::Util::IsPortOpen.is_port_open?(test_host_ip, host_port)
             else
               raise Errors::ForwardPortHostIPNotFound, name: machine.name, host_ip: host_ip

--- a/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
+++ b/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
@@ -195,12 +195,23 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
     end
 
     context "when host ip does not exist" do
-      let(:host_ip) { "127.0.0.2" }
+      let(:host_ip) { "192.168.99.100" }
       let(:name) { "default" }
 
       it "should raise an error including the machine name" do
         allow(machine).to receive(:name).and_return(name)
-        expect{ instance.send(:port_check, host_ip, host_port) }.to raise_error(Vagrant::Errors::ForwardPortHostIPNotFound, /#{name}/)
+        expect{ instance.send(:port_check, host_ip, host_port) }.
+          to raise_error(Vagrant::Errors::ForwardPortHostIPNotFound, /#{name}/)
+      end
+    end
+
+    context "with loopback address" do
+      let (:host_ip) { "127.1.2.40" }
+      let (:addrinfo) { double("addrinfo", ipv4_loopback?: true) }
+
+      it "should check if the port is open" do
+        expect(instance).to receive(:is_port_open?).with(host_ip, host_port).and_return(true)
+        instance.send(:port_check, host_ip, host_port)
       end
     end
   end

--- a/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
+++ b/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
@@ -209,7 +209,7 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
       let (:host_ip) { "127.1.2.40" }
 
       it "should check if the port is open" do
-        expect(instance).to receive(:is_port_open?).with(host_ip, host_port).and_return(true)
+        expect(Vagrant::Util::IsPortOpen).to receive(:is_port_open?).with(host_ip, host_port).and_return(true)
         instance.send(:port_check, host_ip, host_port)
       end
     end

--- a/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
+++ b/test/unit/vagrant/action/builtin/handle_forwarded_port_collisions_test.rb
@@ -207,7 +207,6 @@ describe Vagrant::Action::Builtin::HandleForwardedPortCollisions do
 
     context "with loopback address" do
       let (:host_ip) { "127.1.2.40" }
-      let (:addrinfo) { double("addrinfo", ipv4_loopback?: true) }
 
       it "should check if the port is open" do
         expect(instance).to receive(:is_port_open?).with(host_ip, host_port).and_return(true)


### PR DESCRIPTION
If the given host_ip is a loopback address, proceed with the regular
port check.