### PR TITLE
Default #in_installer? to false

### DIFF
--- a/test/unit/vagrant/util/downloader_test.rb
+++ b/test/unit/vagrant/util/downloader_test.rb
@@ -19,6 +19,7 @@ describe Vagrant::Util::Downloader do
 
   before :each do
     allow(Vagrant::Util::Subprocess).to receive(:execute).and_return(subprocess_result)
+    allow(Vagrant).to receive(:in_installer?).and_return(false)
   end
 
   describe "#download!" do


### PR DESCRIPTION
This ensures that these tests will pass if the environment has
`VAGRANT_INSTALLER_ENV=1` set (e.g. in a local development environment).