### PR TITLE
Update @hashicorp/react-product-downloader dependency

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1579,9 +1579,9 @@
       }
     },
     "@hashicorp/react-product-downloader": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-product-downloader/-/react-product-downloader-3.3.0.tgz",
-      "integrity": "sha512-/7kVCUCN7WAyOITvrW5ga1x5+/yDkzt7SJqyH+o+2TEpZWUiP2BQ8yRHvAuxby9IU1k55XLXtsXzJkrztZNDzQ==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-product-downloader/-/react-product-downloader-3.3.1.tgz",
+      "integrity": "sha512-J3cYejY+jMjGCAKwRGINFY35dNCulfJF4PPYjK7sItng4kgnz0ind3T8QaFhYHEWYFVgXs3vMnV+6K1rlFSSXw==",
       "requires": {
         "@hashicorp/react-button": "^2.2.0"
       }

--- a/website/package.json
+++ b/website/package.json
@@ -15,7 +15,7 @@
     "@hashicorp/react-head": "^1.0.0",
     "@hashicorp/react-image": "^2.0.1",
     "@hashicorp/react-mega-nav": "^4.0.1-2",
-    "@hashicorp/react-product-downloader": "^3.3.0",
+    "@hashicorp/react-product-downloader": "^3.3.1",
     "@hashicorp/react-section-header": "^2.0.0",
     "@hashicorp/react-subnav": "^3.2.1",
     "@hashicorp/react-tabs": "^0.4.0",


### PR DESCRIPTION
- Exposes new branch logic affecting vmware product download link

Ref: https://github.com/hashicorp/web-components/pull/1171/files#diff-cc5d4cccbfcba7e00d061f4b0c683855R28-R37

```diff
-  const installationLink =
-    productNameLowerCase === 'sentinel'
-      ? `/sentinel/intro/getting-started/install/`
-      : `https://learn.hashicorp.com/${baseProductNameLowerCase}/getting-started/install`
+  const installationLink = (productNameLowerCase => {
+    switch (productNameLowerCase) {
+      case 'sentinel':
+        return `/sentinel/intro/getting-started/install/`
+      case 'vagrant-vmware-utility':
+        return '/docs/providers/vmware/installation'
+      default:
+        return `https://learn.hashicorp.com/${baseProductNameLowerCase}/getting-started/install`
+    }
+  })(productNameLowerCase)
```