### PR TITLE
Update childprocess to 4.0.0

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "bcrypt_pbkdf", "~> 1.0.0"
-  s.add_dependency "childprocess", "~> 3.0.0"
+  s.add_dependency "childprocess", "~> 4.0.0"
   s.add_dependency "ed25519", "~> 1.2.4"
   s.add_dependency "erubis", "~> 2.7.0"
   s.add_dependency "i18n", "~> 1.8"


### PR DESCRIPTION
This release drops support for ruby 2.3 and fixes the detach behavior for Windows
similar vagrant-spec pr: https://github.com/hashicorp/vagrant-spec/pull/36

ref: https://github.com/enkessler/childprocess/releases/tag/v4.0.0