### PR TITLE
Raise an error on nil exit status

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -796,6 +796,10 @@ module Vagrant
       error_key(:ssh_key_type_not_supported)
     end
 
+    class SSHNoExitStatus < VagrantError
+      error_key(:ssh_no_exit_status)
+    end
+
     class SSHNoRoute < VagrantError
       error_key(:ssh_no_route)
     end

--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -729,6 +729,11 @@ module VagrantPlugins
           yield :stdout, data if block_given?
         end
 
+        if !exit_status
+          @logger.debug("Exit status: #{exit_status.inspect}")
+          raise Vagrant::Errors::SSHNoExitStatus
+        end
+
         # Return the final exit status
         return exit_status
       end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1435,6 +1435,11 @@ en:
         usually indicates that SSH within the guest machine was unable to
         properly start up. Please boot the VM in GUI mode to check whether
         it is booting properly.
+      ssh_no_exit_status: |-
+        The SSH command completed, but Vagrant did not receive an exit status.
+        This indicates that the command was terminated unexpectedly. Please
+        check that the VM has sufficient memory to run the command and that no
+        processes were killed by the guest operating system.
       ssh_no_route: |-
         While attempting to connect with SSH, a "no route to host" (EHOSTUNREACH)
         error was received. Please verify your network settings are correct

--- a/test/unit/plugins/communicators/ssh/communicator_test.rb
+++ b/test/unit/plugins/communicators/ssh/communicator_test.rb
@@ -317,6 +317,15 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
       end
     end
 
+    context "with no exit code received" do
+      let(:exit_data) { double("exit_data", read_long: nil) }
+
+      it "raises error when exit code is nil" do
+        expect(command_channel).to receive(:send_data).with(/make\n/)
+        expect{ communicator.execute("make") }.to raise_error(Vagrant::Errors::SSHNoExitStatus)
+      end
+    end
+
     context "with garbage content prepended to command output" do
       let(:command_stdout_data) do
         "Line of garbage\nMore garbage\n#{command_garbage_marker}bin\ntmp\n"


### PR DESCRIPTION
This commit changes the SSH communicator to raise an error if Vagrant
doesn't receive an exit status from an SSH command, for example if the
command is terminated by the OOM-killer.

Closes #11715.