### PR TITLE
Fix sometimes-failed test cases that depend on running order

### DIFF
--- a/plugins/guests/debian/cap/change_host_name.rb
+++ b/plugins/guests/debian/cap/change_host_name.rb
@@ -83,10 +83,10 @@ module VagrantPlugins
           interfaces = VagrantPlugins::GuestLinux::Cap::NetworkInterfaces.network_interfaces(machine)
           nettools = true
           if systemd?(comm)
-            @logger.debug("Attempting to restart networking with systemctl")
+            logger.debug("Attempting to restart networking with systemctl")
             nettools = false
           else
-            @logger.debug("Attempting to restart networking with ifup/down nettools")
+            logger.debug("Attempting to restart networking with ifup/down nettools")
           end
 
           interfaces.each do |iface|

--- a/test/unit/plugins/providers/virtualbox/synced_folder_test.rb
+++ b/test/unit/plugins/providers/virtualbox/synced_folder_test.rb
@@ -205,6 +205,7 @@ describe VagrantPlugins::ProviderVirtualBox::SyncedFolder do
       allow(machine).to receive(:env)
       allow(subject).to receive(:driver).and_return(driver)
       allow(driver).to receive(:share_folders)
+      allow(ENV).to receive(:[]).and_call_original
       allow(ENV).to receive(:[]).with("VAGRANT_DISABLE_VBOXSYMLINKCREATE").and_return(symlink_create_disable)
     end
 

--- a/test/unit/vagrant/util/experimental_test.rb
+++ b/test/unit/vagrant/util/experimental_test.rb
@@ -4,7 +4,8 @@ require "vagrant/util/experimental"
 
 describe Vagrant::Util::Experimental do
   include_context "unit"
-  before(:each) { described_class.reset! }
+  before(:all) { described_class.reset! }
+  after(:each) { described_class.reset! }
   subject { described_class }
 
   describe "#enabled?" do

--- a/test/unit/vagrant/util/platform_test.rb
+++ b/test/unit/vagrant/util/platform_test.rb
@@ -4,7 +4,8 @@ require "vagrant/util/platform"
 
 describe Vagrant::Util::Platform do
   include_context "unit"
-  after{ described_class.reset! }
+  before(:all) { described_class.reset! }
+  after { described_class.reset! }
   subject { described_class }
 
   describe "#cygwin_path" do

--- a/test/unit/vagrant_test.rb
+++ b/test/unit/vagrant_test.rb
@@ -48,11 +48,6 @@ describe Vagrant do
   end
 
   describe "has_plugin?" do
-    after(:each) do
-      manager.reset!
-    end
-
-    let(:manager) { described_class.plugin("2").manager }
 
     it "should find the installed plugin by the registered name" do
       Class.new(described_class.plugin(Vagrant::Config::CURRENT_VERSION)) do


### PR DESCRIPTION
Hi,

I was going to add some new feature to vagrant, after forking and cloning, I ran unit tests by `bundle exec rake`, but found some errors happened sometimes. So I digged into the failed tests, and made some changes to fix that issue.

Every error is caused by the running order of all specs. Inline comments show the details.