### PR TITLE
Set secure boot template setting for hyper-v

### DIFF
--- a/plugins/providers/hyperv/scripts/utils/VagrantVM/VagrantVM.psm1
+++ b/plugins/providers/hyperv/scripts/utils/VagrantVM/VagrantVM.psm1
@@ -223,6 +223,7 @@ function New-VagrantVMXML {
 
     # Determine if secure boot is enabled
     $SecureBoot = (Select-Xml -XML $VMConfig -XPath "//secure_boot_enabled").Node."#text"
+    $SecureBootTemplate = (Select-Xml -XML $VMConfig -XPath "//secure_boot_template").Node."#text"
 
     $NewVMConfig = @{
         Name = $VMName;
@@ -242,6 +243,9 @@ function New-VagrantVMXML {
     if($Gen -gt 1) {
         if($SecureBoot -eq "True") {
             Hyper-V\Set-VMFirmware -VM $VM -EnableSecureBoot On
+            if(![System.String]::IsNullOrEmpty($SecureBootTemplate)) {
+                Hyper-V\Set-VMFirmware -VM $VM -SecureBootTemplate $SecureBootTemplate
+            }
         } else {
             Hyper-V\Set-VMFirmware -VM $VM -EnableSecureBoot Off
         }


### PR DESCRIPTION
The hyper-v secure boot template information was added to the box.xml recently. See the corresponding [pull request](https://github.com/hashicorp/packer/pull/9552) for packer.

This PR adds the needed changes for vagrant. The code reads the information out of the box and uses powershell to set the boot template for the VM.
The change is backwards compatible so boxes where this information is missing are still working.