### PR TITLE
Ensure VirtualBox Disk capability works only off of guest attached disks

### DIFF
--- a/plugins/providers/virtualbox/driver/meta.rb
+++ b/plugins/providers/virtualbox/driver/meta.rb
@@ -146,6 +146,7 @@ module VagrantPlugins
           :set_mac_address,
           :set_name,
           :share_folders,
+          :show_medium_info,
           :ssh_port,
           :start,
           :suspend,

--- a/plugins/providers/virtualbox/driver/version_5_0.rb
+++ b/plugins/providers/virtualbox/driver/version_5_0.rb
@@ -982,7 +982,7 @@ module VagrantPlugins
                                uuid: uuid,
                                location: location }
 
-                extra_disk_data.each do |dk,dv|
+                extra_disk_data&.each do |dk,dv|
                   # NOTE: We convert the keys from VirtualBox to symbols
                   # to be consistent with the other keys
                   attachment[dk.downcase.gsub(' ', '_').to_sym] = dv

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -946,7 +946,7 @@ en:
         Failed to build iso image. The following command returned an error:
 
         %{cmd}
-        
+
         Stdout from the command:
 
         %{stdout}
@@ -2265,12 +2265,11 @@ en:
         disk_not_found: |-
           Disk '%{name}' could not be found, and could not be properly removed. Please remove this disk manually if it still exists
       configure_disks:
-        start: "Configuring storage mediums..."
+        create_disk: |-
+          Disk '%{name}' not found in guest. Creating and attaching disk to guest...
         floppy_not_supported: "Floppy disk configuration not yet supported. Skipping disk '%{name}'..."
         shrink_size_not_supported: |-
           VirtualBox does not support shrinking disk sizes. Cannot shrink '%{name}' disks size.
-        create_disk: |-
-          Disk '%{name}' not found in guest. Creating and attaching disk to guest...
         resize_disk: |-
           Disk '%{name}' needs to be resized. Resizing disk...
         recovery_from_resize: |-
@@ -2279,6 +2278,7 @@ en:
           If Vagrant fails to reattach the original disk, it is recommended that you open the VirtualBox GUI and navigate to the current guests settings for '%{name}' and look at the 'storage' section. Here is where you can reattach a missing disk if Vagrant fails to do so...
         recovery_attached_disks: |-
           Disk has been reattached. Vagrant will now continue on an raise the exception receieved
+        start: "Configuring storage mediums..."
     cloud_init:
       content_type_not_set: |-
         'content_type' must be defined for a cloud_init config. Guest '%{machine}'

--- a/test/unit/plugins/providers/virtualbox/cap/configure_disks_test.rb
+++ b/test/unit/plugins/providers/virtualbox/cap/configure_disks_test.rb
@@ -31,49 +31,75 @@ describe VagrantPlugins::ProviderVirtualBox::Cap::ConfigureDisks do
 
   let(:attachments) { [{:port=>"0", :device=>"0",
                       :uuid=>"12345",
+                      :storage_format=>"VMDK",
+                      :capacity=>"65536 MBytes",
                       :disk_name=>"ubuntu-18.04-amd64-disk001",
                       :location=>"/home/vagrant/VirtualBox VMs/ubuntu-18.04-amd64-disk001.vmdk"},
                      {:port=>"1", :device=>"0",
                       :uuid=>"67890",
+                      :storage_format=>"VDI",
+                      :capacity=>"10240 MBytes",
                       :disk_name=>"disk-0",
                       :location=>"/home/vagrant/VirtualBox VMs/disk-0.vdi"},
                      {:port=>"2", :device=>"0",
                       :uuid=>"10111",
+                      :storage_format=>"VDI",
+                      :capacity=>"10240 MBytes",
                       :disk_name=>"disk-1",
                       :location=>"/home/vagrant/VirtualBox VMs/disk-1.vdi"}] }
 
-  let(:defined_disks) { [double("disk", name: "vagrant_primary", size: "5GB", primary: true, type: :disk),
-                         double("disk", name: "disk-0", size: "5GB", primary: false, type: :disk),
-                         double("disk", name: "disk-1", size: "5GB", primary: false, type: :disk),
+  let(:defined_disks) { [double("disk", name: "vagrant_primary", size: Vagrant::Util::Numeric::string_to_bytes("65GB"), primary: true, type: :disk),
+                         double("disk", name: "disk-0", size: Vagrant::Util::Numeric::string_to_bytes("10GB"), primary: false, type: :disk),
+                         double("disk", name: "disk-1", size: "10GB", primary: false, type: :disk),
                          double("disk", name: "disk-2", size: "5GB", primary: false, type: :disk)] }
 
-  let(:all_disks) { [{"UUID"=>"12345",
-          "Parent UUID"=>"base",
-          "State"=>"created",
-          "Type"=>"normal (base)",
-          "Location"=>"/home/vagrant/VirtualBox VMs/ubuntu-18.04-amd64-disk001.vmdk",
-          "Disk Name"=>"ubuntu-18.04-amd64-disk001",
-          "Storage format"=>"VMDK",
-          "Capacity"=>"65536 MBytes",
-          "Encryption"=>"disabled"},
-         {"UUID"=>"67890",
-          "Parent UUID"=>"base",
-          "State"=>"created",
-          "Type"=>"normal (base)",
-          "Location"=>"/home/vagrant/VirtualBox VMs/disk-0.vdi",
-          "Disk Name"=>"disk-0",
-          "Storage format"=>"VDI",
-          "Capacity"=>"10240 MBytes",
-          "Encryption"=>"disabled"},
-         {"UUID"=>"324bbb53-d5ad-45f8-9bfa-1f2468b199a8",
-          "Parent UUID"=>"base",
-          "State"=>"created",
-          "Type"=>"normal (base)",
-          "Location"=>"/home/vagrant/VirtualBox VMs/disk-1.vdi",
-          "Disk Name"=>"disk-1",
-          "Storage format"=>"VDI",
-          "Capacity"=>"5120 MBytes",
-          "Encryption"=>"disabled"}] }
+
+  let(:all_disks) { [{:port=>"0", :device=>"0",
+                      :uuid=>"12345",
+                      :storage_format=>"VMDK",
+                      :capacity=>"65536 MBytes",
+                      :disk_name=>"ubuntu-18.04-amd64-disk001",
+                      :location=>"/home/vagrant/VirtualBox VMs/ubuntu-18.04-amd64-disk001.vmdk"},
+                     {:port=>"1", :device=>"0",
+                      :uuid=>"67890",
+                      :storage_format=>"VDI",
+                      :capacity=>"10240 MBytes",
+                      :disk_name=>"disk-0",
+                      :location=>"/home/vagrant/VirtualBox VMs/disk-0.vdi"},
+                     {:port=>"2", :device=>"0",
+                      :uuid=>"10111",
+                      :storage_format=>"VDI",
+                      :capacity=>"10240 MBytes",
+                      :disk_name=>"disk-1",
+                      :location=>"/home/vagrant/VirtualBox VMs/disk-1.vdi"}] }
+
+  let(:list_hdds_result) { [{"UUID"=>"12345",
+                            "Parent UUID"=>"base",
+                            "State"=>"created",
+                            "Type"=>"normal (base)",
+                            "Location"=>"/home/vagrant/VirtualBox VMs/ubuntu-18.04-amd64-disk001.vmdk",
+                            "Disk Name"=>"ubuntu-18.04-amd64-disk001",
+                            "Storage format"=>"VMDK",
+                            "Capacity"=>"65536 MBytes",
+                            "Encryption"=>"disabled"},
+                           {"UUID"=>"67890",
+                            "Parent UUID"=>"base",
+                            "State"=>"created",
+                            "Type"=>"normal (base)",
+                            "Location"=>"/home/vagrant/VirtualBox VMs/disk-0.vdi",
+                            "Disk Name"=>"disk-0",
+                            "Storage format"=>"VDI",
+                            "Capacity"=>"10240 MBytes",
+                            "Encryption"=>"disabled"},
+                           {"UUID"=>"324bbb53-d5ad-45f8-9bfa-1f2468b199a8",
+                            "Parent UUID"=>"base",
+                            "State"=>"created",
+                            "Type"=>"normal (base)",
+                            "Location"=>"/home/vagrant/VirtualBox VMs/disk-1.vdi",
+                            "Disk Name"=>"disk-1",
+                            "Storage format"=>"VDI",
+                            "Capacity"=>"5120 MBytes",
+                            "Encryption"=>"disabled"}] }
 
   let(:subject) { described_class }
 
@@ -212,21 +238,19 @@ describe VagrantPlugins::ProviderVirtualBox::Cap::ConfigureDisks do
 
   describe "#handle_configure_disk" do
     context "when creating a new disk" do
-      let(:all_disks) { [{"UUID"=>"12345",
-              "Parent UUID"=>"base",
-              "State"=>"created",
-              "Type"=>"normal (base)",
-              "Location"=>"/home/vagrant/VirtualBox VMs/ubuntu-18.04-amd64-disk001.vmdk",
-              "Disk Name"=>"ubuntu-18.04-amd64-disk001",
-              "Storage format"=>"VMDK",
-              "Capacity"=>"65536 MBytes",
-              "Encryption"=>"disabled"}] }
+      let(:all_disks) { [{:port=>"0", :device=>"0",
+                          :uuid=>"12345",
+                          :storage_format=>"VMDK",
+                          :capacity=>"65536 MBytes",
+                          :disk_name=>"ubuntu-18.04-amd64-disk001",
+                          :location=>"/home/vagrant/VirtualBox VMs/ubuntu-18.04-amd64-disk001.vmdk"}] }
 
       let(:disk_meta) { {uuid: "67890", name: "disk-0", controller: "controller", port: "1", device: "1"} }
 
       it "creates a new disk if it doesn't yet exist" do
         expect(subject).to receive(:create_disk).with(machine, defined_disks[1], controller)
           .and_return(disk_meta)
+        expect(controller).to receive(:attachments).and_return(all_disks)
 
         subject.handle_configure_disk(machine, defined_disks[1], controller.name)
       end
@@ -234,6 +258,7 @@ describe VagrantPlugins::ProviderVirtualBox::Cap::ConfigureDisks do
       it "includes disk attachment info in metadata" do
         expect(subject).to receive(:create_disk).with(machine, defined_disks[1], controller)
           .and_return(disk_meta)
+        expect(controller).to receive(:attachments).and_return(all_disks)
 
         disk_metadata = subject.handle_configure_disk(machine, defined_disks[1], controller.name)
         expect(disk_metadata).to have_key(:controller)
@@ -244,26 +269,22 @@ describe VagrantPlugins::ProviderVirtualBox::Cap::ConfigureDisks do
     end
 
     context "when a disk needs to be resized" do
-      let(:all_disks) { [{"UUID"=>"12345",
-              "Parent UUID"=>"base",
-              "State"=>"created",
-              "Type"=>"normal (base)",
-              "Location"=>"/home/vagrant/VirtualBox VMs/ubuntu-18.04-amd64-disk001.vmdk",
-              "Disk Name"=>"ubuntu-18.04-amd64-disk001",
-              "Storage format"=>"VMDK",
-              "Capacity"=>"65536 MBytes",
-              "Encryption"=>"disabled"},
-             {"UUID"=>"67890",
-              "Parent UUID"=>"base",
-              "State"=>"created",
-              "Type"=>"normal (base)",
-              "Location"=>"/home/vagrant/VirtualBox VMs/disk-0.vdi",
-              "Disk Name"=>"disk-0",
-              "Storage format"=>"VDI",
-              "Capacity"=>"10240 MBytes",
-              "Encryption"=>"disabled"}] }
+      let(:all_disks) { [{:port=>"0", :device=>"0",
+                          :uuid=>"12345",
+                          :storage_format=>"VMDK",
+                          :capacity=>"65536 MBytes",
+                          :disk_name=>"ubuntu-18.04-amd64-disk001",
+                          :location=>"/home/vagrant/VirtualBox VMs/ubuntu-18.04-amd64-disk001.vmdk"},
+                         {:port=>"1", :device=>"0",
+                          :uuid=>"67890",
+                          :storage_format=>"VDI",
+                          :capacity=>"10240 MBytes",
+                          :disk_name=>"disk-0",
+                          :location=>"/home/vagrant/VirtualBox VMs/disk-0.vdi"}] }
 
       it "resizes a disk" do
+        expect(controller).to receive(:attachments).and_return(all_disks)
+
         expect(subject).to receive(:get_current_disk).
           with(machine, defined_disks[1], all_disks).and_return(all_disks[1])
 
@@ -278,24 +299,18 @@ describe VagrantPlugins::ProviderVirtualBox::Cap::ConfigureDisks do
     end
 
     context "if no additional disk configuration is required" do
-      let(:all_disks) { [{"UUID"=>"12345",
-              "Parent UUID"=>"base",
-              "State"=>"created",
-              "Type"=>"normal (base)",
-              "Location"=>"/home/vagrant/VirtualBox VMs/ubuntu-18.04-amd64-disk001.vmdk",
-              "Disk Name"=>"ubuntu-18.04-amd64-disk001",
-              "Storage format"=>"VMDK",
-              "Capacity"=>"65536 MBytes",
-              "Encryption"=>"disabled"},
-             {"UUID"=>"67890",
-              "Parent UUID"=>"base",
-              "State"=>"created",
-              "Type"=>"normal (base)",
-              "Location"=>"/home/vagrant/VirtualBox VMs/disk-0.vdi",
-              "Disk Name"=>"disk-0",
-              "Storage format"=>"VDI",
-              "Capacity"=>"10240 MBytes",
-              "Encryption"=>"disabled"}] }
+      let(:all_disks) { [{:port=>"0", :device=>"0",
+                          :uuid=>"12345",
+                          :storage_format=>"VMDK",
+                          :capacity=>"65536 MBytes",
+                          :disk_name=>"ubuntu-18.04-amd64-disk001",
+                          :location=>"/home/vagrant/VirtualBox VMs/ubuntu-18.04-amd64-disk001.vmdk"},
+                         {:port=>"1", :device=>"0",
+                          :uuid=>"67890",
+                          :storage_format=>"VDI",
+                          :capacity=>"10240 MBytes",
+                          :disk_name=>"disk-0",
+                          :location=>"/home/vagrant/VirtualBox VMs/disk-0.vdi"}] }
 
       let(:disk_info) { {port: "1", device: "0"} }
 
@@ -309,6 +324,8 @@ describe VagrantPlugins::ProviderVirtualBox::Cap::ConfigureDisks do
                           :location=>"/home/vagrant/VirtualBox VMs/disk-0.vdi"}] }
 
       it "reattaches disk if vagrant defined disk exists but is not attached to guest" do
+        expect(controller).to receive(:attachments).and_return(all_disks)
+
         expect(subject).to receive(:get_current_disk).
           with(machine, defined_disks[1], all_disks).and_return(all_disks[1])
 
@@ -322,12 +339,14 @@ describe VagrantPlugins::ProviderVirtualBox::Cap::ConfigureDisks do
                                                      (disk_info[:port].to_i + 1).to_s,
                                                      disk_info[:device],
                                                      "hdd",
-                                                     all_disks[1]["Location"])
+                                                     all_disks[1][:location])
 
         subject.handle_configure_disk(machine, defined_disks[1], controller.name)
       end
 
       it "does nothing if all disks are properly configured" do
+        expect(controller).to receive(:attachments).and_return(all_disks)
+
         expect(subject).to receive(:get_current_disk).
           with(machine, defined_disks[1], all_disks).and_return(all_disks[1])
 
@@ -459,7 +478,7 @@ describe VagrantPlugins::ProviderVirtualBox::Cap::ConfigureDisks do
         expect(driver).to receive(:get_port_and_device).with("12345").
           and_return(attach_info)
 
-        expect(driver).to receive(:vmdk_to_vdi).with(all_disks[0]["Location"]).
+        expect(driver).to receive(:vmdk_to_vdi).with(all_disks[0][:location]).
           and_return(vdi_disk_file)
 
         expect(driver).to receive(:resize_disk).with(vdi_disk_file, disk_config.size.to_i).and_return(true)
@@ -475,7 +494,8 @@ describe VagrantPlugins::ProviderVirtualBox::Cap::ConfigureDisks do
           with(controller.name, attach_info[:port], attach_info[:device], "hdd", vmdk_disk_file).and_return(true)
         expect(driver).to receive(:close_medium).with(vdi_disk_file).and_return(true)
 
-        expect(driver).to receive(:list_hdds).and_return(all_disks)
+        expect(driver).to receive(:read_storage_controllers)
+        expect(storage_controllers).to receive(:get_controller)
 
         expect(FileUtils).to receive(:remove).with("#{vmdk_disk_file}.backup", force: true).
           and_return(true)
@@ -490,7 +510,7 @@ describe VagrantPlugins::ProviderVirtualBox::Cap::ConfigureDisks do
         expect(driver).to receive(:get_port_and_device).with("12345").
           and_return(attach_info)
 
-        expect(driver).to receive(:vmdk_to_vdi).with(all_disks[0]["Location"]).
+        expect(driver).to receive(:vmdk_to_vdi).with(all_disks[0][:location]).
           and_return(vdi_disk_file)
 
         expect(driver).to receive(:resize_disk).with(vdi_disk_file, disk_config.size.to_i).and_return(true)
@@ -512,9 +532,9 @@ describe VagrantPlugins::ProviderVirtualBox::Cap::ConfigureDisks do
                                  primary: false, type: :disk, disk_ext: "vdi",
                                  provider_config: nil) }
       it "resizes the disk" do
-        expect(driver).to receive(:resize_disk).with(all_disks[1]["Location"], disk_config.size.to_i)
+        expect(driver).to receive(:resize_disk).with(all_disks[1][:location], disk_config.size.to_i)
 
-        expect(driver).to receive(:get_port_and_device).with(all_disks[1]["UUID"]).
+        expect(driver).to receive(:get_port_and_device).with(all_disks[1][:uuid]).
           and_return({port: "1", device: "0"})
 
         subject.resize_disk(machine, disk_config, all_disks[1], controller)

--- a/test/unit/plugins/providers/virtualbox/cap/configure_disks_test.rb
+++ b/test/unit/plugins/providers/virtualbox/cap/configure_disks_test.rb
@@ -484,9 +484,6 @@ describe VagrantPlugins::ProviderVirtualBox::Cap::ConfigureDisks do
         expect(FileUtils).to receive(:mv).with(vmdk_disk_file, "#{vmdk_disk_file}.backup").
           and_return(true)
 
-        expect(driver).to receive(:get_port_and_device).with("12345").
-          and_return(attach_info)
-
         expect(driver).to receive(:vmdk_to_vdi).with(all_disks[0][:location]).
           and_return(vdi_disk_file)
 
@@ -516,9 +513,6 @@ describe VagrantPlugins::ProviderVirtualBox::Cap::ConfigureDisks do
         expect(FileUtils).to receive(:mv).with(vmdk_disk_file, "#{vmdk_disk_file}.backup").
           and_return(true)
 
-        expect(driver).to receive(:get_port_and_device).with("12345").
-          and_return(attach_info)
-
         expect(driver).to receive(:vmdk_to_vdi).with(all_disks[0][:location]).
           and_return(vdi_disk_file)
 
@@ -530,7 +524,7 @@ describe VagrantPlugins::ProviderVirtualBox::Cap::ConfigureDisks do
 
         allow(driver).to receive(:vdi_to_vmdk).and_raise(StandardError)
 
-        expect(subject).to receive(:recover_from_resize).with(machine, attach_info, "#{vmdk_disk_file}.backup", all_disks[0], vdi_disk_file, controller)
+        expect(subject).to receive(:recover_from_resize).with(machine, all_disks[0], "#{vmdk_disk_file}.backup", all_disks[0], vdi_disk_file, controller)
 
         expect{subject.resize_disk(machine, disk_config, all_disks[0], controller)}.to raise_error(Exception)
       end
@@ -542,9 +536,6 @@ describe VagrantPlugins::ProviderVirtualBox::Cap::ConfigureDisks do
                                  provider_config: nil) }
       it "resizes the disk" do
         expect(driver).to receive(:resize_disk).with(all_disks[1][:location], disk_config.size.to_i)
-
-        expect(driver).to receive(:get_port_and_device).with(all_disks[1][:uuid]).
-          and_return({port: "1", device: "0"})
 
         subject.resize_disk(machine, disk_config, all_disks[1], controller)
       end

--- a/test/unit/plugins/providers/virtualbox/driver/version_5_0_test.rb
+++ b/test/unit/plugins/providers/virtualbox/driver/version_5_0_test.rb
@@ -123,7 +123,54 @@ OUTPUT
           "SATA Controller-1-0" => "/tmp/secondary.vdi",
           "SATA Controller-ImageUUID-1-0" => "67890" }
       )
+
+      allow(subject).to receive(:list_hdds).and_return(
+        [
+         {"UUID"=>"12345",
+         "Parent UUID"=>"base",
+         "State"=>"created",
+         "Type"=>"normal (base)",
+         "Location"=>"/tmp/primary.vdi",
+         "Disk Name"=>"primary",
+         "Storage format"=>"VDI",
+         "Capacity"=>"65536 MBytes",
+         "Encryption"=>"disabled"},
+         {"UUID"=>"67890",
+         "Parent UUID"=>"base",
+         "State"=>"created",
+         "Type"=>"normal (base)",
+         "Location"=>"/tmp/secondary.vdi",
+         "Disk Name"=>"primary",
+         "Storage format"=>"VDI",
+         "Capacity"=>"65536 MBytes",
+         "Encryption"=>"disabled"}
+        ]
+      )
     end
+
+    let(:attachments_result) { [{:port=>"0",
+                                 :device=>"0",
+                                 :uuid=>"12345",
+                                 :location=>"/tmp/primary.vdi",
+                                 :parent_uuid=>"base",
+                                 :state=>"created",
+                                 :type=>"normal (base)",
+                                 :disk_name=>"primary",
+                                 :storage_format=>"VDI",
+                                 :capacity=>"65536 MBytes",
+                                 :encryption=>"disabled"},
+                                {:port=>"1",
+                                 :device=>"0",
+                                 :uuid=>"67890",
+                                 :location=>"/tmp/secondary.vdi",
+                                 :parent_uuid=>"base",
+                                 :state=>"created",
+                                 :type=>"normal (base)",
+                                 :disk_name=>"primary",
+                                 :storage_format=>"VDI",
+                                 :capacity=>"65536 MBytes",
+                                 :encryption=>"disabled"}] }
+
 
     it "returns a list of storage controllers" do
       storage_controllers = subject.read_storage_controllers
@@ -136,7 +183,7 @@ OUTPUT
     it "includes attachments for each storage controller" do
       storage_controllers = subject.read_storage_controllers
 
-      expect(storage_controllers.first.attachments).to eq([{port: "0", device: "0", uuid: "12345", disk_name: "primary", location: "/tmp/primary.vdi"}, {port: "1", device: "0", uuid: "67890", disk_name: "secondary", location: "/tmp/secondary.vdi"}])
+      expect(storage_controllers.first.attachments).to eq(attachments_result)
     end
   end
 end

--- a/test/unit/plugins/providers/virtualbox/driver/version_5_0_test.rb
+++ b/test/unit/plugins/providers/virtualbox/driver/version_5_0_test.rb
@@ -98,7 +98,7 @@ OUTPUT
         storagectl = args[args.index("--storagectl") + 1]
         expect(storagectl).to eq(controller_name)
       end
-      subject.attach_disk(controller_name, anything, anything, anything, anything) 
+      subject.attach_disk(controller_name, anything, anything, anything, anything)
     end
   end
 
@@ -136,8 +136,7 @@ OUTPUT
     it "includes attachments for each storage controller" do
       storage_controllers = subject.read_storage_controllers
 
-      expect(storage_controllers.first.attachments).to include(port: "0", device: "0", uuid: "12345", location: "/tmp/primary.vdi")
-      expect(storage_controllers.first.attachments).to include(port: "1", device: "0", uuid: "67890", location: "/tmp/secondary.vdi")
+      expect(storage_controllers.first.attachments).to eq([{port: "0", device: "0", uuid: "12345", disk_name: "primary", location: "/tmp/primary.vdi"}, {port: "1", device: "0", uuid: "67890", disk_name: "secondary", location: "/tmp/secondary.vdi"}])
     end
   end
 end


### PR DESCRIPTION
This pull request updates the configure_disks capability to only work off of a guests attached disks. Before this, it worked off of the results of `vboxmanage list hdds` which lists every disk for all virtual machines running in VirtualBox. This updates that to instead filter out only the disks associated with the guest, and store that information in the storage controllers attachments data structure to be used instead of the results of `list hdds`.

Fixes #11755