### PR TITLE
Document check_guest_additions option

### DIFF
--- a/website/pages/docs/providers/virtualbox/configuration.mdx
+++ b/website/pages/docs/providers/virtualbox/configuration.mdx
@@ -75,7 +75,7 @@ end
 To have backward compatibility:
 
 ```ruby
-config.vm.provider 'virtualbox' do |v|
+config.vm.provider "virtualbox" do |v|
   v.linked_clone = true if Gem::Version.new(Vagrant::VERSION) >= Gem::Version.new('1.8.0')
 end
 ```
@@ -86,6 +86,20 @@ support linked cloning, you can use `Vagrant.require_version` with 1.8.
 -> **Note:** the generated master VMs are currently not removed
 automatically by Vagrant. This has to be done manually. However, a master
 VM can only be removed when there are no linked clones connected to it.
+
+## Checking for Guest Additions
+
+By default Vagrant will check for the [VirtualBox Guest
+Additions](https://www.virtualbox.org/manual/ch04.html) when starting a
+machine, and will output a warning if the guest additions are missing or
+out-of-date. You can skip the guest additions check by setting the
+`check_guest_additions` option:
+
+```ruby
+config.vm.provider "virtualbox" do |v|
+  v.check_guest_additions = false
+end
+```
 
 ## VBoxManage Customizations
 


### PR DESCRIPTION
Adds an example of setting `check_guest_additions = false` to skip the VirtualBox guest additions check.