### PR TITLE
Use the correct powershell executable for privileged commands

### DIFF
--- a/lib/vagrant/util/powershell.rb
+++ b/lib/vagrant/util/powershell.rb
@@ -231,7 +231,7 @@ module Vagrant
             "-PassThru -WindowStyle Hidden -Wait -Verb RunAs; if($p){ exit $p.ExitCode; }else{ exit 1 }"
 
           cmd = [
-            "powershell",
+            executable,
             "-NoLogo",
             "-NoProfile",
             "-NonInteractive",

--- a/test/unit/vagrant/util/powershell_test.rb
+++ b/test/unit/vagrant/util/powershell_test.rb
@@ -281,4 +281,35 @@ describe Vagrant::Util::PowerShell do
     end
 
   end
+
+  describe ".powerup_command" do
+    let(:result) do
+      Vagrant::Util::Subprocess::Result.new( exit_code, stdout, stderr)
+    end
+    let(:exit_code){ 0 }
+    let(:stdout){ "" }
+    let(:stderr){ "" }
+
+    context "when the powershell executable is 'powershell'" do
+      before do
+        allow(described_class).to receive(:executable).and_return("powershell")
+      end
+
+      it "should use the 'powershell' executable" do
+        expect(Vagrant::Util::Subprocess).to receive(:execute).with("powershell", any_args).and_return(result)
+        described_class.powerup_command("run", [], [])
+      end
+    end
+
+    context "when the powershell executable is 'powershell.exe'" do
+      before do
+        allow(described_class).to receive(:executable).and_return("powershell.exe")
+      end
+
+      it "should use the 'powershell.exe' executable" do
+        expect(Vagrant::Util::Subprocess).to receive(:execute).with("powershell.exe", any_args).and_return(result)
+        described_class.powerup_command("run", [], [])
+      end
+    end
+  end
 end


### PR DESCRIPTION
For the other occurrences of the powershell executable in `lib/vagrant/util/powershell.rb` this change has already been implemeted in back in 2018: https://github.com/hashicorp/vagrant/pull/9300/commits/ed686ce724f2b6117b03a3267f26d9f66286b387.