### PR TITLE
Updating "VMware" name usage across website

### DIFF
--- a/website/components/footer/index.jsx
+++ b/website/components/footer/index.jsx
@@ -15,7 +15,7 @@ export default function Footer({ openConsentManager }) {
           Book
         </a>
         <Link href="/vmware">
-          <a>VMWare</a>
+          <a>VMware</a>
         </Link>
         <a href="https://hashicorp.com/privacy">Privacy</a>
         <Link href="/security">

--- a/website/data/subnav.js
+++ b/website/data/subnav.js
@@ -10,7 +10,7 @@ export default [
     type: 'inbound',
   },
   {
-    text: 'VMWare',
+    text: 'VMware',
     url: '/vmware',
     type: 'inbound',
   },

--- a/website/pages/docs/providers/vmware/installation.mdx
+++ b/website/pages/docs/providers/vmware/installation.mdx
@@ -97,11 +97,11 @@ $ vagrant plugin update vagrant-vmware-desktop
 
 ## Frequently Asked Questions
 
-**Q: Can Vagrant VMWare Plugin work without internet?**
+**Q: Can Vagrant VMware Plugin work without internet?**
 
-No, Vagrant VMWare plugin requires a new license every 6 weeks. Vagrant will try to renew the
+No, Vagrant VMware plugin requires a new license every 6 weeks. Vagrant will try to renew the
 license automatically. If you are on an environment without internet, after 4 weeks Vagrant will emit a warning,
-and after 6 weeks, the VMWare plugin will stop working. You can install a new license to reactive vagrant.
+and after 6 weeks, the VMware plugin will stop working. You can install a new license to reactive vagrant.
 
 **Q: I purchased a Vagrant VMware plugin license, but I did not receive an email?**
 

--- a/website/pages/docs/providers/vmware/kernel-upgrade.mdx
+++ b/website/pages/docs/providers/vmware/kernel-upgrade.mdx
@@ -27,7 +27,7 @@ This setting is disabled by default. The Vagrantfile settings below will
 enable auto-upgrading:
 
 ```ruby
-# Ensure that VMWare Tools recompiles kernel modules
+# Ensure that VMware Tools recompiles kernel modules
 # when we update the linux images
 $fix_vmware_tools_script = <<SCRIPT
 sed -i.bak 's/answer AUTO_KMODS_ENABLED_ANSWER no/answer AUTO_KMODS_ENABLED_ANSWER yes/g' /etc/vmware-tools/locations

--- a/website/pages/downloads/index.jsx
+++ b/website/pages/downloads/index.jsx
@@ -15,7 +15,7 @@ export default function DownloadsPage({ releaseData }) {
         releaseData={releaseData}
       >
         <Link href="/vmware/downloads">
-          <a>&raquo; Download VMWare Utility</a>
+          <a>&raquo; Download VMware Utility</a>
         </Link>
       </ProductDownloader>
     </div>

--- a/website/pages/vmware/downloads/index.jsx
+++ b/website/pages/vmware/downloads/index.jsx
@@ -9,10 +9,10 @@ export default function DownloadsPage({ releaseData }) {
     <div className={s.root}>
       <HashiHead
         is={Head}
-        title="VMWare Utility Downloads | Vagrant by HashiCorp"
+        title="VMware Utility Downloads | Vagrant by HashiCorp"
       />
       <ProductDownloader
-        product="Vagrant VMWare Utility"
+        product="Vagrant VMware Utility"
         baseProduct="Vagrant"
         version={VMWARE_UTILITY_VERSION}
         releaseData={releaseData}

--- a/website/pages/vmware/index.jsx
+++ b/website/pages/vmware/index.jsx
@@ -7,13 +7,13 @@ import HashiHead from '@hashicorp/react-head'
 export default function VmwareIndex() {
   return (
     <>
-      <HashiHead is={Head} title="VMWare Integration | Vagrant by HashiCorp" />
+      <HashiHead is={Head} title="VMware Integration | Vagrant by HashiCorp" />
       <section className={s.header}>
         <div className="g-grid-container">
           <div className={s.logos}>
             <img src="/img/logo-text.svg" alt="Vagrant Logo" />
             <span>+</span>
-            <img src="/img/vmware.svg" alt="VMWare Logo" />
+            <img src="/img/vmware.svg" alt="VMware Logo" />
           </div>
           <h1 className={s.mainHeadline}>
             Supercharged Development Environments


### PR DESCRIPTION
Updating the Vagrant website to have a consistent, orthographic spelling of VMware. Meaning that all instances of "VMWare" are updated to be "VMware"