### PR TITLE
Pass guest platform into spec runner

### DIFF
--- a/test/vagrant-spec/Vagrantfile.spec
+++ b/test/vagrant-spec/Vagrantfile.spec
@@ -85,6 +85,7 @@ Vagrant.configure(2) do |global_config|
         end
         guest_boxes.each_with_index do |box_info, idx|
           guest_box, box_version = box_info
+          guest_platform = guest_box.split('/').last.sub(/[^a-z]+$/, '')
           spec_cmd_args = ENV["VAGRANT_SPEC_ARGS"]
           if idx != 0
             spec_cmd_args = "#{spec_cmd_args} --without-component cli/*".strip
@@ -96,7 +97,8 @@ Vagrant.configure(2) do |global_config|
               keep_color: true,
               env: {
                 "VAGRANT_SPEC_ARGS" => "--no-builtin #{spec_cmd_args}".strip,
-                "VAGRANT_SPEC_BOX" => "c:/vagrant/#{guest_box.sub('/', '_')}.#{provider_name}.#{box_version}.box"
+                "VAGRANT_SPEC_BOX" => "c:/vagrant/#{guest_box.sub('/', '_')}.#{provider_name}.#{box_version}.box",
+                "VAGRANT_SPEC_GUEST_PLATFORM" => guest_platform
               }
             )
           else
@@ -106,7 +108,8 @@ Vagrant.configure(2) do |global_config|
               keep_color: true,
               env: {
                 "VAGRANT_SPEC_ARGS" => "--no-builtin #{spec_cmd_args}".strip,
-                "VAGRANT_SPEC_BOX" => "/vagrant/test/vagrant-spec/boxes/#{guest_box.sub('/', '_')}.#{provider_name}.#{box_version}.box"
+                "VAGRANT_SPEC_BOX" => "/vagrant/test/vagrant-spec/boxes/#{guest_box.sub('/', '_')}.#{provider_name}.#{box_version}.box",
+                "VAGRANT_SPEC_GUEST_PLATFORM" => guest_platform
               }
             )
           end

--- a/test/vagrant-spec/Vagrantfile.spec
+++ b/test/vagrant-spec/Vagrantfile.spec
@@ -86,6 +86,7 @@ Vagrant.configure(2) do |global_config|
         guest_boxes.each_with_index do |box_info, idx|
           guest_box, box_version = box_info
           guest_platform = guest_box.split('/').last.sub(/[^a-z]+$/, '')
+          guest_platform = PLATFORM_SCRIPT_MAPPING[guest_platform]
           spec_cmd_args = ENV["VAGRANT_SPEC_ARGS"]
           if idx != 0
             spec_cmd_args = "#{spec_cmd_args} --without-component cli/*".strip


### PR DESCRIPTION
This will allow us to filter specs based on the guest operating system,
for example if we don't want to run certain tests on a Windows guest.

See https://github.com/hashicorp/vagrant-spec/pull/35/files#diff-411e94c903d454a80d43973dd16f9b7bR19
for an example.