### PR TITLE
Gem::Specification.default_specifications_dir is deprecated.

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -326,7 +326,7 @@ module Vagrant
     # @return [Array<[Gem::Specification, String]>] spec and directory pairs
     def vagrant_internal_specs
       list = {}
-      directories = [Gem::Specification.default_specifications_dir]
+      directories = [Gem.default_specifications_dir]
       Gem::Specification.find_all{true}.each do |spec|
         list[spec.full_name] = spec
       end


### PR DESCRIPTION
Use Gem.default_specifications_dir instead.

_ _ _ _
When run with Ruby 2.7 (Rubygems 3.1).

Can be seen in vagrant-libvirt test suite f.e.: https://gist.github.com/pvalena/ddeafe6a0e44f5443ef96aed6678fc8b