### PR TITLE
Fix SMB credential checks

### DIFF
--- a/plugins/hosts/windows/plugin.rb
+++ b/plugins/hosts/windows/plugin.rb
@@ -70,6 +70,11 @@ module VagrantPlugins
         require_relative "cap/ssh"
         Cap::SSH
       end
+
+      host_capability("windows", "smb_validate_password") do
+        require_relative "cap/smb"
+        Cap::SMB
+      end
     end
   end
 end

--- a/plugins/synced_folders/smb/synced_folder.rb
+++ b/plugins/synced_folders/smb/synced_folder.rb
@@ -66,7 +66,7 @@ module VagrantPlugins
             if machine.env.host.capability?(:smb_validate_password)
               Vagrant::Util::CredentialScrubber.sensitive(smb_password)
               auth_success = machine.env.host.capability(:smb_validate_password,
-                smb_username, smb_password)
+                machine, smb_username, smb_password)
             end
 
             break if auth_success

--- a/test/unit/plugins/synced_folders/smb/synced_folder_test.rb
+++ b/test/unit/plugins/synced_folders/smb/synced_folder_test.rb
@@ -126,18 +126,18 @@ describe VagrantPlugins::SyncedFolderSMB::SyncedFolder do
         let(:host_caps){ [:smb_start, :smb_prepare, :smb_validate_password] }
 
         it "should validate the password" do
-          expect(host).to receive(:capability).with(:smb_validate_password, 'username', 'password').and_return(true)
+          expect(host).to receive(:capability).with(:smb_validate_password, machine, 'username', 'password').and_return(true)
           subject.prepare(machine, folders, options)
         end
 
         it "should retry when validation fails" do
-          expect(host).to receive(:capability).with(:smb_validate_password, 'username', 'password').and_return(false)
-          expect(host).to receive(:capability).with(:smb_validate_password, 'username', 'password').and_return(true)
+          expect(host).to receive(:capability).with(:smb_validate_password, machine, 'username', 'password').and_return(false)
+          expect(host).to receive(:capability).with(:smb_validate_password, machine, 'username', 'password').and_return(true)
           subject.prepare(machine, folders, options)
         end
 
         it "should raise an error if it exceeds the maximum number of retries" do
-          expect(host).to receive(:capability).with(:smb_validate_password, 'username', 'password').and_return(false).
+          expect(host).to receive(:capability).with(:smb_validate_password, machine, 'username', 'password').and_return(false).
             exactly(VagrantPlugins::SyncedFolderSMB::SyncedFolder::CREDENTIAL_RETRY_MAX).times
           expect{ subject.prepare(machine, folders, options) }.to raise_error(VagrantPlugins::SyncedFolderSMB::Errors::CredentialsRequestError)
         end


### PR DESCRIPTION
The credential checking capability was not added to the Windows host plugin. This prevented the capability from running, and also caused the tests to be skipped.

The function signature for the `smb_validate_password` method was also different to where it was being used in both the synced_folder plugin and the tests.

The unit tests succeed, but as I'm very unfamiliar with Ruby, I don't really understand them (for example, it looks to me like the `should retry when validation fails` test is sending the same username and password each time, but expecting different results)