### PR TITLE
Fix WSL 2 Docker Sync Issue

### DIFF
--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -561,7 +561,7 @@ module Vagrant
               result = Util::Subprocess.execute("mount")
               result.stdout.each_line do |line|
                 info = line.match(MOUNT_PATTERN)
-                if info && info[:type] == "drvfs"
+                if info && (info[:type] == "drvfs" || info[:type] == "9p")
                   @_wsl_drvfs_mounts << info[:mount]
                 end
               end

--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -87,6 +87,8 @@ module VagrantPlugins
               # means that there's no long path support). Hopefully this
               # will be fixed someday and the gsub below can be removed.
               host, guest = v.split(":", 2)
+              # If using WSL within a drvfs file system
+              # we want to continue to use linux pathing
               if (!ENV["VAGRANT_WSL_ENABLE_WINDOWS_ACCESS"])
                 host = Vagrant::Util::Platform.windows_path(host)
                 host.gsub!(/^[^A-Za-z]+/, "")

--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -83,12 +83,14 @@ module VagrantPlugins
               host = "//" + host[0].downcase + host[2..-1]
               v = [host, guest].join(":")
             else
-              host, guest = v.split(":", 2)
-              # host = Vagrant::Util::Platform.windows_path(host)
               # NOTE: Docker does not support UNC style paths (which also
               # means that there's no long path support). Hopefully this
               # will be fixed someday and the gsub below can be removed.
-              # host.gsub!(/^[^A-Za-z]+/, "")
+              host, guest = v.split(":", 2)
+              if (!ENV["VAGRANT_WSL_ENABLE_WINDOWS_ACCESS"])
+                host = Vagrant::Util::Platform.windows_path(host)
+                host.gsub!(/^[^A-Za-z]+/, "")
+              end
               v = [host, guest].join(":")
             end
           end

--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -84,11 +84,11 @@ module VagrantPlugins
               v = [host, guest].join(":")
             else
               host, guest = v.split(":", 2)
-              host = Vagrant::Util::Platform.windows_path(host)
+              # host = Vagrant::Util::Platform.windows_path(host)
               # NOTE: Docker does not support UNC style paths (which also
               # means that there's no long path support). Hopefully this
               # will be fixed someday and the gsub below can be removed.
-              host.gsub!(/^[^A-Za-z]+/, "")
+              # host.gsub!(/^[^A-Za-z]+/, "")
               v = [host, guest].join(":")
             end
           end

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary       = "Build and distribute virtualized development environments."
   s.description   = "Vagrant is a tool for building and distributing virtualized development environments."
 
-  s.required_ruby_version     = "~> 2.4", "< 2.7"
+  s.required_ruby_version     = "~> 2.4", "< 2.8"
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "bcrypt_pbkdf", "~> 1.0.0"


### PR DESCRIPTION
By adjusting the conditional check for the file system, we can also check for 9P systems, which is what WSLs server is classed as. After changing this, we no longer get the error regarding the project being stored on the incorrect filesystem, however there still is an issue with pathing, as it formats the source location according to Windows pathing standards, although we're using WSL. If WSL is enabled, we want to use standard unix pathing as Docker recognizes that when mapping it's volumes. These changes allow for dockers folder sync to work, if the source if an absolute path.