### PR TITLE
Allow docker run images to specify version with ':'

### DIFF
--- a/plugins/provisioners/container/client.rb
+++ b/plugins/provisioners/container/client.rb
@@ -160,7 +160,7 @@ module VagrantPlugins
         # If the name is the automatically assigned name, then
         # replace the "/" with "-" because "/" is not a valid
         # character for a container name.
-        name = name.gsub("/", "-") if name == config[:original_name]
+        name = name.gsub("/", "-").gsub(":", "-") if name == config[:original_name]
         name
       end
 

--- a/test/unit/plugins/provisioners/container/client_test.rb
+++ b/test/unit/plugins/provisioners/container/client_test.rb
@@ -1,0 +1,17 @@
+require File.expand_path("../../../../base", __FILE__)
+
+require Vagrant.source_root.join("plugins/provisioners/container/client")
+
+describe VagrantPlugins::ContainerProvisioner::Client do
+  
+  let(:machine) { double("machine") }
+  let(:container_command) { double("docker") }
+  subject { described_class.new(machine, container_command) }
+
+  describe "#container_name" do
+    it "converts a container name to a run appropriate form" do
+      config = { :name => "test/test:1.1.1", :original_name => "test/test:1.1.1" }
+      expect(subject.container_name(config)).to eq("test-test-1.1.1")
+    end
+  end
+end

--- a/website/pages/docs/provisioning/docker.mdx
+++ b/website/pages/docs/provisioning/docker.mdx
@@ -149,9 +149,9 @@ In addition to the name, the `run` method accepts a set of options, all optional
 
 - `auto_assign_name` (boolean) - If true, the `--name` of the container will
   be set to the first argument of the run. By default this is true. If the
-  name set contains a "/" (because of the image name), it will be replaced
-  with "-". Therefore, if you do `d.run "foo/bar"`, then the name of the
-  container will be "foo-bar".
+  name set contains a "/" or ":" (because of the image name or version), it will be 
+  replaced with "-". Therefore, if you do `d.run "foo/bar:0.0.1"`, then the name of the
+  container will be "foo-bar-0.0.1".
 
 - `daemonize` (boolean) - If true, the "-d" flag is given to `docker run` to
   daemonize the containers. By default this is true.


### PR DESCRIPTION
fixes https://github.com/hashicorp/vagrant/issues/9418