### PR TITLE
Capture escape character [3J

### DIFF
--- a/lib/vagrant/util/ansi_escape_code_remover.rb
+++ b/lib/vagrant/util/ansi_escape_code_remover.rb
@@ -19,7 +19,7 @@ module Vagrant
                     /\e\[\?[1-9][hl]/,     # Matches \e[?2h
                     /\e\[20[hl]/,          # Matches \e[20l]
                     /\e[DME78H]/,          # Matches \eD, \eH, etc.
-                    /\e\[[0-2]?[JK]/,      # Matches \e[0J, \e[K, etc.
+                    /\e\[[0-3]?[JK]/,      # Matches \e[0J, \e[K, etc.
                     ]
 
         # Take each matcher and replace it with emptiness.


### PR DESCRIPTION
fixes https://github.com/hashicorp/vagrant/issues/11135

Looks like a `\e[3J` was getting added from tmux