### PR TITLE
Replace unmaintained Erubis by Erubi.

### DIFF
--- a/lib/vagrant/util/template_renderer.rb
+++ b/lib/vagrant/util/template_renderer.rb
@@ -1,7 +1,7 @@
 require 'ostruct'
 require "pathname"
 
-require 'erubis'
+require 'erubi'
 
 module Vagrant
   module Util
@@ -73,7 +73,7 @@ module Vagrant
       #
       # @return [String]
       def render_string
-        Erubis::Eruby.new(template, trim: true).result(binding)
+        eval(Erubi::Engine.new(template).src)
       end
 
       # Returns the full path to the template, taking into account the gem directory

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency "bcrypt_pbkdf", "~> 1.0.0"
   s.add_dependency "childprocess", "~> 4.0.0"
   s.add_dependency "ed25519", "~> 1.2.4"
-  s.add_dependency "erubis", "~> 2.7.0"
+  s.add_dependency "erubi"
   s.add_dependency "hashicorp-checkpoint", "~> 0.1.5"
   s.add_dependency "i18n", "~> 1.8"
   s.add_dependency "listen", "~> 3.1"


### PR DESCRIPTION
Erubis is not maintained since 2011 and it has some unfixed security issues. Erubi is used by Ruby on Rails, so it should be much better choice.