### PR TITLE
Allow dependabot to update GitHub action versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
https://docs.github.com/en/github/administering-a-repository/keeping-your-actions-up-to-date-with-github-dependabot