### PR TITLE
Remove not functional from disks warning

### DIFF
--- a/website/pages/docs/disks/hyperv/index.mdx
+++ b/website/pages/docs/disks/hyperv/index.mdx
@@ -11,7 +11,7 @@ description: |-
 
 ~> **Warning!** This feature is experimental and may break or
 change in between releases. Use at your own risk. It currently is not officially
-supported or functional.
+supported.
 
 This feature currently reqiures the experimental flag to be used. To explicitly enable this feature, you can set the experimental flag to:
 

--- a/website/pages/docs/disks/hyperv/usage.mdx
+++ b/website/pages/docs/disks/hyperv/usage.mdx
@@ -11,7 +11,7 @@ description: |-
 
 ~> **Warning!** This feature is experimental and may break or
 change in between releases. Use at your own risk. It currently is not officially
-supported or functional.
+supported.
 
 This feature currently reqiures the experimental flag to be used. To explicitly enable this feature, you can set the experimental flag to:
 

--- a/website/pages/docs/disks/index.mdx
+++ b/website/pages/docs/disks/index.mdx
@@ -9,7 +9,7 @@ description: Introduction to Vagrant Disks
 
 ~> **Warning!** This feature is experimental and may break or
 change in between releases. Use at your own risk. It currently is not officially
-supported or functional. Please refer to the provider specific disk documentation
+supported. Please refer to the provider specific disk documentation
 for more information on how to use and enable this feature.
 
 Vagrant Disks is a feature that allows users to define what mediums should be attached

--- a/website/pages/docs/disks/usage.mdx
+++ b/website/pages/docs/disks/usage.mdx
@@ -9,7 +9,7 @@ description: Various Vagrant Disk examples
 
 ~> **Warning!** This feature is experimental and may break or
 change in between releases. Use at your own risk. It currently is not officially
-supported or functional.
+supported.
 
 This feature currently reqiures the experimental flag to be used. To explicitly enable this feature, you can set the experimental flag to:
 

--- a/website/pages/docs/disks/virtualbox/index.mdx
+++ b/website/pages/docs/disks/virtualbox/index.mdx
@@ -11,7 +11,7 @@ description: |-
 
 ~> **Warning!** This feature is experimental and may break or
 change in between releases. Use at your own risk. It currently is not officially
-supported or functional.
+supported.
 
 This feature currently reqiures the experimental flag to be used. To explicitly enable this feature, you can set the experimental flag to:
 

--- a/website/pages/docs/disks/virtualbox/usage.mdx
+++ b/website/pages/docs/disks/virtualbox/usage.mdx
@@ -11,7 +11,7 @@ description: |-
 
 ~> **Warning!** This feature is experimental and may break or
 change in between releases. Use at your own risk. It currently is not officially
-supported or functional.
+supported.
 
 This feature currently reqiures the experimental flag to be used. To explicitly enable this feature, you can set the experimental flag to:
 


### PR DESCRIPTION
This commit removes the text about the disk feature being not functional
from the experimental warning. Now that both VirtualBox and Hyper-V have
shipped under the experimental flag, these providers are now functional.