### PR TITLE
Avoid sorting of controllers with nil boot_priority

### DIFF
--- a/plugins/providers/virtualbox/model/storage_controller_array.rb
+++ b/plugins/providers/virtualbox/model/storage_controller_array.rb
@@ -27,10 +27,8 @@ module VagrantPlugins
         #
         # @return [VagrantPlugins::ProviderVirtualBox::Model::StorageController]
         def get_primary_controller
-          ordered = sort { |a, b| a.boot_priority <=> b.boot_priority }
-          controller = ordered.detect do |c|
-            c.supported? && c.attachments.any? { |a| hdd?(a) }
-          end
+          ordered = find_all(&:supported?).sort_by(&:boot_priority)
+          controller = ordered.detect { |c| c.attachments.any? { |a| hdd?(a) } }
 
           if !controller
             raise Vagrant::Errors::VirtualBoxDisksNoSupportedControllers,
@@ -62,8 +60,8 @@ module VagrantPlugins
         #
         # @return [VagrantPlugins::ProviderVirtualBox::Model::StorageController]
         def get_dvd_controller
-          ordered = sort { |a, b| a.boot_priority <=> b.boot_priority }
-          controller = ordered.detect { |c| c.supported? }
+          ordered = find_all(&:supported?).sort_by(&:boot_priority)
+          controller = ordered.first
           if !controller
             raise Vagrant::Errors::VirtualBoxDisksNoSupportedControllers,
               supported_types: supported_types.join(" ,")

--- a/test/unit/plugins/providers/virtualbox/model/storage_controller_array_test.rb
+++ b/test/unit/plugins/providers/virtualbox/model/storage_controller_array_test.rb
@@ -91,7 +91,7 @@ describe VagrantPlugins::ProviderVirtualBox::Model::StorageControllerArray do
 
   describe "#get_dvd_controller" do
     context "with one controller" do
-      let(:controller) { double("controller", supported?: true) }
+      let(:controller) { double("controller", supported?: true, boot_priority: 1) }
 
       before do
         subject.replace([controller])
@@ -111,9 +111,10 @@ describe VagrantPlugins::ProviderVirtualBox::Model::StorageControllerArray do
     context "with multiple controllers" do
       let(:controller1) { double("controller", supported?: true, boot_priority: 2) }
       let(:controller2) { double("controller", supported?: true, boot_priority: 1) }
+      let(:controller3) { double("controller", supported?: false, boot_priority: nil) }
 
       before do
-        subject.replace([controller1, controller2])
+        subject.replace([controller1, controller2, controller3])
       end
 
       it "returns the first supported controller" do


### PR DESCRIPTION
Some unsupported storage controllers (e.g. floppy) report a nil
boot_priority which results in a failed sort. Select only supported
storage controllers to avoid that case.