### PR TITLE
[WIP] Change `mkdir` command on Windows for rsync

### DIFF
--- a/plugins/guests/windows/cap/rsync.rb
+++ b/plugins/guests/windows/cap/rsync.rb
@@ -13,7 +13,11 @@ module VagrantPlugins
           machine.communicate.tap do |comm|
             # rsync does not construct any gaps in the path to the target directory
             # make sure that all subdirectories are created
-            comm.execute("mkdir -p '#{opts[:guestpath]}'")
+            # NB: Per #11878, the `mkdir` command on Windows is different than used on Unix.
+            # This formulation matches the form used in the WinRM communicator plugin.
+            # This will ignore any -p switches, which are redundant in PowerShell,
+            # and ambiguous in PowerShell 4+
+            comm.execute("mkdir \"#{opts[:guestpath]}\" -force")
           end
         end
       end

--- a/test/unit/plugins/guests/windows/cap/rsync_test.rb
+++ b/test/unit/plugins/guests/windows/cap/rsync_test.rb
@@ -19,7 +19,7 @@ describe "VagrantPlugins::GuestWindows::Cap::RSync" do
 
   describe ".rsync_pre" do
     it 'makes the guestpath directory with mkdir' do
-      communicator.expect_command("mkdir -p '/sync_dir'")
+      communicator.expect_command("mkdir \"/sync_dir\" -force")
       described_class.rsync_pre(machine, guestpath: '/sync_dir')
     end
   end


### PR DESCRIPTION
This corrects the `mkdir` command used by rsync on Windows to make sure
the destination directory exists before starting to sync.  The old form
was correct on Linux but not on Windows, and it was just a coincidence
that the `-p` argument appeared to be work.

Please note that I am completely unfamiliar with the Vagrant codebase, so I am not sure how to properly test this.  The bug appears to be serious enough that it should always fail, at least on newer Powershell versions (I haven't tried to reproduce on any guest other than Windows 2019 with Powershell 7).

I use the patch herein on my local development system to fix this issue; that is as much testing as this patch has undergone so far.

Closes #11878