### PR TITLE
Support existence of other storage controllers

### DIFF
--- a/plugins/providers/virtualbox/model/storage_controller.rb
+++ b/plugins/providers/virtualbox/model/storage_controller.rb
@@ -7,17 +7,15 @@ module VagrantPlugins
         IDE_CONTROLLER_TYPES = ["PIIX4", "PIIX3", "ICH6"].map(&:freeze).freeze
         SATA_CONTROLLER_TYPES = ["IntelAhci"].map(&:freeze).freeze
         SCSI_CONTROLLER_TYPES = ["LsiLogic", "BusLogic"].map(&:freeze).freeze
-        FLOPPY_CONTROLLER_TYPES = ["I82078"].map(&:freeze).freeze
 
         IDE_DEVICES_PER_PORT = 2.freeze
         SATA_DEVICES_PER_PORT = 1.freeze
         SCSI_DEVICES_PER_PORT = 1.freeze
-        FLOPPY_DEVICES_PER_PORT = 1.freeze
 
         IDE_BOOT_PRIORITY = 1.freeze
         SATA_BOOT_PRIORITY = 2.freeze
         SCSI_BOOT_PRIORITY = 3.freeze
-        FLOPPY_BOOT_PRIORITY = 4.freeze
+        DEFAULT_BOOT_PRIORITY = 4.freeze
 
         # The name of the storage controller.
         #
@@ -80,13 +78,10 @@ module VagrantPlugins
             @storage_bus = :scsi
             @devices_per_port = SCSI_DEVICES_PER_PORT
             @boot_priority = SCSI_BOOT_PRIORITY
-          elsif FLOPPY_CONTROLLER_TYPES.include?(@type)
-            @storage_bus = :floppy
-            @devices_per_port = FLOPPY_DEVICES_PER_PORT
-            @boot_priority = FLOPPY_BOOT_PRIORITY
           else
             @storage_bus = :unknown
             @devices_per_port = 1
+            @boot_priority = DEFAULT_BOOT_PRIORITY
           end
 
           @limit = @maxportcount * @devices_per_port
@@ -113,7 +108,7 @@ module VagrantPlugins
         #
         # @return [Boolean]
         def supported?
-          [:ide, :sata, :scsi, :floppy].include?(@storage_bus)
+          [:ide, :sata, :scsi].include?(@storage_bus)
         end
 
         # Returns true if the storage controller is a IDE type controller.
@@ -135,13 +130,6 @@ module VagrantPlugins
         # @return [Boolean]
         def scsi?
           @storage_bus == :scsi
-        end
-
-        # Returns true if the storage controller is a Floppy type controller.
-        #
-        # @return [Boolean]
-        def floppy?
-          @storage_bus == :floppy
         end
       end
     end

--- a/plugins/providers/virtualbox/model/storage_controller.rb
+++ b/plugins/providers/virtualbox/model/storage_controller.rb
@@ -6,15 +6,18 @@ module VagrantPlugins
       class StorageController
         IDE_CONTROLLER_TYPES = ["PIIX4", "PIIX3", "ICH6"].map(&:freeze).freeze
         SATA_CONTROLLER_TYPES = ["IntelAhci"].map(&:freeze).freeze
-        SCSI_CONTROLLER_TYPES = [ "LsiLogic", "BusLogic"].map(&:freeze).freeze
+        SCSI_CONTROLLER_TYPES = ["LsiLogic", "BusLogic"].map(&:freeze).freeze
+        FLOPPY_CONTROLLER_TYPES = ["I82078"].map(&:freeze).freeze
 
         IDE_DEVICES_PER_PORT = 2.freeze
         SATA_DEVICES_PER_PORT = 1.freeze
         SCSI_DEVICES_PER_PORT = 1.freeze
+        FLOPPY_DEVICES_PER_PORT = 1.freeze
 
         IDE_BOOT_PRIORITY = 1.freeze
         SATA_BOOT_PRIORITY = 2.freeze
         SCSI_BOOT_PRIORITY = 3.freeze
+        FLOPPY_BOOT_PRIORITY = 4.freeze
 
         # The name of the storage controller.
         #
@@ -77,6 +80,10 @@ module VagrantPlugins
             @storage_bus = :scsi
             @devices_per_port = SCSI_DEVICES_PER_PORT
             @boot_priority = SCSI_BOOT_PRIORITY
+          elsif FLOPPY_CONTROLLER_TYPES.include?(@type)
+            @storage_bus = :floppy
+            @devices_per_port = FLOPPY_DEVICES_PER_PORT
+            @boot_priority = FLOPPY_BOOT_PRIORITY
           else
             @storage_bus = :unknown
             @devices_per_port = 1
@@ -106,7 +113,7 @@ module VagrantPlugins
         #
         # @return [Boolean]
         def supported?
-          [:ide, :sata, :scsi].include?(@storage_bus)
+          [:ide, :sata, :scsi, :floppy].include?(@storage_bus)
         end
 
         # Returns true if the storage controller is a IDE type controller.
@@ -128,6 +135,13 @@ module VagrantPlugins
         # @return [Boolean]
         def scsi?
           @storage_bus == :scsi
+        end
+
+        # Returns true if the storage controller is a Floppy type controller.
+        #
+        # @return [Boolean]
+        def floppy?
+          @storage_bus == :floppy
         end
       end
     end

--- a/test/unit/plugins/providers/virtualbox/model/storage_controller_array_test.rb
+++ b/test/unit/plugins/providers/virtualbox/model/storage_controller_array_test.rb
@@ -3,13 +3,14 @@ require File.expand_path("../../base", __FILE__)
 describe VagrantPlugins::ProviderVirtualBox::Model::StorageControllerArray do
   include_context "unit"
 
-  let(:controller1) { double("controller1", name: "IDE Controller", supported?: true, boot_priority: 1) }
-  let(:controller2) { double("controller2", name: "SATA Controller", supported?: true, boot_priority: 2) }
+  let(:controller1) { VagrantPlugins::ProviderVirtualBox::Model::StorageController.new("IDE Controller", "PIIX4", 1, 1) }
+  let(:controller2) { VagrantPlugins::ProviderVirtualBox::Model::StorageController.new("SATA Controller", "IntelAhci", 1, 1) }
+  let(:controller3) { VagrantPlugins::ProviderVirtualBox::Model::StorageController.new("RANDO Controller", "unknown", 1, 0) }
 
   let(:primary_disk) { {location: "/tmp/primary.vdi"} }
 
   before do
-    subject.replace([controller1, controller2])
+    subject.replace([controller1, controller2, controller3])
   end
 
   describe "#get_controller" do


### PR DESCRIPTION
fixes https://github.com/hashicorp/vagrant/issues/11883

This PR will assign a default boot priority for an unknown controller type. In particular, it allows
https://github.com/hashicorp/vagrant/blob/master/plugins/providers/virtualbox/model/storage_controller_array.rb#L30 to not fail on a storage controller with a nil boot priority. However, does it make sense to have a default boot priority?