### PR TITLE
Don't try to "fix" a /etc/fstab that does not exist

### DIFF
--- a/plugins/guests/linux/cap/persist_mount_shared_folder.rb
+++ b/plugins/guests/linux/cap/persist_mount_shared_folder.rb
@@ -54,7 +54,9 @@ module VagrantPlugins
         private
 
         def self.remove_vagrant_managed_fstab(machine)
-          machine.communicate.sudo("sed -i '/\#VAGRANT-BEGIN/,/\#VAGRANT-END/d' /etc/fstab")
+          # machines don't *need* an /etc/fstab and if this function gets called
+          # on such a machine, then it will fail
+          machine.communicate.sudo("[ -e /etc/fstab ] && sed -i '/\#VAGRANT-BEGIN/,/\#VAGRANT-END/d' /etc/fstab || :")
         end
       end
     end


### PR DESCRIPTION
`remove_vagrant_managed_fstab()` gets called in `self.persist_mount_shared_folder` when `folders` is `nil`. This is an issue for boxes that don't have a `/etc/fstab`, as they can boot but will break once the `sed` call is executed.

Thus we guard it with a check whether `/etc/fstab` exists and only try to remove the modifications then.