### PR TITLE
--yes options added to CloudCommand::VersionCommand::Command::Release

### DIFF
--- a/plugins/commands/cloud/version/release.rb
+++ b/plugins/commands/cloud/version/release.rb
@@ -18,6 +18,10 @@ module VagrantPlugins
               o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |u|
                 options[:username] = u
               end
+              options[:assume_yes] = false
+              o.on("-y", "--yes", "Automatic yes to prompts") do |y|
+                options[:assume_yes] = y
+              end
             end
 
             # Parse the options
@@ -28,9 +32,11 @@ module VagrantPlugins
                 help: opts.help.chomp
             end
 
-            @env.ui.warn(I18n.t("cloud_command.version.release_warn", version: argv[1], box: argv.first))
-            cont = @env.ui.ask(I18n.t("cloud_command.continue"))
-            return 1 if cont.strip.downcase != "y"
+            if not options[:assume_yes]
+                @env.ui.warn(I18n.t("cloud_command.version.release_warn", version: argv[1], box: argv.first))
+                cont = @env.ui.ask(I18n.t("cloud_command.continue"))
+                return 1 if cont.strip.downcase != "y"
+            end
 
             @client = VagrantPlugins::CloudCommand::Util.client_login(@env, options[:username])
             box = argv.first.split('/', 2)

--- a/plugins/commands/cloud/version/release.rb
+++ b/plugins/commands/cloud/version/release.rb
@@ -18,9 +18,9 @@ module VagrantPlugins
               o.on("-u", "--username USERNAME_OR_EMAIL", String, "Vagrant Cloud username or email address") do |u|
                 options[:username] = u
               end
-              options[:assume_yes] = false
-              o.on("-y", "--yes", "Automatic yes to prompts") do |y|
-                options[:assume_yes] = y
+              options[:force] = false
+              o.on("-f", "--force", "Release without confirmation") do |f|
+                options[:force] = f
               end
             end
 
@@ -32,7 +32,7 @@ module VagrantPlugins
                 help: opts.help.chomp
             end
 
-            if not options[:assume_yes]
+            if not options[:force]
                 @env.ui.warn(I18n.t("cloud_command.version.release_warn", version: argv[1], box: argv.first))
                 cont = @env.ui.ask(I18n.t("cloud_command.continue"))
                 return 1 if cont.strip.downcase != "y"

--- a/test/unit/plugins/commands/cloud/version/release_test.rb
+++ b/test/unit/plugins/commands/cloud/version/release_test.rb
@@ -67,7 +67,7 @@ describe VagrantPlugins::CloudCommand::VersionCommand::Command::Release do
   end
 
   context "non-interactive mode with arguments" do
-    let (:argv) { ["--yes", "vagrant/box-name", "1.0.0"] }
+    let (:argv) { ["--force", "vagrant/box-name", "1.0.0"] }
 
     it "releases a version" do
       allow(VagrantCloud::Version).to receive(:new).

--- a/test/unit/plugins/commands/cloud/version/release_test.rb
+++ b/test/unit/plugins/commands/cloud/version/release_test.rb
@@ -30,8 +30,6 @@ describe VagrantPlugins::CloudCommand::VersionCommand::Command::Release do
     allow(VagrantCloud::Box).to receive(:new)
       .with(anything, "box-name", nil, nil, nil, client.token)
       .and_return(box)
-    allow(iso_env.ui).to receive(:ask).
-      and_return("y")
   end
 
   context "with no arguments" do
@@ -41,8 +39,35 @@ describe VagrantPlugins::CloudCommand::VersionCommand::Command::Release do
     end
   end
 
-  context "with arguments" do
+  context "interactive mode with arguments" do
     let (:argv) { ["vagrant/box-name", "1.0.0"] }
+
+    it "releases a version" do
+      allow(iso_env.ui).to receive(:ask).
+        and_return("y")
+      allow(VagrantCloud::Version).to receive(:new).
+        with(box, "1.0.0", nil, nil, client.token).
+        and_return(version)
+
+      expect(version).to receive(:release).and_return({})
+      expect(subject.execute).to eq(0)
+    end
+
+    it "displays an error if encoutering a problem with the request" do
+      allow(iso_env.ui).to receive(:ask).
+        and_return("y")
+      allow(VagrantCloud::Version).to receive(:new).
+        with(box, "1.0.0", nil, nil, client.token).
+        and_return(version)
+
+      allow(version).to receive(:release).
+        and_raise(VagrantCloud::ClientError.new("Fail Message", "Message", 404))
+      expect(subject.execute).to eq(1)
+    end
+  end
+
+  context "non-interactive mode with arguments" do
+    let (:argv) { ["--yes", "vagrant/box-name", "1.0.0"] }
 
     it "releases a version" do
       allow(VagrantCloud::Version).to receive(:new).


### PR DESCRIPTION
Hi everyone,

this is my first contribution here (and the very first contribution with ruby).
I ran into a little problem at my workplace during automating a vagrant box build process namely that there's no 'assume yes' option at the ```vagrant cloud version release``` command which requires a 'y' to release the version.
I know that I could use programs like 'expect' and 'yes' to solve this but I've always found it more elegant to use the offered ```--yes``` option.

P.S: I hope I didn't violate any of the rules of this community. If I did, please let me know and I'll try my best.

Thank you in advance for looking into my PR.