### PR TITLE
Install smbclient when setting up arch smb

### DIFF
--- a/plugins/guests/arch/cap/smb.rb
+++ b/plugins/guests/arch/cap/smb.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
           if !comm.test("test -f /usr/bin/mount.cifs")
             comm.sudo <<-EOH.gsub(/^ {14}/, '')
               pacman -Sy --noconfirm
-              pacman -S --noconfirm cifs-utils
+              pacman -S --noconfirm smbclient cifs-utils
             EOH
           end
         end

--- a/test/unit/plugins/guests/arch/cap/smb_test.rb
+++ b/test/unit/plugins/guests/arch/cap/smb_test.rb
@@ -25,7 +25,7 @@ describe "VagrantPlugins::GuestArch::Cap::SMB" do
       described_class.smb_install(machine)
 
       expect(comm.received_commands[1]).to match(/pacman -Sy --noconfirm/)
-      expect(comm.received_commands[1]).to match(/pacman -S --noconfirm cifs-utils/)
+      expect(comm.received_commands[1]).to match(/pacman -S --noconfirm smbclient cifs-utils/)
     end
 
     it "does not install smb when /usr/bin/mount.cifs exists" do


### PR DESCRIPTION
Leaving out smbclient from the install will cause a cyclical
dependency error.

```
Was getting error
Stderr from the command:

warning: dependency cycle detected:
warning: smbclient will be installed before its cifs-utils dependency
error: failed to commit transaction (conflicting files)
```