### PR TITLE
Add guest definitions for Oracle Linux

### DIFF
--- a/plugins/guests/oraclelinux/cap/flavor.rb
+++ b/plugins/guests/oraclelinux/cap/flavor.rb
@@ -1,0 +1,27 @@
+# Copyright (c) 2020, Oracle and/or its affiliates.
+# Licensed under the MIT License.
+
+module VagrantPlugins
+  module GuestOracleLinux
+    module Cap
+      class Flavor
+        def self.flavor(machine)
+          # Read the version file
+          output = ""
+          machine.communicate.sudo("cat /etc/oracle-release") do |_, data|
+            output = data
+          end
+
+          # Detect various flavors we care about
+          if output =~ /(Oracle Linux)( .+)? 7/i
+            return :oraclelinux_7
+          elsif output =~ /(Oracle Linux)( .+)? 8/i
+            return :oraclelinux_8
+          else
+            return :oraclelinux
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/oraclelinux/guest.rb
+++ b/plugins/guests/oraclelinux/guest.rb
@@ -1,0 +1,12 @@
+# Copyright (c) 2020, Oracle and/or its affiliates.
+# Licensed under the MIT License.
+
+module VagrantPlugins
+  module GuestOracleLinux
+    class Guest < Vagrant.plugin("2", :guest)
+      def detect?(machine)
+        machine.communicate.test("cat /etc/oracle-release")
+      end
+    end
+  end
+end

--- a/plugins/guests/oraclelinux/plugin.rb
+++ b/plugins/guests/oraclelinux/plugin.rb
@@ -1,0 +1,23 @@
+# Copyright (c) 2020, Oracle and/or its affiliates.
+# Licensed under the MIT License.
+
+require "vagrant"
+
+module VagrantPlugins
+  module GuestOracleLinux
+    class Plugin < Vagrant.plugin("2")
+      name "Oracle Linux guest"
+      description "Oracle Linux guest support."
+
+      guest(:oraclelinux, :redhat) do
+        require_relative "guest"
+        Guest
+      end
+
+      guest_capability(:oraclelinux, :flavor) do
+        require_relative "cap/flavor"
+        Cap::Flavor
+      end
+    end
+  end
+end

--- a/plugins/provisioners/ansible/cap/guest/oraclelinux/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/oraclelinux/ansible_install.rb
@@ -1,0 +1,80 @@
+# Copyright (c) 2020, Oracle and/or its affiliates.
+# Licensed under the MIT License.
+
+require_relative "../facts"
+require_relative "../pip/pip"
+
+module VagrantPlugins
+  module Ansible
+    module Cap
+      module Guest
+        module OracleLinux
+          module AnsibleInstall
+
+            def self.ansible_install(machine, install_mode, ansible_version, pip_args, pip_install_cmd = "")
+              case install_mode
+              when :pip
+                pip_setup machine, pip_install_cmd
+                Pip::pip_install machine, "ansible", ansible_version, pip_args, true
+              when :pip_args_only
+                pip_setup machine, pip_install_cmd
+                Pip::pip_install machine, "", "", pip_args, false
+              else
+                ansible_rpm_install machine
+              end
+            end
+
+            private
+
+            def self.ansible_rpm_install(machine)
+              rpm_package_manager = Facts::rpm_package_manager(machine)
+              case machine.guest.capability("flavor")
+              when :oraclelinux_7
+                package = "oracle-epel-release-el7"
+                repo = "ol7_developer_EPEL"
+              when :oraclelinux_8
+                package = "oracle-epel-release-el8"
+                repo = "ol8_developer_EPEL"
+              else
+                # Go to Fedora EPEL (most probably Oracle Linux 6...)
+                dist = nil
+                machine.communicate.execute "rpm -E %dist | sed -n 's/.*el\\([0-9]\\).*/\\1/p'" do |type, data|
+                    if type == :stdout
+                    dist = data.chomp
+                  end
+                end
+                package = "https://dl.fedoraproject.org/pub/epel/epel-release-latest-#{dist}.noarch.rpm"
+                repo = "epel"
+              end
+              epel = machine.communicate.execute "#{rpm_package_manager} repolist #{repo} | grep -q #{repo}", error_check: false
+              if epel != 0
+                machine.communicate.sudo "#{rpm_package_manager} -y install #{package}"
+              end
+              machine.communicate.sudo "#{rpm_package_manager} -y --enablerepo=#{repo} install ansible"
+            end
+
+            def self.pip_setup(machine, pip_install_cmd = "")
+              rpm_package_manager = Facts::rpm_package_manager(machine)
+              case machine.guest.capability("flavor")
+              when :oraclelinux_7
+                packages = "curl gcc libffi-devel openssl-devel python-crypto python-devel python-setuptools"
+              when :oraclelinux_8
+                packages = "curl gcc libffi-devel openssl-devel python3-cryptography python36-devel python3-setuptools"
+                if pip_install_cmd.to_s.empty?
+                  pip_install_cmd = "curl https://bootstrap.pypa.io/get-pip.py | sudo python3.6 - --prefix /usr"
+                end
+              else
+                # Most probably Oracle Linux 6; latest pip/ansible won't install
+                raise Ansible::Errors::AnsiblePipInstallIsNotSupported
+              end
+
+              machine.communicate.sudo("#{rpm_package_manager} -y install #{packages}")
+              Pip::get_pip machine, pip_install_cmd
+            end
+
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/provisioners/ansible/plugin.rb
+++ b/plugins/provisioners/ansible/plugin.rb
@@ -70,6 +70,11 @@ module VagrantPlugins
         Cap::Guest::RedHat::AnsibleInstall
       end
 
+      guest_capability(:oraclelinux, :ansible_install) do
+        require_relative "cap/guest/oraclelinux/ansible_install"
+        Cap::Guest::OracleLinux::AnsibleInstall
+      end
+
       guest_capability(:suse, :ansible_install) do
         require_relative "cap/guest/suse/ansible_install"
         Cap::Guest::SUSE::AnsibleInstall

--- a/plugins/provisioners/docker/cap/oraclelinux/docker_install.rb
+++ b/plugins/provisioners/docker/cap/oraclelinux/docker_install.rb
@@ -1,0 +1,55 @@
+# Copyright (c) 2020, Oracle and/or its affiliates.
+# Licensed under the MIT License.
+
+# Enable the Docker provisioner for guests running Oracle Linux 7 / UEK5
+
+module VagrantPlugins
+  module DockerProvisioner
+    module Cap
+      module OracleLinux
+        module DockerInstall
+          def self.docker_install(machine)
+            case machine.guest.capability("flavor")
+            when :oraclelinux_7
+              kernel = nil
+              machine.communicate.execute "uname -r" do |type, data|
+                if type == :stdout
+                  kernel = data.chomp
+                end
+              end
+            unless kernel.to_s.match(/4\.14\.35-.*el7uek/)
+              raise DockerError, :not_supported
+            end
+            machine.communicate.tap do |comm|
+                comm.sudo("yum install -y -q yum-utils")
+                comm.sudo("yum-config-manager --enable ol7_addons")
+                comm.sudo("yum install -y -q docker-engine docker-cli")
+                # Select appropriate driver based on the filesystem type
+                comm.sudo <<~SHELL
+                  fstype=$(stat -f -c %T /var/lib/docker || stat -f -c %T /var/lib)
+                  storage_driver=""
+                  case "${fstype}" in
+                      btrfs)
+                          storage_driver="btrfs"
+                          ;;
+                      xfs)
+                          storage_driver="overlay2"
+                          ;;
+                  esac
+                  if [[ -n ${storage_driver} ]]; then
+                      [ ! -d /etc/docker ] && mkdir -m 0770 /etc/docker && chown root:root /etc/docker
+                      echo -e "{\n    \\"storage-driver\\": \\"${storage_driver}\\"\n}" > /etc/docker/daemon.json 
+                  fi
+                SHELL
+                comm.sudo("systemctl enable --now docker.service")
+                end
+            else
+              raise DockerError, :not_supported
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/plugins/provisioners/docker/cap/oraclelinux/docker_install.rb
+++ b/plugins/provisioners/docker/cap/oraclelinux/docker_install.rb
@@ -17,10 +17,10 @@ module VagrantPlugins
                   kernel = data.chomp
                 end
               end
-            unless kernel.to_s.match(/4\.14\.35-.*el7uek/)
-              raise DockerError, :not_supported
-            end
-            machine.communicate.tap do |comm|
+              unless kernel.to_s.match(/4\.14\.35-.*el7uek/)
+                raise DockerError, :not_supported
+              end
+              machine.communicate.tap do |comm|
                 comm.sudo("yum install -y -q yum-utils")
                 comm.sudo("yum-config-manager --enable ol7_addons")
                 comm.sudo("yum install -y -q docker-engine docker-cli")
@@ -29,20 +29,20 @@ module VagrantPlugins
                   fstype=$(stat -f -c %T /var/lib/docker || stat -f -c %T /var/lib)
                   storage_driver=""
                   case "${fstype}" in
-                      btrfs)
-                          storage_driver="btrfs"
-                          ;;
-                      xfs)
-                          storage_driver="overlay2"
-                          ;;
+                    btrfs)
+                      storage_driver="btrfs"
+                      ;;
+                    xfs)
+                      storage_driver="overlay2"
+                      ;;
                   esac
                   if [[ -n ${storage_driver} ]]; then
-                      [ ! -d /etc/docker ] && mkdir -m 0770 /etc/docker && chown root:root /etc/docker
-                      echo -e "{\n    \\"storage-driver\\": \\"${storage_driver}\\"\n}" > /etc/docker/daemon.json 
+                    [ ! -d /etc/docker ] && mkdir -m 0770 /etc/docker && chown root:root /etc/docker
+                    echo -e "{\n    \\"storage-driver\\": \\"${storage_driver}\\"\n}" > /etc/docker/daemon.json 
                   fi
                 SHELL
                 comm.sudo("systemctl enable --now docker.service")
-                end
+              end
             else
               raise DockerError, :not_supported
             end

--- a/plugins/provisioners/docker/cap/oraclelinux/docker_start_service.rb
+++ b/plugins/provisioners/docker/cap/oraclelinux/docker_start_service.rb
@@ -1,0 +1,23 @@
+# Copyright (c) 2020, Oracle and/or its affiliates.
+# Licensed under the MIT License.
+
+module VagrantPlugins
+  module DockerProvisioner
+    module Cap
+      module OracleLinux
+        module DockerStartService
+          def self.docker_start_service(machine)
+            case machine.guest.capability("flavor")
+            when :oraclelinux_7
+              machine.communicate.tap do |comm|
+                comm.sudo("systemctl enable --now docker.service")
+              end
+            else
+              raise DockerError, :not_supported
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/provisioners/docker/plugin.rb
+++ b/plugins/provisioners/docker/plugin.rb
@@ -39,6 +39,16 @@ module VagrantPlugins
         Cap::Centos::DockerStartService
       end
 
+      guest_capability("oraclelinux", "docker_install") do
+        require_relative "cap/oraclelinux/docker_install"
+        Cap::OracleLinux::DockerInstall
+      end
+
+      guest_capability("oraclelinux", "docker_start_service") do
+        require_relative "cap/oraclelinux/docker_start_service"
+        Cap::OracleLinux::DockerStartService
+      end
+
       guest_capability("linux", "docker_installed") do
         require_relative "cap/linux/docker_installed"
         Cap::Linux::DockerInstalled

--- a/plugins/provisioners/podman/cap/oraclelinux/podman_install.rb
+++ b/plugins/provisioners/podman/cap/oraclelinux/podman_install.rb
@@ -1,0 +1,25 @@
+# Copyright (c) 2020, Oracle and/or its affiliates.
+# Licensed under the MIT License.
+
+module VagrantPlugins
+  module PodmanProvisioner
+    module Cap
+      module OracleLinux
+        module PodmanInstall
+          def self.podman_install(machine, kubic)
+            case machine.guest.capability("flavor")
+            when :oraclelinux_7
+              machine.communicate.tap do |comm|
+                comm.sudo("yum install -y yum-utils oraclelinux-developer-release-el7")
+                comm.sudo("yum-config-manager --enable ol7_addons ol7_developer")
+                comm.sudo("yum install -y podman slirp4netns")
+              end
+            when :oraclelinux_8
+              machine.communicate.sudo("dnf module install -y container-tools:ol8")
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/provisioners/podman/plugin.rb
+++ b/plugins/provisioners/podman/plugin.rb
@@ -24,6 +24,11 @@ module VagrantPlugins
         Cap::Centos::PodmanInstall
       end
 
+      guest_capability("oraclelinux", "podman_install") do
+        require_relative "cap/oraclelinux/podman_install"
+        Cap::OracleLinux::PodmanInstall
+      end
+
       guest_capability("linux", "podman_installed") do
         require_relative "cap/linux/podman_installed"
         Cap::Linux::PodmanInstalled

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2970,6 +2970,8 @@ en:
           provisioner
         not_running: "Docker is not running on the guest VM."
         install_failed: "Docker installation failed."
+        not_supported: |-
+          Unfortunately Docker is not supported on the guest OS running in the machine.
 
       podman:
         wrong_provisioner: |-

--- a/test/unit/plugins/guests/oraclelinux/cap/flavor_test.rb
+++ b/test/unit/plugins/guests/oraclelinux/cap/flavor_test.rb
@@ -1,0 +1,39 @@
+# Copyright (c) 2020, Oracle and/or its affiliates.
+# Licensed under the MIT License.
+
+require_relative "../../../../base"
+
+describe "VagrantPlugins::GuestOracleLinux::Cap::Flavor" do
+  let(:caps) do
+    VagrantPlugins::GuestOracleLinux::Plugin
+      .components
+      .guest_capabilities[:oraclelinux]
+  end
+
+  let(:machine) { double("machine") }
+  let(:comm) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(comm)
+  end
+
+  after do
+    comm.verify_expectations!
+  end
+
+  describe ".flavor" do
+    let(:cap) { caps.get(:flavor) }
+
+    {
+      "Oracle Linux Server release 7.8" => :oraclelinux_7,
+      "Oracle Linux Server release 8.2" => :oraclelinux_8,
+      "Oracle Linux Server release 6.10" => :oraclelinux,
+      "Unexpected release" => :oraclelinux,
+    }.each do |str, expected|
+      it "returns #{expected} for #{str}" do
+        comm.stub_command("cat /etc/oracle-release", stdout: str)
+        expect(cap.flavor(machine)).to be(expected)
+      end
+    end
+  end
+end


### PR DESCRIPTION
As of today, Oracle Linux guests are seen as RedHat guests.

This PR defines Oracle Linux as guest, allowing specific handling where OL differs from RH.

From an implementation perspective it inherits from RedHat, that is: by default it will behave as a RedHat guest.

Using the above definition, we add the following provisioners:
- Ansible: using the Oracle provided EPEL repository instead of the Fedora one
- Docker: which is not available for RedHat
- Podman: the repository layout is different for OL.

--
Signed-off-by: Philippe Vanhaesendonck <philippe.vanhaesendonck@oracle.com>