### PR TITLE
Vagrant is unable to execute Get-WindowsOptionalFeature Command #11932

### DIFF
--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -141,10 +141,9 @@ module Vagrant
           @_windows_hyperv_enabled = -> {
             {:"Get-WindowsOptionalFeature" => ["-Online"], :"Get-WindowsFeature" => []}.each do |cmd_name, arguments|
               parameters = arguments.join " "
+              ps_cmd = "$(#{cmd_name} -FeatureName Microsoft-Hyper-V-Hypervisor #{parameters}).State"
               if cmd_name == "Get-WindowsFeature"
                 ps_cmd = "if (Get-Command #{cmd_name} -ErrorAction SilentlyContinue){ $(#{cmd_name} -FeatureName Microsoft-Hyper-V-Hypervisor #{parameters}).State } else { 'Disabled' }"
-              else
-                ps_cmd = "$(#{cmd_name} -FeatureName Microsoft-Hyper-V-Hypervisor #{parameters}).State"
               end
               begin
                 output = Vagrant::Util::PowerShell.execute_cmd(ps_cmd)

--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -139,17 +139,19 @@ module Vagrant
           return @_windows_hyperv_enabled if defined?(@_windows_hyperv_enabled)
 
           @_windows_hyperv_enabled = -> {
-            {:"Get-WindowsOptionalFeature" => ["-Online"], :"Get-WindowsFeature" => []}.each do |cmd_name, arguments|
-              parameters = arguments.join " "
-              ps_cmd = "$(#{cmd_name} -FeatureName Microsoft-Hyper-V-Hypervisor #{parameters}).State"
-              if cmd_name == "Get-WindowsFeature"
-                ps_cmd = "if (Get-Command #{cmd_name} -ErrorAction SilentlyContinue){ $(#{cmd_name} -FeatureName Microsoft-Hyper-V-Hypervisor #{parameters}).State } else { 'Disabled' }"
-              end
+            check_commands = Array.new.tap do |c|
+              c << "(Get-WindowsOptionalFeature -FeatureName Microsoft-Hyper-V-Hypervisor -Online).State"
+              c << "(Get-WindowsFeature -FeatureName Microsoft-Hyper-V-Hypervisor).State"
+            end
+            check_commands.each do |ps_cmd|
               begin
                 output = Vagrant::Util::PowerShell.execute_cmd(ps_cmd)
                 return true if output == "Enabled"
               rescue Errors::PowerShellInvalidVersion
                 logger.warn("Invalid PowerShell version detected during Hyper-V enable check")
+                return false
+              rescue Errors::PowerShellError
+                logger.warn("Powershell command not found or error on execution of command")
                 return false
               end
             end


### PR DESCRIPTION
Fixes the background issue where the vagrant failing where Get-WindowsFeature command is not available. 

Fixes #11932