### PR TITLE
[Website] Bump HSM version

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1562,18 +1562,18 @@
       "integrity": "sha512-lv6XR2plm2m3+qO6VE+RYquTzOODIt3mQ/1fBT1bn7wsR0qxFiuryW4JfsF94oCGk++LkDkRt/8V742HiT+fHw=="
     },
     "@hashicorp/react-hashi-stack-menu": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-hashi-stack-menu/-/react-hashi-stack-menu-1.0.3.tgz",
-      "integrity": "sha512-bzO6fBodh61OrunYIMQKfGSJQUKIq70TQ74dt2trBPjBsgURHMCIkiMmKffjuSdJjhCxx2nb+y0/B/PwxxHxmg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-hashi-stack-menu/-/react-hashi-stack-menu-1.0.5.tgz",
+      "integrity": "sha512-Gmd0KBidYLSCo4q/RIqoamNsBjKUSAW0aygVmO+qbPLhOC5VzYpGvKHcb3d8LS6LxoskSXaFDgN+ps7nvyhyXA==",
       "requires": {
-        "@hashicorp/react-inline-svg": "^1.0.2",
+        "@hashicorp/react-inline-svg": "^4.0.2",
         "slugify": "1.3.4"
       },
       "dependencies": {
         "@hashicorp/react-inline-svg": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/@hashicorp/react-inline-svg/-/react-inline-svg-1.0.2.tgz",
-          "integrity": "sha512-AAFnBslSTgnEr++dTbMn3sybAqvn7myIj88ijGigF6u11eSRiV64zqEcyYLQKWTV6dF4AvYoxiYC6GSOgiM0Yw=="
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/@hashicorp/react-inline-svg/-/react-inline-svg-4.0.2.tgz",
+          "integrity": "sha512-6He5uWsIzeofKgYcHdMsT8Y00JGG3pry1yUy4HiKFQ0TTXEPQNK/FAZQ4KzlX9FM+Q8i8wRxe1Dg/5JxSEBrLA=="
         },
         "slugify": {
           "version": "1.3.4",

--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -1562,18 +1562,18 @@
       "integrity": "sha512-lv6XR2plm2m3+qO6VE+RYquTzOODIt3mQ/1fBT1bn7wsR0qxFiuryW4JfsF94oCGk++LkDkRt/8V742HiT+fHw=="
     },
     "@hashicorp/react-hashi-stack-menu": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-hashi-stack-menu/-/react-hashi-stack-menu-1.0.5.tgz",
-      "integrity": "sha512-Gmd0KBidYLSCo4q/RIqoamNsBjKUSAW0aygVmO+qbPLhOC5VzYpGvKHcb3d8LS6LxoskSXaFDgN+ps7nvyhyXA==",
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-hashi-stack-menu/-/react-hashi-stack-menu-1.0.6.tgz",
+      "integrity": "sha512-GKUmF6hoPal9mi/y1lVFeQcizQ9Kc1iYVcYwgqEDMi40C84na6Wd/AFYRckC4MNruCFXtuS3Fs8Sv7l5qqW4wA==",
       "requires": {
-        "@hashicorp/react-inline-svg": "^4.0.2",
+        "@hashicorp/react-inline-svg": "^1.0.2",
         "slugify": "1.3.4"
       },
       "dependencies": {
         "@hashicorp/react-inline-svg": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/@hashicorp/react-inline-svg/-/react-inline-svg-4.0.2.tgz",
-          "integrity": "sha512-6He5uWsIzeofKgYcHdMsT8Y00JGG3pry1yUy4HiKFQ0TTXEPQNK/FAZQ4KzlX9FM+Q8i8wRxe1Dg/5JxSEBrLA=="
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/@hashicorp/react-inline-svg/-/react-inline-svg-1.0.2.tgz",
+          "integrity": "sha512-AAFnBslSTgnEr++dTbMn3sybAqvn7myIj88ijGigF6u11eSRiV64zqEcyYLQKWTV6dF4AvYoxiYC6GSOgiM0Yw=="
         },
         "slugify": {
           "version": "1.3.4",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "@hashicorp/react-docs-page": "4.0.0",
     "@hashicorp/react-docs-sidenav": "3.2.5",
     "@hashicorp/react-global-styles": "4.4.0",
-    "@hashicorp/react-hashi-stack-menu": "^1.0.3",
+    "@hashicorp/react-hashi-stack-menu": "^1.0.5",
     "@hashicorp/react-head": "1.1.1",
     "@hashicorp/react-image": "2.0.1",
     "@hashicorp/react-product-downloader": "4.0.2",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "@hashicorp/react-docs-page": "4.0.0",
     "@hashicorp/react-docs-sidenav": "3.2.5",
     "@hashicorp/react-global-styles": "4.4.0",
-    "@hashicorp/react-hashi-stack-menu": "^1.0.5",
+    "@hashicorp/react-hashi-stack-menu": "^1.0.6",
     "@hashicorp/react-head": "1.1.1",
     "@hashicorp/react-image": "2.0.1",
     "@hashicorp/react-product-downloader": "4.0.2",


### PR DESCRIPTION
This PR updates the `<HashiStackMenu />` on the documentation website

[🔍  Preview Link](https://deploy-preview-11962--vagrant-docs.netlify.app/) 