### PR TITLE
Check search_path for nil in which.rb

### DIFF
--- a/lib/vagrant/util/which.rb
+++ b/lib/vagrant/util/which.rb
@@ -37,11 +37,13 @@ module Vagrant
           search_path = ENV['PATH']
         end
 
-        SilenceWarnings.silence! do
-          search_path.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '').split(File::PATH_SEPARATOR).each do |path|
-            exts.each do |ext|
-              exe = "#{path}#{File::SEPARATOR}#{cmd}#{ext}"
-              return exe if File.executable? exe
+        if !search_path.nil?
+          SilenceWarnings.silence! do
+            search_path.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '').split(File::PATH_SEPARATOR).each do |path|
+              exts.each do |ext|
+                exe = "#{path}#{File::SEPARATOR}#{cmd}#{ext}"
+                return exe if File.executable? exe
+              end
             end
           end
         end


### PR DESCRIPTION
Related issue: #11966.

`search_path` can be `nil` because `PATH` might have not been set, which results in an exception when `search_path.encode` is exercised.

If `PATH` is not set, `which.rb` should probably simply consider that the executable isn't found.

Please note I don't develop in Ruby so edit as necessary.

