### PR TITLE
Gemfile: update vagrant-spec branch #11976

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 if File.exist?(File.expand_path("../../vagrant-spec", __FILE__))
   gem 'vagrant-spec', path: "../vagrant-spec"
 else
-  gem 'vagrant-spec', git: "https://github.com/hashicorp/vagrant-spec.git"
+  gem 'vagrant-spec', git: "https://github.com/hashicorp/vagrant-spec.git", branch: :main
 end


### PR DESCRIPTION
This updates the Gemfile to specify the branch for vagrant-spec following GitHub updating branch naming conventions. Until RubyGems fixes it on their end, the branch specification will need to be made.

Fixes #11976 