### PR TITLE
Add TPM functionality for Gen 2 Hyper-V machines

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 if File.exist?(File.expand_path("../../vagrant-spec", __FILE__))
   gem 'vagrant-spec', path: "../vagrant-spec"
 else
-  gem 'vagrant-spec', git: "https://github.com/hashicorp/vagrant-spec.git", branch: :main
+  gem 'vagrant-spec', git: "https://github.com/hashicorp/vagrant-spec.git"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,5 @@ gemspec
 if File.exist?(File.expand_path("../../vagrant-spec", __FILE__))
   gem 'vagrant-spec', path: "../vagrant-spec"
 else
-  gem 'vagrant-spec', git: "https://github.com/hashicorp/vagrant-spec.git"
+  gem 'vagrant-spec', git: "https://github.com/hashicorp/vagrant-spec.git", branch: :main
 end

--- a/plugins/providers/hyperv/action/configure.rb
+++ b/plugins/providers/hyperv/action/configure.rb
@@ -72,6 +72,7 @@ module VagrantPlugins
             "EnableCheckpoints" => env[:machine].provider_config.enable_checkpoints,
             "EnableAutomaticCheckpoints" => env[:machine].provider_config.enable_automatic_checkpoints,
             "VirtualizationExtensions" => !!env[:machine].provider_config.enable_virtualization_extensions,
+            "EnableTrustedPlatformModule" => env[:machine].provider_config.enable_trusted_platform_module
           }
           options.delete_if{|_,v| v.nil? }
 

--- a/plugins/providers/hyperv/config.rb
+++ b/plugins/providers/hyperv/config.rb
@@ -50,6 +50,8 @@ module VagrantPlugins
       attr_accessor :vm_integration_services
       # @return [Boolean] Enable Enhanced session mode
       attr_accessor :enable_enhanced_session_mode
+      # @return [Boolean] Enable Trusted Platform Module
+      attr_accessor :enable_trusted_platform_module
 
       def initialize
         @ip_address_timeout = UNSET_VALUE
@@ -68,6 +70,7 @@ module VagrantPlugins
         @enable_checkpoints = UNSET_VALUE
         @vm_integration_services = {}
         @enable_enhanced_session_mode = UNSET_VALUE
+        @enable_trusted_platform_module = UNSET_VALUE
       end
 
       def finalize!
@@ -107,6 +110,8 @@ module VagrantPlugins
         @enable_checkpoints ||= @enable_automatic_checkpoints
 
         @enable_enhanced_session_mode = false if @enable_enhanced_session_mode == UNSET_VALUE
+
+        @enable_trusted_platform_module = false if @enable_trusted_platform_module == UNSET_VALUE
       end
 
       def validate(machine)

--- a/plugins/providers/hyperv/scripts/configure_vm.ps1
+++ b/plugins/providers/hyperv/scripts/configure_vm.ps1
@@ -20,7 +20,9 @@ param(
     [parameter (Mandatory=$false)]
     [switch] $EnableCheckpoints,
     [parameter (Mandatory=$false)]
-    [switch] $EnableAutomaticCheckpoints
+    [switch] $EnableAutomaticCheckpoints,
+    [parameter (Mandatory=$false)]
+    [switch] $EnableTrustedPlatformModule
 )
 
 $ErrorActionPreference = "Stop"
@@ -124,4 +126,18 @@ try {
 } catch {
     Write-ErrorMessage "Failed to ${AutoAction} automatic checkpoints on VM: ${PSItem}"
     exit 1
+}
+
+if($VM.Generation -gt 1) {
+    try {
+        if($EnableTrustedPlatformModule) {
+            Hyper-V\Enable-VMTPM -VM $VM
+            $tpmAction = "enable"
+        } else {
+            Hyper-V\Disable-VMTPM -VM $VM
+            $tpmAction = "disable"
+        }
+    } catch {
+        Write-ErrorMessage "Failed to ${tpmAction} Trusted Platform Module on VM: ${PSItem}"
+    }
 }

--- a/test/unit/plugins/providers/hyperv/action/configure_test.rb
+++ b/test/unit/plugins/providers/hyperv/action/configure_test.rb
@@ -29,7 +29,8 @@ describe VagrantPlugins::HyperV::Action::Configure do
       enable_automatic_checkpoints: true,
       enable_virtualization_extensions: false,
       vm_integration_services: vm_integration_services,
-      enable_enhanced_session_mode: enable_enhanced_session_mode
+      enable_enhanced_session_mode: enable_enhanced_session_mode,
+      enable_trusted_platform_module: false
     )
   }
   let(:vm_integration_services){ {} }

--- a/test/unit/plugins/providers/hyperv/config_test.rb
+++ b/test/unit/plugins/providers/hyperv/config_test.rb
@@ -255,4 +255,17 @@ describe VagrantPlugins::HyperV::Config do
       expect(subject.enable_enhanced_session_mode).to eq(true)
     end
   end
+
+  describe "#enable_trusted_platform_module" do
+    it "is false by default" do
+      subject.finalize!
+      expect(subject.enable_trusted_platform_module).to eq(false)
+    end
+
+    it "can be set" do
+      subject.enable_trusted_platform_module = true
+      subject.finalize!
+      expect(subject.enable_trusted_platform_module).to eq(true)
+    end
+  end
 end

--- a/website/pages/docs/providers/hyperv/configuration.mdx
+++ b/website/pages/docs/providers/hyperv/configuration.mdx
@@ -20,6 +20,7 @@ you may set. A complete reference is shown below:
 - `enable_checkpoints` (boolean) Enable checkpoints of the VM. Default: true
 - `enable_automatic_checkpoints` (boolean) Enable automatic checkpoints of the VM. Default: false
 - `enable_enhanced_session_mode` (boolean) - Enable enhanced session transport type for the VM. Default: false
+- `enable_trusted_platform_module` (boolean) - Enable Trusted Platform Module functionality for the VM. Default: false
 - `ip_address_timeout` (integer) - Number of seconds to wait for the VM to report an IP address. Default: 120.
 - `linked_clone` (boolean) - Use differencing disk instead of cloning entire VHD. Default: false
 - `mac` (string) - MAC address for the guest network interface


### PR DESCRIPTION
This allows for the [Trusted Platform Module](https://docs.microsoft.com/en-us/powershell/module/hyper-v/enable-vmtpm?view=win10-ps) to be enabled for Hyper-V machines. I only have Windows 10 Home, so I can't actually test this out beyond unit testing in RSpec, and would appreciate if someone is able to do that.

Also, in general it's my first time contributing here so any pointers / changes just let me know.

Fixes #11861 