### PR TITLE
Use docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build-website-docker-image:
     docker:
-      - image: circleci/buildpack-deps
+      - image: docker.mirror.hashicorp.services/circleci/buildpack-deps
     shell: /usr/bin/env bash -euo pipefail -c
     steps:
       - checkout

--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10.16.3-alpine
+FROM docker.mirror.hashicorp.services/node:10.16.3-alpine
 RUN apk add --update --no-cache git make g++ automake autoconf libtool nasm libpng-dev
 
 COPY ./package.json /website/package.json

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,7 +1,7 @@
 # Default: run this if working on the website locally to run in watch mode.
 website:
 	@echo "==> Downloading latest Docker image..."
-	@docker pull hashicorp/vagrant-website
+	@docker pull docker.mirror.hashicorp.services/hashicorp/vagrant-website
 	@echo "==> Starting website in Docker..."
 	@docker run \
 		--interactive \
@@ -11,13 +11,13 @@ website:
 		--volume "$(shell pwd):/website" \
 		--volume "/website/node_modules" \
 		--publish "3000:3000" \
-		hashicorp/vagrant-website \
+		docker.mirror.hashicorp.services/hashicorp/vagrant-website \
 		npm start
 
 # This command will generate a static version of the website to the "out" folder.
 build:
 	@echo "==> Downloading latest Docker image..."
-	@docker pull hashicorp/vagrant-website
+	@docker pull docker.mirror.hashicorp.services/hashicorp/vagrant-website
 	@echo "==> Starting build in Docker..."
 	@docker run \
 		--interactive \
@@ -26,7 +26,7 @@ build:
 		--workdir "/website" \
 		--volume "$(shell pwd):/website" \
 		--volume "/website/node_modules" \
-		hashicorp/vagrant-website \
+		docker.mirror.hashicorp.services/hashicorp/vagrant-website \
 		npm run static
 
 # If you are changing node dependencies locally, run this to generate a new


### PR DESCRIPTION
Hello! Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. LMK if you have any q's, otherwise feel free to approve and merge on your own