### PR TITLE
Make note that the `extra_args` option is only for the `ssh` command

### DIFF
--- a/website/pages/docs/vagrantfile/ssh_settings.mdx
+++ b/website/pages/docs/vagrantfile/ssh_settings.mdx
@@ -48,7 +48,9 @@ defaults are typically fine, but you can fine tune whatever you would like.
   as reverse tunneling down into the ssh program. These options can either be
   single flags set as strings such as `"-6"` for IPV6 or an array of arguments
   such as `["-L", "8008:localhost:80"]` for enabling a tunnel from host port 8008
-  to port 80 on guest.
+  to port 80 on guest. **Note:** This option only affects the `ssh` command or instances
+  where the SSH executable is invoked (non-interactive SSH connections use the internal
+  SSH communicator which is unaffected by this setting).
 
 - `config.ssh.forward_agent` (boolean) - If `true`, agent forwarding over SSH
   connections is enabled. Defaults to false.


### PR DESCRIPTION
Update documentation to clarify the `extra_args` option
within the ssh configuration only applies to the invocation
of the SSH executable and not the internal ssh communicator.

Context: #12005
