### PR TITLE
Handle Errno::EALREADY exceptions on port checks

### DIFF
--- a/lib/vagrant/util/is_port_open.rb
+++ b/lib/vagrant/util/is_port_open.rb
@@ -17,7 +17,7 @@ module Vagrant
           Socket.tcp(host, port, connect_timeout: 0.1).close
           true
         rescue Errno::ETIMEDOUT, Errno::ECONNREFUSED, Errno::EHOSTUNREACH, \
-            Errno::ENETUNREACH, Errno::EACCES, Errno::ENOTCONN
+            Errno::ENETUNREACH, Errno::EACCES, Errno::ENOTCONN, Errno::EALREADY
           false
         end
       end

--- a/test/unit/vagrant/util/is_port_open_test.rb
+++ b/test/unit/vagrant/util/is_port_open_test.rb
@@ -55,4 +55,9 @@ describe Vagrant::Util::IsPortOpen do
     expect(Socket).to receive(:tcp).with("0.0.0.0", open_port, any_args).and_raise(Errno::EADDRNOTAVAIL)
     expect { subject.is_port_open?("0.0.0.0", open_port) }.to raise_error(Errno::EADDRNOTAVAIL)
   end
+
+  it "should treat operation already in progress as unavailable" do
+    expect(Socket).to receive(:tcp).with("0.0.0.0", closed_port, any_args).and_raise(Errno::EALREADY)
+    expect(subject.is_port_open?("0.0.0.0", closed_port)).to be(false)
+  end
 end


### PR DESCRIPTION
With WSL port checks can end up resulting in Errno::EALREADY being
raised. When encountered, assume port is unavailable.

Fixes #12006
