### PR TITLE
Make the max reboot retry duration configurable

### DIFF
--- a/plugins/guests/linux/cap/reboot.rb
+++ b/plugins/guests/linux/cap/reboot.rb
@@ -6,7 +6,7 @@ module VagrantPlugins
     module Cap
       class Reboot
         extend Vagrant::Util::GuestInspection::Linux
-        MAX_REBOOT_RETRY_DURATION = 120
+        MAX_REBOOT_RETRY_DURATION = ENV.fetch('VAGRANT_MAX_REBOOT_RETRY_TIMEOUT', 120).to_i
 
         def self.reboot(machine)
           @logger = Log4r::Logger.new("vagrant::linux::reboot")

--- a/plugins/guests/linux/cap/reboot.rb
+++ b/plugins/guests/linux/cap/reboot.rb
@@ -6,7 +6,9 @@ module VagrantPlugins
     module Cap
       class Reboot
         extend Vagrant::Util::GuestInspection::Linux
-        MAX_REBOOT_RETRY_DURATION = ENV.fetch('VAGRANT_MAX_REBOOT_RETRY_TIMEOUT', 120).to_i
+
+        DEFAULT_MAX_REBOOT_RETRY_DURATION = 120
+        WAIT_SLEEP_TIME = 5
 
         def self.reboot(machine)
           @logger = Log4r::Logger.new("vagrant::linux::reboot")
@@ -25,14 +27,17 @@ module VagrantPlugins
 
           @logger.debug("Waiting for machine to finish rebooting")
 
-          wait_remaining = MAX_REBOOT_RETRY_DURATION
+          wait_remaining = ENV.fetch("VAGRANT_MAX_REBOOT_RETRY_DURATION",
+            DEFAULT_MAX_REBOOT_RETRY_DURATION).to_i
+          wait_remaining = DEFAULT_MAX_REBOOT_RETRY_DURATION if wait_remaining < 1
+
           begin
             wait_for_reboot(machine)
-          rescue Vagrant::Errors::MachineGuestNotReady => e
+          rescue Vagrant::Errors::MachineGuestNotReady
             raise if wait_remaining < 0
             @logger.warn("Machine not ready, cannot start reboot yet. Trying again")
-            sleep(5)
-            wait_remaining -= 5
+            sleep(WAIT_SLEEP_TIME)
+            wait_remaining -= WAIT_SLEEP_TIME
             retry
           end
         end

--- a/plugins/guests/windows/cap/reboot.rb
+++ b/plugins/guests/windows/cap/reboot.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
   module GuestWindows
     module Cap
       class Reboot
-        MAX_REBOOT_RETRY_DURATION = 120
+        MAX_REBOOT_RETRY_DURATION = ENV.fetch('VAGRANT_MAX_REBOOT_RETRY_TIMEOUT', 120).to_i
 
         def self.reboot(machine)
           @logger = Log4r::Logger.new("vagrant::windows::reboot")

--- a/test/unit/plugins/guests/linux/cap/reboot_test.rb
+++ b/test/unit/plugins/guests/linux/cap/reboot_test.rb
@@ -75,5 +75,22 @@ describe "VagrantPlugins::GuestLinux::Cap::Reboot" do
         end
       end
     end
+
+    context "reboot configuration" do
+      before do
+        allow(communicator).to receive(:execute)
+        expect(communicator).to receive(:execute).with(/reboot/, nil).and_return(0)
+        allow(described_class).to receive(:sleep)
+        allow(described_class).to receive(:wait_for_reboot).and_raise(Vagrant::Errors::MachineGuestNotReady)
+      end
+
+      describe ".reboot default" do
+        it "allows setting a custom max reboot retry duration" do
+          max_retries = 26 # initial call + 25 retries since multiple of 5
+          expect(described_class).to receive(:wait_for_reboot).exactly(max_retries).times
+          expect { described_class.reboot(machine) }.to raise_error(Vagrant::Errors::MachineGuestNotReady)
+        end
+      end
+    end
   end
 end

--- a/test/unit/plugins/guests/linux/cap/reboot_test.rb
+++ b/test/unit/plugins/guests/linux/cap/reboot_test.rb
@@ -64,15 +64,13 @@ describe "VagrantPlugins::GuestLinux::Cap::Reboot" do
         communicator.verify_expectations!
       end
 
-      describe ".reboot" do
-        it "reboots the vm" do
-          allow(communicator).to receive(:execute)
+      it "reboots the vm" do
+        allow(communicator).to receive(:execute)
 
-          expect(communicator).to receive(:execute).with(/systemctl reboot/, nil).and_return(0)
-          expect(described_class).to receive(:wait_for_reboot)
+        expect(communicator).to receive(:execute).with(/systemctl reboot/, nil).and_return(0)
+        expect(described_class).to receive(:wait_for_reboot)
 
-          described_class.reboot(machine)
-        end
+        described_class.reboot(machine)
       end
     end
 
@@ -80,13 +78,28 @@ describe "VagrantPlugins::GuestLinux::Cap::Reboot" do
       before do
         allow(communicator).to receive(:execute)
         expect(communicator).to receive(:execute).with(/reboot/, nil).and_return(0)
-        allow(described_class).to receive(:sleep)
+        allow(described_class).to receive(:sleep).and_return(described_class::WAIT_SLEEP_TIME)
         allow(described_class).to receive(:wait_for_reboot).and_raise(Vagrant::Errors::MachineGuestNotReady)
       end
 
-      describe ".reboot default" do
-        it "allows setting a custom max reboot retry duration" do
-          max_retries = 26 # initial call + 25 retries since multiple of 5
+      context "default retry duration value" do
+        let(:max_retries) { (described_class::DEFAULT_MAX_REBOOT_RETRY_DURATION / described_class::WAIT_SLEEP_TIME) + 2 }
+
+        it "should receive expected number of wait_for_reboot calls" do
+          expect(described_class).to receive(:wait_for_reboot).exactly(max_retries).times
+          expect { described_class.reboot(machine) }.to raise_error(Vagrant::Errors::MachineGuestNotReady)
+        end
+      end
+
+      context "with custom retry duration value" do
+        let(:duration) { 10 }
+        let(:max_retries) { (duration / described_class::WAIT_SLEEP_TIME) + 2 }
+
+        before do
+          expect(ENV).to receive(:fetch).with("VAGRANT_MAX_REBOOT_RETRY_DURATION", anything).and_return(duration)
+        end
+
+        it "should receive expected number of wait_for_reboot calls" do
           expect(described_class).to receive(:wait_for_reboot).exactly(max_retries).times
           expect { described_class.reboot(machine) }.to raise_error(Vagrant::Errors::MachineGuestNotReady)
         end

--- a/test/unit/plugins/guests/windows/cap/reboot_test.rb
+++ b/test/unit/plugins/guests/windows/cap/reboot_test.rb
@@ -112,4 +112,22 @@ describe "VagrantPlugins::GuestWindows::Cap::Reboot" do
       end
     end
   end
+
+  context "reboot configuration" do
+    before do
+      allow(communicator).to receive(:execute)
+      expect(communicator).to receive(:test).with(/# Function/, { error_check: false, shell: :powershell }).and_return(0)
+      expect(communicator).to receive(:execute).with(/shutdown/, { shell: :powershell }).and_return(0)
+      allow(described_class).to receive(:sleep)
+      allow(described_class).to receive(:wait_for_reboot).and_raise(StandardError)
+    end
+
+    describe ".reboot default" do
+      it "allows setting a custom max reboot retry duration" do
+        max_retries = 26 # initial call + 25 retries since multiple of 5
+        expect(described_class).to receive(:wait_for_reboot).exactly(max_retries).times
+        expect { described_class.reboot(machine) }.to raise_error(Exception)
+      end
+    end
+  end
 end

--- a/test/unit/plugins/guests/windows/cap/reboot_test.rb
+++ b/test/unit/plugins/guests/windows/cap/reboot_test.rb
@@ -122,11 +122,26 @@ describe "VagrantPlugins::GuestWindows::Cap::Reboot" do
       allow(described_class).to receive(:wait_for_reboot).and_raise(StandardError)
     end
 
-    describe ".reboot default" do
-      it "allows setting a custom max reboot retry duration" do
-        max_retries = 26 # initial call + 25 retries since multiple of 5
+    context "default retry duration value" do
+      let(:max_retries) { (described_class::DEFAULT_MAX_REBOOT_RETRY_DURATION / described_class::WAIT_SLEEP_TIME) + 2 }
+
+      it "should receive expected number of wait_for_reboot calls" do
         expect(described_class).to receive(:wait_for_reboot).exactly(max_retries).times
-        expect { described_class.reboot(machine) }.to raise_error(Exception)
+        expect { described_class.reboot(machine) }.to raise_error(StandardError)
+      end
+    end
+
+    context "with custom retry duration value" do
+      let(:duration) { 10 }
+      let(:max_retries) { (duration / described_class::WAIT_SLEEP_TIME) + 2 }
+
+      before do
+        expect(ENV).to receive(:fetch).with("VAGRANT_MAX_REBOOT_RETRY_DURATION", anything).and_return(duration)
+      end
+
+      it "should receive expected number of wait_for_reboot calls" do
+        expect(described_class).to receive(:wait_for_reboot).exactly(max_retries).times
+        expect { described_class.reboot(machine) }.to raise_error(StandardError)
       end
     end
   end

--- a/website/pages/docs/other/environmental-variables.mdx
+++ b/website/pages/docs/other/environmental-variables.mdx
@@ -225,6 +225,13 @@ and can help identify certain issues.
 some knowledge of Vagrant internals. It is the best output to attach to
 a support request or bug report, however.
 
+## `VAGRANT_MAX_REBOOT_RETRY_TIMEOUT`
+
+By default, Vagrant will wait up to 120 seconds for a machine to reboot.
+However, if you're finding your OS is taking longer than 120 seconds to
+reboot successfully, you can configure this environment variable and Vagrant
+will wait for the configured number of seconds.
+
 ## `VAGRANT_NO_COLOR`
 
 If this is set to any value, then Vagrant will not use any colorized

--- a/website/pages/docs/other/environmental-variables.mdx
+++ b/website/pages/docs/other/environmental-variables.mdx
@@ -225,7 +225,7 @@ and can help identify certain issues.
 some knowledge of Vagrant internals. It is the best output to attach to
 a support request or bug report, however.
 
-## `VAGRANT_MAX_REBOOT_RETRY_TIMEOUT`
+## `VAGRANT_MAX_REBOOT_RETRY_DURATION`
 
 By default, Vagrant will wait up to 120 seconds for a machine to reboot.
 However, if you're finding your OS is taking longer than 120 seconds to


### PR DESCRIPTION
Previously the maximum amount of time Vagrant would poll for whether a VM has successfully reboot was hard coded to 120 seconds.

This change introduces the `VAGRANT_MAX_REBOOT_RETRY_TIMEOUT` environment variable to allow users to configure the maximum time to support OS configurations that happen to take longer than 120 seconds to reboot.

This PR also adds RSpec tests for the maximum retry logic. I wanted to add some tests around the actual environment variable, but since it's set to a constant on the class it'll require unloading and loading the class back up which was fairly ugly to do in the test. You can see below the environment variable in action (and failing the test because the number of retries don't match).

<img width="1368" alt="Screen Shot 2020-10-31 at 6 18 56 PM" src="https://user-images.githubusercontent.com/167443/97791149-8cc1d880-1ba5-11eb-911e-916ccc3a9ca5.png">

Hopefully this is useful, thank you!

Fixes #11695
