### PR TITLE
Use stdout for the experimental log message

### DIFF
--- a/bin/vagrant
+++ b/bin/vagrant
@@ -194,9 +194,9 @@ begin
     ui = Vagrant::UI::Prefixed.new(env.ui, "vagrant")
     logger.debug("Experimental flag is enabled")
     if Vagrant::Util::Experimental.global_enabled?
-      ui.warn(I18n.t("vagrant.general.experimental.all"), bold: true, prefix: true, channel: :error)
+      ui.warn(I18n.t("vagrant.general.experimental.all"), bold: true, prefix: true)
     else
-      ui.warn(I18n.t("vagrant.general.experimental.features", features: experimental.join(", ")), bold: true, prefix: true, channel: :error)
+      ui.warn(I18n.t("vagrant.general.experimental.features", features: experimental.join(", ")), bold: true, prefix: true)
     end
   end
 


### PR DESCRIPTION
Use stdout instead of stderr fix the failing packer vagrant builds.

This pull request implements the enhancement to support experimental
features for packer vagrant builder.
https://github.com/hashicorp/vagrant/issues/12012