### PR TITLE
Fix application of action named triggers/hooks

### DIFF
--- a/lib/vagrant/action/runner.rb
+++ b/lib/vagrant/action/runner.rb
@@ -85,7 +85,7 @@ module Vagrant
         action_name = environment[:action_name]
 
         # We place a process lock around every action that is called
-        @logger.info("Running action: #{environment[:action_name]} #{callable_id}")
+        @logger.info("Running action: #{action_name} #{callable_id}")
         Util::Busy.busy(int_callback) { callable.call(environment) }
 
         # Return the environment in case there are things in there that

--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -231,15 +231,18 @@ module Vagrant
     # @param [Proc] callable
     # @param [Hash] extra_env Extra env for the action env.
     # @return [Hash] The resulting env
-    def action_raw(name, callable, extra_env=nil)
+    def action_raw(name, callable, extra_env={})
+      if !extra_env.is_a?(Hash)
+        extra_env = {}
+      end
+
       # Run the action with the action runner on the environment
-      env = {
+      env = {ui: @ui}.merge(extra_env).merge(
         raw_action_name: name,
         action_name: "machine_action_#{name}".to_sym,
         machine: self,
-        machine_action: name,
-        ui: @ui,
-      }.merge(extra_env || {})
+        machine_action: name
+      )
       @env.action_runner.run(callable, env)
     end
 


### PR DESCRIPTION
When expanding stack track the origin action name and only apply
it once the stack has completed its expansion. The local env data
is marked with origin action to prevent it from being applied in
nested builders as they are expanded. The value of the stored action
name is checked and invalidated if another action is applied to the
same env in the future so hooks / triggers for that action are
applied as expected.

Fixes #11898 #11972
