### PR TITLE
Check dependency list on initialization

### DIFF
--- a/lib/vagrant/shared_helpers.rb
+++ b/lib/vagrant/shared_helpers.rb
@@ -122,7 +122,8 @@ module Vagrant
   #
   # @return [Boolean]
   def self.prerelease?
-    Gem::Version.new(Vagrant::VERSION).prerelease?
+    !!ENV["VAGRANT_ALLOW_PRERELEASE"] ||
+      Gem::Version.new(Vagrant::VERSION).prerelease?
   end
 
   # This allows control over dependency resolution when installing

--- a/lib/vagrant/shared_helpers.rb
+++ b/lib/vagrant/shared_helpers.rb
@@ -122,8 +122,15 @@ module Vagrant
   #
   # @return [Boolean]
   def self.prerelease?
-    !!ENV["VAGRANT_ALLOW_PRERELEASE"] ||
-      Gem::Version.new(Vagrant::VERSION).prerelease?
+    Gem::Version.new(Vagrant::VERSION).prerelease?
+  end
+
+  # This returns true/false if the Vagrant should allow prerelease
+  # versions when resolving plugin dependency constraints
+  #
+  # @return [Boolean]
+  def self.allow_prerelease_dependencies?
+    !!ENV["VAGRANT_ALLOW_PRERELEASE"]
   end
 
   # This allows control over dependency resolution when installing

--- a/test/unit/support/shared/base_context.rb
+++ b/test/unit/support/shared/base_context.rb
@@ -103,9 +103,10 @@ shared_context "unit" do
     allow(ENV).to receive(:[]).and_call_original
 
     hash.each do |key, value|
+      v = value.nil? ? nil : value.to_s
       allow(ENV).to receive(:[])
         .with(key.to_s)
-        .and_return(value.to_s)
+        .and_return(v)
     end
   end
 

--- a/test/unit/vagrant/bundler_test.rb
+++ b/test/unit/vagrant/bundler_test.rb
@@ -618,6 +618,117 @@ describe Vagrant::Bundler do
         end
       end
     end
+
+    describe "#enable_prerelease!" do
+      before do
+        @_ev = ENV.delete("VAGRANT_ALLOW_PRERELEASE")
+      end
+
+      after do
+        ENV["VAGRANT_ALLOW_PRERELEASE"] = @_ev
+      end
+
+      context "with specification list" do
+        let(:specifications) { [] }
+
+        it "should not modify prerelease by default" do
+          subject.send(:enable_prerelease!, specs: specifications)
+          expect(ENV["VAGRANT_ALLOW_PRERELEASE"]).to be_falsey
+        end
+
+        it "should not have enabled allow prerelease dependencies" do
+          subject.send(:enable_prerelease!, specs: specifications)
+          expect(Vagrant.allow_prerelease_dependencies?).to be_falsey
+        end
+
+        context "when specifications do not contain prerelease versions" do
+          let(:specifications) { [
+            double("spec1", full_name: "spec1", version: double("version1", prerelease?: false)),
+            double("spec2", full_name: "spec2", version: double("version2", prerelease?: false)),
+            double("spec3", full_name: "spec3", version: double("version3", prerelease?: false))
+          ] }
+
+          it "should not modify prerelease" do
+            subject.send(:enable_prerelease!, specs: specifications)
+            expect(ENV["VAGRANT_ALLOW_PRERELEASE"]).to be_falsey
+          end
+
+          it "should not have enabled allow prerelease dependencies" do
+            subject.send(:enable_prerelease!, specs: specifications)
+            expect(Vagrant.allow_prerelease_dependencies?).to be_falsey
+          end
+        end
+
+        context "when specifications contain prerelease versions" do
+          let(:specifications) { [
+            double("spec1", full_name: "spec1", version: double("version1", prerelease?: false)),
+            double("spec2", full_name: "spec2", version: double("version2", prerelease?: true)),
+            double("spec3", full_name: "spec3", version: double("version3", prerelease?: false))
+          ] }
+
+          it "should enable prerelease" do
+            subject.send(:enable_prerelease!, specs: specifications)
+            expect(ENV["VAGRANT_ALLOW_PRERELEASE"]).to be_truthy
+          end
+
+          it "should have enabled allow prerelease dependencies" do
+            subject.send(:enable_prerelease!, specs: specifications)
+            expect(Vagrant.allow_prerelease_dependencies?).to be_truthy
+          end
+        end
+      end
+
+      context "with request set" do
+        let(:request_set) { double("request_set", dependencies: dependencies) }
+        let(:dependencies) { [] }
+
+        it "should not modify prerelease by default" do
+          subject.send(:enable_prerelease!, request_set: request_set)
+          expect(ENV["VAGRANT_ALLOW_PRERELEASE"]).to be_falsey
+        end
+
+        it "should not have enabled allow prerelease dependencies" do
+          subject.send(:enable_prerelease!, request_set: request_set)
+          expect(Vagrant.allow_prerelease_dependencies?).to be_falsey
+        end
+
+        context "when specifications do not contain prerelease versions" do
+          let(:dependencies) { [
+            double("dep1", prerelease?: false, to_s: nil),
+            double("dep2", prerelease?: false, to_s: nil),
+            double("dep3", prerelease?: false, to_s: nil)
+          ] }
+
+          it "should not modify prerelease" do
+            subject.send(:enable_prerelease!, request_set: request_set)
+            expect(ENV["VAGRANT_ALLOW_PRERELEASE"]).to be_falsey
+          end
+
+          it "should not have enabled allow prerelease dependencies" do
+            subject.send(:enable_prerelease!, request_set: request_set)
+            expect(Vagrant.allow_prerelease_dependencies?).to be_falsey
+          end
+        end
+
+        context "when specifications contain prerelease versions" do
+          let(:dependencies) { [
+            double("dep1", prerelease?: false, to_s: nil),
+            double("dep2", prerelease?: true, to_s: nil),
+            double("dep3", prerelease?: false, to_s: nil)
+          ] }
+
+          it "should enable prerelease" do
+            subject.send(:enable_prerelease!, request_set: request_set)
+            expect(ENV["VAGRANT_ALLOW_PRERELEASE"]).to be_truthy
+          end
+
+          it "should have enabled allow prerelease dependencies" do
+            subject.send(:enable_prerelease!, request_set: request_set)
+            expect(Vagrant.allow_prerelease_dependencies?).to be_truthy
+          end
+        end
+      end
+    end
   end
 
   describe Vagrant::Bundler::PluginSet do

--- a/test/unit/vagrant/shared_helpers_test.rb
+++ b/test/unit/vagrant/shared_helpers_test.rb
@@ -142,24 +142,22 @@ describe Vagrant do
       stub_const("Vagrant::VERSION", "1.0.0")
       expect(subject.prerelease?).to be(false)
     end
+  end
 
+  describe ".allow_prerelease_dependencies?" do
     context "with environment variable set" do
       before { allow(ENV).to receive(:[]).with("VAGRANT_ALLOW_PRERELEASE").and_return("1") }
 
-      context "when version is development version" do
-        before { stub_const("Vagrant::VERSION", "1.0.0.dev") }
-
-        it "should return true" do
-          expect(subject.prerelease?).to be(true)
-        end
+      it "should return true" do
+        expect(subject.allow_prerelease_dependencies?).to be(true)
       end
+    end
 
-      context "when version is non-development version" do
-        before { stub_const("Vagrant::VERSION", "1.0.0") }
+    context "with environment variable unset" do
+      before { allow(ENV).to receive(:[]).with("VAGRANT_ALLOW_PRERELEASE").and_return(nil) }
 
-        it "should return true" do
-          expect(subject.prerelease?).to be(true)
-        end
+      it "should return false" do
+        expect(subject.allow_prerelease_dependencies?).to be(false)
       end
     end
   end

--- a/test/unit/vagrant/shared_helpers_test.rb
+++ b/test/unit/vagrant/shared_helpers_test.rb
@@ -142,6 +142,26 @@ describe Vagrant do
       stub_const("Vagrant::VERSION", "1.0.0")
       expect(subject.prerelease?).to be(false)
     end
+
+    context "with environment variable set" do
+      before { allow(ENV).to receive(:[]).with("VAGRANT_ALLOW_PRERELEASE").and_return("1") }
+
+      context "when version is development version" do
+        before { stub_const("Vagrant::VERSION", "1.0.0.dev") }
+
+        it "should return true" do
+          expect(subject.prerelease?).to be(true)
+        end
+      end
+
+      context "when version is non-development version" do
+        before { stub_const("Vagrant::VERSION", "1.0.0") }
+
+        it "should return true" do
+          expect(subject.prerelease?).to be(true)
+        end
+      end
+    end
   end
 
   describe ".enable_resolv_replace" do


### PR DESCRIPTION
When initializing for internal plugin resolution inspect contraints
on all defined dependencies. If a prerelease constraint is detected,
automatically enable prerelease resolution.

Also includes option to enable prerelease resolution via environment
variable when custom resolution behavior is desired.
