### PR TITLE
vagrant init Operation not permitted Error

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -1054,7 +1054,7 @@ module Vagrant
       if !Util::Platform.windows?
         # On Windows, permissions don't matter as much, so don't worry
         # about doing chmod.
-        if Util::FileMode.from_octal(@default_private_key_path.stat.mode) != "600"
+        if Util::FileMode.from_octal(@default_private_key_path.stat.mode) < "600"
           @logger.info("Changing permissions on private key to 0600")
           @default_private_key_path.chmod(0600)
         end


### PR DESCRIPTION

Hello

I posted issue #12077 

In relation to digging, the file was in 777 mode,
It would be okay if I didn't change the mode of this file, and I changed the operator to apply the original intent.( from != "600" to < "600")
After changing the operator, I checked that it works normally.
Please review and approve it.
Thank you.