### PR TITLE
Add example config to disable default share

### DIFF
--- a/templates/commands/init/Vagrantfile.erb
+++ b/templates/commands/init/Vagrantfile.erb
@@ -45,6 +45,13 @@ Vagrant.configure(2) do |config|
   # argument is a set of non-required options.
   # config.vm.synced_folder "../data", "/vagrant_data"
 
+  # Disable the default share of the current code directory. Doing this
+  # provides improved isolation between the vagrant box and your host
+  # by making sure your Vagrantfile isn't accessable to the vagrant box.
+  # If you use this you may want to enable additional shared subfolders as
+  # shown above.
+  # config.vm.synced_folder ".", "/vagrant", disabled: true
+
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
   # Example for VirtualBox:


### PR DESCRIPTION
When you use the default share the guest has access to the Vagrantfile on the host. Disabling the default share and using sharing another subfolder is an easy way to work around this.

Would like to include this in the default examples if possible since I end up needing to google it everytime I use Vagrant. I personally do this in all my configs because I often use vagrant to run semi-trusted software (i.e. trusted, but I'm overly paranoid).

I wrote up a post on the issues on the default share, I'll post that below. Apologies if it comes off a bit dramatic, I think I was just surprised when I originally noticed it.

https://blog.ryanjarv.sh/2019/06/08/malicious-vagrant-boxes.html

<s>
On another note even with the default share disabled, using virtual box in the default configuration is a bad idea for isolation. I might come back and make another PR like this for working around that as well.

https://blog.ryanjarv.sh/2020/11/13/virtual-box-networking.html
</s>

Edit: Second thing really should be in another pr, can just ignore that for now.