### PR TITLE
Add ruby test files to testing workflow and bump rake dependency

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,6 +8,9 @@ on:
       - 'lib/**'
       - 'plugins/**'
       - 'test/**'
+      - 'Gemfile'
+      - 'vagrant.gemspec'
+      - 'Rakefile'
   pull_request:
     branches:
       - main
@@ -16,6 +19,9 @@ on:
       - 'lib/**'
       - 'plugins/**'
       - 'test/**'
+      - 'Gemfile'
+      - 'vagrant.gemspec'
+      - 'Rakefile'
 
 jobs:
   unit-tests:

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -14,4 +14,4 @@ for each item will be kept below.
   starting machines.
 * `vim` - Contains a `.vim` file for enabling Ruby syntax highlighting
   for `Vagrantfile`s in `vim`.
-  * `zsh` - Contains a zsh script for improving autocompletion with zsh.
+* `zsh` - Contains a zsh script for improving autocompletion with zsh.

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
 
   # Constraint rake to properly handle deprecated method usage
   # from within rspec
-  s.add_development_dependency "rake", "~> 12.3.3"
+  s.add_development_dependency "rake", "~> 13.0"
   s.add_development_dependency "rspec", "~> 3.5.0"
   s.add_development_dependency "rspec-its", "~> 1.3.0"
   s.add_development_dependency "webmock", "~> 2.3.1"


### PR DESCRIPTION
Update rake to `~> 13.0`. Also, I've fixed the indentation in `contrib/README.md` and sneaked it into this PR :wink: 

### EDIT:
I have realized that the testsuite is not being run when the `vagrant.gemspec` is modified. I believe that is an oversight and so I took this opportunity to add it to the testing github action.