### PR TITLE
Add disks flag in cloud-init usage

### DIFF
--- a/website/content/docs/cloud-init/usage.mdx
+++ b/website/content/docs/cloud-init/usage.mdx
@@ -14,7 +14,7 @@ supported or functional.
 This feature currently reqiures the experimental flag to be used. To explicitly enable this feature, you can set the experimental flag to:
 
 ```
-VAGRANT_EXPERIMENTAL="cloud_init"
+VAGRANT_EXPERIMENTAL="cloud_init,disks"
 ```
 
 Please note that `VAGRANT_EXPERIMENTAL` is an environment variable. For more


### PR DESCRIPTION
As pointed out here, https://www.grzegorowski.com/how-to-test-cloud-init-locally-with-vagrant, `cloud-init` doesn't work without `disks` flag, so it's being added it.