### PR TITLE
Fix typo in typed trigger validation

### DIFF
--- a/plugins/kernel_v2/config/vm_trigger.rb
+++ b/plugins/kernel_v2/config/vm_trigger.rb
@@ -218,7 +218,7 @@ module VagrantPlugins
         end
 
         if @type == :command || !@type
-          commands = Vagrant.plugin("2").manager.commands.keys.map(&:to_s)
+          commands = Vagrant.plugin("2").manager.commands.keys.map(&:to_sym)
 
           if !commands.include?(@command) && @command != :all
             machine.ui.warn(I18n.t("vagrant.config.triggers.bad_command_warning",


### PR DESCRIPTION
This removes annoying warning in `type = :command` triggers:

==> b-1: The command 'provision' was not found for this trigger.
==> b-1: The command 'provision' was not found for this trigger.
..
```
  config.trigger.after :provision, type: :command do |t|
    t.name = "finally run real provision over all boxes"
    t.run = { inline: "bash -ex -c '
       id
     '"}
  end
```