### PR TITLE
Modernize Salt bootstrap script

### DIFF
--- a/plugins/provisioners/salt/bootstrap-salt.sh
+++ b/plugins/provisioners/salt/bootstrap-salt.sh
@@ -4,13 +4,16 @@ cd `mktemp -d`
 
 # We just download the bootstrap script by default and execute that.
 if [ -x /usr/bin/fetch ]; then
-    /usr/bin/fetch -o bootstrap-salt.sh https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh
+    /usr/bin/fetch -o bootstrap-salt.sh https://bootstrap.saltproject.io
 elif [ -x /usr/bin/curl ]; then
-    /usr/bin/curl --silent --show-error -L -O https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh
+    /usr/bin/curl --silent --show-error -L --output bootstrap-salt.sh https://bootstrap.saltproject.io
 elif [ -x /usr/bin/wget ]; then
-    /usr/bin/wget -O bootstrap-salt.sh https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh
+    /usr/bin/wget -O bootstrap-salt.sh https://bootstrap.saltproject.io
+elif [ "2" = `python -c 'import sys; sys.stdout.write(str(sys.version_info.major))'` ]; then
+    # TODO: remove after there is no supported distros with Python 2
+    python -c 'import urllib; urllib.urlretrieve("https://bootstrap.saltproject.io", "bootstrap-salt.sh")'
 else
-    python -c 'import urllib; urllib.urlretrieve("https://raw.githubusercontent.com/saltstack/salt-bootstrap/stable/bootstrap-salt.sh", "bootstrap-salt.sh")'
+    python -c 'import urllib.request; urllib.request.urlretrieve("https://bootstrap.saltproject.io", "bootstrap-salt.sh")'
 fi
 
 if [ -e bootstrap-salt.sh ]; then


### PR DESCRIPTION
1. Use new `saltproject.io` domain (see [the note](https://github.com/hashicorp/vagrant/pull/12127#discussion_r552869282))
2. Support Python 3