### PR TITLE
Use test doubles instead of `true`.

### DIFF
--- a/test/unit/plugins/providers/docker/provider_test.rb
+++ b/test/unit/plugins/providers/docker/provider_test.rb
@@ -78,7 +78,7 @@ describe VagrantPlugins::DockerProvider::Provider do
     it "returns the host machine object" do
       allow(machine.provider_config).to receive(:vagrant_vagrantfile).and_return("/path/to/Vagrantfile")
       allow(machine.provider_config).to receive(:vagrant_machine).and_return(:default)
-      allow(machine).to receive(:env).and_return(true)
+      allow(machine).to receive(:env).and_return(double())
       allow(machine.env).to receive(:root_path).and_return("/.vagrant.d")
       allow(machine.env).to receive(:home_path).and_return("/path/to")
       allow(machine.env).to receive(:ui_class).and_return(true)

--- a/test/unit/plugins/provisioners/puppet/provisioner/puppet_test.rb
+++ b/test/unit/plugins/provisioners/puppet/provisioner/puppet_test.rb
@@ -81,7 +81,7 @@ describe VagrantPlugins::Puppet::Provisioner::Puppet do
     let(:environment_paths) { ["/etc/puppet/environment"] }
 
     it "builds structured facts if set" do
-      allow(machine).to receive(:guest).and_return(true)
+      allow(machine).to receive(:guest).and_return(double())
       allow(machine.guest).to receive(:capability?).and_return(false)
       allow(config).to receive(:environment_path).and_return(environment_paths)
       allow(config).to receive(:environment).and_return("production")
@@ -105,7 +105,7 @@ describe VagrantPlugins::Puppet::Provisioner::Puppet do
     end
 
     it "does not build structured facts if not set" do
-      allow(machine).to receive(:guest).and_return(true)
+      allow(machine).to receive(:guest).and_return(double())
       allow(machine.guest).to receive(:capability?).and_return(false)
       allow(config).to receive(:environment_path).and_return(environment_paths)
       allow(config).to receive(:environment).and_return("production")

--- a/test/unit/plugins/synced_folders/rsync/command/rsync_auto_test.rb
+++ b/test/unit/plugins/synced_folders/rsync/command/rsync_auto_test.rb
@@ -81,7 +81,7 @@ describe VagrantPlugins::SyncedFolderRSync::Command::RsyncAuto do
       allow(machine.env).to receive(:cwd).
         and_return("/Users/brian/code/vagrant-sandbox")
       allow(machine.provider).to receive(:capability?).and_return(false)
-      allow(machine.config).to receive(:vm).and_return(true)
+      allow(machine.config).to receive(:vm).and_return(double())
       allow(machine.config.vm).to receive(:synced_folders).and_return(config_synced_folders)
 
       allow(subject).to receive(:synced_folders).

--- a/test/unit/vagrant/util/ssh_test.rb
+++ b/test/unit/vagrant/util/ssh_test.rb
@@ -270,7 +270,7 @@ describe Vagrant::Util::SSH do
         # mock out ChildProcess
         process = double()
         allow(ChildProcess).to receive(:build).and_return(process)
-        allow(process).to receive(:io).and_return(true)
+        allow(process).to receive(:io).and_return(double())
         allow(process.io).to receive(:inherit!).and_return(true)
         allow(process).to receive(:start).and_return(true)
         allow(process).to receive(:wait).and_return(true)


### PR DESCRIPTION
This solves possible issues such as:

~~~
  1) VagrantPlugins::DockerProvider::Provider#host_vm returns the host machine object
     Failure/Error: allow(machine.env).to receive(:root_path).and_return("/.vagrant.d")
     ArgumentError:
       Cannot proxy frozen objects, rspec-mocks relies on proxies for method stubbing and expectations.
     # ./test/unit/plugins/providers/docker/provider_test.rb:82:in `block (3 levels) in <top (required)>'
~~~

This is not good idea, because frozen object should not receive modifications, because these possibly can't be undone. This is prohibited since rspec-mock 3.10.1.

Signed-off-by: Vít Ondruch <vondruch@redhat.com>

As always, I'm not going to sign CLA, so do whatever you have to do.