### PR TITLE
Remove not required bcrypt_pbkdf gem

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -15,7 +15,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = "~> 2.5", "< 2.8"
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "bcrypt_pbkdf", "~> 1.0.0"
   s.add_dependency "childprocess", "~> 4.0.0"
   s.add_dependency "ed25519", "~> 1.2.4"
   s.add_dependency "erubi"


### PR DESCRIPTION
This gem is no longer required by vagrant and was forgotten to get removed.