### PR TITLE
Update Vagrantfile.min.erb add vi mode for ruby

### DIFF
--- a/templates/commands/init/Vagrantfile.min.erb
+++ b/templates/commands/init/Vagrantfile.min.erb
@@ -1,3 +1,6 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
 Vagrant.configure("2") do |config|
   config.vm.box = "<%= box_name %>"
   <% if box_version -%>


### PR DESCRIPTION
This PR is to add 

```
# -*- mode: ruby -*-
# vi: set ft=ruby :
``` 

to the Vagrantfile created when using `init -m`

this is very convenient to have in the file to improve the experience of advanced users that would like minimal Vagrantfile