### PR TITLE
Fix network config for recent NixOS releases

### DIFF
--- a/templates/guests/nixos/network.erb
+++ b/templates/guests/nixos/network.erb
@@ -1,16 +1,15 @@
 { config, pkgs, ... }:
 {
-  networking.interfaces = [
+  networking.interfaces = {
     <% networks.select {|n| n[:device]}.each do |network| %>
-    { 
-      name         = "<%= network[:device] %>";
+    <%= network[:device] %>.ipv4.addresses = [{
       <% if network[:type] == :static %>
-      ipAddress    = "<%= network[:ip] %>";
+      address = "<%= network[:ip] %>";
       <% end %>
       <% if network[:prefix_length] %>
       prefixLength = <%= network[:prefix_length] %>;
       <% end %>
-    }
+    }];
     <% end %>
-  ];
+  };
 }

--- a/test/unit/templates/guests/nixos/network_test.rb
+++ b/test/unit/templates/guests/nixos/network_test.rb
@@ -1,0 +1,27 @@
+require_relative "../../../base"
+
+require "vagrant/util/template_renderer"
+
+describe "templates/guests/nixos/network" do
+  let(:template) { "guests/nixos/network" }
+
+  it "renders the template" do
+    result = Vagrant::Util::TemplateRenderer.render(template, networks: [{
+      device: "en0",
+      ip: "1.1.1.1",
+      prefix_length: "24",
+      type: :static,
+    }])
+    expect(result).to eq <<-EOH.gsub(/^ {6}/, "")
+      { config, pkgs, ... }:
+      {
+        networking.interfaces = {
+          en0.ipv4.addresses = [{
+            address = "1.1.1.1";
+            prefixLength = 24;
+          }];
+        };
+      }
+      EOH
+  end
+end


### PR DESCRIPTION
The old config style doesn't build anymore on the current release NixOS 20.09. It stopped working some releases ago.