### PR TITLE
update sudo usage example

### DIFF
--- a/website/content/docs/synced-folders/rsync.mdx
+++ b/website/content/docs/synced-folders/rsync.mdx
@@ -95,12 +95,12 @@ end
 ## Rsync to a restricted folder
 
 If required to copy to a destination where `vagrant` user does not have
-permissions, use `"--rsync-path='sudo rsync'"` to run rsync with sudo on the guest
+permissions, use option `rsync__rsync_path` to run rsync with sudo on the guest
 
 ```ruby
 Vagrant.configure("2") do |config|
   config.vm.synced_folder "bin", "/usr/local/bin", type: "rsync",
     rsync__exclude: ".git/",
-    rsync__args: ["--verbose", "--rsync-path='sudo rsync'", "--archive", "--delete", "-z"]
+    rsync__rsync_path: "sudo rsync"
 end
 ```


### PR DESCRIPTION
the example was not more working, I suspect the option `rsync__rsync_path` got introduced at a later point and the example was just not updated.