### PR TITLE
Fix minimal Vagrantfile test

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,6 +8,7 @@ on:
       - 'lib/**'
       - 'plugins/**'
       - 'test/**'
+      - 'templates/**'
       - 'Gemfile'
       - 'vagrant.gemspec'
       - 'Rakefile'
@@ -20,6 +21,7 @@ on:
       - 'plugins/**'
       - 'test/**'
       - 'Gemfile'
+      - 'templates/**'
       - 'vagrant.gemspec'
       - 'Rakefile'
 

--- a/test/unit/plugins/commands/init/command_test.rb
+++ b/test/unit/plugins/commands/init/command_test.rb
@@ -33,7 +33,6 @@ describe VagrantPlugins::CommandInit::Command do
     it "creates a minimal Vagrantfile" do
       described_class.new(["-m"], env).execute
       contents = File.read(vagrantfile_path)
-      expect(contents).to_not match(/#/)
       expect(contents).to_not match(/provision/)
     end
 


### PR DESCRIPTION
A minimal Vagrantfile may set the vi mode for ruby