### PR TITLE
Added a note to the changelog documenting the change from a .vagrant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3327,6 +3327,10 @@ BACKWARDS INCOMPATIBILITIES:
     format, but this is _opt-in_. Old Vagrantfile format continues to be supported,
     as promised. To use the new features that will be introduced throughout
     the 1.x series, you'll have to upgrade at some point.
+  - The .vagrant file is no longer supported and has been replaced by
+    a .vagrant directory. Running vagrant will automatically upgrade
+    to the new style directory format, after which old versions of
+    Vagrant will not be able to see or control your VM.
 
 FEATURES:
 


### PR DESCRIPTION
file to a .vagrant directory which occurred at approximately commit
4e649cc98792c192c1589a0bd86e8433e90f60cd.