### PR TITLE
Update networking template for latest NixOs format

### DIFF
--- a/templates/guests/nixos/network.erb
+++ b/templates/guests/nixos/network.erb
@@ -4,10 +4,18 @@
     <% networks.select {|n| n[:device]}.each do |network| %>
     "<%= network[:device] %>" = { 
       <% if network[:type] == :static %>
-      ipAddress    = "<%= network[:ip] %>";
-      <% end %>
-      <% if network[:prefix_length] %>
-      prefixLength = <%= network[:prefix_length] %>;
+      ipv4.addresses = [{
+        address = "<%= network[:ip] %>";
+        <% if network[:prefix_length] %>
+        prefixLength = <%= network[:prefix_length] %>;
+        <% end %>
+      }];
+      <% else %>
+        <% if network[:prefix_length] %>
+      ipv4.addresses = [{
+        prefixLength = <%= network[:prefix_length] %>;
+      }];
+        <% end %>
       <% end %>
     };
     <% end %>

--- a/templates/guests/nixos/network.erb
+++ b/templates/guests/nixos/network.erb
@@ -1,16 +1,15 @@
 { config, pkgs, ... }:
 {
-  networking.interfaces = [
+  networking.interfaces = {
     <% networks.select {|n| n[:device]}.each do |network| %>
-    { 
-      name         = "<%= network[:device] %>";
+    "<%= network[:device] %>" = { 
       <% if network[:type] == :static %>
       ipAddress    = "<%= network[:ip] %>";
       <% end %>
       <% if network[:prefix_length] %>
       prefixLength = <%= network[:prefix_length] %>;
       <% end %>
-    }
+    };
     <% end %>
-  ];
+  };
 }


### PR DESCRIPTION
NixOs uses a new format to define network interfaces.  In version 20.03, this script would still work and show a deprecation notice.  In version 20.09, this now throws an error, preventing the machine from working.