### PR TITLE
Bump bcrypt_pbkdf version

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = "~> 2.5", "< 2.8"
   s.required_rubygems_version = ">= 1.3.6"
 
-  s.add_dependency "bcrypt_pbkdf", "~> 1.0.0"
+  s.add_dependency "bcrypt_pbkdf", "~> 1.1"
   s.add_dependency "childprocess", "~> 4.0.0"
   s.add_dependency "ed25519", "~> 1.2.4"
   s.add_dependency "erubi"


### PR DESCRIPTION
There were no functional changes between 1.0.0 and 1.1.0:
https://github.com/net-ssh/bcrypt_pbkdf-ruby/compare/b5d1a921fcec8daa368236f5b4c469e08200fd5c...v1.1.0
so this update should be safe