### PR TITLE
Pre-Commit Hook for Vagrant Validate

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: vagrant-validate
+  name: Validate Vagrantfile
+  description: Runs vagrant validate to validate Vagrantfiles
+  language: system
+  types: ["vagrantfile"]
+  entry: vagrant validate
+ 


### PR DESCRIPTION
Git pre-commit hooks are a great integration point for linters, because
they (1) guarantee that all committed code is consistently formatted and
syntactically correct and (2) do not require you to run linters on every
build or test. Since Vagrant ships with a `validate` command, it is, in
a way, an elaborate linter and so it makes sense to integrate this
linting functionality into the Git lifecycle. Support for Pre-Commit, a
"framework for managing and maintaining multi-language pre-commit
hooks," is added through the addition of the .pre-commit-hooks.yaml
file.