### PR TITLE
Pre-commit hook for vagrant validate

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+- id: vagrant-validate
+  name: Validate Vagrantfile
+  description: Runs vagrant validate to validate Vagrantfiles
+  language: system
+  files: "(.+\\.)?Vagrantfile"
+  entry: vagrant validate


### PR DESCRIPTION
Git pre-commit hooks are a great integration point for linters, because they (1) guarantee that all committed code is consistently formatted and syntactically correct and (2) do not require you to run linters on every build or test. The `vagrant validate` command is a linter, so it makes sense to run it at the same time as linters for other languages (e.g., `flake8`, `gofmt`) . Support for [pre-commit](https://pre-commit.com/), a "framework for managing and maintaining multi-language pre-commit hooks," is added through the addition of a `.pre-commit-hooks.yaml` file. Test changes to the pre-commit hook by running `pre-commit try-repo . --all-files` and install the pre-commit hook in other repositories by adding the following to a top-level `.pre-commit-config.yaml` file and running `pre-commit install`.

```yaml
repos:
  - repo: https://github.com/hashicorp/vagrant
    rev: v2.2.15
    hooks:
      - id: vagrant-validate
```