### PR TITLE
Removal requires sudo access on Mac

### DIFF
--- a/website/content/docs/installation/uninstallation.mdx
+++ b/website/content/docs/installation/uninstallation.mdx
@@ -30,8 +30,7 @@ On **Windows**
 On **Mac OS X**:
 
 ```sh
-rm -rf /opt/vagrant
-rm -f /usr/local/bin/vagrant
+sudo rm -rf /opt/vagrant /usr/local/bin/vagrant
 sudo pkgutil --forget com.vagrant.vagrant
 ```
 


### PR DESCRIPTION
Tested on latest Mac OS.
  System Version:	macOS 11.2.2 (20D80)
  Kernel Version:	Darwin 20.3.0

uname -a
Darwin argent.local 20.3.0 Darwin Kernel Version 20.3.0: Thu Jan 21 00:07:06 PST 2021; root:xnu-7195.81.3~1/RELEASE_X86_64 x86_64