### PR TITLE
Add development depency for crack

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -41,6 +41,8 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.5.0"
   s.add_development_dependency "rspec-its", "~> 1.3.0"
   s.add_development_dependency "webmock", "~> 2.3.1"
+  # Prevent dependency issues with rexml
+  s.add_development_dependency "crack", "~> 0.4.4"
   s.add_development_dependency "fake_ftp", "~> 0.1.1"
 
   # The following block of code determines the files that should be included


### PR DESCRIPTION
Avoids getting an updated version of the crack gem so as to avoid
a dependency issue with rexml.

Previously, installing any vagrant plugin from a development environment caused this error
```
Vagrant failed to properly resolve required dependencies. These
errors can commonly be caused by misconfigured plugin installations
or transient network issues. The reported error is:
conflicting dependencies rexml (= 3.2.4) and rexml (= 3.2.3)
  Activated rexml-3.2.3
  which does not match conflicting dependency (= 3.2.4)
  Conflicting dependency chains:
    rexml (= 3.2.3), 3.2.3 activated
  versus:
    rexml (= 3.2.4)
  Gems matching rexml (= 3.2.4):
    rexml-3.2.4
```