### PR TITLE
Prevent notification on default store, fix client end point

### DIFF
--- a/plugins/commands/cloud/client/client.rb
+++ b/plugins/commands/cloud/client/client.rb
@@ -18,6 +18,7 @@ module VagrantPlugins
       ######################################################################
       APP = "app".freeze
 
+      include Util
       include Vagrant::Util::Presence
 
       attr_accessor :client
@@ -32,7 +33,10 @@ module VagrantPlugins
       def initialize(env)
         @logger = Log4r::Logger.new("vagrant::cloud::client")
         @env    = env
-        @client = VagrantCloud::Client.new(access_token: token)
+        @client = VagrantCloud::Client.new(
+          access_token: token,
+          url_base: api_server_url
+        )
       end
 
       # Removes the token, effectively logging the user out.
@@ -72,7 +76,10 @@ module VagrantPlugins
             password: password, description: description, code: code)
 
           Vagrant::Util::CredentialScrubber.sensitive(r[:token])
-          @client = VagrantCloud::Client.new(access_token: r[:token])
+          @client = VagrantCloud::Client.new(
+            access_token: r[:token],
+            url_base: api_server_url
+          )
           r[:token]
         end
       end
@@ -106,7 +113,7 @@ module VagrantPlugins
         end
 
         # Reset after we store the token since this is now _our_ token
-        @client = VagrantCloud::Client.new(access_token: token)
+        @client = VagrantCloud::Client.new(access_token: token, url_base: api_server_url)
 
         nil
       end

--- a/plugins/commands/cloud/locales/en.yml
+++ b/plugins/commands/cloud/locales/en.yml
@@ -112,7 +112,7 @@ en:
           Failed to update box %{org}/%{box_name}
       whoami:
         read_error: |-
-          Failed to read organization %{org}
+          Failed to locate account information
       provider:
         create_fail: |-
           Failed to create provider %{provider} on box %{org}/%{box_name} for version %{version}

--- a/plugins/commands/cloud/util.rb
+++ b/plugins/commands/cloud/util.rb
@@ -5,8 +5,16 @@ module VagrantPlugins
       def api_server_url
         if Vagrant.server_url == Vagrant::DEFAULT_SERVER_URL
           return "#{Vagrant.server_url}/api/v1"
-        else
-          return Vagrant.server_url
+        end
+        begin
+          addr = URI.parse(Vagrant.server_url.to_s)
+          if addr.path.empty? || addr.path.to_s == "/"
+            addr.path = "/api/v1"
+          end
+
+          addr.to_s
+        rescue URI::Error
+          Vagrant.server_url
         end
       end
 

--- a/plugins/commands/cloud/util.rb
+++ b/plugins/commands/cloud/util.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
           return "#{Vagrant.server_url}/api/v1"
         end
         begin
-          addr = URI.parse(Vagrant.server_url.to_s)
+          addr = URI.parse(Vagrant.server_url)
           if addr.path.empty? || addr.path.to_s == "/"
             addr.path = "/api/v1"
           end

--- a/test/unit/plugins/commands/cloud/auth/middleware/add_downloader_authentication_test.rb
+++ b/test/unit/plugins/commands/cloud/auth/middleware/add_downloader_authentication_test.rb
@@ -53,16 +53,16 @@ describe VagrantPlugins::CloudCommand::AddDownloaderAuthentication do
       it "warns when adding token to custom server" do
         server_url = "https://surprise.com"
         allow(Vagrant).to receive(:server_url).and_return(server_url)
-  
+
         token = "foobarbaz"
         VagrantPlugins::CloudCommand::Client.new(iso_env).store_token(token)
-  
+
         expect(subject).to receive(:sleep).once
         expect(ui).to receive(:warn).once
-  
+
         env[:downloader] = dwnloader
         subject.call(env)
-  
+
         expect(env[:downloader].headers).to eq(["Authorization: Bearer #{token}"])
       end
     end
@@ -97,11 +97,11 @@ describe VagrantPlugins::CloudCommand::AddDownloaderAuthentication do
       let(:auth_header) { "Authorization Bearer: token" }
       let(:other_header) {"some: thing"}
       let(:dwnloader) { Vagrant::Util::Downloader.new(server_url, "/some/path", {headers: [other_header]}) }
-    
+
       it "appends the auth header" do
         token = "foobarbaz"
         VagrantPlugins::CloudCommand::Client.new(iso_env).store_token(token)
-  
+
         env[:downloader] = dwnloader
         subject.call(env)
 
@@ -115,7 +115,7 @@ describe VagrantPlugins::CloudCommand::AddDownloaderAuthentication do
         it "returns original urls when not modified" do
           env[:downloader] = dwnloader
           subject.call(env)
-          
+
           expect(env[:downloader].source).to eq(file_path)
           expect(env[:downloader].headers.empty?).to eq(true)
         end
@@ -125,7 +125,7 @@ describe VagrantPlugins::CloudCommand::AddDownloaderAuthentication do
         dwnloader.headers << auth_header
         token = "foobarbaz"
         VagrantPlugins::CloudCommand::Client.new(iso_env).store_token(token)
-  
+
         env[:downloader] = dwnloader
         subject.call(env)
 

--- a/test/unit/plugins/commands/cloud/client_test.rb
+++ b/test/unit/plugins/commands/cloud/client_test.rb
@@ -101,7 +101,7 @@ describe VagrantPlugins::CloudCommand::Client do
     end
 
     it "should create a new internal client" do
-      expect(VagrantCloud::Client).to receive(:new).with(access_token: new_token)
+      expect(VagrantCloud::Client).to receive(:new).with(access_token: new_token, url_base: anything)
       subject.login
     end
 
@@ -174,7 +174,7 @@ describe VagrantPlugins::CloudCommand::Client do
     end
 
     it "should create a new internal client with token" do
-      expect(VagrantCloud::Client).to receive(:new).with(access_token: new_token)
+      expect(VagrantCloud::Client).to receive(:new).with(access_token: new_token, url_base: anything)
       subject.store_token(new_token)
     end
 


### PR DESCRIPTION
Prevents redirect notification when getting asset from
the default store. Also fixes some places where the
cloud client was not using the helper method for the
server url. Custom server urls also have api path appended
automatically when not detected.
