### PR TITLE
Fix for uuid generation on machine index

### DIFF
--- a/lib/vagrant/machine_index.rb
+++ b/lib/vagrant/machine_index.rb
@@ -200,6 +200,7 @@ module Vagrant
             self.each do |other|
               if entry.name == other.name &&
                 entry.provider == other.provider &&
+                entry.local_data_path.to_s == other.local_data_path.to_s &&
                 entry.vagrantfile_path.to_s == other.vagrantfile_path.to_s
                 id = other.id
                 break


### PR DESCRIPTION
This change fixes rare locking errors `Vagrant can't use the requested machine because it is locked!`, in the environments that share everything except VAGRANT_DOTFILE_PATH. 