### PR TITLE
Fix dependency resolution where default gems are included

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -516,6 +516,9 @@ module Vagrant
         @logger.debug("Enabling strict dependency enforcement")
         plugin_deps += vagrant_internal_specs.map do |spec|
           next if system_plugins.include?(spec.name)
+          # If this spec is for a default plugin included in
+          # the ruby stdlib, ignore it
+          next if spec.default_gem?
           # If we are not running within the installer and
           # we are not within a bundler environment then we
           # only want activated specs


### PR DESCRIPTION
    Parts of the stdlib which have been externalized but are still
    included within Ruby introduce issues when pinning Vagrant's
    dependencies to resolve plugin installs. When determining
    Vagrant's dependency list prior to solution generation, check
    the specification and ignore any default gems to prevent
    pinning versions that are not actual dependencies.

Fixes #12248
