### PR TITLE
Fix shell provisioner with ruby 3.0

### DIFF
--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -78,7 +78,7 @@ module VagrantPlugins
           options = {}
           options[:color] = color if !config.keep_color
 
-          @machine.ui.detail(data.chomp, options)
+          @machine.ui.detail(data.chomp, **options)
         end
       end
 


### PR DESCRIPTION
I recently updated to Fedora 34 (which uses ruby 3.0), and `vagrant up` errors out like this:

```
/usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/ui.rb:230:in `say': wrong number of arguments (given 4, expected 2..3) (ArgumentError)
	from (eval):3:in `detail'
	from (eval):9:in `detail'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/plugins/provisioners/shell/provisioner.rb:79:in `handle_comm'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/plugins/provisioners/shell/provisioner.rb:127:in `block (3 levels) in provision_ssh'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/plugins/communicators/ssh/communicator.rb:254:in `block (2 levels) in execute'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/plugins/communicators/ssh/communicator.rb:617:in `block (3 levels) in shell_execute'
	from /usr/share/gems/gems/net-ssh-6.1.0/lib/net/ssh/connection/channel.rb:598:in `do_extended_data'
	from /usr/share/gems/gems/net-ssh-6.1.0/lib/net/ssh/connection/session.rb:673:in `channel_extended_data'
	from /usr/share/gems/gems/net-ssh-6.1.0/lib/net/ssh/connection/session.rb:548:in `dispatch_incoming_packets'
	from /usr/share/gems/gems/net-ssh-6.1.0/lib/net/ssh/connection/session.rb:248:in `ev_preprocess'
	from /usr/share/gems/gems/net-ssh-6.1.0/lib/net/ssh/connection/event_loop.rb:100:in `each'
	from /usr/share/gems/gems/net-ssh-6.1.0/lib/net/ssh/connection/event_loop.rb:100:in `ev_preprocess'
	from /usr/share/gems/gems/net-ssh-6.1.0/lib/net/ssh/connection/event_loop.rb:28:in `process'
	from /usr/share/gems/gems/net-ssh-6.1.0/lib/net/ssh/connection/session.rb:227:in `process'
	from /usr/share/gems/gems/net-ssh-6.1.0/lib/net/ssh/connection/session.rb:180:in `block in loop'
	from /usr/share/gems/gems/net-ssh-6.1.0/lib/net/ssh/connection/session.rb:180:in `loop'
	from /usr/share/gems/gems/net-ssh-6.1.0/lib/net/ssh/connection/session.rb:180:in `loop'
	from /usr/share/gems/gems/net-ssh-6.1.0/lib/net/ssh/connection/channel.rb:272:in `wait'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/plugins/communicators/ssh/communicator.rb:702:in `shell_execute'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/plugins/communicators/ssh/communicator.rb:247:in `block in execute'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/plugins/communicators/ssh/communicator.rb:391:in `connect'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/plugins/communicators/ssh/communicator.rb:240:in `execute'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/plugins/provisioners/shell/provisioner.rb:122:in `block (2 levels) in provision_ssh'
	from <internal:kernel>:90:in `tap'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/plugins/provisioners/shell/provisioner.rb:96:in `block in provision_ssh'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/plugins/provisioners/shell/provisioner.rb:329:in `with_script_file'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/plugins/provisioners/shell/provisioner.rb:94:in `provision_ssh'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/plugins/provisioners/shell/provisioner.rb:33:in `provision'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/builtin/provision.rb:138:in `run_provisioner'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:127:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:127:in `block in finalize_action'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/builder.rb:149:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/runner.rb:89:in `block in run'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/util/busy.rb:19:in `busy'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/runner.rb:89:in `run'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/environment.rb:525:in `hook'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/builtin/provision.rb:126:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/builtin/provision.rb:126:in `block in call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/builtin/provision.rb:103:in `each'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/builtin/provision.rb:103:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-libvirt-0.1.2/lib/vagrant-libvirt/action/create_domain.rb:363:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-libvirt-0.1.2/lib/vagrant-libvirt/action/create_domain_volume.rb:89:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-libvirt-0.1.2/lib/vagrant-libvirt/action/handle_box_image.rb:124:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/builtin/handle_box.rb:56:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-libvirt-0.1.2/lib/vagrant-libvirt/action/handle_storage_pool.rb:57:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-libvirt-0.1.2/lib/vagrant-libvirt/action/set_name_of_domain.rb:32:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:127:in `block in finalize_action'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/warden.rb:48:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/builder.rb:149:in `call'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/runner.rb:89:in `block in run'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/util/busy.rb:19:in `busy'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/runner.rb:89:in `run'
	from /usr/share/vagrant/gems/gems/vagrant-2.2.9/lib/vagrant/action/builtin/call.rb:53:in `call'
```

I'm not a ruby expert but I believe it's related to [this breaking change](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/). This change fixes it for me.