### PR TITLE
Bugfix20210302/10831 hyperv disk import

### DIFF
--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -5,7 +5,6 @@ module VagrantPlugins
   module HyperV
     module Action
       class Import
-
         VALID_HD_EXTENSIONS = [".vhd".freeze, ".vhdx".freeze].freeze
 
         def initialize(app, env)
@@ -42,33 +41,44 @@ module VagrantPlugins
             @logger.info("Found box configuration path: #{config_path}")
           end
 
+          # Fixes: 10831: This original logic with image_path does not work, if there is more than one disk (we cannot rely on the first disk
+          # indicating the destination directory, and any additional disks overwrite this)
+          # A better approach is passing the destination directory (instead of guessing it), to powershell
+          # and use the HyperV module to derive the needed paths from the VMConfig, which is used by the powershell
+          # code anyway to find the necessary drives.
           image_path = nil
+          source_disk_files = []
           hd_dir.each_child do |file|
             if VALID_HD_EXTENSIONS.include?(file.extname.downcase)
               image_path = file
-              break
+              # source_disk_files.push(Vagrant::Util::Platform.wsl_to_windows_path(file).gsub("/", "\\"))
+              source_disk_files.push(file.to_s)
+              @logger.info("Use original disk from box: #{file.to_s}")
             end
           end
 
           if !image_path
-            @logger.error("Failed to locate box image path")
+            @logger.error("Failed to locate any disks in this box.")
             raise Errors::BoxInvalid, name: env[:machine].name
           else
-            @logger.info("Found box image path: #{image_path}")
           end
 
           env[:ui].output("Importing a Hyper-V instance")
-          dest_path = env[:machine].data_dir.join("Virtual Hard Disks").join(image_path.basename).to_s
+          dest_dir = env[:machine].data_dir.join("Virtual Hard Disks").to_s
+          @logger.info("Putting all disk drives into  #{dest_dir}")
 
           options = {
             "VMConfigFile" => Vagrant::Util::Platform.wsl_to_windows_path(config_path).gsub("/", "\\"),
-            "DestinationPath" => Vagrant::Util::Platform.wsl_to_windows_path(dest_path).gsub("/", "\\"),
+            "DestinationDirectory" => Vagrant::Util::Platform.wsl_to_windows_path(dest_dir).gsub("/", "\\"),
             "DataPath" => Vagrant::Util::Platform.wsl_to_windows_path(env[:machine].data_dir).gsub("/", "\\"),
             "LinkedClone" => !!env[:machine].provider_config.linked_clone,
-            "SourcePath" => Vagrant::Util::Platform.wsl_to_windows_path(image_path).gsub("/", "\\"),
             "VMName" => env[:machine].provider_config.vmname,
+            # Catenate the values using a "|" character, withstood all attempts to use a standard representation of the array or JSON or similar
+            "SourceDiskFilesString" => source_disk_files.collect {
+              |item|
+              Vagrant::Util::Platform.wsl_to_windows_path(item).gsub("/", "\\")
+            }.join("|"),
           }
-
 
           env[:ui].detail("Creating and registering the VM...")
           server = env[:machine].provider.driver.import(options)

--- a/plugins/providers/hyperv/scripts/import_vm.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm.ps1
@@ -4,15 +4,18 @@ param(
     [parameter (Mandatory=$true)]
     [string] $VMConfigFile,
     [parameter (Mandatory=$true)]
-    [string] $DestinationPath,
+    [string] $DestinationDirectory,
     [parameter (Mandatory=$true)]
     [string] $DataPath,
-    [parameter (Mandatory=$true)]
-    [string] $SourcePath,
     [parameter (Mandatory=$false)]
     [switch] $LinkedClone,
     [parameter (Mandatory=$false)]
-    [string] $VMName=$null
+    [string] $VMName=$null,
+    # The full paths to the virtual disk files in the downloaded and unpacked box, usually in $ENV:VAGRANT_HOME
+    [parameter (Mandatory=$false)]
+    [string]$SourceDiskFilesString = [string]::Empty,
+    [parameter (Mandatory=$false)]
+    [string[]] $SourceDiskFiles = ($SourceDiskFilesString -split "\|")
 )
 
 $ErrorActionPreference = "Stop"
@@ -23,9 +26,13 @@ try {
     } else {
         $linked = $false
     }
+    $SourceFileHash = @{}
+    foreach ($sourceFile in $SourceDiskFiles) {
+        $SourceFileHash.Add([System.IO.Path]::GetFileName($sourceFile).ToLower(), $sourceFile)
+    }
 
-    $VM = New-VagrantVM -VMConfigFile $VMConfigFile -DestinationPath $DestinationPath `
-      -DataPath $DataPath -SourcePath $SourcePath -LinkedClone $linked -VMName $VMName
+    $VM = New-VagrantVM -VMConfigFile $VMConfigFile -DestinationDirectory $DestinationDirectory `
+      -DataPath $DataPath -LinkedClone $linked -VMName $VMName -SourceFileHash $SourceFileHash
 
     $Result = @{
         id = $VM.Id.Guid;


### PR DESCRIPTION
This fixes #10831 by looping over the *.vhdx files instead of picking the first in alphabetical order and ignoring the others. Contrary to what the author of the issue #10831 states, a virtual machine with more than one *.vhdx reliably reproduces the issue. Tested with Windows 10 guests on Windows10 and Windows 2012R2 hosts.