### PR TITLE
Fix the included Vagrantfile for running rspec tests

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,6 +34,8 @@ No pull request template is provided on GitHub. The expected changes are often a
 
 ### Setup a development installation of Vagrant
 
+*A Vagrantfile is provided that should take care setting up a VM for running the rspec tests.* If you only need to run those tests and don't also want to run a development version of Vagrant from a host machine then it's recommended to use that.
+
 There are a few prerequisites for setting up a development environment with Vagrant. Ensure you have the following installed on your machine:
 
 * git

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -14,7 +14,12 @@ Vagrant.configure("2") do |config|
     end
   end
 
-  config.vm.provision "shell", inline: $shell
+  # We split apart `install_rvm` from `setup_tests` because rvm says to
+  # logout and log back in just after installing RVM.
+  # https://github.com/rvm/ubuntu_rvm#3-reboot
+  config.vm.provision "shell", path: "scripts/install_rvm"
+
+  config.vm.provision "shell", path: "scripts/setup_tests"
 
   config.push.define "www", strategy: "local-exec" do |push|
     push.script = "scripts/website_push_www.sh"
@@ -24,54 +29,3 @@ Vagrant.configure("2") do |config|
     push.script = "scripts/website_push_docs.sh"
   end
 end
-
-$shell = <<-'CONTENTS'
-export DEBIAN_FRONTEND=noninteractive
-MARKER_FILE="/usr/local/etc/vagrant_provision_marker"
-RUBY_VER_REQ=$(awk '$1 == "s.required_ruby_version" { print $4 }' /vagrant/vagrant.gemspec | tr -d '"')
-
-# Only provision once
-if [ -f "${MARKER_FILE}" ]; then
-  exit 0
-fi
-
-# Add ubuntu_rvm repo
-apt-add-repository -y ppa:rael-gc/rvm
-
-# Update apt
-apt-get update --quiet
-
-# Add vagrant user to sudo group:
-# ubuntu_rvm only adds users in group sudo to group rvm
-usermod -a -G sudo vagrant
-
-# Install basic dependencies and RVM
-apt-get install -qy build-essential bsdtar rvm
-
-# Import the mpapis public key to verify downloaded releases
-su -l -c 'gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3' vagrant
-
-# Install next-to-last Ruby that complies with Vagrant's version constraint
-RUBY_VER=$(su -l -c 'rvm list known' vagrant | tr '[]-' ' ' | awk "/^ ruby  ${RUBY_VER_REQ:0:1}\./ { print \$2 }" | sort -r | sed -n '2p')
-su -l -c "rvm install ${RUBY_VER}" vagrant
-su -l -c "rvm --default use ${RUBY_VER}" vagrant
-
-# Output the Ruby version (for sanity)
-su -l -c 'ruby --version' vagrant
-
-# Install Git
-apt-get install -qy git
-
-# Upgrade Rubygems
-su -l -c "rvm ${RUBY_VER} do gem update --system" vagrant
-
-# Prepare to run unit tests
-su -l -c 'cd /vagrant; bundle install' vagrant
-
-# Automatically move into the shared folder, but only add the command
-# if it's not already there.
-grep -q 'cd /vagrant' /home/vagrant/.bash_profile 2>/dev/null || echo 'cd /vagrant' >> /home/vagrant/.bash_profile
-
-# Touch the marker file so we don't do this again
-touch ${MARKER_FILE}
-CONTENTS

--- a/scripts/install_rvm
+++ b/scripts/install_rvm
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+
+export DEBIAN_FRONTEND=noninteractive
+
+if ! rvm --version
+then
+  # https://github.com/rvm/ubuntu_rvm#install
+  apt-add-repository -y ppa:rael-gc/rvm &&
+    apt-get update -y &&
+    apt-get install -y rvm || {
+      echo 'Failed to install rvm' >&2
+      exit 1
+    }
+fi
+
+usermod -a -G rvm vagrant || {
+  echo 'Failed to add vagrant to the rvm group' >&2
+  exit 1
+}

--- a/scripts/setup_tests
+++ b/scripts/setup_tests
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+rvm --version || {
+  echo 'rvm not installed' >&2
+  exit 1
+}
+
+# bsdtar is required for a small subset of the tests
+if ! bsdtar --version
+then
+  apt-get install -y bsdtar &&
+    bsdtar --version || {
+      echo 'Failed to install bsdtar' >&2
+      exit 1
+    }
+fi
+
+# Install next-to-last Ruby that complies with Vagrant's version
+# constraint
+RUBY_VER_REQ=$(
+  awk '
+    $1 == "s.required_ruby_version" { print $4 }
+  ' /vagrant/vagrant.gemspec |
+    tr -d '"')
+RUBY_VER=$(sudo -u vagrant -i rvm list known |
+             tr '[]-' ' ' |
+             awk "/^ ruby  ${RUBY_VER_REQ:0:1}\./ { print \$2 }" |
+             sort -r |
+             sed -n '2p')
+sudo -u vagrant -i rvm install "${RUBY_VER}"
+sudo -u vagrant -i rvm --default use "${RUBY_VER}"
+
+# Output the Ruby version (for sanity)
+sudo -u vagrant -i ruby --version
+
+# Upgrade Rubygems
+sudo -u vagrant -i rvm "${RUBY_VER}" do gem update --system
+
+# Prepare to run unit tests
+sudo -u vagrant -i bash -c 'cd /vagrant; bundle install'
+
+# Automatically move into the shared folder, but only add the command if
+# it's not already there.
+if ! grep -q 'cd /vagrant' /home/vagrant/.bash_profile
+then
+  cat <<EOF >> /home/vagrant/.bash_profile
+cd /vagrant
+EOF
+fi


### PR DESCRIPTION
In attempting to get a development environment set up to run the rspec
tests for a forthcoming PR I noticed that the Vagrantfile doesn't appear
to actually set up a functioning environment. I'm not sure when this
changed or how it's been missed but I figured I'd contribute a patch to
fix it up for my benefit and others.

In summary:

1. RVM no longer appears to be installed and configured the way the
   current provisioning script expects it be. Namely it requires users to
   be added to the `rvm` group rather than the `sudo` group and also
   requires a log out and then back in to finish setting up. In light of
   that I broke apart the provisioning into two separate shell scripts to
   get that 'log out and back in' behavior.
2. While I was there I tried to 'clean up' the script's logic, making it
   idempotent, using `sudo -u vagrant -i` rather than the `su`
   incantation, removing apparentyl unnecessary dependencies like
   `build-essential` and the GPG key, etc. I suspect there's some
   significant unnecessary complexity in the ruby version extraction but
   that could be tacked on later. This change is already big enough.
   
What do you think? I'm happy to cleanup the commits if there's interest in
the patch.

---

```
$ vagrant -v; VBoxManage -v
Vagrant 2.2.14
6.1.18r142142
```

Pre Change:

```
$ time {
    vagrant destroy -f &&
    vagrant up &&
    vagrant ssh-config |
      tee default.conf &&
    ssh -F default.conf default $'
      bash -lc \'
        hostname;
        date;
        cd /vagrant &&
          bundle exec rake; hostname
      \'
    '
  }
…
(Reading database ... 45709 files and directories currently installed.)
    default: Preparing to unpack .../git_1%3a2.17.1-1ubuntu0.8_amd64.deb ...
    default: Unpacking git (1:2.17.1-1ubuntu0.8) over (1:2.17.1-1ubuntu0.4) ...
    default: Setting up git (1:2.17.1-1ubuntu0.8) ...
    default: Ruby ruby-2.6.6 is not installed.
    default: -su: bundle: command not found
…

vagrant
Mon Apr 12 15:42:40 UTC 2021
bash: line 4: bundle: command not found
vagrant

real    3m7.343s
user    0m13.897s
sys     0m4.263s
```

Post Change:

```
$ time {
    vagrant destroy -f &&
    vagrant up &&
    vagrant ssh-config |
      tee default.conf &&
    ssh -F default.conf default $'
      bash -lc \'
        hostname;
        date;
        cd /vagrant &&
          bundle exec rake; hostname
      \'
    '
  }
…
Finished in 19 minutes 2 seconds (files took 3.09 seconds to load)
4674 examples, 0 failures, 3 pending

vagrant

real    26m21.810s
user    0m13.517s
sys     0m4.281s
```