### PR TITLE
[WIP]: Add a `failed_up_message` to complement to `post_up_message`

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -47,6 +47,7 @@ module VagrantPlugins
       attr_accessor :guest
       attr_accessor :hostname
       attr_accessor :post_up_message
+      attr_accessor :failed_up_message
       attr_accessor :usable_port_range
       attr_reader :provisioners
       attr_reader :disks
@@ -85,6 +86,7 @@ module VagrantPlugins
         @guest                         = UNSET_VALUE
         @hostname                      = UNSET_VALUE
         @post_up_message               = UNSET_VALUE
+        @failed_up_message             = UNSET_VALUE
         @provisioners                  = []
         @disks                         = []
         @cloud_init_configs            = []
@@ -543,6 +545,7 @@ module VagrantPlugins
         @hostname = nil if @hostname == UNSET_VALUE
         @hostname = @hostname.to_s if @hostname
         @post_up_message = "" if @post_up_message == UNSET_VALUE
+        @failed_up_message = "" if @failed_up_message == UNSET_VALUE
 
         if @usable_port_range == UNSET_VALUE
           @usable_port_range = (2200..2250)

--- a/test/unit/plugins/kernel_v2/config/vm_test.rb
+++ b/test/unit/plugins/kernel_v2/config/vm_test.rb
@@ -373,6 +373,19 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
     end
   end
 
+  describe "#failed_up_message" do
+    it "defaults to empty string" do
+      subject.finalize!
+      expect(subject.failed_up_message).to eq("")
+    end
+
+    it "can be set" do
+      subject.failed_up_message = "bar"
+      subject.finalize!
+      expect(subject.failed_up_message).to eq("bar")
+    end
+  end
+
   describe "#provider and #__providers" do
     it "returns the providers in order" do
       subject.provider "foo"


### PR DESCRIPTION
Users of the Vagrantfiles that I have maintained have always had trouble
spotting when vagrant has failed to create or provision a box. I've
scripted around this in the past and emitted at various times a rocket
ship blasting off for success and a mushroom cloud explosion for failure.
This has always seemed to make it clearer to my users whether things
worked or not or at least has allowed me to ask "Did you see the rocket
ship?" rather than asking them whether the box creation worked or not.

I was excited recently to find the `post_up_message` configuration and
started using that immediately, but I'd really like a complementary
`failed_up_message` (not married to the name) that allowed me to specify
what to do in the case of a failure.

This changeset should get that.

---

WIP:

- [x] Add the `failed_up_message` property to
      `VagrantPlugins::Kernel_V2::VMConfig` class.
- [ ] Use `failed_up_message` if applicable during error handling of
      `reload` and `up`. Both messages, IMHO, could be useful for
      `provision` as well but we don't need to open that can of worms just
      now as then the property name should likely change.
      
      *Help Needed:* I'm not actually sure how to do this. I don't see any
      error handling code in `up/command.rb` or `reload/command.rb` so I'm
      assuming that's somehow part of the framework here which may or may
      not make this harder than I thought it would be?