### PR TITLE
Fix matching on build output for docker provider

### DIFF
--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -25,9 +25,9 @@ module VagrantPlugins
         opts = {with_stderr: true}
         result = execute('docker', 'build', *args, opts, &block)
         # Check for the new output format 'writing image sha256...'
-        # In this case, docker builtkit is enabled. Its format is different
+        # In this case, docker buildkit is enabled. Its format is different
         # from standard docker
-        matches = result.scan(/writing image .+:([0-9a-z]+) done/i).last
+        matches = result.scan(/writing image .+:([^\s]+)/i).last
         if !matches
           if podman?
             # Check for podman format when it is emulating docker CLI.

--- a/test/unit/plugins/providers/docker/driver_test.rb
+++ b/test/unit/plugins/providers/docker/driver_test.rb
@@ -154,7 +154,8 @@ describe VagrantPlugins::DockerProvider::Driver do
 
   describe '#build' do
     let(:result) { "Successfully built other_package\nSuccessfully built 1a2b3c4d" }
-    let(:buildkit_result) { "writing image sha256:1a2b3c4d done" }
+    let(:buildkit_result_old) { "writing image sha256:1a2b3c4d done" }
+    let(:buildkit_result) { "writing image sha256:1a2b3c4d 0.0s done" }
     let(:podman_result) { "1a2b3c4d5e6f7g8h9i10j11k12l13m14n16o17p18q19r20s21t22u23v24w25x2" }
     let(:cid) { "1a2b3c4d" }
 
@@ -168,6 +169,14 @@ describe VagrantPlugins::DockerProvider::Driver do
 
     it "builds a container with buildkit docker" do
       allow(subject).to receive(:execute).and_return(buildkit_result)
+
+      container_id = subject.build("/tmp/fakedir")
+
+      expect(container_id).to eq(cid)
+    end
+
+    it "builds a container with buildkit docker (old output)" do
+      allow(subject).to receive(:execute).and_return(buildkit_result_old)
 
       container_id = subject.build("/tmp/fakedir")
 


### PR DESCRIPTION
Relax the pattern matching to allow updated output
format to be properly detected along with the old
output format.

Fixes #12245
