### PR TITLE
implement --info flag for package cmd #12191

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -592,6 +592,10 @@ module Vagrant
       error_key(:requires_directory, "vagrant.actions.general.package")
     end
 
+    class PackageInvalidInfo < VagrantError
+      error_key(:package_invalid_info)
+    end
+
     class PowerShellNotFound < VagrantError
       error_key(:powershell_not_found)
     end

--- a/plugins/commands/box/command/list.rb
+++ b/plugins/commands/box/command/list.rb
@@ -52,7 +52,7 @@ module VagrantPlugins
             @env.ui.machine("box-version", version)
 
             info_file = @env.boxes.find(name, provider, version).
-              directory.join("include", "info.json")
+              directory.join("info.json")
             if info_file.file?
               info = JSON.parse(info_file.read)
               info.each do |k, v|

--- a/plugins/commands/box/command/list.rb
+++ b/plugins/commands/box/command/list.rb
@@ -52,7 +52,7 @@ module VagrantPlugins
             @env.ui.machine("box-version", version)
 
             info_file = @env.boxes.find(name, provider, version).
-              directory.join("info.json")
+              directory.join("include", "info.json")
             if info_file.file?
               info = JSON.parse(info_file.read)
               info.each do |k, v|

--- a/plugins/commands/package/command.rb
+++ b/plugins/commands/package/command.rb
@@ -29,6 +29,10 @@ module VagrantPlugins
             options[:include] = i
           end
 
+          o.on("--info FILE", "Path to a custom info.json file containing additional box information") do |info|
+            options[:info] = info
+          end
+
           o.on("--vagrantfile FILE", "Vagrantfile to package with the box") do |v|
             options[:vagrantfile] = v
           end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1293,6 +1293,9 @@ en:
         A file or directory you're attempting to include with your packaged
         box has symlinks in it. Vagrant cannot include symlinks in the
         resulting package. Please remove the symlinks and try again.
+      package_invalid_info: |-
+        The information file that you've attempted to include doesn't exist or isn't a valid JSON file.
+        Please check that the file exists and is titled 'info.json' and try again.
       provider_cant_install: |-
         The provider '%{provider}' doesn't support automatic installation.
         This is a limitation of this provider. Please report this as a feature

--- a/test/unit/vagrant/action/general/package_test.rb
+++ b/test/unit/vagrant/action/general/package_test.rb
@@ -183,6 +183,34 @@ describe Vagrant::Action::General::Package do
     end
   end
 
+  describe "#copy_info" do
+    let(:package_directory) { @package_directory }
+    let(:package_info) { File.join(@package_info_directory, "info.json") }
+
+    before do
+      @package_directory = Dir.mktmpdir
+      @package_info_directory = Dir.mktmpdir
+      FileUtils.touch(File.join(@package_info_directory, "info.json"))
+      env["package.info"] = package_info
+      env["package.directory"] = package_directory
+      subject.instance_variable_set(:@env, env)
+
+      allow(ui).to receive(:info)
+    end
+
+    after do
+      FileUtils.rm_rf(@package_directory)
+      FileUtils.rm_rf(@package_info_directory)
+    end
+
+    it "should copy the specified info.json to package directory" do
+      subject.copy_info
+      expected_info = File.join(package_directory, "info.json")
+
+      expect(File.file? expected_info).to be_truthy
+    end
+  end
+
   describe "#compress" do
     let(:package_directory) { @package_directory }
     let(:fullpath) { "PATH" }

--- a/website/content/docs/cli/package.mdx
+++ b/website/content/docs/cli/package.mdx
@@ -29,6 +29,10 @@ and if the provider supports it.
   can be used by a packaged Vagrantfile (documented below) to perform additional
   tasks.
 
+- `--info path/to/info.json` - The package will include a custom JSON file containing
+  information to be displayed by the [list](/docs/cli/box#box-list) command when invoked
+  with the `-i` flag
+
 - `--vagrantfile FILE` - Packages a Vagrantfile with the box, that is loaded
   as part of the [Vagrantfile load order](/docs/vagrantfile/#load-order)
   when the resulting box is used.


### PR DESCRIPTION
Assuming that `info.json` belongs in the `include` directory, this fixes #12191 by pre-pending `include` as the first arg when joining the pathname.