### PR TITLE
fix versioning syntax #12305

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        ruby: [ '2.5.x', '2.6.x', '2.7.x' ]
+        ruby: [ '2.5', '2.6', '2.7' ]
     name: Vagrant unit tests on Ruby ${{ matrix.ruby }}
     steps:
       - name: Code Checkout


### PR DESCRIPTION
This should fix #12305 by changing to approved syntax versioning listed [here](https://github.com/ruby/setup-ruby#supported-version-syntax)