### PR TITLE
rem python2-futures from bootstrap script #12286

### DIFF
--- a/plugins/provisioners/salt/bootstrap-salt.sh
+++ b/plugins/provisioners/salt/bootstrap-salt.sh
@@ -17,6 +17,8 @@ else
 fi
 
 if [ -e bootstrap-salt.sh ]; then
+  # Until Bootstrap's next official release that includes the fix, remove deprecated package source
+  sed -i 's/python2-futures //g' bootstrap-salt.sh
   sh bootstrap-salt.sh "$@"
 else
   exit 1


### PR DESCRIPTION
Was able to repro the issue locally, seems to be due to a [package sourcing issue](https://github.com/saltstack/salt-bootstrap/pull/1546).

Removing the package name from the script using `sed` should fix #12286 , until the newest release of the bootstrap script includes the fix