### PR TITLE
Allow for use with nested virtualization in WSL2

### DIFF
--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -44,7 +44,8 @@ module Vagrant
             @_wsl = false
             SilenceWarnings.silence! do
               # Find 'microsoft' in /proc/version indicative of WSL
-              if File.file?('/proc/version')
+              # When VAGRANT_WSL_NESTED_VIRTUALIZATION is true, @_wsl will remain false, acting as if not on WSL
+              if File.file?('/proc/version') && !ENV["VAGRANT_WSL_NESTED_VIRTUALIZATION"]
                 osversion = File.open('/proc/version', &:gets)
                 if osversion.downcase.include?("microsoft")
                   @_wsl = true

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1867,6 +1867,8 @@ en:
         Please ensure both installation of Vagrant are the same. If you do not want
         update your Vagrant installations you can disable Windows access by unsetting
         the `VAGRANT_WSL_ACCESS_WINDOWS_USER` environment variable.
+        You can also use nested virtualization within WSL2 by setting
+        the `VAGRANT_WSL_NESTED_VIRTUALIZATION` environment variable.
 
           Windows Vagrant version: %{windows_version}
           Windows Subsystem for Linux Vagrant version: %{wsl_version}
@@ -1874,16 +1876,21 @@ en:
         Vagrant will not operate outside the Windows Subsystem for Linux unless explicitly
         instructed. Due to the inability to enforce expected Linux file ownership and
         permissions on the Windows system, Vagrant will not make modifications to prevent
-        unexpected errors. To learn more about this, and the options that are available,
+        unexpected errors. You can use nested virtualization within WSL2 by setting
+        the `VAGRANT_WSL_NESTED_VIRTUALIZATION` environment variable.
+        To learn more about this, and the options that are available,
         please refer to the Vagrant documentation:
 
           https://www.vagrantup.com/docs/other/wsl.html
       wsl_virtualbox_windows_access: |-
         Vagrant is unable to use the VirtualBox provider from the Windows Subsystem for
         Linux without access to the Windows environment. Enabling this access must be
-        done with caution and an understanding of the implications. For more information
-        on enabling Windows access and using VirtualBox from the Windows Subsystem for
-        Linux, please refer to the Vagrant documentation:
+        done with caution and an understanding of the implications.
+        You can use providers within WSL2 via nested virtualization by setting
+        the `VAGRANT_WSL_NESTED_VIRTUALIZATION` environment variable.
+        For more information on enabling Windows access and using VirtualBox from the
+        Windows Subsystem for Linux, please refer to the Vagrant documentation:
+          
 
           https://www.vagrantup.com/docs/other/wsl.html
       wsl_rootfs_not_found_error: |-


### PR DESCRIPTION
by setting the `VAGRANT_WSL_NESTED_VIRTUALIZATION` environment variable, users can set up vagrant as if they were running vagrant on a standard linux box. With the latest kernel for WSL2 in windows insiders edition, nested virtualization (and even native GUI support) are available. This allows users to use libvirt/kvm. Therefore this environment variable will allow people to set up vagrant to pretend it's not on WSL.