### PR TITLE
Website and Templates: Fix links to Ansible inventory user guide

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2882,7 +2882,7 @@ en:
           Vagrant has detected a host range pattern in the `groups` option.
           Vagrant doesn't fully check the validity of these parameters!
 
-          Please check https://docs.ansible.com/ansible/intro_inventory.html#hosts-and-groups
+          Please check https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#inventory-basics-formats-hosts-and-groups
           for more information.
         cannot_detect: |-
           Vagrant does not support detecting whether Ansible is installed

--- a/website/content/docs/provisioning/ansible_common.mdx
+++ b/website/content/docs/provisioning/ansible_common.mdx
@@ -99,7 +99,7 @@ Some of these options are for advanced usage only and should not be used unless 
   }
   ```
 
-  Example with [group variables](https://docs.ansible.com/ansible/intro_inventory.html#group-variables):
+  Example with [group variables](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#assigning-a-variable-to-many-machines-group-variables):
 
   ```ruby
   ansible.groups = {
@@ -114,7 +114,7 @@ Some of these options are for advanced usage only and should not be used unless 
   - Alphanumeric patterns are not supported (e.g. `db-[a:f]`, `vm[01:10]`).
   - This option has no effect when the `inventory_path` option is defined.
 
-- `host_vars` (hash) - Set of inventory host variables to be included in the [auto-generated inventory file](https://docs.ansible.com/ansible/intro_inventory.html#host-variables).
+- `host_vars` (hash) - Set of inventory host variables to be included in the [auto-generated inventory file](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#assigning-a-variable-to-one-machine-host-variables).
 
   Example:
 

--- a/website/content/docs/provisioning/ansible_intro.mdx
+++ b/website/content/docs/provisioning/ansible_intro.mdx
@@ -112,7 +112,7 @@ Note that the generated inventory file is uploaded to the guest VM in a subdirec
 
 #### Host Variables
 
-As of Vagrant 1.8.0, the [`host_vars`](/docs/provisioning/ansible_common#host_vars) option can be used to set [variables for individual hosts](https://docs.ansible.com/ansible/intro_inventory.html#host-variables) in the generated inventory file (see also the notes on group variables below).
+As of Vagrant 1.8.0, the [`host_vars`](/docs/provisioning/ansible_common#host_vars) option can be used to set [variables for individual hosts](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#assigning-a-variable-to-one-machine-host-variables) in the generated inventory file (see also the notes on group variables below).
 
 With this configuration example:
 
@@ -145,7 +145,7 @@ host2 ansible_ssh_host=... http_port=303 maxRequestsPerChild=909
 
 The [`groups`](/docs/provisioning/ansible_common#groups) option can be used to pass a hash of group names and group members to be included in the generated inventory file.
 
-As of Vagrant 1.8.0, it is also possible to specify [group variables](https://docs.ansible.com/ansible/intro_inventory.html#group-variables), and group members as [host ranges (with numeric or alphabetic patterns)](https://docs.ansible.com/ansible/intro_inventory.html#hosts-and-groups).
+As of Vagrant 1.8.0, it is also possible to specify [group variables](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#assigning-a-variable-to-many-machines-group-variables), and group members as [host ranges (with numeric or alphabetic patterns)](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#inventory-basics-formats-hosts-and-groups).
 
 With this configuration example:
 
@@ -217,7 +217,7 @@ variable2=example
   }
   ```
 
-- [Host range patterns (numeric and alphabetic ranges)](https://docs.ansible.com/ansible/intro_inventory.html#hosts-and-groups) will not be validated by Vagrant. As of Vagrant 1.8.0, host range patterns will be added as group members to the inventory anyway, this might lead to errors in Ansible (e.g _unreachable host_).
+- [Host range patterns (numeric and alphabetic ranges)](https://docs.ansible.com/ansible/latest/user_guide/intro_inventory.html#inventory-basics-formats-hosts-and-groups) will not be validated by Vagrant. As of Vagrant 1.8.0, host range patterns will be added as group members to the inventory anyway, this might lead to errors in Ansible (e.g _unreachable host_).
 
 ### Static Inventory
 


### PR DESCRIPTION
Page `https://docs.ansible.com/ansible/intro_inventory.html` has been moved and returns a 404. This PR fixes all references and updates the jump anchors as well.