### PR TITLE
Ensure expanded box url when adding local box has the form 'file:///'

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -56,7 +56,7 @@ module Vagrant
             # Expand the path and try to use that, if possible
             p = File.expand_path(@parser.unescape(u.gsub(/^file:\/\//, "")))
             p = Util::Platform.cygwin_windows_path(p)
-            next "file://#{@parser.escape(p.gsub("\\", "/"))}" if File.file?(p)
+            next "file:///#{@parser.escape(p.gsub("\\", "/"))}" if File.file?(p)
 
             u
           end


### PR DESCRIPTION
This ensures that the URI.parse step will correctly parse the box
url

fixes https://github.com/hashicorp/vagrant/issues/12340