### PR TITLE
Remove unsused &block in add_provider_config.

### DIFF
--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -85,7 +85,7 @@ module VagrantPlugins
       # Duplicates will be overriden
       #
       # @param [Hash] options
-      def add_provider_config(**options, &block)
+      def add_provider_config(**options)
         current = {}
         options.each do |k,v|
           opts = k.to_s.split("__")


### PR DESCRIPTION
Also AFAIK this is not valid with Ruby 3.0.