### PR TITLE
Fix compatibility with Ruby 3.0

### DIFF
--- a/test/unit/plugins/kernel_v2/config/disk_test.rb
+++ b/test/unit/plugins/kernel_v2/config/disk_test.rb
@@ -119,7 +119,7 @@ describe VagrantPlugins::Kernel_V2::VagrantConfigDisk do
   describe "#add_provider_config" do
     it "normalizes provider config" do
       test_provider_config = {provider__something: "special" }
-      subject.add_provider_config(test_provider_config)
+      subject.add_provider_config(**test_provider_config)
       expect(subject.provider_config).to eq( { provider: {something: "special" }} )
     end
   end


### PR DESCRIPTION
Currently it fails with Ruby 3.0:
```
  1) VagrantPlugins::Kernel_V2::VagrantConfigDisk#add_provider_config normalizes
provider config
     Failure/Error: subject.add_provider_config(test_provider_config)

     ArgumentError:
       wrong number of arguments (given 1, expected 0)
     # ./plugins/kernel_v2/config/disk.rb:88:in `add_provider_config'
     # ./test/unit/plugins/kernel_v2/config/disk_test.rb:122:in `block (3 levels)
in <top (required)>'
     # /usr/share/gems/gems/webmock-3.12.1/lib/webmock/rspec.rb:37:in `block (2
levels) in <top (required)>'
```