### PR TITLE
Add package manager override for brew install instructions

### DIFF
--- a/website/pages/downloads/index.jsx
+++ b/website/pages/downloads/index.jsx
@@ -46,6 +46,24 @@ export default function DownloadsPage(staticProps) {
           <a>&raquo; Download VMware Utility</a>
         </Link>
       }
+      packageManagerOverrides={[
+        {
+          label: 'Homebrew',
+          commands: [
+            `brew tap hashicorp/tap`,
+            `brew install ${productSlug}`,
+          ],
+          os: 'darwin',
+        },
+        {
+          label: 'Homebrew',
+          commands: [
+              `brew tap hashicorp/tap`,
+              `brew install ${productSlug}`,
+          ],
+          os: 'linux',
+      },
+      ]}
       {...staticProps}
     />
   )


### PR DESCRIPTION
ref:
https://github.com/hashicorp/homebrew-tap#what-packages-are-available

fixes: https://github.com/hashicorp/vagrant/issues/12349 and https://github.com/hashicorp/vagrant/issues/12354