### PR TITLE
Update "Default Router" shell script in publc_network.mdx documentation

### DIFF
--- a/website/content/docs/networking/public_network.mdx
+++ b/website/content/docs/networking/public_network.mdx
@@ -152,5 +152,18 @@ Vagrant.configure("2") do |config|
 end
 ```
 
-Note the above is fairly complex and may be guest OS specific, but we
+Or, an alternative, simpler version, assuming you get DHCP from your public network:
+
+```ruby
+Vagrant.configure("2") do |config|
+  config.vm.network "public_network"
+
+  # default router
+  config.vm.provision "shell",
+    run: "always",
+    inline: "ip route del default via 10.0.2.2 || true"
+end
+```
+
+Note the above are fairly complex and will be guest OS specific, but we
 document the rough idea of how to do it because it is a common question.


### PR DESCRIPTION
In more recent linux versions, if you receive a DHCP address from your `public_network` interface, it will "simply" add a new gateway to your list of possible routes. You can remove this using the `ip route del` command, as seen in this PR.