### PR TITLE
detects new versions of ansible-4.0.0+

### DIFF
--- a/plugins/provisioners/ansible/provisioner/base.rb
+++ b/plugins/provisioners/ansible/provisioner/base.rb
@@ -389,7 +389,7 @@ gathered version stdout version:
             if ansible_version_pattern
               _, @gathered_version, _ = ansible_version_pattern.captures
               if @gathered_version
-                @gathered_version_major = @gathered_version.match(/^(\d)\..+$/).captures[0].to_i
+                @gathered_version_major = @gathered_version.match(/(\d)\..+$/).captures[0].to_i
               end
             end
           end


### PR DESCRIPTION
Ansible has switched dependency between version 3.4.0 (ansible-base) and 4.0.0 (ansible-core), which now outputs new version scheme of "ansible [core 2.11.0]" instead of "ansible 2.10.9". This fix keeps old and new version detection working.