### PR TITLE
Escape spaces in SSH key_path

### DIFF
--- a/plugins/hosts/windows/cap/ssh.rb
+++ b/plugins/hosts/windows/cap/ssh.rb
@@ -10,7 +10,7 @@ module VagrantPlugins
         def self.set_ssh_key_permissions(env, key_path)
           script_path = Host.scripts_path.join("set_ssh_key_permissions.ps1")
           result = Vagrant::Util::PowerShell.execute(
-            script_path.to_s, "-KeyPath", key_path.to_s,
+            script_path.to_s, "-KeyPath", key_path.to_s.gsub(' ', '` '),
             module_path: Host.modules_path.to_s
           )
           if result.exit_code != 0


### PR DESCRIPTION
### Vagrant version

`Vagrant 2.2.16`

### Host operating system

`Windows 10, Version 21H1 (OS build 19043.1023)`

### Problem description

If Vagrant machine is located in directory where space is in the path, Vagrant fails to set permissions for generated SSH private key.

#### Before the change

`vagrant ssh` does not work:
```
PS D:\Vagrant Machines\debian_buster64> vagrant ssh
vagrant@127.0.0.1: Permission denied (publickey).
```
Direct SSH connection:
```
PS D:\Vagrant Machines\debian_buster64> ssh -p 2222 -i ".vagrant/machines/default/virtualbox/private_key" -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null vagrant@127.0.0.1
Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
@         WARNING: UNPROTECTED PRIVATE KEY FILE!          @
@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
Permissions for '.vagrant/machines/default/virtualbox/private_key' are too open.
It is required that your private key files are NOT accessible by others.
This private key will be ignored.
Load key ".vagrant/machines/default/virtualbox/private_key": bad permissions
vagrant@127.0.0.1: Permission denied (publickey).
```
SSH version used
```
PS D:\Vagrant Machines\debian_buster64> Get-Command ssh

CommandType     Name                                               Version    Source
-----------     ----                                               -------    ------
Application     ssh.exe                                            8.1.0.1    C:\WINDOWS\System32\OpenSSH\ssh.exe

PS D:\Vagrant Machines\debian_buster64> ssh -V
OpenSSH_for_Windows_8.1p1, LibreSSL 3.0.2
```
To identify the problem debug prints were added to `set_sss_key_permissions.ps1`:
```
KeyPath in set_sss_key_permissions.ps1: D:/Vagrant
Principal in set_sss_key_permissions.ps1: Machines/debian_buster64/.vagrant/machines/default/virtualbox/private_key
```

#### After the change

`vagrant ssh` works fine. In debug prints from `set_sss_key_permissions.ps1` following can be seen:
```
KeyPath in set_sss_key_permissions.ps1: D:/Vagrant Machines/debian_buster64/.vagrant/machines/default/virtualbox/private_key
Principal in set_sss_key_permissions.ps1: 
```