### PR TITLE
Update Hyper-V link.

### DIFF
--- a/website/content/docs/providers/index.mdx
+++ b/website/content/docs/providers/index.mdx
@@ -10,7 +10,7 @@ description: |-
 # Providers
 
 While Vagrant ships out of the box with support for [VirtualBox](https://www.virtualbox.org),
-[Hyper-V](https://www.microsoft.com/hyper-v), and [Docker](https://www.docker.io),
+[Hyper-V](https://en.wikipedia.org/wiki/Hyper-V), and [Docker](https://www.docker.io),
 Vagrant has the ability to manage other types of machines as well. This is done
 by using other _providers_ with Vagrant.
 


### PR DESCRIPTION
This brings it in line with the hyper-v overview page: https://github.com/hashicorp/vagrant/blob/main/website/content/docs/providers/hyperv/index.mdx