### PR TITLE
Allow newer net-scp version

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "mime-types", "~> 3.3"
   s.add_dependency "net-ssh", ">= 6.1.0", "< 6.2"
   s.add_dependency "net-sftp", "~> 3.0"
-  s.add_dependency "net-scp", "~> 1.2.0"
+  s.add_dependency "net-scp", ">= 1.2.0", "< 4.0"
   s.add_dependency "rb-kqueue", "~> 0.2.0"
   s.add_dependency "rubyzip", "~> 2.0"
   s.add_dependency "vagrant_cloud", "~> 3.0.4"


### PR DESCRIPTION
I've tested this in Fedora with net-scp 3.0 and it works fine, incl. the test suite. Are there any corner-cases I should test, specifically?

Test suite [*]: https://download.copr.fedorainfracloud.org/results/pvalena/vagrant/fedora-rawhide-x86_64/02225998-vagrant/builder-live.log.gz

Additional integration testing: https://git.io/JGMFw

[*] _Run as a part of Fedora build process, note that some tests are still failing after upgrading to Ruby 3.0._