### PR TITLE
Use more conservative TLS settings to work on older .NET versions

### DIFF
--- a/plugins/provisioners/salt/bootstrap-salt.ps1
+++ b/plugins/provisioners/salt/bootstrap-salt.ps1
@@ -1,5 +1,5 @@
-# Powershell supports only TLS 1.0 by default. Add support for TLS 1.2 and TLS 1.3
-[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls12,Tls13'
+# Powershell supports only TLS 1.0 by default. Add support for TLS 1.2
+[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]'Tls12'
 
 # Define script root for PowerShell 2.0
 $ScriptRoot = Split-Path $script:MyInvocation.MyCommand.Path


### PR DESCRIPTION
A follow-up fix for https://github.com/hashicorp/vagrant/pull/12127

Tls13 is only available on .NET Framework 4.8, so the settings should be more conservative to work on older Windows versions. Based on testing reports from other collaborators:

https://github.com/hashicorp/vagrant/pull/12127#issuecomment-855910966
https://github.com/hashicorp/vagrant/pull/12127#issuecomment-856883383

Thanks to @leon-kleyn, @dafyddj and msmith in Salt Slack community.