### PR TITLE
Update tests to use real UI instance

### DIFF
--- a/lib/vagrant/plugin/v2/trigger.rb
+++ b/lib/vagrant/plugin/v2/trigger.rb
@@ -271,7 +271,7 @@ module Vagrant
                 options[:color] = :red if !config.keep_color
               end
 
-              @ui.detail(data, options)
+              @ui.detail(data, **options)
             end
             if !exit_codes.include?(result.exit_code)
               raise Errors::TriggersBadExitCodes,

--- a/plugins/providers/docker/action/prepare_networks.rb
+++ b/plugins/providers/docker/action/prepare_networks.rb
@@ -171,8 +171,8 @@ module VagrantPlugins
               raise Errors::NetworkNoInterfaces
             elsif valid_interfaces.size == 1
               bridge_interface = valid_interfaces.first
-            elsif i = valid_interfaces.detect{|i| Array(root_options[:bridge]).include?(i.name) }
-              bridge_interface = i
+            elsif idx = valid_interfaces.detect{|i| Array(root_options[:bridge]).include?(i.name) }
+              bridge_interface = idx
             end
             if !bridge_interface
               env[:ui].info(I18n.t("vagrant.actions.vm.bridged_networking.available"),

--- a/plugins/provisioners/container/client.rb
+++ b/plugins/provisioners/container/client.rb
@@ -10,7 +10,7 @@ module VagrantPlugins
 
       # Build an image given a path to a Dockerfile
       #
-      # @param [String] - Path to the Dockerfile to pass to
+      # @param [Array<Array<String, Hash>>] - Path and options to the Dockerfile to pass to
       #   container build command
       def build_images(images)
         @machine.communicate.tap do |comm|
@@ -195,7 +195,7 @@ module VagrantPlugins
           options = {}
           #options[:color] = color if !config.keep_color
 
-          @machine.ui.info(data.chomp, options)
+          @machine.ui.info(data.chomp, **options)
         end
       end
     end

--- a/test/unit/plugins/commands/box/command/prune_test.rb
+++ b/test/unit/plugins/commands/box/command/prune_test.rb
@@ -67,16 +67,12 @@ describe VagrantPlugins::CommandBox::Command::Prune do
 
         iso_vagrant_env.machine_index.set(new_entry("foo", "foobox", "virtualbox", 1))
 
-        output = ""
-        allow(iso_vagrant_env.ui).to receive(:info) do |data|
-          output << data
-        end
+        allow(iso_vagrant_env.ui).to receive(:info).and_call_original
+        expect(iso_vagrant_env.ui).to receive(:info).with(/No old versions of boxes/).
+          and_call_original
         expect(iso_vagrant_env.boxes.all.count).to eq(2)
         expect(subject.execute).to eq(0)
         expect(iso_vagrant_env.boxes.all.count).to eq(2)
-
-        expect(output).to include("No old versions of boxes to remove...")
-
       end
     end
 

--- a/test/unit/plugins/commands/cloud/auth/middleware/add_authentication_test.rb
+++ b/test/unit/plugins/commands/cloud/auth/middleware/add_authentication_test.rb
@@ -21,7 +21,6 @@ describe VagrantPlugins::CloudCommand::AddAuthentication do
 
   before do
     allow(Vagrant).to receive(:server_url).and_return(server_url)
-    allow(ui).to receive(:warn)
     allow(VagrantPlugins::CloudCommand::Client).to receive(:new).
       with(iso_env).and_return(client)
     stub_env("ATLAS_TOKEN" => nil)
@@ -123,7 +122,7 @@ describe VagrantPlugins::CloudCommand::AddAuthentication do
         expected[3] = expected[3] + "?access_token=#{token}"
 
         expect(subject).to receive(:sleep).once
-        expect(ui).to receive(:warn).once
+        expect(ui).to receive(:warn).once.and_call_original
 
         env[:box_urls] = original.dup
         subject.call(env)

--- a/test/unit/plugins/commands/cloud/auth/middleware/add_downloader_authentication_test.rb
+++ b/test/unit/plugins/commands/cloud/auth/middleware/add_downloader_authentication_test.rb
@@ -21,7 +21,6 @@ describe VagrantPlugins::CloudCommand::AddDownloaderAuthentication do
 
   before do
     allow(Vagrant).to receive(:server_url).and_return(server_url)
-    allow(ui).to receive(:warn)
     stub_env("ATLAS_TOKEN" => nil)
     stub_env("VAGRANT_SERVER_ACCESS_TOKEN_BY_URL" => nil)
   end
@@ -59,7 +58,7 @@ describe VagrantPlugins::CloudCommand::AddDownloaderAuthentication do
         VagrantPlugins::CloudCommand::Client.new(iso_env).store_token(token)
 
         expect(subject).to receive(:sleep).once
-        expect(ui).to receive(:warn).once
+        expect(ui).to receive(:warn).once.and_call_original
 
         env[:downloader] = dwnloader
         subject.call(env)

--- a/test/unit/plugins/commands/cloud/box/create_test.rb
+++ b/test/unit/plugins/commands/cloud/box/create_test.rb
@@ -19,10 +19,6 @@ describe VagrantPlugins::CloudCommand::BoxCommand::Command::Create do
     let(:argv) { [] }
 
     before do
-      allow(ui).to receive(:info)
-      allow(ui).to receive(:warn)
-      allow(ui).to receive(:success)
-      allow(ui).to receive(:error)
       allow(env).to receive(:ui).and_return(ui)
       allow(VagrantCloud::Account).to receive(:new).
         with(custom_server: anything, access_token: access_token).

--- a/test/unit/plugins/commands/cloud/box/delete_test.rb
+++ b/test/unit/plugins/commands/cloud/box/delete_test.rb
@@ -19,10 +19,6 @@ describe VagrantPlugins::CloudCommand::BoxCommand::Command::Delete do
     let(:argv) { [] }
 
     before do
-      allow(ui).to receive(:info)
-      allow(ui).to receive(:warn)
-      allow(ui).to receive(:success)
-      allow(ui).to receive(:error)
       allow(env).to receive(:ui).and_return(ui)
       allow(VagrantCloud::Account).to receive(:new).
         with(custom_server: anything, access_token: access_token).

--- a/test/unit/plugins/commands/cloud/box/show_test.rb
+++ b/test/unit/plugins/commands/cloud/box/show_test.rb
@@ -19,11 +19,6 @@ describe VagrantPlugins::CloudCommand::BoxCommand::Command::Show do
     let(:argv) { [] }
 
     before do
-      allow(ui).to receive(:info)
-      allow(ui).to receive(:warn)
-      allow(ui).to receive(:success)
-      allow(ui).to receive(:error)
-      allow(ui).to receive(:output)
       allow(env).to receive(:ui).and_return(ui)
       allow(VagrantCloud::Account).to receive(:new).
         with(custom_server: anything, access_token: access_token).

--- a/test/unit/plugins/commands/cloud/box/update_test.rb
+++ b/test/unit/plugins/commands/cloud/box/update_test.rb
@@ -18,10 +18,6 @@ describe VagrantPlugins::CloudCommand::BoxCommand::Command::Update do
     let(:argv) { [] }
 
     before do
-      allow(ui).to receive(:info)
-      allow(ui).to receive(:warn)
-      allow(ui).to receive(:success)
-      allow(ui).to receive(:error)
       allow(env).to receive(:ui).and_return(ui)
       allow(VagrantCloud::Account).to receive(:new).
         with(custom_server: anything, access_token: access_token).

--- a/test/unit/plugins/commands/cloud/provider/create_test.rb
+++ b/test/unit/plugins/commands/cloud/provider/create_test.rb
@@ -23,10 +23,6 @@ describe VagrantPlugins::CloudCommand::ProviderCommand::Command::Create do
     let(:argv) { [] }
 
     before do
-      allow(ui).to receive(:info)
-      allow(ui).to receive(:warn)
-      allow(ui).to receive(:success)
-      allow(ui).to receive(:error)
       allow(env).to receive(:ui).and_return(ui)
       allow(VagrantCloud::Account).to receive(:new).
         with(custom_server: anything, access_token: access_token).

--- a/test/unit/plugins/commands/cloud/provider/delete_test.rb
+++ b/test/unit/plugins/commands/cloud/provider/delete_test.rb
@@ -22,10 +22,6 @@ describe VagrantPlugins::CloudCommand::ProviderCommand::Command::Delete do
     let(:argv) { [] }
 
     before do
-      allow(ui).to receive(:info)
-      allow(ui).to receive(:warn)
-      allow(ui).to receive(:success)
-      allow(ui).to receive(:error)
       allow(env).to receive(:ui).and_return(ui)
       allow(VagrantCloud::Account).to receive(:new).
         with(custom_server: anything, access_token: access_token).

--- a/test/unit/plugins/commands/cloud/provider/update_test.rb
+++ b/test/unit/plugins/commands/cloud/provider/update_test.rb
@@ -23,10 +23,6 @@ describe VagrantPlugins::CloudCommand::ProviderCommand::Command::Update do
     let(:ui) { Vagrant::UI::Silent.new }
 
     before do
-      allow(ui).to receive(:info)
-      allow(ui).to receive(:warn)
-      allow(ui).to receive(:success)
-      allow(ui).to receive(:error)
       allow(env).to receive(:ui).and_return(ui)
       allow(VagrantCloud::Account).to receive(:new).
         with(custom_server: anything, access_token: access_token).

--- a/test/unit/plugins/commands/cloud/provider/upload_test.rb
+++ b/test/unit/plugins/commands/cloud/provider/upload_test.rb
@@ -26,11 +26,6 @@ describe VagrantPlugins::CloudCommand::ProviderCommand::Command::Upload do
     let(:uploader) { double("uploader") }
 
     before do
-      allow(ui).to receive(:info)
-      allow(ui).to receive(:output)
-      allow(ui).to receive(:warn)
-      allow(ui).to receive(:success)
-      allow(ui).to receive(:error)
       allow(I18n).to receive(:t)
       allow(env).to receive(:ui).and_return(ui)
       allow(VagrantCloud::Account).to receive(:new).

--- a/test/unit/plugins/commands/cloud/publish_test.rb
+++ b/test/unit/plugins/commands/cloud/publish_test.rb
@@ -21,10 +21,6 @@ describe VagrantPlugins::CloudCommand::Command::Publish do
   subject { described_class.new(argv, iso_env) }
 
   before do
-    allow(ui).to receive(:info)
-    allow(ui).to receive(:warn)
-    allow(ui).to receive(:success)
-    allow(ui).to receive(:error)
     allow(iso_env).to receive(:ui).and_return(ui)
     allow(File).to receive(:stat).with(box).
       and_return(double("box_stat", size: box_size))

--- a/test/unit/plugins/commands/cloud/version/create_test.rb
+++ b/test/unit/plugins/commands/cloud/version/create_test.rb
@@ -20,10 +20,6 @@ describe VagrantPlugins::CloudCommand::VersionCommand::Command::Create do
     let(:argv) { [] }
 
     before do
-      allow(ui).to receive(:info)
-      allow(ui).to receive(:warn)
-      allow(ui).to receive(:success)
-      allow(ui).to receive(:error)
       allow(env).to receive(:ui).and_return(ui)
       allow(VagrantCloud::Account).to receive(:new).
         with(custom_server: anything, access_token: access_token).

--- a/test/unit/plugins/commands/cloud/version/delete_test.rb
+++ b/test/unit/plugins/commands/cloud/version/delete_test.rb
@@ -20,10 +20,6 @@ describe VagrantPlugins::CloudCommand::VersionCommand::Command::Delete do
     let(:argv) { [] }
 
     before do
-      allow(ui).to receive(:info)
-      allow(ui).to receive(:warn)
-      allow(ui).to receive(:success)
-      allow(ui).to receive(:error)
       allow(env).to receive(:ui).and_return(ui)
       allow(VagrantCloud::Account).to receive(:new).
         with(custom_server: anything, access_token: access_token).

--- a/test/unit/plugins/commands/cloud/version/release_test.rb
+++ b/test/unit/plugins/commands/cloud/version/release_test.rb
@@ -20,10 +20,6 @@ describe VagrantPlugins::CloudCommand::VersionCommand::Command::Release do
     let(:argv) { [] }
 
     before do
-      allow(ui).to receive(:info)
-      allow(ui).to receive(:warn)
-      allow(ui).to receive(:success)
-      allow(ui).to receive(:error)
       allow(env).to receive(:ui).and_return(ui)
       allow(VagrantCloud::Account).to receive(:new).
         with(custom_server: anything, access_token: access_token).

--- a/test/unit/plugins/commands/cloud/version/revoke_test.rb
+++ b/test/unit/plugins/commands/cloud/version/revoke_test.rb
@@ -20,10 +20,6 @@ describe VagrantPlugins::CloudCommand::VersionCommand::Command::Revoke do
     let(:argv) { [] }
 
     before do
-      allow(ui).to receive(:info)
-      allow(ui).to receive(:warn)
-      allow(ui).to receive(:success)
-      allow(ui).to receive(:error)
       allow(env).to receive(:ui).and_return(ui)
       allow(VagrantCloud::Account).to receive(:new).
         with(custom_server: anything, access_token: access_token).

--- a/test/unit/plugins/commands/cloud/version/update_test.rb
+++ b/test/unit/plugins/commands/cloud/version/update_test.rb
@@ -20,10 +20,6 @@ describe VagrantPlugins::CloudCommand::VersionCommand::Command::Update do
     let(:argv) { [] }
 
     before do
-      allow(ui).to receive(:info)
-      allow(ui).to receive(:warn)
-      allow(ui).to receive(:success)
-      allow(ui).to receive(:error)
       allow(env).to receive(:ui).and_return(ui)
       allow(VagrantCloud::Account).to receive(:new).
         with(custom_server: anything, access_token: access_token).

--- a/test/unit/plugins/commands/port/command_test.rb
+++ b/test/unit/plugins/commands/port/command_test.rb
@@ -54,18 +54,16 @@ describe VagrantPlugins::CommandPort::Command do
 
     it "ensures the vm is running" do
       allow(state).to receive(:id).and_return(:stopped)
-      expect(env.ui).to receive(:error).with(any_args) { |message, _|
-        expect(message).to include("does not support listing forwarded ports")
-      }
+      expect(env.ui).to receive(:error).with(/does not support listing forwarded ports/).
+        and_call_original
 
       expect(subject.execute).to eq(1)
     end
 
     it "shows a friendly error when the capability is not supported" do
       allow(machine.provider).to receive(:capability?).and_return(false)
-      expect(env.ui).to receive(:error).with(any_args) { |message, _|
-        expect(message).to include("does not support listing forwarded ports")
-      }
+      expect(env.ui).to receive(:error).with(/does not support listing forwarded ports/).
+        and_call_original
 
       expect(subject.execute).to eq(1)
     end
@@ -75,9 +73,8 @@ describe VagrantPlugins::CommandPort::Command do
       allow(machine.provider).to receive(:capability).with(:forwarded_ports)
         .and_return([])
 
-      expect(env.ui).to receive(:info).with(any_args) { |message, _|
-        expect(message).to include("there are no forwarded ports")
-      }
+      expect(env.ui).to receive(:info).with(/there are no forwarded ports/).
+        and_call_original
 
       expect(subject.execute).to eq(0)
     end
@@ -125,14 +122,10 @@ describe VagrantPlugins::CommandPort::Command do
       allow(machine.provider).to receive(:capability).with(:forwarded_ports)
         .and_return([[2222,22]])
 
-      output = ""
-      allow(env.ui).to receive(:error) do |data|
-        output << data
-      end
+      expect(env.ui).to receive(:error).with(/not currently mapping port 80/).
+        and_call_original
 
       expect(subject.execute).to_not eq(0)
-
-      expect(output).to include("not currently mapping port 80")
     end
   end
 end

--- a/test/unit/plugins/commands/snapshot/command/list_test.rb
+++ b/test/unit/plugins/commands/snapshot/command/list_test.rb
@@ -52,8 +52,8 @@ describe VagrantPlugins::CommandSnapshot::Command::List do
       it "prints a message if the vm does not exist" do
         machine.id = nil
 
-        expect(iso_env.ui).to receive(:info).with("==> default: VM not created. Moving on...", anything)
-          .and_return({})
+        expect(iso_env.ui).to receive(:info).with("==> default: VM not created. Moving on...", anything).
+          and_call_original
         expect(machine).to_not receive(:action)
         expect(subject.execute).to eq(0)
       end
@@ -61,7 +61,7 @@ describe VagrantPlugins::CommandSnapshot::Command::List do
       it "prints a message if no snapshots have been taken" do
         machine.id = "foo"
 
-        expect(iso_env.ui).to receive(:output)
+        expect(iso_env.ui).to receive(:output).and_call_original
           .with(/No snapshots have been taken yet!/, anything)
         expect(subject.execute).to eq(0)
       end
@@ -72,9 +72,9 @@ describe VagrantPlugins::CommandSnapshot::Command::List do
         allow(machine.provider).to receive(:capability).with(:snapshot_list).
           and_return(["foo", "bar", "baz"])
 
-        expect(iso_env.ui).to receive(:output).with(/default/, anything)
-        expect(iso_env.ui).to receive(:detail).with(/foo/, anything)
-        expect(iso_env.ui).to receive(:detail).with(/bar/, anything)
+        expect(iso_env.ui).to receive(:output).with(/default/, anything).and_call_original
+        expect(iso_env.ui).to receive(:detail).with(/foo/, anything).and_call_original
+        expect(iso_env.ui).to receive(:detail).with(/bar/, anything).and_call_original
         expect(iso_env.ui).to receive(:detail).with(/baz/, anything)
         expect(subject.execute).to eq(0)
       end

--- a/test/unit/plugins/communicators/winrm/communicator_test.rb
+++ b/test/unit/plugins/communicators/winrm/communicator_test.rb
@@ -8,7 +8,7 @@ describe VagrantPlugins::CommunicatorWinRM::Communicator do
   let(:winrm) { double("winrm", timeout: 1, host: nil, port: 5986, guest_port: 5986) }
   let(:config) { double("config", winrm: winrm) }
   let(:provider) { double("provider") }
-  let(:ui) { double("ui") }
+  let(:ui) { Vagrant::UI::Silent.new }
   let(:machine) { double("machine", config: config, provider: provider, ui: ui) }
   let(:shell) { double("shell") }
   let(:good_output) { WinRM::Output.new.tap { |out| out.exitcode = 0 } }
@@ -33,7 +33,6 @@ describe VagrantPlugins::CommunicatorWinRM::Communicator do
         allow(provider).to receive(:capability?).with(:winrm_info).and_return(false)
 
         # Get us through the detail prints
-        allow(ui).to receive(:detail)
         allow(shell).to receive(:host)
         allow(shell).to receive(:port)
         allow(shell).to receive(:username)

--- a/test/unit/plugins/communicators/winssh/communicator_test.rb
+++ b/test/unit/plugins/communicators/winssh/communicator_test.rb
@@ -33,8 +33,7 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
   let(:config) { double("config", winssh: winssh, ssh: ssh) }
   # Provider mock
   let(:provider) { double("provider") }
-  # UI mock
-  let(:ui) { double("ui") }
+  let(:ui) { Vagrant::UI::Silent.new }
   # SSH info mock
   let(:ssh_info) { double("ssh_info") }
   # Machine mock built with previously defined
@@ -111,10 +110,6 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
   describe "#wait_for_ready" do
     before(&connection_setup)
     context "with no static config (default scenario)" do
-      before do
-        allow(ui).to receive(:detail)
-      end
-
       context "when ssh_info requires a multiple tries before it is ready" do
         before do
           expect(machine).to receive(:ssh_info).

--- a/test/unit/plugins/guests/freebsd/cap/mount_virtual_box_shared_folder_test.rb
+++ b/test/unit/plugins/guests/freebsd/cap/mount_virtual_box_shared_folder_test.rb
@@ -152,9 +152,8 @@ describe "VagrantPlugins::GuestFreeBSD::Cap::MountVirtualBoxSharedFolder" do
 
     context "with custom mount options" do
 
-      let(:ui){ double(:ui) }
+      let(:ui){ Vagrant::UI::Silent.new }
       before do
-        allow(ui).to receive(:warn)
         allow(machine).to receive(:ui).and_return(ui)
       end
 

--- a/test/unit/plugins/guests/linux/cap/persist_mount_shared_folder_test.rb
+++ b/test/unit/plugins/guests/linux/cap/persist_mount_shared_folder_test.rb
@@ -48,11 +48,10 @@ describe "VagrantPlugins::GuestLinux::Cap::PersistMountSharedFolder" do
 
   describe ".persist_mount_shared_folder" do
 
-    let(:ui){ double(:ui) }
+    let(:ui){ Vagrant::UI::Silent.new }
 
     before do
       allow(comm).to receive(:sudo).with(any_args)
-      allow(ui).to receive(:warn)
       allow(machine).to receive(:ui).and_return(ui)
     end
 
@@ -101,7 +100,7 @@ describe "VagrantPlugins::GuestLinux::Cap::PersistMountSharedFolder" do
         cap.persist_mount_shared_folder(machine, nil)
       end
     end
-   
+
     context "smb folder" do
       let (:fstab_folders) {
         Vagrant::Plugin::V2::SyncedFolder::Collection[
@@ -123,13 +122,13 @@ describe "VagrantPlugins::GuestLinux::Cap::PersistMountSharedFolder" do
           allow(folder_plugin).to receive(:capability?).with(:mount_name).and_return(true)
           allow(folder_plugin).to receive(:capability).with(:mount_name, instance_of(String), any_args).and_return("//192.168.42.42/dummyname")
         end
-      
+
         it "inserts folders into /etc/fstab" do
           expected_entry_vagrant = "//192.168.42.42/dummyname /vagrant cifs #{expected_mount_options} 0 0"
           expected_entry_test = "//192.168.42.42/dummyname /test1 cifs #{expected_mount_options} 0 0"
           expect(cap).to receive(:remove_vagrant_managed_fstab)
           expect(comm).to receive(:sudo).with(/#{expected_entry_test}\n#{expected_entry_vagrant}/)
-    
+
           cap.persist_mount_shared_folder(machine, folders)
         end
       end

--- a/test/unit/plugins/guests/linux/cap/reboot_test.rb
+++ b/test/unit/plugins/guests/linux/cap/reboot_test.rb
@@ -18,7 +18,6 @@ describe "VagrantPlugins::GuestLinux::Cap::Reboot" do
       allow(machine).to receive(:guest).and_return(guest)
       allow(machine.guest).to receive(:ready?).and_return(true)
       allow(machine).to receive(:ui).and_return(ui)
-      allow(ui).to receive(:info)
       allow(communicator).to receive(:test).and_return(false)
     end
 
@@ -45,7 +44,7 @@ describe "VagrantPlugins::GuestLinux::Cap::Reboot" do
         after { described_class.reboot(machine) }
 
         it "sends message to user that guest is rebooting" do
-          expect(ui).to receive(:info)
+          expect(ui).to receive(:info).and_call_original
         end
       end
     end
@@ -56,7 +55,6 @@ describe "VagrantPlugins::GuestLinux::Cap::Reboot" do
         allow(machine).to receive(:guest).and_return(guest)
         allow(machine.guest).to receive(:ready?).and_return(true)
         allow(machine).to receive(:ui).and_return(ui)
-        allow(ui).to receive(:info)
         allow(communicator).to receive(:test).and_return(true)
       end
 

--- a/test/unit/plugins/guests/windows/cap/reboot_test.rb
+++ b/test/unit/plugins/guests/windows/cap/reboot_test.rb
@@ -19,7 +19,6 @@ describe "VagrantPlugins::GuestWindows::Cap::Reboot" do
     allow(machine.guest).to receive(:ready?).and_return(true)
     allow(machine).to receive(:config).and_return(config)
     allow(config).to receive(:vm).and_return(vm)
-    allow(ui).to receive(:info)
   end
 
   describe ".reboot" do
@@ -47,7 +46,7 @@ describe "VagrantPlugins::GuestWindows::Cap::Reboot" do
 
       it "sends message to user that guest is rebooting" do
         expect(communicator).to receive(:test).and_return(true)
-        expect(ui).to receive(:info)
+        expect(ui).to receive(:info).and_call_original
       end
     end
 

--- a/test/unit/plugins/hosts/bsd/cap/nfs_test.rb
+++ b/test/unit/plugins/hosts/bsd/cap/nfs_test.rb
@@ -20,7 +20,6 @@ describe VagrantPlugins::HostBSD::Cap::NFS do
       allow(described_class).to receive(:nfs_cleanup)
       allow(described_class).to receive(:system)
       allow(File).to receive(:writable?).with("/etc/exports")
-      allow(ui).to receive(:info)
 
       allow(Vagrant::Util::Subprocess).to receive(:execute).with("nfsd", "checkexports").
         and_return(Vagrant::Util::Subprocess::Result.new(0, "", ""))

--- a/test/unit/plugins/hosts/linux/cap/nfs_test.rb
+++ b/test/unit/plugins/hosts/linux/cap/nfs_test.rb
@@ -17,7 +17,7 @@ describe VagrantPlugins::HostLinux::Cap::NFS do
   end
   let(:exports_path){ VagrantPlugins::HostLinux::Cap::NFS::NFS_EXPORTS_PATH }
   let(:env){ double(:env) }
-  let(:ui){ double(:ui) }
+  let(:ui){ Vagrant::UI::Silent.new }
   let(:host){ double(:host) }
 
   before do
@@ -125,7 +125,6 @@ describe VagrantPlugins::HostLinux::Cap::NFS do
       allow(host).to receive(:capability).with(:nfs_apply_command).and_return("/bin/true")
       allow(host).to receive(:capability).with(:nfs_check_command).and_return("/bin/true")
       allow(host).to receive(:capability).with(:nfs_start_command).and_return("/bin/true")
-      allow(ui).to receive(:info)
       allow(Vagrant::Util::Subprocess).to receive(:execute).and_call_original
       allow(Vagrant::Util::Subprocess).to receive(:execute).with("sudo", "/bin/true").and_return(double(:result, exit_code: 0))
       allow(Vagrant::Util::Subprocess).to receive(:execute).with("/bin/true").and_return(double(:result, exit_code: 0))
@@ -206,7 +205,6 @@ EOH
     let(:cap){ caps.get(:nfs_prune) }
 
     before do
-      allow(ui).to receive(:info)
       allow(Vagrant::Util::Subprocess).to receive(:execute).with("mv", any_args).
         and_call_original
     end

--- a/test/unit/plugins/hosts/windows/cap/smb_test.rb
+++ b/test/unit/plugins/hosts/windows/cap/smb_test.rb
@@ -4,7 +4,7 @@ require_relative "../../../../../../plugins/hosts/windows/cap/smb"
 
 describe VagrantPlugins::HostWindows::Cap::SMB do
   let(:subject){ VagrantPlugins::HostWindows::Cap::SMB }
-  let(:machine){ double(:machine, env: double(:machine_env, ui: double(:ui))) }
+  let(:machine){ double(:machine, env: double(:machine_env, ui: Vagrant::UI::Silent.new)) }
   let(:env){ double(:env) }
   let(:options){ {} }
   let(:result){ Vagrant::Util::Subprocess::Result }
@@ -62,7 +62,6 @@ Remark     Not Vagrant Owned
     allow(subject).to receive(:machine_id).and_return("CUSTOM_ID")
     allow(Vagrant::Util::PowerShell).to receive(:version).and_return(powershell_version)
     allow(Vagrant::Util::PowerShell).to receive(:execute_cmd).and_return("")
-    allow(machine.env.ui).to receive(:warn)
     allow(subject).to receive(:sleep)
   end
 
@@ -103,7 +102,7 @@ Remark     Not Vagrant Owned
     after{ subject.smb_cleanup(env, machine, options) }
 
     it "should pause after warning user" do
-      expect(machine.env.ui).to receive(:warn)
+      expect(machine.env.ui).to receive(:warn).and_call_original
       expect(subject).to receive(:sleep)
     end
 
@@ -184,7 +183,7 @@ Remark     Not Vagrant Owned
     end
 
     it "should pause after warning user" do
-      expect(machine.env.ui).to receive(:warn)
+      expect(machine.env.ui).to receive(:warn).and_call_original
       expect(subject).to receive(:sleep)
       subject.smb_prepare(env, machine, folders, options)
     end

--- a/test/unit/plugins/providers/hyperv/action/check_enabled_test.rb
+++ b/test/unit/plugins/providers/hyperv/action/check_enabled_test.rb
@@ -11,8 +11,6 @@ describe VagrantPlugins::HyperV::Action::CheckEnabled do
   let(:machine){ double("machine", provider: provider) }
   let(:subject){ described_class.new(app, env) }
 
-  before{ allow(ui).to receive(:output) }
-
   it "should continue when Hyper-V is enabled" do
     expect(driver).to receive(:execute).and_return("result" => true)
     expect(app).to receive(:call)

--- a/test/unit/plugins/providers/hyperv/action/configure_test.rb
+++ b/test/unit/plugins/providers/hyperv/action/configure_test.rb
@@ -41,8 +41,6 @@ describe VagrantPlugins::HyperV::Action::Configure do
     allow(driver).to receive(:execute)
     allow(app).to receive(:call)
     expect(driver).to receive(:execute).with(:get_switches).and_return(switches)
-    allow(ui).to receive(:detail)
-    allow(ui).to receive(:output)
     allow(ui).to receive(:ask).and_return("1")
     allow(data_dir).to receive(:join).and_return(sentinel)
     allow(sentinel).to receive(:file?).and_return(false)

--- a/test/unit/plugins/providers/hyperv/action/delete_vm_test.rb
+++ b/test/unit/plugins/providers/hyperv/action/delete_vm_test.rb
@@ -13,7 +13,6 @@ describe VagrantPlugins::HyperV::Action::DeleteVM do
 
   before do
     allow(app).to receive(:call)
-    allow(ui).to receive(:info)
     allow(driver).to receive(:delete_vm)
     allow(FileUtils).to receive(:rm_rf)
     allow(FileUtils).to receive(:mkdir_p)

--- a/test/unit/plugins/providers/hyperv/action/export_test.rb
+++ b/test/unit/plugins/providers/hyperv/action/export_test.rb
@@ -16,9 +16,6 @@ describe VagrantPlugins::HyperV::Action::Export do
 
   before do
     allow(app).to receive(:call)
-    allow(ui).to receive(:info)
-    allow(ui).to receive(:clear_line)
-    allow(ui).to receive(:report_progress)
     allow(driver).to receive(:export)
   end
 

--- a/test/unit/plugins/providers/hyperv/action/import_test.rb
+++ b/test/unit/plugins/providers/hyperv/action/import_test.rb
@@ -36,8 +36,6 @@ describe VagrantPlugins::HyperV::Action::Import do
     allow(data_dir).to receive(:to_s).and_return("DATA_DIR_PATH")
     allow(driver).to receive(:import).and_return("id" => "VMID")
     allow(machine).to receive(:id=)
-    allow(ui).to receive(:output)
-    allow(ui).to receive(:detail)
   end
 
   context "with missing virtual machines directory" do

--- a/test/unit/plugins/providers/hyperv/action/net_set_mac_test.rb
+++ b/test/unit/plugins/providers/hyperv/action/net_set_mac_test.rb
@@ -14,7 +14,6 @@ describe VagrantPlugins::HyperV::Action::NetSetMac do
   let(:subject){ described_class.new(app, env) }
 
   before do
-    allow(ui).to receive(:info)
     allow(driver).to receive(:net_set_mac)
     allow(app).to receive(:call)
   end

--- a/test/unit/plugins/providers/hyperv/action/net_set_vlan_test.rb
+++ b/test/unit/plugins/providers/hyperv/action/net_set_vlan_test.rb
@@ -14,7 +14,6 @@ describe VagrantPlugins::HyperV::Action::NetSetVLan do
   let(:subject){ described_class.new(app, env) }
 
   before do
-    allow(ui).to receive(:info)
     allow(driver).to receive(:net_set_vlan)
     allow(app).to receive(:call)
   end

--- a/test/unit/plugins/providers/hyperv/action/set_name_test.rb
+++ b/test/unit/plugins/providers/hyperv/action/set_name_test.rb
@@ -17,7 +17,6 @@ describe VagrantPlugins::HyperV::Action::SetName do
   let(:subject){ described_class.new(app, env) }
 
   before do
-    allow(ui).to receive(:info)
     allow(driver).to receive(:set_name)
     allow(app).to receive(:call)
     allow(data_dir).to receive(:join).and_return(sentinel)

--- a/test/unit/plugins/providers/hyperv/action/wait_for_ip_address_test.rb
+++ b/test/unit/plugins/providers/hyperv/action/wait_for_ip_address_test.rb
@@ -15,8 +15,6 @@ describe VagrantPlugins::HyperV::Action::WaitForIPAddress do
   let(:subject){ described_class.new(app, env) }
 
   before do
-    allow(ui).to receive(:output)
-    allow(ui).to receive(:detail)
     allow(driver).to receive(:read_guest_ip).and_return("ip" => "127.0.0.1")
     allow(app).to receive(:call)
   end

--- a/test/unit/plugins/providers/virtualbox/action/match_mac_address_test.rb
+++ b/test/unit/plugins/providers/virtualbox/action/match_mac_address_test.rb
@@ -16,7 +16,6 @@ describe VagrantPlugins::ProviderVirtualBox::Action::MatchMACAddress do
   let(:subject) { described_class.new(app, env) }
 
   before do
-    allow(ui).to receive(:info)
     allow(app).to receive(:call)
   end
 

--- a/test/unit/plugins/providers/virtualbox/cap/mount_options_test.rb
+++ b/test/unit/plugins/providers/virtualbox/cap/mount_options_test.rb
@@ -129,9 +129,8 @@ describe "VagrantPlugins::ProviderVirtualBox::Cap::MountOptions" do
     end
 
     context "with custom mount options" do
-      let(:ui){ double(:ui) }
+      let(:ui){ Vagrant::UI::Silent.new }
       before do
-        allow(ui).to receive(:warn)
         allow(machine).to receive(:ui).and_return(ui)
       end
 

--- a/test/unit/plugins/providers/virtualbox/synced_folder_test.rb
+++ b/test/unit/plugins/providers/virtualbox/synced_folder_test.rb
@@ -59,7 +59,7 @@ describe VagrantPlugins::ProviderVirtualBox::SyncedFolder do
   end
 
   describe "#enable" do
-    let(:ui){ double(:ui) }
+    let(:ui){ Vagrant::UI::Silent.new }
     let(:guest) { double("guest") }
 
     let(:no_guestpath_folder) { {"/no_guestpath_folder"=>
@@ -72,8 +72,6 @@ describe VagrantPlugins::ProviderVirtualBox::SyncedFolder do
 
     before do
       allow(subject).to receive(:share_folders).and_return(true)
-      allow(ui).to receive(:detail).with(any_args)
-      allow(ui).to receive(:output).with(any_args)
       allow(machine).to receive(:ui).and_return(ui)
       allow(machine).to receive(:ssh_info).and_return({:username => "test"})
       allow(machine).to receive(:guest).and_return(guest)
@@ -226,7 +224,6 @@ describe VagrantPlugins::ProviderVirtualBox::SyncedFolder do
         allow(env.data_dir).to receive(:join).and_return(gate_file)
         allow(gate_file).to receive(:exist?).and_return(false)
         allow(FileUtils).to receive(:touch)
-        allow(env.ui).to receive(:warn)
       end
 
       it "should create file" do
@@ -234,7 +231,7 @@ describe VagrantPlugins::ProviderVirtualBox::SyncedFolder do
       end
 
       it "should output warning to user" do
-        expect(env.ui).to receive(:warn)
+        expect(env.ui).to receive(:warn).and_call_original
       end
     end
 
@@ -243,7 +240,6 @@ describe VagrantPlugins::ProviderVirtualBox::SyncedFolder do
         allow(env.data_dir).to receive(:join).and_return(gate_file)
         allow(gate_file).to receive(:exist?).and_return(true)
         allow(FileUtils).to receive(:touch)
-        allow(env.ui).to receive(:warn)
       end
 
       it "should not create/update file" do
@@ -251,7 +247,7 @@ describe VagrantPlugins::ProviderVirtualBox::SyncedFolder do
       end
 
       it "should not output warning to user" do
-        expect(env.ui).not_to receive(:warn)
+        expect(env.ui).not_to receive(:warn).and_call_original
       end
     end
   end

--- a/test/unit/plugins/provisioners/container/client_test.rb
+++ b/test/unit/plugins/provisioners/container/client_test.rb
@@ -3,15 +3,53 @@ require File.expand_path("../../../../base", __FILE__)
 require Vagrant.source_root.join("plugins/provisioners/container/client")
 
 describe VagrantPlugins::ContainerProvisioner::Client do
-  
-  let(:machine) { double("machine") }
-  let(:container_command) { double("docker") }
+
+  let(:machine) { double("machine", communicate: communicator, ui: ui) }
+  let(:ui) { Vagrant::UI::Silent.new }
+  let(:communicator) { double("communicator") }
+  let(:container_command) { "CONTAINER_COMMAND" }
   subject { described_class.new(machine, container_command) }
 
   describe "#container_name" do
     it "converts a container name to a run appropriate form" do
       config = { :name => "test/test:1.1.1", :original_name => "test/test:1.1.1" }
       expect(subject.container_name(config)).to eq("test-test-1.1.1")
+    end
+  end
+
+  describe "#build_images" do
+    before { allow(communicator).to receive(:sudo) }
+
+    it "should use sudo to run command" do
+      expect(communicator).to receive(:sudo).with(/#{Regexp.escape(container_command)}/)
+      subject.build_images([["path", {}]])
+    end
+
+    it "should output information to use" do
+      expect(ui).to receive(:info).and_call_original
+      subject.build_images([["path", {}]])
+    end
+
+    it "should handle communicator output" do
+      expect(communicator).to receive(:sudo).with(/#{Regexp.escape(container_command)}/).
+        and_yield(:stdout, "some output")
+      subject.build_images([["path", {}]])
+    end
+  end
+
+  describe "#pull_images" do
+    before do
+      allow(communicator).to receive(:sudo)
+    end
+
+    it "should use sudo to run command" do
+      expect(communicator).to receive(:sudo).with(/#{Regexp.escape(container_command)}/)
+      subject.pull_images(:image)
+    end
+
+    it "should output information to use" do
+      expect(ui).to receive(:info).and_call_original
+      subject.pull_images(:image)
     end
   end
 end

--- a/test/unit/plugins/provisioners/shell/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/shell/provisioner_test.rb
@@ -673,7 +673,8 @@ describe "Vagrant::Shell::Provisioner" do
       end
 
       it "should color the output" do
-        expect(ui).to receive(:detail).with(data, hash_including(color: :green))
+        expect(ui).to receive(:detail).with(data, hash_including(color: :green)).
+          and_call_original
         vsp.send(:handle_comm, type, data)
       end
 
@@ -700,7 +701,8 @@ describe "Vagrant::Shell::Provisioner" do
       end
 
       it "should color the output" do
-        expect(ui).to receive(:detail).with(data, hash_including(color: :red))
+        expect(ui).to receive(:detail).with(data, hash_including(color: :red)).
+          and_call_original
         vsp.send(:handle_comm, type, data)
       end
 

--- a/test/unit/plugins/synced_folders/rsync/command/rsync_auto_test.rb
+++ b/test/unit/plugins/synced_folders/rsync/command/rsync_auto_test.rb
@@ -42,9 +42,6 @@ describe VagrantPlugins::SyncedFolderRSync::Command::RsyncAuto do
       allow(m).to receive(:state).and_return(double("state", id: :not_created))
       allow(m).to receive(:env).and_return(iso_env)
       allow(m).to receive(:config).and_return(double("config"))
-
-
-      allow(m.ui).to receive(:error).and_return(nil)
     end
   end
 
@@ -76,7 +73,6 @@ describe VagrantPlugins::SyncedFolderRSync::Command::RsyncAuto do
 
     before do
       allow(subject).to receive(:with_target_vms) { |&block| block.call machine }
-      allow(machine.ui).to receive(:info)
       allow(machine.state).to receive(:id).and_return(:created)
       allow(machine.env).to receive(:cwd).
         and_return("/Users/brian/code/vagrant-sandbox")
@@ -92,12 +88,16 @@ describe VagrantPlugins::SyncedFolderRSync::Command::RsyncAuto do
     end
 
     it "does not sync folders outside of the cwd" do
+      allow(machine.ui).to receive(:info).and_call_original
       expect(machine.ui).to receive(:info).
-        with("Not syncing /Not/The/Same/Path as it is not part of the current working directory.")
+        with("Not syncing /Not/The/Same/Path as it is not part of the current working directory.").
+        and_call_original
       expect(machine.ui).to receive(:info).
-        with("Watching: /Users/brian/code/vagrant-sandbox")
+        with("Watching: /Users/brian/code/vagrant-sandbox").
+        and_call_original
       expect(machine.ui).to receive(:info).
-        with("Watching: /Users/brian/code/relative-dir")
+        with("Watching: /Users/brian/code/relative-dir").
+        and_call_original
       expect(helper_class).to receive(:rsync_single)
 
       expect(Listen).to receive(:to).
@@ -237,7 +237,6 @@ describe VagrantPlugins::SyncedFolderRSync::Command::RsyncAuto do
       before do
         allow_any_instance_of(Vagrant::Errors::VagrantError).
           to receive(:translate_error)
-        allow(machine.ui).to receive(:error)
       end
 
       context "when rsync command fails" do
@@ -247,7 +246,7 @@ describe VagrantPlugins::SyncedFolderRSync::Command::RsyncAuto do
         end
 
         it "should notify on error" do
-          expect(machine.ui).to receive(:error)
+          expect(machine.ui).to receive(:error).and_call_original
           subject.callback(*args)
         end
 
@@ -263,7 +262,7 @@ describe VagrantPlugins::SyncedFolderRSync::Command::RsyncAuto do
         end
 
         it "should notify on error" do
-          expect(machine.ui).to receive(:error)
+          expect(machine.ui).to receive(:error).and_call_original
           subject.callback(*args)
         end
 

--- a/test/unit/vagrant/action/builtin/box_add_test.rb
+++ b/test/unit/vagrant/action/builtin/box_add_test.rb
@@ -339,7 +339,7 @@ describe Vagrant::Action::Builtin::BoxAdd, :skip_windows, :bsdtar do
 
         expect(app).to receive(:call).with(env)
 
-        expect(env[:ui]).to receive(:warn)
+        expect(env[:ui]).to receive(:warn).and_call_original
           .with(/It looks like you attempted to add a box with a URL for the name/)
 
         subject.call(env)
@@ -383,8 +383,9 @@ describe Vagrant::Action::Builtin::BoxAdd, :skip_windows, :bsdtar do
             true
           }.and_return(box)
 
-          allow(env[:ui]).to receive(:detail)
-          expect(env[:ui]).to receive(:detail).with(%r{.*http://(?!#{username}).+?:(?!#{password}).+?@127\.0\.0\.1:#{port}/#{box_path.basename}.*})
+          allow(env[:ui]).to receive(:detail).and_call_original
+          expect(env[:ui]).to receive(:detail).with(%r{.*http://(?!#{username}).+?:(?!#{password}).+?@127\.0\.0\.1:#{port}/#{box_path.basename}.*}).
+            and_call_original
           expect(app).to receive(:call).with(env)
 
           subject.call(env)

--- a/test/unit/vagrant/action/builtin/cloud_init_wait_test.rb
+++ b/test/unit/vagrant/action/builtin/cloud_init_wait_test.rb
@@ -13,10 +13,6 @@ describe Vagrant::Action::Builtin::CloudInitWait do
 
   describe "#call" do
 
-    before do
-      allow(ui).to receive(:output)
-    end
-
     context "cloud init configuration exists" do
 
       let(:vm) { double("vm", cloud_init_configs: ["some config"]) }

--- a/test/unit/vagrant/action/builtin/set_hostname_test.rb
+++ b/test/unit/vagrant/action/builtin/set_hostname_test.rb
@@ -11,7 +11,6 @@ describe Vagrant::Action::Builtin::SetHostname do
   before do
     allow(machine).to receive_message_chain(:config, :vm, :hostname).and_return("whatever")
     allow(machine).to receive_message_chain(:guest, :capability)
-    allow(ui).to receive(:info)
   end
 
   it "should change hostname if hosts modification enabled" do

--- a/test/unit/vagrant/action/general/package_test.rb
+++ b/test/unit/vagrant/action/general/package_test.rb
@@ -87,7 +87,6 @@ describe Vagrant::Action::General::Package do
     let(:path) { double("path") }
 
     before do
-      allow(ui).to receive(:info)
       allow(FileUtils).to receive(:mkdir_p)
       subject.instance_variable_set(:@env, env)
     end
@@ -158,8 +157,6 @@ describe Vagrant::Action::General::Package do
       env["package.files"] = package_files
       env["package.directory"] = package_directory
       subject.instance_variable_set(:@env, env)
-
-      allow(ui).to receive(:info)
     end
 
     after do
@@ -178,7 +175,7 @@ describe Vagrant::Action::General::Package do
     end
 
     it "should notify user of copy" do
-      expect(ui).to receive(:info)
+      expect(ui).to receive(:info).at_least(1).and_call_original
       subject.copy_include_files
     end
   end
@@ -333,8 +330,6 @@ describe Vagrant::Action::General::Package do
     let(:fullpath) { "FULLPATH" }
 
     before do
-      allow(ui).to receive(:info)
-
       allow(described_class).to receive(:validate!)
       allow(subject).to receive(:fullpath).and_return(fullpath)
       allow(subject).to receive(:package_with_folder_path)
@@ -362,7 +357,7 @@ describe Vagrant::Action::General::Package do
     end
 
     it "should notify of package compressing" do
-      expect(ui).to receive(:info)
+      expect(ui).to receive(:info).and_call_original
       subject.call(env)
     end
 

--- a/test/unit/vagrant/box_collection_test.rb
+++ b/test/unit/vagrant/box_collection_test.rb
@@ -49,7 +49,7 @@ describe Vagrant::BoxCollection, :skip_windows do
       environment.box3("foo-VAGRANTSLASH-bar", "1.0", :virtualbox)
       environment.box3("foo-VAGRANTCOLON-colon", "1.0", :virtualbox)
 
-      expect(ui).to receive(:warn).once
+      expect(ui).to receive(:warn).once.and_call_original
 
       # Verify some output
       results = subject.all

--- a/test/unit/vagrant/machine_test.rb
+++ b/test/unit/vagrant/machine_test.rb
@@ -335,7 +335,6 @@ describe Vagrant::Machine do
       initial_action_name  = :destroy
       second_action_name  = :reload
       callable     = lambda { |_env| }
-      original_cwd = env.cwd.to_s
 
       allow(provider).to receive(:action).with(initial_action_name).and_return(callable)
       allow(provider).to receive(:action).with(second_action_name).and_return(callable)

--- a/test/unit/vagrant/util/downloader_test.rb
+++ b/test/unit/vagrant/util/downloader_test.rb
@@ -36,12 +36,6 @@ describe Vagrant::Util::Downloader do
       let(:redirect) { nil }
       let(:progress_data) { "Location: #{redirect}" }
 
-      before do
-        allow(ui).to receive(:clear_line)
-        allow(ui).to receive(:detail)
-        allow(ui).to receive(:rewriting).and_yield(ui)
-      end
-
       after do
         expect(subject).to receive(:execute_curl) do |*_, &data_proc|
           expect(data_proc).not_to be_nil
@@ -62,7 +56,7 @@ describe Vagrant::Util::Downloader do
         let(:redirect) { "http://example.com/vagrant.box" }
 
         it "should output redirection information" do
-          expect(ui).to receive(:detail).with(/example.com/)
+          expect(ui).to receive(:detail).with(/example.com/).and_call_original
         end
       end
 
@@ -70,7 +64,7 @@ describe Vagrant::Util::Downloader do
         let(:redirect) { "http://downloads.example.org/vagrant.box" }
 
         it "should output redirection information" do
-          expect(ui).to receive(:detail).with(/downloads.example.org/)
+          expect(ui).to receive(:detail).with(/downloads.example.org/).and_call_original
         end
       end
 
@@ -87,7 +81,7 @@ describe Vagrant::Util::Downloader do
           let(:progress_data) { "X-Custom-Location: #{custom_redirect}\nLocation: #{redirect}" }
 
           it "should output redirection information" do
-            expect(ui).to receive(:detail).with(/downloads.example.com/)
+            expect(ui).to receive(:detail).with(/downloads.example.com/).and_call_original
           end
         end
       end


### PR DESCRIPTION
    Replaces use of UI doubles within tests to use actual UI instance
    to ensure calls are passing parameters correctly.
