### PR TITLE
website: upgrade react-head

### DIFF
--- a/website/package-lock.json
+++ b/website/package-lock.json
@@ -2041,9 +2041,9 @@
       }
     },
     "@hashicorp/react-head": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-3.0.2.tgz",
-      "integrity": "sha512-kKY/5XwWkBsDSvF8jHgNnxG4hx8ryPjoEtPFxPMVCly/ouwbslilIrWzqSYbeP7vUO686JzBLf5xkwq+HV0aig=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/react-head/-/react-head-3.1.0.tgz",
+      "integrity": "sha512-tXfxi9Aqhx83p6wt753WfiYUhOEMzrsWKON200zsNFdwN2WkHPwArWbR6+ludVXleEmsBufL8GRYq7iqnnKKlQ=="
     },
     "@hashicorp/react-image": {
       "version": "2.0.4",

--- a/website/package.json
+++ b/website/package.json
@@ -11,7 +11,7 @@
     "@hashicorp/react-code-block": "4.1.2",
     "@hashicorp/react-docs-page": "13.2.0",
     "@hashicorp/react-hashi-stack-menu": "2.0.3",
-    "@hashicorp/react-head": "^3.0.2",
+    "@hashicorp/react-head": "3.1.0",
     "@hashicorp/react-product-downloader": "4.1.5",
     "@hashicorp/react-product-downloads-page": "2.0.2",
     "@hashicorp/react-search": "^5.0.2",


### PR DESCRIPTION
[Preview](https://vagrant-46yu3t8uk-hashicorp.vercel.app/)

Upgrading `react-head` and dependencies to set the new Safari theme-color feature.

[_Created by Sourcegraph campaign `kstraut/upgrade-react-head`._](https://sourcegraph.hashi-mktg.com/users/kstraut/campaigns/upgrade-react-head)

**Before**
<img width="1256" alt="Screen Shot 2021-06-25 at 8 31 53 AM" src="https://user-images.githubusercontent.com/36613477/123448498-d5dcf780-d58f-11eb-9ccc-47db44f20806.png">

**After**
<img width="1257" alt="Screen Shot 2021-06-25 at 8 31 47 AM" src="https://user-images.githubusercontent.com/36613477/123448499-d70e2480-d58f-11eb-8cf4-c77d5a92eb83.png">
