### PR TITLE
Line buffer utility and shell provisioner usage

### DIFF
--- a/lib/vagrant/util.rb
+++ b/lib/vagrant/util.rb
@@ -26,6 +26,7 @@ module Vagrant
     autoload :IPV4Interfaces,            'vagrant/util/ipv4_interfaces'
     autoload :IsPortOpen,                'vagrant/util/is_port_open'
     autoload :KeyPair,                   'vagrant/util/key_pair'
+    autoload :LineBuffer,                'vagrant/util/line_buffer'
     autoload :LineEndingHelpers,         'vagrant/util/line_ending_helpers'
     autoload :LoggingFormatter,          'vagrant/util/logging_formatter'
     autoload :MapCommandOptions,         'vagrant/util/map_command_options'

--- a/lib/vagrant/util/line_buffer.rb
+++ b/lib/vagrant/util/line_buffer.rb
@@ -1,0 +1,35 @@
+require 'stringio'
+
+module Vagrant
+  module Util
+    class LineBuffer
+      def initialize
+        @buffer = StringIO.new
+      end
+
+      def lines(data, &block)
+        if data == nil
+          return
+        end
+        remaining_buffer = StringIO.new
+        @buffer << data
+        @buffer.string.each_line do |line|
+          if line.end_with? "\n"
+            block.call(line.rstrip)
+          else
+            remaining_buffer << line
+            break
+          end
+        end
+        @buffer = remaining_buffer
+      end
+
+      def remaining(&block)
+        if @buffer.length > 0
+          block.call(@buffer.string.rstrip)
+          @buffer = StringIO.new
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant/util/line_buffer.rb
+++ b/lib/vagrant/util/line_buffer.rb
@@ -1,34 +1,59 @@
-require 'stringio'
-
 module Vagrant
   module Util
     class LineBuffer
-      def initialize
-        @buffer = StringIO.new
+
+      # Maximum number of characters to buffer before sending
+      # to callback without detecting a new line
+      MAX_LINE_LENGTH = 5000.freeze
+
+      # Create a new line buffer. The registered block
+      # will be called when a new line is encountered on
+      # provided input, or the max line length is reached
+      def initialize(&callback)
+        raise ArgumentError,
+          "Expected callback but received none" if callback.nil?
+        @mu = Mutex.new
+        @callback = callback
+        @buffer = ""
       end
 
-      def lines(data, &block)
-        if data == nil
-          return
-        end
-        remaining_buffer = StringIO.new
-        @buffer << data
-        @buffer.string.each_line do |line|
-          if line.end_with? "\n"
-            block.call(line.rstrip)
-          else
-            remaining_buffer << line
-            break
+      # Add string data to output
+      #
+      # @param [String] str String of data to output
+      # @return [self]
+      def <<(str)
+        @mu.synchronize do
+          while i = str.index("\n")
+            @callback.call((@buffer + str[0, i+1]).rstrip)
+            @buffer.clear
+            str = str[i+1, str.length].to_s
+          end
+
+          @buffer << str.to_s
+
+          if @buffer.length > MAX_LINE_LENGTH
+            @callback.call(@buffer.dup)
+            @buffer.clear
           end
         end
-        @buffer = remaining_buffer
+        self
       end
 
-      def remaining(&block)
-        if @buffer.length > 0
-          block.call(@buffer.string.rstrip)
-          @buffer = StringIO.new
+      # Closes the buffer. Any remaining data that has
+      # been buffered will be given to the callback.
+      # Once closed the instance will no longer be usable.
+      #
+      # @return [self]
+      def close
+        @mu.synchronize do
+          # Send any remaining output on the buffer
+          @callback.call(@buffer.dup) if !@buffer.empty?
+          # Disable this buffer instance
+          @callback = nil
+          @buffer.clear
+          @buffer.freeze
         end
+        self
       end
     end
   end

--- a/test/unit/vagrant/util/line_buffer_test.rb
+++ b/test/unit/vagrant/util/line_buffer_test.rb
@@ -1,0 +1,60 @@
+require File.expand_path("../../../base", __FILE__)
+require "vagrant/util/line_buffer"
+
+describe Vagrant::Util::LineBuffer do
+  it "should raise error when no callback is provided" do
+    expect { subject }.to raise_error(ArgumentError)
+  end
+
+  context "with block defined" do
+    let(:block) { proc{ |l| output << l } }
+    let(:output) { [] }
+    let(:partial) { "this is part of a line. " }
+    let(:line) { "this is a full line\n" }
+
+    subject { described_class.new(&block) }
+
+    it "should not raise an error when callback is provided" do
+      expect { subject }.not_to raise_error
+    end
+
+    describe "#<<" do
+      it "should add line to the output" do
+        subject << line
+        expect(output).to eq([line.rstrip])
+      end
+
+      it "should not add partial line to output" do
+        subject << partial
+        expect(output).to be_empty
+      end
+
+      it "should add partial line to output once full line is given" do
+        subject << partial
+        expect(output).to be_empty
+        subject << line
+        expect(output).to eq([partial + line.rstrip])
+      end
+
+      it "should add line once it has surpassed max line length" do
+        overflow = "a" * (described_class.const_get(:MAX_LINE_LENGTH) + 1)
+        subject << overflow
+        expect(output).to eq([overflow])
+      end
+    end
+
+    describe "#close" do
+      it "should output any partial data left in buffer" do
+        subject << partial
+        expect(output).to be_empty
+        subject.close
+        expect(output).to eq([partial])
+      end
+
+      it "should not be writable after closing" do
+        subject.close
+        expect { subject << partial }.to raise_error(FrozenError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is an extension of #12403. It's a slight refactor to remove the inclusion
of the StringIO library and to provide a max length for buffering to prevent
a badly behaving provisioner from consuming excess amounts of memory on the
host. Test coverage has also been included.

Thanks @rgl! This changeset also includes a rebase of main and I didn't want
to force push onto your branch so I opened a new PR instead.

Fixes #12403
Fixes #11047
