### PR TITLE
Use systemctl poweroff in the background instead of shutdown

### DIFF
--- a/plugins/guests/suse/cap/halt.rb
+++ b/plugins/guests/suse/cap/halt.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
       class Halt
         def self.halt(machine)
           begin
-            machine.communicate.sudo("/sbin/shutdown -h now")
+            machine.communicate.sudo("/usr/bin/systemctl poweroff &")
           rescue IOError, Vagrant::Errors::SSHDisconnected
             # Do nothing, because it probably means the machine shut down
             # and SSH connection was lost.

--- a/test/unit/plugins/guests/suse/cap/halt_test.rb
+++ b/test/unit/plugins/guests/suse/cap/halt_test.rb
@@ -22,19 +22,19 @@ describe "VagrantPlugins::GuestSUSE::Cap::Halt" do
     let(:cap) { caps.get(:halt) }
 
     it "runs the shutdown command" do
-      comm.expect_command("/sbin/shutdown -h now")
+      comm.expect_command("/usr/bin/systemctl poweroff &")
       cap.halt(machine)
     end
 
     it "does not raise an IOError" do
-      comm.stub_command("shutdown -h now", raise: IOError)
+      comm.stub_command("/usr/bin/systemctl poweroff &", raise: IOError)
       expect {
         cap.halt(machine)
       }.to_not raise_error
     end
 
     it "ignores a Vagrant::Errors::SSHDisconnected" do
-      comm.stub_command("shutdown -h now", raise: Vagrant::Errors::SSHDisconnected)
+      comm.stub_command("/usr/bin/systemctl poweroff &", raise: Vagrant::Errors::SSHDisconnected)
       expect {
         cap.halt(machine)
       }.to_not raise_error


### PR DESCRIPTION
We have started seeing occasional shutdown failures on openSUSE Tumbleweed with
Virtualbox inside a qemu virtual machine, where `shutdown -h now` would return
nil. While the machine is successfully turned off, the command fails and vagrant
reports an error.
This commit changes the shutdown command to launch in the background which
also triggers a shutdown, but always succeeds.