### PR TITLE
Remove no longer required gem webmock

### DIFF
--- a/test/unit/base.rb
+++ b/test/unit/base.rb
@@ -3,7 +3,6 @@ require "rubygems"
 
 # Gems
 require "checkpoint"
-require "webmock/rspec"
 require "rspec/its"
 
 # Require Vagrant itself so we can reference the proper

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -41,7 +41,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "~> 13.0"
   s.add_development_dependency "rspec", "~> 3.10.0"
   s.add_development_dependency "rspec-its", "~> 1.3.0"
-  s.add_development_dependency "webmock", "~> 2.3.1"
   s.add_development_dependency "fake_ftp", "~> 0.1.1"
   s.add_development_dependency "webrick", "~> 1.7.0"
 


### PR DESCRIPTION
This gem was added a long time ago and probably used to test the functionality
that is now provided by the vagrant_cloud gem