### PR TITLE
FreeBSD: Ansible - Refer to a pkg origin

### DIFF
--- a/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install.rb
@@ -11,7 +11,7 @@ module VagrantPlugins
               if install_mode != :default
                 raise Ansible::Errors::AnsiblePipInstallIsNotSupported
               else
-                machine.communicate.sudo "pkg install -qy py37-ansible"
+                machine.communicate.sudo "pkg install -qy sysutils/ansible"
               end
             end
 

--- a/test/unit/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install_test.rb
+++ b/test/unit/plugins/provisioners/ansible/cap/guest/freebsd/ansible_install_test.rb
@@ -31,7 +31,7 @@ describe VagrantPlugins::Ansible::Cap::Guest::FreeBSD::AnsibleInstall do
 
     describe "when install_mode is :default (or unknown)" do
       it "installs ansible with 'pkg' package manager" do
-        expect(communicator).to receive(:sudo).with("pkg install -qy py37-ansible")
+        expect(communicator).to receive(:sudo).with("pkg install -qy sysutils/ansible")
 
         subject.ansible_install(machine, :default, "", "", "")
       end


### PR DESCRIPTION
This avoids manually submitting python version bumps.

Related to: 582f46231b3ea8a874b1773b3553e4234dd72060, e95a7f3e8a9a81ba2a5b03b7d33d0b59e048e1fb