### PR TITLE
Fix of error "install_plugin: wrong number of arguments (given 2, expected 1) (ArgumentError)" after upgrade to Vagrant 2.2.17

### DIFF
--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -1011,7 +1011,7 @@ module Vagrant
           options[:require] = pconfig[:entry_point] if pconfig[:entry_point]
           options[:version] = pconfig[:version] if pconfig[:version]
 
-          spec = Plugin::Manager.instance.install_plugin(name, options)
+          spec = Plugin::Manager.instance.install_plugin(name, **options)
 
           ui.info(I18n.t("vagrant.commands.plugin.installed",
             name: spec.name, version: spec.version.to_s))


### PR DESCRIPTION
Closes #12453

Hi @soapy1 ! 👋 

After upgrade to Vagrant 2.2.17, `vagrant up` throws the following error:

```bash
install_plugin: wrong number of arguments (given 2, expected 1) (ArgumentError)
    from C:/HashiCorp/Vagrant/embedded/gems/2.2.17/gems/vagrant-2.2.17/lib/vagrant/environment.rb:1014:in `block in process_configured_plugins'
    ...
```

You can test this scenario with the Vagrantfile below:

```ruby
Vagrant.configure('2') do |config|
  config.vagrant.plugins = ['vagrant-vbguest', 'vagrant-disksize']
  config.vm.box = 'centos/8'
end
```

The vagrantfile above works in `2.2.16`, but in `2.2.17` not 👍  The bugfix that I made here in my PC was the code present in PR 🤝 

Thanks a lot! 🍻 