### PR TITLE
Fix typo in IP reporting for Hyper-V provider

### DIFF
--- a/plugins/providers/hyperv/scripts/get_network_config.ps1
+++ b/plugins/providers/hyperv/scripts/get_network_config.ps1
@@ -18,7 +18,7 @@ try {
     $netdev = Hyper-V\Get-VMNetworkAdapter -VM $vm | Select-Object -Index 0
     if ($netdev -ne $null) {
         if ($netdev.IpAddresses.Length -gt 0) {
-            foreach ($ip_address in $network.IpAddresses) {
+            foreach ($ip_address in $netdev.IpAddresses) {
                 if ($ip_address.Contains(".") -And [string]::IsNullOrEmpty($ip4_address)) {
                     $ip4_address = $ip_address
                 } elseif ($ip_address.Contains(":") -And [string]::IsNullOrEmpty($ip6_address)) {


### PR DESCRIPTION
Fix for #12456 - I have not yet run tests because the scope is so small but will endeavour to do so if that's maintainers' preference. Cheers, folks.

Previously we were iterating over a list of `networks`, doing operations on each `network`. Now, we do operations on only one `netdev` (see 1148658a53b0ce15696e7e1b3df8042599950529), but the variable name was not changed. Correcting here.