### PR TITLE
Add Astra Linux platforms guest detection and support

### DIFF
--- a/plugins/guests/astra/guest.rb
+++ b/plugins/guests/astra/guest.rb
@@ -1,0 +1,10 @@
+require_relative '../linux/guest'
+
+module VagrantPlugins
+  module GuestAstra
+    class Guest < VagrantPlugins::GuestLinux::Guest
+      # Name used for guest detection
+      GUEST_DETECTION_NAME = "astra".freeze
+    end
+  end
+end

--- a/plugins/guests/astra/plugin.rb
+++ b/plugins/guests/astra/plugin.rb
@@ -1,0 +1,15 @@
+require "vagrant"
+
+module VagrantPlugins
+  module GuestAstra
+    class Plugin < Vagrant.plugin("2")
+      name "Astra Linux guest"
+      description "Astra Linux guest support."
+
+      guest(:astra, :debian) do
+        require_relative "guest"
+        Guest
+      end
+    end
+  end
+end


### PR DESCRIPTION
These changes are necessary for correct work with Astra Linux images hosted on Vagrantcloud.