### PR TITLE
WinSSH: Send eof to let server know we're done

### DIFF
--- a/plugins/communicators/winssh/communicator.rb
+++ b/plugins/communicators/winssh/communicator.rb
@@ -96,6 +96,9 @@ module VagrantPlugins
               # probably done. This fixes up issues with hanging.
               ch.close
             end
+            
+            # Send eof to let server know we're done
+            ch2.eof!
 
           end
         end


### PR DESCRIPTION
Just adds an EOF when done. Without this, the SSH connection can just persist and eventually time out. The fix matches the behaviour in the ssh communicator.