### PR TITLE
Add fallback for SLE 11 guest machines

### DIFF
--- a/plugins/guests/suse/cap/halt.rb
+++ b/plugins/guests/suse/cap/halt.rb
@@ -4,7 +4,11 @@ module VagrantPlugins
       class Halt
         def self.halt(machine)
           begin
-            machine.communicate.sudo("/usr/bin/systemctl poweroff &")
+            if machine.communicate.test("test -e /usr/bin/systemctl")
+              machine.communicate.sudo("/usr/bin/systemctl poweroff &")
+            else
+              machine.communicate.sudo("/sbin/shutdown -h now &")
+            end
           rescue IOError, Vagrant::Errors::SSHDisconnected
             # Do nothing, because it probably means the machine shut down
             # and SSH connection was lost.

--- a/test/unit/plugins/guests/suse/cap/halt_test.rb
+++ b/test/unit/plugins/guests/suse/cap/halt_test.rb
@@ -21,12 +21,22 @@ describe "VagrantPlugins::GuestSUSE::Cap::Halt" do
   describe ".halt" do
     let(:cap) { caps.get(:halt) }
 
-    it "runs the shutdown command" do
+    it "runs systemctl shutdown when systemctl is present" do
+      comm.stub_command('test -e /usr/bin/systemctl', exit_code: 0)
+      comm.expect_command('test -e /usr/bin/systemctl')
       comm.expect_command("/usr/bin/systemctl poweroff &")
       cap.halt(machine)
     end
 
+    it "runs shutdown when systemctl is not present" do
+      comm.stub_command('test -e /usr/bin/systemctl', exit_code: 1)
+      comm.expect_command('test -e /usr/bin/systemctl')
+      comm.expect_command("/sbin/shutdown -h now &")
+      cap.halt(machine)
+    end
+
     it "does not raise an IOError" do
+      comm.stub_command('test -e /usr/bin/systemctl', exit_code: 0)
       comm.stub_command("/usr/bin/systemctl poweroff &", raise: IOError)
       expect {
         cap.halt(machine)
@@ -34,7 +44,8 @@ describe "VagrantPlugins::GuestSUSE::Cap::Halt" do
     end
 
     it "ignores a Vagrant::Errors::SSHDisconnected" do
-      comm.stub_command("/usr/bin/systemctl poweroff &", raise: Vagrant::Errors::SSHDisconnected)
+      comm.stub_command('test -e /usr/bin/systemctl', exit_code: 1)
+      comm.stub_command("/sbin/shutdown -h now &", raise: Vagrant::Errors::SSHDisconnected)
       expect {
         cap.halt(machine)
       }.to_not raise_error


### PR DESCRIPTION
SLE 11 does not ship systemd and then using `systemctl poweroff` does not work. Therefore we fall back to using `/sbin/shutdown` for machines without systemd.
This fixes https://github.com/hashicorp/vagrant/issues/12487