### PR TITLE
website: update alert banner

### DIFF
--- a/website/data/alert-banner.js
+++ b/website/data/alert-banner.js
@@ -2,11 +2,11 @@ export const ALERT_BANNER_ACTIVE = true
 
 // https://github.com/hashicorp/web-components/tree/master/packages/alert-banner
 export default {
-  tag: 'June 8-11',
-  url: 'https://hashiconf.com/europe/?utm_source=DocsBanner',
-  text: 'HashiConf Europe is happening now. Join all sessions live June 8 & 9',
-  linkText: 'Join Now',
-  // Set the `expirationDate prop with a datetime string (e.g. `2020-01-31T12:00:00-07:00`)
+  tag: 'Event',
+  url: 'https://hashiconf.com/global/?utm_campaign=22Q3_WW_HASHICONFGLOBAL_EVENT-USER&utm_source=CorpBanner&utm_medium=EVT&utm_offer=EVENT-USER',
+  text: 'Join us for HashiConf Global - product updates, technical sessions, workshops & more',
+  linkText: 'Register now',
+  // Set the expirationDate prop with a datetime string (e.g. '2020-01-31T12:00:00-07:00')
   // if you'd like the component to stop showing at or after a certain date
-  expirationDate: `2021-06-12T12:00:00-07:00`,
+  expirationDate: '2021-10-01T12:00:00-07:00',
 }


### PR DESCRIPTION
Updates alert banner content to promote HashiConf US 2021

[_Created by Sourcegraph campaign `mwickett/update-alert-banner-hashiconf-2021`._](https://sourcegraph.hashi-mktg.com/users/mwickett/campaigns/update-alert-banner-hashiconf-2021)