### PR TITLE
[OpenBSD rsync] Do not rely on hardcoded PKG_PATH URI but rather on the default behav…

### DIFF
--- a/plugins/guests/openbsd/cap/rsync.rb
+++ b/plugins/guests/openbsd/cap/rsync.rb
@@ -8,9 +8,7 @@ module VagrantPlugins
 
         def self.rsync_install(machine)
           install_output = {:stderr => '', :stdout => ''}
-          command = 'PKG_PATH="http://ftp.openbsd.org/pub/OpenBSD/' \
-            '`uname -r`/packages/`arch -s`/" ' \
-            'pkg_add -I rsync--'
+          command = 'pkg_add -I rsync--'
           machine.communicate.sudo(command) do |type, data|
             install_output[type] << data if install_output.key?(type)
           end


### PR DESCRIPTION
…ior of pkg_add(1) which selects the mirror based on the content of '/etc/installurl' to install rsync on OpenBSD targets.

This behaviour is present since OpenBSD 6.1 (released April 11, 2017).

The hardcoded URI prevents the use of custom OpenBSD mirrors (written down to '/etc/installurl' by the installer) while using the rsync directive in Vagrantfiles.

This prevents 'Installing rsync to the VM...' failure when provisioning a VM configured with a custom mirror.

https://man.openbsd.org/pkg_add.1
https://man.openbsd.org/installurl.5