### PR TITLE
use nfsd update for macos

### DIFF
--- a/plugins/hosts/darwin/cap/nfs.rb
+++ b/plugins/hosts/darwin/cap/nfs.rb
@@ -5,6 +5,10 @@ module VagrantPlugins
         def self.nfs_exports_template(environment)
           "nfs/exports_darwin"
         end
+        
+        def self.nfs_restart_command(environment)
+          ["sudo", "nfsd", "update"]
+        end
       end
     end
   end


### PR DESCRIPTION
When using udp as nfs protocol restarting nfs on macos results in udp port still being bound and nfsd being unabled to bind to the udp port after restart. nfsd update just tells the nfs server to reload the configuration and exports which is enough after the exports file has been updated.
As nfs via tcp no longer seems to work reliably under big sur, this has some urgency.