### PR TITLE
use nfsd update for macos

### DIFF
--- a/plugins/hosts/darwin/cap/nfs.rb
+++ b/plugins/hosts/darwin/cap/nfs.rb
@@ -5,6 +5,10 @@ module VagrantPlugins
         def self.nfs_exports_template(environment)
           "nfs/exports_darwin"
         end
+        
+        def self.nfs_restart_command(environment)
+          ["sudo", "nfsd", "update"]
+        end
       end
     end
   end

--- a/plugins/hosts/darwin/plugin.rb
+++ b/plugins/hosts/darwin/plugin.rb
@@ -70,6 +70,11 @@ module VagrantPlugins
         require_relative "cap/nfs"
         Cap::NFS
       end
+
+      host_capability("darwin", "nfs_restart_command") do
+        require_relative "cap/nfs"
+        Cap::NFS
+      end
     end
   end
 end


### PR DESCRIPTION
when using udp as nfs protocol nfs restart is not an option, since the
udp port can no longer be used by nfsd since it is still bound even
after the nfsd process has been stopped.

nfsd update rereads the configuration files and exports without stopping
nfsd so nfs is still available via udp