### PR TITLE
Fix syntax error in trigger configuration docs

### DIFF
--- a/website/content/docs/triggers/configuration.mdx
+++ b/website/content/docs/triggers/configuration.mdx
@@ -191,7 +191,7 @@ Vagrant and in every Vagrant plugin.
 
 ```ruby
 config.trigger.before :"Action::Class::Name", type: :action do |t|
-  t.info = "Before action class!
+  t.info = "Before action class!"
 end
 ```
 


### PR DESCRIPTION
Hi!

I've spotted a syntax error in the docs. I haven't checked if this part of the documentation is correct and makes sense as a whole, though.