### PR TITLE
Fix for :dvd example in disks configuration docs.

### DIFF
--- a/website/content/docs/disks/configuration.mdx
+++ b/website/content/docs/disks/configuration.mdx
@@ -61,7 +61,7 @@ You can set a disk type with the first argument of a disk config in your Vagrant
 
 ```ruby
 config.vm.disk :disk, name: "backup", size: "10GB"
-config.vm.disk :dvd, name: "installer", path: "./installer.iso"
+config.vm.disk :dvd, name: "installer", file: "./installer.iso"
 config.vm.disk :floppy, name: "cool_files"
 ```
 


### PR DESCRIPTION
Option passed to :dvd disk type should be `file` not `path`.

```
There are errors in the configuration of this machine. Please fix
the following errors and try again:

vm:
* The following settings shouldn't exist: path
* A 'file' option is required when defining a disk of type ':dvd' for guest 'default'.
```