### PR TITLE
Updates install checks for Chef provisioners

### DIFF
--- a/plugins/provisioners/chef/cap/freebsd/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/freebsd/chef_installed.rb
@@ -6,11 +6,13 @@ module VagrantPlugins
           # Check if Chef is installed at the given version.
           # @return [true, false]
           def self.chef_installed(machine, product, version)
-            knife = "/opt/#{product}/bin/knife"
-            command = "test -x #{knife}"
+            product_name = product == 'chef-workstation' ? 'chef-workstation' : 'chef'
+            product_binary = product_name == 'chef-workstation' ? 'chef' : 'chef-client'
+            test_binary = "/opt/#{product_name}/bin/#{product_binary}"
+            command = "test -x #{test_binary}"
 
             if version != :latest
-              command << "&& #{knife} --version | grep '#{version}'"
+              command << "&& #{test_binary} --version | grep '#{version}'"
             end
 
             machine.communicate.test(command, sudo: true)

--- a/plugins/provisioners/chef/cap/freebsd/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/freebsd/chef_installed.rb
@@ -7,12 +7,12 @@ module VagrantPlugins
           # @return [true, false]
           def self.chef_installed(machine, product, version)
             product_name = product == 'chef-workstation' ? 'chef-workstation' : 'chef'
-            product_binary = product_name == 'chef-workstation' ? 'chef' : 'chef-client'
-            test_binary = "/opt/#{product_name}/bin/#{product_binary}"
-            command = "test -x #{test_binary}"
+            verify_bin = product_name == 'chef-workstation' ? 'chef' : 'chef-client'
+            verify_path = "/opt/#{product_name}/bin/#{verify_bin}"
+            command = "test -x #{verify_path}"
 
             if version != :latest
-              command << "&& #{test_binary} --version | grep '#{version}'"
+              command << "&& #{verify_path} --version | grep '#{version}'"
             end
 
             machine.communicate.test(command, sudo: true)

--- a/plugins/provisioners/chef/cap/linux/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/linux/chef_installed.rb
@@ -6,11 +6,13 @@ module VagrantPlugins
           # Check if Chef is installed at the given version.
           # @return [true, false]
           def self.chef_installed(machine, product, version)
-            knife = "/opt/#{product}/bin/knife"
-            command = "test -x #{knife}"
+            product_name = product == 'chef-workstation' ? 'chef-workstation' : 'chef'
+            product_binary = product_name == 'chef-workstation' ? 'chef' : 'chef-client'
+            test_binary = "/opt/#{product_name}/bin/#{product_binary}"
+            command = "test -x #{test_binary}"
 
             if version != :latest
-              command << "&& #{knife} --version | grep '#{version}'"
+              command << "&& #{test_binary} --version | grep '#{version}'"
             end
 
             machine.communicate.test(command, sudo: true)

--- a/plugins/provisioners/chef/cap/linux/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/linux/chef_installed.rb
@@ -7,12 +7,12 @@ module VagrantPlugins
           # @return [true, false]
           def self.chef_installed(machine, product, version)
             product_name = product == 'chef-workstation' ? 'chef-workstation' : 'chef'
-            product_binary = product_name == 'chef-workstation' ? 'chef' : 'chef-client'
-            test_binary = "/opt/#{product_name}/bin/#{product_binary}"
-            command = "test -x #{test_binary}"
+            verify_bin = product_name == 'chef-workstation' ? 'chef' : 'chef-client'
+            verify_path = "/opt/#{product_name}/bin/#{verify_bin}"
+            command = "test -x #{verify_path}"
 
             if version != :latest
-              command << "&& #{test_binary} --version | grep '#{version}'"
+              command << "&& #{verify_path} --version | grep '#{version}'"
             end
 
             machine.communicate.test(command, sudo: true)

--- a/plugins/provisioners/chef/cap/omnios/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/omnios/chef_installed.rb
@@ -8,12 +8,12 @@ module VagrantPlugins
           # @return [true, false]
           def self.chef_installed(machine, product, version)
             product_name = product == 'chef-workstation' ? 'chef-workstation' : 'chef'
-            product_binary = product_name == 'chef-workstation' ? 'chef' : 'chef-client'
-            test_binary = "/opt/#{product_name}/bin/#{product_binary}"
-            command = "test -x #{test_binary}"
+            verify_bin = product_name == 'chef-workstation' ? 'chef' : 'chef-client'
+            verify_path = "/opt/#{product_name}/bin/#{verify_bin}"
+            command = "test -x #{verify_path}"
 
             if version != :latest
-              command << "&& #{test_binary} --version | grep '#{version}'"
+              command << "&& #{verify_path} --version | grep '#{version}'"
             end
 
             machine.communicate.test(command, sudo: true)

--- a/plugins/provisioners/chef/cap/omnios/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/omnios/chef_installed.rb
@@ -2,19 +2,21 @@ module VagrantPlugins
   module Chef
     module Cap
       module OmniOS
-        module ChefInstalled 
+        module ChefInstalled
           # TODO: this is the same code as cap/linux/chef_installed, consider merging
           # Check if Chef is installed at the given version.
           # @return [true, false]
           def self.chef_installed(machine, product, version)
-            knife = "/opt/#{product}/bin/knife"
-            command = "test -x #{knife}"
+            product_name = product == 'chef-workstation' ? 'chef-workstation' : 'chef'
+            product_binary = product_name == 'chef-workstation' ? 'chef' : 'chef-client'
+            test_binary = "/opt/#{product_name}/bin/#{product_binary}"
+            command = "test -x #{test_binary}"
 
             if version != :latest
-              command << "&& #{knife} --version | grep '#{version}'"
+              command << "&& #{test_binary} --version | grep '#{version}'"
             end
 
-            machine.communicate.test(command, sudo: true)         
+            machine.communicate.test(command, sudo: true)
           end
         end
       end

--- a/plugins/provisioners/chef/cap/windows/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/windows/chef_installed.rb
@@ -6,11 +6,11 @@ module VagrantPlugins
           # Check if Chef is installed at the given version.
           # @return [true, false]
           def self.chef_installed(machine, product, version)
-            test_binary = product == 'chef-workstation' ? 'chef' : 'chef-client'
+            verify_bin = product == 'chef-workstation' ? 'chef' : 'chef-client'
             if version != :latest
-              command = 'if ((&' + test_binary + ' --version) -Match "' + version.to_s + '"){ exit 0 } else { exit 1 }'
+              command = 'if ((&' + verify_bin + ' --version) -Match "' + version.to_s + '"){ exit 0 } else { exit 1 }'
             else
-              command = 'if ((&' + test_binary + ' --version) -Match "Chef*"){ exit 0 } else { exit 1 }'
+              command = 'if ((&' + verify_bin + ' --version) -Match "Chef*"){ exit 0 } else { exit 1 }'
             end
             machine.communicate.test(command, sudo: true)
           end

--- a/plugins/provisioners/chef/cap/windows/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/windows/chef_installed.rb
@@ -6,10 +6,11 @@ module VagrantPlugins
           # Check if Chef is installed at the given version.
           # @return [true, false]
           def self.chef_installed(machine, product, version)
+            test_binary = product == 'chef-workstation' ? 'chef' : 'chef-client'
             if version != :latest
-              command = 'if ((&knife --version) -Match "' + version.to_s + '"){ exit 0 } else { exit 1 }'
+              command = 'if ((&' + test_binary + ' --version) -Match "' + version.to_s + '"){ exit 0 } else { exit 1 }'
             else
-              command = 'if ((&knife --version) -Match "Chef*"){ exit 0 } else { exit 1 }'
+              command = 'if ((&' + test_binary + ' --version) -Match "Chef*"){ exit 0 } else { exit 1 }'
             end
             machine.communicate.test(command, sudo: true)
           end

--- a/test/unit/plugins/provisioners/chef/cap/freebsd/chef_installed_test.rb
+++ b/test/unit/plugins/provisioners/chef/cap/freebsd/chef_installed_test.rb
@@ -23,19 +23,38 @@ describe VagrantPlugins::Chef::Cap::FreeBSD::ChefInstalled do
   end
 
   describe "#chef_installed" do
-    let(:version) { "15.0.0" }
-    let(:command) { "test -x /opt/chef_solo/bin/knife&& /opt/chef_solo/bin/knife --version | grep '15.0.0'" }
+    describe "when chef-workstation" do
+      let(:version) { "15.0.0" }
+      let(:command) { "test -x /opt/chef-workstation/bin/chef&& /opt/chef-workstation/bin/chef --version | grep '15.0.0'" }
 
-    it "returns true if installed" do
-      expect(machine.communicate).to receive(:test).
-        with(command, sudo: true).and_return(true)
-      subject.chef_installed(machine, "chef_solo", version)
+      it "returns true if installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(true)
+        subject.chef_installed(machine, "chef-workstation", version)
+      end
+
+      it "returns false if not installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(false)
+        expect(subject.chef_installed(machine, "chef-workstation", version)).to be_falsey
+      end
     end
 
-    it "returns false if not installed" do
-      expect(machine.communicate).to receive(:test).
-        with(command, sudo: true).and_return(false)
-      expect(subject.chef_installed(machine, "chef_solo", version)).to be_falsey
+    describe "when not chef-workstation" do
+      let(:version) { "15.0.0" }
+      let(:command) { "test -x /opt/chef/bin/chef-client&& /opt/chef/bin/chef-client --version | grep '15.0.0'" }
+
+      it "returns true if installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(true)
+        subject.chef_installed(machine, "chef_solo", version)
+      end
+
+      it "returns false if not installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(false)
+        expect(subject.chef_installed(machine, "chef_solo", version)).to be_falsey
+      end
     end
   end
 end

--- a/test/unit/plugins/provisioners/chef/cap/linux/chef_installed_test.rb
+++ b/test/unit/plugins/provisioners/chef/cap/linux/chef_installed_test.rb
@@ -23,19 +23,38 @@ describe VagrantPlugins::Chef::Cap::Linux::ChefInstalled do
   end
 
   describe "#chef_installed" do
-    let(:version) { "15.0.0" }
-    let(:command) { "test -x /opt/chef_solo/bin/knife&& /opt/chef_solo/bin/knife --version | grep '15.0.0'" }
+    describe "when chef-workstation" do
+      let(:version) { "15.0.0" }
+      let(:command) { "test -x /opt/chef-workstation/bin/chef&& /opt/chef-workstation/bin/chef --version | grep '15.0.0'" }
 
-    it "returns true if installed" do
-      expect(machine.communicate).to receive(:test).
-        with(command, sudo: true).and_return(true)
-      subject.chef_installed(machine, "chef_solo", version)
+      it "returns true if installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(true)
+        subject.chef_installed(machine, "chef-workstation", version)
+      end
+
+      it "returns false if not installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(false)
+        expect(subject.chef_installed(machine, "chef-workstation", version)).to be_falsey
+      end
     end
 
-    it "returns false if not installed" do
-      expect(machine.communicate).to receive(:test).
-        with(command, sudo: true).and_return(false)
-      expect(subject.chef_installed(machine, "chef_solo", version)).to be_falsey
+    describe "when not chef-workstation" do
+      let(:version) { "15.0.0" }
+      let(:command) { "test -x /opt/chef/bin/chef-client&& /opt/chef/bin/chef-client --version | grep '15.0.0'" }
+
+      it "returns true if installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(true)
+        subject.chef_installed(machine, "chef_solo", version)
+      end
+
+      it "returns false if not installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(false)
+        expect(subject.chef_installed(machine, "chef_solo", version)).to be_falsey
+      end
     end
   end
 end

--- a/test/unit/plugins/provisioners/chef/cap/omnios/chef_installed_test.rb
+++ b/test/unit/plugins/provisioners/chef/cap/omnios/chef_installed_test.rb
@@ -23,19 +23,38 @@ describe VagrantPlugins::Chef::Cap::OmniOS::ChefInstalled do
   end
 
   describe "#chef_installed" do
-    let(:version) { "15.0.0" }
-    let(:command) { "test -x /opt/chef_solo/bin/knife&& /opt/chef_solo/bin/knife --version | grep '15.0.0'" }
+    describe "when chef-workstation" do
+      let(:version) { "15.0.0" }
+      let(:command) { "test -x /opt/chef-workstation/bin/chef&& /opt/chef-workstation/bin/chef --version | grep '15.0.0'" }
 
-    it "returns true if installed" do
-      expect(machine.communicate).to receive(:test).
-        with(command, sudo: true).and_return(true)
-      subject.chef_installed(machine, "chef_solo", version)
+      it "returns true if installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(true)
+        subject.chef_installed(machine, "chef-workstation", version)
+      end
+
+      it "returns false if not installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(false)
+        expect(subject.chef_installed(machine, "chef-workstation", version)).to be_falsey
+      end
     end
 
-    it "returns false if not installed" do
-      expect(machine.communicate).to receive(:test).
-        with(command, sudo: true).and_return(false)
-      expect(subject.chef_installed(machine, "chef_solo", version)).to be_falsey
+    describe "when not chef-workstation" do
+      let(:version) { "15.0.0" }
+      let(:command) { "test -x /opt/chef/bin/chef-client&& /opt/chef/bin/chef-client --version | grep '15.0.0'" }
+
+      it "returns true if installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(true)
+        subject.chef_installed(machine, "chef_solo", version)
+      end
+
+      it "returns false if not installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(false)
+        expect(subject.chef_installed(machine, "chef_solo", version)).to be_falsey
+      end
     end
   end
 end

--- a/test/unit/plugins/provisioners/chef/cap/windows/chef_installed_test.rb
+++ b/test/unit/plugins/provisioners/chef/cap/windows/chef_installed_test.rb
@@ -23,19 +23,38 @@ describe VagrantPlugins::Chef::Cap::Windows::ChefInstalled do
   end
 
   describe "#chef_installed" do
-    let(:version) { "15.0.0" }
-    let(:command) { "if ((&knife --version) -Match \"15.0.0\"){ exit 0 } else { exit 1 }" }
+    describe "when chef-workstation" do
+      let(:version) { "15.0.0" }
+      let(:command) { "if ((&chef --version) -Match \"15.0.0\"){ exit 0 } else { exit 1 }" }
 
-    it "returns true if installed" do
-      expect(machine.communicate).to receive(:test).
-        with(command, sudo: true).and_return(true)
-      subject.chef_installed(machine, "chef_solo", version)
+      it "returns true if installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(true)
+        subject.chef_installed(machine, "chef-workstation", version)
+      end
+
+      it "returns false if not installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(false)
+        expect(subject.chef_installed(machine, "chef-workstation", version)).to be_falsey
+      end
     end
 
-    it "returns false if not installed" do
-      expect(machine.communicate).to receive(:test).
-        with(command, sudo: true).and_return(false)
-      expect(subject.chef_installed(machine, "chef_solo", version)).to be_falsey
+    describe "when chef-workstation" do
+      let(:version) { "15.0.0" }
+      let(:command) { "if ((&chef-client --version) -Match \"15.0.0\"){ exit 0 } else { exit 1 }" }
+
+      it "returns true if installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(true)
+        subject.chef_installed(machine, "chef_solo", version)
+      end
+
+      it "returns false if not installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(false)
+        expect(subject.chef_installed(machine, "chef_solo", version)).to be_falsey
+      end
     end
   end
 end


### PR DESCRIPTION
## Issues Resolved

- #12346 
- #12337

## Changes

- Fixes `chef_installed` detection to be compatible with Chef Infra Client 17+.  Chef Infra Client 17 removed the `knife` gem from the omnibus installation so existing detection of the install status is broken.  Updates the `chef_installed` checks to look for the existence of the `chef-client` binary instead of `knife` and performs version checking with 'chef-client'
- Updates the `chef_installed` detection to use the `chef` binary if `chef-workstation` is configured as the `chef.product`. Updates to use the Chef Workstation version (via `chef --version`) for comparison if `chef.version` is specified along with `chef.product = 'chef-workstation'`.