### PR TITLE
Validate VirtualBox hostonly network range

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        ruby: [ '2.5', '2.6', '2.7', '3.0' ]
+        ruby: [ '2.6', '2.7', '3.0' ]
     name: Vagrant unit tests on Ruby ${{ matrix.ruby }}
     steps:
       - name: Code Checkout

--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -1024,6 +1024,10 @@ module Vagrant
       error_key(:virtualbox_version_empty)
     end
 
+    class VirtualBoxInvalidHostSubnet < VagrantError
+      error_key(:virtualbox_invalid_host_subnet)
+    end
+
     class VMBaseMacNotSpecified < VagrantError
       error_key(:no_base_mac, "vagrant.actions.vm.match_mac")
     end

--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -20,7 +20,7 @@ module VagrantPlugins
         # Location of the VirtualBox networks configuration file
         VBOX_NET_CONF = "/etc/vbox/networks.conf".freeze
         # Version of VirtualBox that introduced hostonly network range restrictions
-        HOSTONLY_VALIDATE_VERSION = Gem::Version.new("6.1.28").freeze
+        HOSTONLY_VALIDATE_VERSION = Gem::Version.new("6.1.28")
         # Default valid range for hostonly networks
         HOSTONLY_DEFAULT_RANGE = [IPAddr.new("192.68.56.0/21").freeze].freeze
 

--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -22,7 +22,7 @@ module VagrantPlugins
         # Version of VirtualBox that introduced hostonly network range restrictions
         HOSTONLY_VALIDATE_VERSION = Gem::Version.new("6.1.28")
         # Default valid range for hostonly networks
-        HOSTONLY_DEFAULT_RANGE = [IPAddr.new("192.68.56.0/21").freeze].freeze
+        HOSTONLY_DEFAULT_RANGE = [IPAddr.new("192.168.56.0/21").freeze].freeze
 
         include Vagrant::Util::NetworkIP
         include Vagrant::Util::ScopedHashOverride
@@ -271,7 +271,7 @@ module VagrantPlugins
               options[:ip] = matching_device[:ip]
             else
               # Default IP is in the 20-bit private network block for DHCP based networks
-              options[:ip] = "192.68.56.1"
+              options[:ip] = "192.168.56.1"
             end
           end
 

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1842,6 +1842,18 @@ en:
         outputted:
 
         %{vboxmanage} --version
+      virtualbox_invalid_host_subnet: |-
+        The IP address configured for the host-only network is not within the
+        allowed ranges. Please update the address used to be within the allowed
+        ranges and run the command again.
+
+          Address: %{address}
+          Ranges: %{ranges}
+
+        Valid ranges can be modified in the /etc/vbox/networks.conf file. For
+        more information including valid format see:
+
+          https://www.virtualbox.org/manual/ch06.html#network_hostonly
       vm_creation_required: |-
         VM must be created before running this command. Run `vagrant up` first.
       vm_inaccessible: |-

--- a/test/unit/plugins/providers/virtualbox/action/network_test.rb
+++ b/test/unit/plugins/providers/virtualbox/action/network_test.rb
@@ -131,6 +131,7 @@ describe VagrantPlugins::ProviderVirtualBox::Action::Network do
     let(:file_contents) { [""] }
 
     before do
+      allow(File).to receive(:exist?).and_call_original
       allow(File).to receive(:exist?).
         with(described_class.const_get(:VBOX_NET_CONF)).
         and_return(true)

--- a/test/unit/plugins/providers/virtualbox/action/network_test.rb
+++ b/test/unit/plugins/providers/virtualbox/action/network_test.rb
@@ -315,29 +315,29 @@ describe VagrantPlugins::ProviderVirtualBox::Action::Network do
       subject.call(env)
 
       expect(driver).to have_received(:create_host_only_network).with({
-        adapter_ip: '192.68.56.1',
+        adapter_ip: '192.168.56.1',
         netmask: '255.255.255.0',
       })
 
       expect(driver).to have_received(:create_dhcp_server).with('vboxnet0', {
-        adapter_ip: "192.68.56.1",
+        adapter_ip: "192.168.56.1",
         auto_config: true,
-        ip: "192.68.56.1",
+        ip: "192.168.56.1",
         mac: nil,
         name: nil,
         netmask: "255.255.255.0",
         nic_type: nil,
         type: :dhcp,
-        dhcp_ip: "192.68.56.2",
-        dhcp_lower: "192.68.56.3",
-        dhcp_upper: "192.68.56.254",
+        dhcp_ip: "192.168.56.2",
+        dhcp_lower: "192.168.56.3",
+        dhcp_upper: "192.168.56.254",
         adapter: 2
       })
 
       expect(guest).to have_received(:capability).with(:configure_networks, [{
         type: :dhcp,
-        adapter_ip: "192.68.56.1",
-        ip: "192.68.56.1",
+        adapter_ip: "192.168.56.1",
+        ip: "192.168.56.1",
         netmask: "255.255.255.0",
         auto_config: true,
         interface: nil
@@ -395,8 +395,8 @@ describe VagrantPlugins::ProviderVirtualBox::Action::Network do
       { ip: 'foo'},
       { ip: '1.2.3'},
       { ip: 'dead::beef::'},
-      { ip: '192.68.56.3', netmask: 64},
-      { ip: '192.68.56.3', netmask: 'ffff:ffff::'},
+      { ip: '192.168.56.3', netmask: 64},
+      { ip: '192.168.56.3', netmask: 'ffff:ffff::'},
       { ip: 'dead:beef::', netmask: 'foo:bar::'},
       { ip: 'dead:beef::', netmask: '255.255.255.0'}
     ].each do |args|

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary       = "Build and distribute virtualized development environments."
   s.description   = "Vagrant is a tool for building and distributing virtualized development environments."
 
-  s.required_ruby_version     = ">= 2.5", "< 3.1"
+  s.required_ruby_version     = ">= 2.6", "< 3.1"
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "bcrypt_pbkdf", "~> 1.1"


### PR DESCRIPTION
VirtualBox introduced a restriction on the valid range for hostonly
networks. When using a version of VirtualBox which includes this
restriction a check is performed on the defined IP address to validate
it is within either the default range (as defined in the VirtualBox
documentation) or the values defined in the network configuration
file.

Fixes (what we can): #12557 #12553
