### PR TITLE
Improve Gem spec selection when resolving

### DIFF
--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -258,7 +258,12 @@ module Vagrant
       if solution_file&.valid?
         @logger.debug("loading cached solution set")
         solution = solution_file.dependency_list.map do |dep|
-          spec = composed_set.find_all(dep).first
+          spec = composed_set.find_all(dep).select do |dep_spec|
+            next(true) unless Gem.loaded_specs.has_key?(dep_spec.name)
+
+            Gem.loaded_specs[dep_spec.name].version.eql?(dep_spec.version)
+          end.first
+
           if !spec
             @logger.warn("failed to locate specification for dependency - #{dep}")
             @logger.warn("invalidating solution file - #{solution_file}")


### PR DESCRIPTION
When computing the solution set, if a gem is already loaded, make sure
to use the specification of the loaded one instead of the first
available as otherwise there is a risk that when multiple matches are
available the specification for the wrong version may be picked.

When this happens an error message will be triggered that looks like

  can't activate json-2.3.0, already activated json-2.5.1

This can occur for distribution packaged vagrants as well as installs
for development purposes where the ruby install may contain a default
gem spec of an older version than is needed.

Fixes: #12521
Fixes: vagrant-libvirt/vagrant-libvirt#1390
Relates: #10826
Relates: #12345