### PR TITLE
show error in documentation

### DIFF
--- a/website/content/docs/provisioning/ansible_local.mdx
+++ b/website/content/docs/provisioning/ansible_local.mdx
@@ -187,9 +187,9 @@ Vagrant.configure(2) do |config|
 end
 ```
 
-### Ansible Parallel Execution from a Guest
+### Ansible Parallel Execution from a Guest deprecated
 
-With the following configuration pattern, you can install and execute Ansible only on a single guest machine (the `"controller"`) to provision all your machines.
+With the following configuration pattern, you can install and execute Ansible only on a single guest machine (the `"controller"`) to provision all your machines. This does not work since .vagrant will not be synced to the guests vms by default. In fact I tried to include it but it's not possible. To quote the doc: "By default, the ".vagrant/" directory is excluded.".
 
 ```ruby
 Vagrant.configure("2") do |config|


### PR DESCRIPTION
I tried the above setup and I could not make it work because the private keys are not copied to the vagrant vms and it's not possible to include them. I even tried: 
```
Vagrant.configure("2") do |config|
  config.vm.synced_folder ".vagrant", "/.vagrant", type: "rsync",
    rsync__exclude: ".git/"
end
```
To include it but the default exclusion of .vagrant makes it not included in the end. 