### PR TITLE
macos: add missing require_relative for version

### DIFF
--- a/plugins/hosts/darwin/cap/path.rb
+++ b/plugins/hosts/darwin/cap/path.rb
@@ -1,3 +1,5 @@
+require_relative "version"
+
 module VagrantPlugins
   module HostDarwin
     module Cap


### PR DESCRIPTION
Fix https://github.com/hashicorp/vagrant/issues/12578 where `uninitialized constant VagrantPlugins::HostDarwin::Cap::Version (NameError)` is raised because `version` is not imported.

This wasn't caught in tests as they use a mocked version of `VagrantPlugins::HostDarwin::Cap::Path::Version`.

This issue leads to `vagrant up` crashing if the VM uses NFS exports.

Tested the fix locally and ensured it works, happy to implement it in a different way if needed!

Kudos to @KSerrania for helping out with figuring the error in Ruby!