### PR TITLE
Fix missing VagrantPlugins::HostDarwin::Cap::Version on Big Sur

### DIFF
--- a/plugins/hosts/darwin/cap/path.rb
+++ b/plugins/hosts/darwin/cap/path.rb
@@ -17,7 +17,8 @@ module VagrantPlugins
         def self.resolve_host_path(env, path)
           path = File.expand_path(path)
           # Only expand firmlink paths on Catalina
-          return path if !CATALINA_CONSTRAINT.satisfied_by?(Cap::Version.version(env))
+          host_version = env.host.capability(:version)
+          return path if !CATALINA_CONSTRAINT.satisfied_by?(host_version)
 
           firmlink = firmlink_map.detect do |mount_path, data_path|
             path.start_with?(mount_path)

--- a/test/unit/plugins/hosts/darwin/cap/path_test.rb
+++ b/test/unit/plugins/hosts/darwin/cap/path_test.rb
@@ -5,13 +5,16 @@ require_relative "../../../../../../plugins/hosts/darwin/cap/version"
 describe VagrantPlugins::HostDarwin::Cap::Path do
   describe ".resolve_host_path" do
     let(:env) { double("environment") }
+    let(:host) { double("host") }
     let(:path) { "/test/vagrant/path" }
     let(:firmlink_map) { {} }
     let(:macos_version) { Gem::Version.new("10.15.1") }
 
     before do
-      allow(VagrantPlugins::HostDarwin::Cap::Version).to receive(:version).
-        with(anything).
+      allow(env).to receive(:host).
+        and_return(host)
+      allow(host).to receive(:capability).
+        with(:version).
         and_return(macos_version)
       allow(described_class).to receive(:firmlink_map).
         and_return(firmlink_map)


### PR DESCRIPTION
On Big Sur, mounting NFS mount is failing with a `VagrantPlugins::HostDarwin::Cap::Version (NameError)`  (https://github.com/hashicorp/vagrant/issues/12578).

This PR is an attempt to fix this issue.

I'm of course very open to any feedback to find a better solution.