### PR TITLE
Added smb_username and smb_password to example

### DIFF
--- a/website/content/docs/synced-folders/smb.mdx
+++ b/website/content/docs/synced-folders/smb.mdx
@@ -90,9 +90,12 @@ The following is an example of using SMB to sync a folder:
 
 ```ruby
 Vagrant.configure("2") do |config|
-  config.vm.synced_folder ".", "/vagrant", type: "smb"
+  config.vm.synced_folder ".", "/vagrant", type: "smb",
+    smb_username: "USERNAME",
+    smb_password: "PASSWORD"
 end
 ```
+Replace "USERNAME" and "PASSWORD" with your SMB username and password.
 
 ## Preventing Idle Disconnects
 


### PR DESCRIPTION
Adding those to the example because I had to Google for this question and answer, and it took a bit to find it:

https://stackoverflow.com/questions/44394725/how-do-i-set-the-smb-username-and-password

Clearly, I wasn't the only one with the question, so I assume updating the docs will help the next person who otherwise would have had to track down that same Q&A?