### PR TITLE
updates Chef provisioners for Cinc install verification

### DIFF
--- a/plugins/provisioners/chef/cap/freebsd/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/freebsd/chef_installed.rb
@@ -6,9 +6,14 @@ module VagrantPlugins
           # Check if Chef is installed at the given version.
           # @return [true, false]
           def self.chef_installed(machine, product, version)
-            product_name = product == 'chef-workstation' ? 'chef-workstation' : 'chef'
-            verify_bin = product_name == 'chef-workstation' ? 'chef' : 'chef-client'
-            verify_path = "/opt/#{product_name}/bin/#{verify_bin}"
+            verify_bin =  case product
+                          when 'chef-workstation' then 'chef'
+                          when 'cinc-workstation' then 'cinc'
+                          when 'cinc' then 'cinc-client'
+                          else 'chef-client'
+                          end
+
+            verify_path = "/opt/#{product}/bin/#{verify_bin}"
             command = "test -x #{verify_path}"
 
             if version != :latest

--- a/plugins/provisioners/chef/cap/linux/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/linux/chef_installed.rb
@@ -6,9 +6,14 @@ module VagrantPlugins
           # Check if Chef is installed at the given version.
           # @return [true, false]
           def self.chef_installed(machine, product, version)
-            product_name = product == 'chef-workstation' ? 'chef-workstation' : 'chef'
-            verify_bin = product_name == 'chef-workstation' ? 'chef' : 'chef-client'
-            verify_path = "/opt/#{product_name}/bin/#{verify_bin}"
+            verify_bin =  case product
+                          when 'chef-workstation' then 'chef'
+                          when 'cinc-workstation' then 'cinc'
+                          when 'cinc' then 'cinc-client'
+                          else 'chef-client'
+                          end
+
+            verify_path = "/opt/#{product}/bin/#{verify_bin}"
             command = "test -x #{verify_path}"
 
             if version != :latest

--- a/plugins/provisioners/chef/cap/omnios/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/omnios/chef_installed.rb
@@ -7,9 +7,14 @@ module VagrantPlugins
           # Check if Chef is installed at the given version.
           # @return [true, false]
           def self.chef_installed(machine, product, version)
-            product_name = product == 'chef-workstation' ? 'chef-workstation' : 'chef'
-            verify_bin = product_name == 'chef-workstation' ? 'chef' : 'chef-client'
-            verify_path = "/opt/#{product_name}/bin/#{verify_bin}"
+            verify_bin =  case product
+                          when 'chef-workstation' then 'chef'
+                          when 'cinc-workstation' then 'cinc'
+                          when 'cinc' then 'cinc-client'
+                          else 'chef-client'
+                          end
+
+            verify_path = "/opt/#{product}/bin/#{verify_bin}"
             command = "test -x #{verify_path}"
 
             if version != :latest

--- a/plugins/provisioners/chef/cap/windows/chef_installed.rb
+++ b/plugins/provisioners/chef/cap/windows/chef_installed.rb
@@ -6,7 +6,13 @@ module VagrantPlugins
           # Check if Chef is installed at the given version.
           # @return [true, false]
           def self.chef_installed(machine, product, version)
-            verify_bin = product == 'chef-workstation' ? 'chef' : 'chef-client'
+            verify_bin =  case product
+                          when 'chef-workstation' then 'chef'
+                          when 'cinc-workstation' then 'cinc'
+                          when 'cinc' then 'cinc-client'
+                          else 'chef-client'
+                          end
+
             if version != :latest
               command = 'if ((&' + verify_bin + ' --version) -Match "' + version.to_s + '"){ exit 0 } else { exit 1 }'
             else

--- a/test/unit/plugins/provisioners/chef/cap/freebsd/chef_installed_test.rb
+++ b/test/unit/plugins/provisioners/chef/cap/freebsd/chef_installed_test.rb
@@ -24,8 +24,8 @@ describe VagrantPlugins::Chef::Cap::FreeBSD::ChefInstalled do
 
   describe "#chef_installed" do
     describe "when chef-workstation" do
-      let(:version) { "15.0.0" }
-      let(:command) { "test -x /opt/chef-workstation/bin/chef&& /opt/chef-workstation/bin/chef --version | grep '15.0.0'" }
+      let(:version) { "17.0.0" }
+      let(:command) { "test -x /opt/chef-workstation/bin/chef&& /opt/chef-workstation/bin/chef --version | grep '17.0.0'" }
 
       it "returns true if installed" do
         expect(machine.communicate).to receive(:test).
@@ -40,20 +40,54 @@ describe VagrantPlugins::Chef::Cap::FreeBSD::ChefInstalled do
       end
     end
 
-    describe "when not chef-workstation" do
-      let(:version) { "15.0.0" }
-      let(:command) { "test -x /opt/chef/bin/chef-client&& /opt/chef/bin/chef-client --version | grep '15.0.0'" }
+    describe "when cinc-workstation" do
+      let(:version) { "17.0.0" }
+      let(:command) { "test -x /opt/cinc-workstation/bin/cinc&& /opt/cinc-workstation/bin/cinc --version | grep '17.0.0'" }
 
       it "returns true if installed" do
         expect(machine.communicate).to receive(:test).
           with(command, sudo: true).and_return(true)
-        subject.chef_installed(machine, "chef_solo", version)
+        subject.chef_installed(machine, "cinc-workstation", version)
       end
 
       it "returns false if not installed" do
         expect(machine.communicate).to receive(:test).
           with(command, sudo: true).and_return(false)
-        expect(subject.chef_installed(machine, "chef_solo", version)).to be_falsey
+        expect(subject.chef_installed(machine, "cinc-workstation", version)).to be_falsey
+      end
+    end
+
+    describe "when cinc" do
+      let(:version) { "17.0.0" }
+      let(:command) { "test -x /opt/cinc/bin/cinc-client&& /opt/cinc/bin/cinc-client --version | grep '17.0.0'" }
+
+      it "returns true if installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(true)
+        subject.chef_installed(machine, "cinc", version)
+      end
+
+      it "returns false if not installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(false)
+        expect(subject.chef_installed(machine, "cinc", version)).to be_falsey
+      end
+    end
+
+    describe "when default (chef)" do
+      let(:version) { "17.0.0" }
+      let(:command) { "test -x /opt/chef/bin/chef-client&& /opt/chef/bin/chef-client --version | grep '17.0.0'" }
+
+      it "returns true if installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(true)
+        subject.chef_installed(machine, "chef", version)
+      end
+
+      it "returns false if not installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(false)
+        expect(subject.chef_installed(machine, "chef", version)).to be_falsey
       end
     end
   end

--- a/test/unit/plugins/provisioners/chef/cap/linux/chef_installed_test.rb
+++ b/test/unit/plugins/provisioners/chef/cap/linux/chef_installed_test.rb
@@ -24,8 +24,8 @@ describe VagrantPlugins::Chef::Cap::Linux::ChefInstalled do
 
   describe "#chef_installed" do
     describe "when chef-workstation" do
-      let(:version) { "15.0.0" }
-      let(:command) { "test -x /opt/chef-workstation/bin/chef&& /opt/chef-workstation/bin/chef --version | grep '15.0.0'" }
+      let(:version) { "17.0.0" }
+      let(:command) { "test -x /opt/chef-workstation/bin/chef&& /opt/chef-workstation/bin/chef --version | grep '17.0.0'" }
 
       it "returns true if installed" do
         expect(machine.communicate).to receive(:test).
@@ -40,20 +40,54 @@ describe VagrantPlugins::Chef::Cap::Linux::ChefInstalled do
       end
     end
 
-    describe "when not chef-workstation" do
-      let(:version) { "15.0.0" }
-      let(:command) { "test -x /opt/chef/bin/chef-client&& /opt/chef/bin/chef-client --version | grep '15.0.0'" }
+    describe "when cinc-workstation" do
+      let(:version) { "17.0.0" }
+      let(:command) { "test -x /opt/cinc-workstation/bin/cinc&& /opt/cinc-workstation/bin/cinc --version | grep '17.0.0'" }
 
       it "returns true if installed" do
         expect(machine.communicate).to receive(:test).
           with(command, sudo: true).and_return(true)
-        subject.chef_installed(machine, "chef_solo", version)
+        subject.chef_installed(machine, "cinc-workstation", version)
       end
 
       it "returns false if not installed" do
         expect(machine.communicate).to receive(:test).
           with(command, sudo: true).and_return(false)
-        expect(subject.chef_installed(machine, "chef_solo", version)).to be_falsey
+        expect(subject.chef_installed(machine, "cinc-workstation", version)).to be_falsey
+      end
+    end
+
+    describe "when cinc" do
+      let(:version) { "17.0.0" }
+      let(:command) { "test -x /opt/cinc/bin/cinc-client&& /opt/cinc/bin/cinc-client --version | grep '17.0.0'" }
+
+      it "returns true if installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(true)
+        subject.chef_installed(machine, "cinc", version)
+      end
+
+      it "returns false if not installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(false)
+        expect(subject.chef_installed(machine, "cinc", version)).to be_falsey
+      end
+    end
+
+    describe "when default (chef)" do
+      let(:version) { "17.0.0" }
+      let(:command) { "test -x /opt/chef/bin/chef-client&& /opt/chef/bin/chef-client --version | grep '17.0.0'" }
+
+      it "returns true if installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(true)
+        subject.chef_installed(machine, "chef", version)
+      end
+
+      it "returns false if not installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(false)
+        expect(subject.chef_installed(machine, "chef", version)).to be_falsey
       end
     end
   end

--- a/test/unit/plugins/provisioners/chef/cap/omnios/chef_installed_test.rb
+++ b/test/unit/plugins/provisioners/chef/cap/omnios/chef_installed_test.rb
@@ -24,8 +24,8 @@ describe VagrantPlugins::Chef::Cap::OmniOS::ChefInstalled do
 
   describe "#chef_installed" do
     describe "when chef-workstation" do
-      let(:version) { "15.0.0" }
-      let(:command) { "test -x /opt/chef-workstation/bin/chef&& /opt/chef-workstation/bin/chef --version | grep '15.0.0'" }
+      let(:version) { "17.0.0" }
+      let(:command) { "test -x /opt/chef-workstation/bin/chef&& /opt/chef-workstation/bin/chef --version | grep '17.0.0'" }
 
       it "returns true if installed" do
         expect(machine.communicate).to receive(:test).
@@ -40,20 +40,54 @@ describe VagrantPlugins::Chef::Cap::OmniOS::ChefInstalled do
       end
     end
 
-    describe "when not chef-workstation" do
-      let(:version) { "15.0.0" }
-      let(:command) { "test -x /opt/chef/bin/chef-client&& /opt/chef/bin/chef-client --version | grep '15.0.0'" }
+    describe "when cinc-workstation" do
+      let(:version) { "17.0.0" }
+      let(:command) { "test -x /opt/cinc-workstation/bin/cinc&& /opt/cinc-workstation/bin/cinc --version | grep '17.0.0'" }
 
       it "returns true if installed" do
         expect(machine.communicate).to receive(:test).
           with(command, sudo: true).and_return(true)
-        subject.chef_installed(machine, "chef_solo", version)
+        subject.chef_installed(machine, "cinc-workstation", version)
       end
 
       it "returns false if not installed" do
         expect(machine.communicate).to receive(:test).
           with(command, sudo: true).and_return(false)
-        expect(subject.chef_installed(machine, "chef_solo", version)).to be_falsey
+        expect(subject.chef_installed(machine, "cinc-workstation", version)).to be_falsey
+      end
+    end
+
+    describe "when cinc" do
+      let(:version) { "17.0.0" }
+      let(:command) { "test -x /opt/cinc/bin/cinc-client&& /opt/cinc/bin/cinc-client --version | grep '17.0.0'" }
+
+      it "returns true if installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(true)
+        subject.chef_installed(machine, "cinc", version)
+      end
+
+      it "returns false if not installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(false)
+        expect(subject.chef_installed(machine, "cinc", version)).to be_falsey
+      end
+    end
+
+    describe "when default (chef)" do
+      let(:version) { "17.0.0" }
+      let(:command) { "test -x /opt/chef/bin/chef-client&& /opt/chef/bin/chef-client --version | grep '17.0.0'" }
+
+      it "returns true if installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(true)
+        subject.chef_installed(machine, "chef", version)
+      end
+
+      it "returns false if not installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(false)
+        expect(subject.chef_installed(machine, "chef", version)).to be_falsey
       end
     end
   end

--- a/test/unit/plugins/provisioners/chef/cap/windows/chef_installed_test.rb
+++ b/test/unit/plugins/provisioners/chef/cap/windows/chef_installed_test.rb
@@ -24,8 +24,8 @@ describe VagrantPlugins::Chef::Cap::Windows::ChefInstalled do
 
   describe "#chef_installed" do
     describe "when chef-workstation" do
-      let(:version) { "15.0.0" }
-      let(:command) { "if ((&chef --version) -Match \"15.0.0\"){ exit 0 } else { exit 1 }" }
+      let(:version) { "17.0.0" }
+      let(:command) { "if ((&chef --version) -Match \"17.0.0\"){ exit 0 } else { exit 1 }" }
 
       it "returns true if installed" do
         expect(machine.communicate).to receive(:test).
@@ -40,9 +40,43 @@ describe VagrantPlugins::Chef::Cap::Windows::ChefInstalled do
       end
     end
 
-    describe "when chef-workstation" do
-      let(:version) { "15.0.0" }
-      let(:command) { "if ((&chef-client --version) -Match \"15.0.0\"){ exit 0 } else { exit 1 }" }
+    describe "when cinc-workstation" do
+      let(:version) { "17.0.0" }
+      let(:command) { "if ((&cinc --version) -Match \"17.0.0\"){ exit 0 } else { exit 1 }" }
+
+      it "returns true if installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(true)
+        subject.chef_installed(machine, "cinc-workstation", version)
+      end
+
+      it "returns false if not installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(false)
+        expect(subject.chef_installed(machine, "cinc-workstation", version)).to be_falsey
+      end
+    end
+
+    describe "when cinc" do
+      let(:version) { "17.0.0" }
+      let(:command) { "if ((&cinc-client --version) -Match \"17.0.0\"){ exit 0 } else { exit 1 }" }
+
+      it "returns true if installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(true)
+        subject.chef_installed(machine, "cinc", version)
+      end
+
+      it "returns false if not installed" do
+        expect(machine.communicate).to receive(:test).
+          with(command, sudo: true).and_return(false)
+        expect(subject.chef_installed(machine, "cinc", version)).to be_falsey
+      end
+    end
+
+    describe "when default (chef)" do
+      let(:version) { "17.0.0" }
+      let(:command) { "if ((&chef-client --version) -Match \"17.0.0\"){ exit 0 } else { exit 1 }" }
 
       it "returns true if installed" do
         expect(machine.communicate).to receive(:test).


### PR DESCRIPTION
Issues Resolved
===

- #12587 


Changes
===

- Adds support for using `cinc` or `cinc-workstation` as configured `chef.product` values with updated `chef_installed` method from #12555 
- Removes un-needed `product_name` assignment for `chef_installed` method calls.  The `product` value, if passed, matches path for bin locations to validate without the need for this additional variable.
- Updates test suites for Chef provisioners to use "chef" instead of "chef_solo" for default `product` name matching as that is the configured default for `cap/config/base.rb` under the provisioners("chef_solo" is never referenced as a `product` for the `chef_installed` method calls)
