### PR TITLE
Only clean up /etc/fstab if it really contains Vagrant data

### DIFF
--- a/plugins/guests/linux/cap/persist_mount_shared_folder.rb
+++ b/plugins/guests/linux/cap/persist_mount_shared_folder.rb
@@ -61,9 +61,17 @@ module VagrantPlugins
           machine.communicate.test("test -f /etc/fstab")
         end
 
+        def self.contains_vagrant_data?(machine)
+          machine.communicate.test("grep '#VAGRANT-BEGIN' /etc/fstab")
+        end
+
         def self.remove_vagrant_managed_fstab(machine)
           if fstab_exists?(machine)
-            machine.communicate.sudo("sed -i '/\#VAGRANT-BEGIN/,/\#VAGRANT-END/d' /etc/fstab")
+            if contains_vagrant_data?(machine)
+                machine.communicate.sudo("sed -i '/\#VAGRANT-BEGIN/,/\#VAGRANT-END/d' /etc/fstab")
+            else
+                @@logger.info("no vagrant data in fstab file, carrying on")
+            end
           else
             @@logger.info("no fstab file found, carrying on")
           end


### PR DESCRIPTION
This change, together with `allow_fstab_modification = false`, allows to run
a guest without root/sudo privileges which been broken since Vagrant 2.2.10.