### PR TITLE
feat: backport-assistant

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -19,4 +19,4 @@ jobs:
         env:
           BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
           BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
-          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.HASHIBOT_TOKEN }}

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,22 @@
+---
+name: Backport Assistant Runner
+
+on:
+  pull_request_target:
+    types:
+      - closed
+      - labeled
+
+jobs:
+  backport:
+    if: github.event.pull_request.merged
+    runs-on: ubuntu-latest
+    container: hashicorpdev/backport-assistant:0.2.3
+    steps:
+      - name: Backport changes to stable-website
+        run: |
+          backport-assistant backport -automerge
+        env:
+          BACKPORT_LABEL_REGEXP: "backport/(?P<target>website)"
+          BACKPORT_TARGET_TEMPLATE: "stable-{{.target}}"
+          GITHUB_TOKEN: ${{ secrets.ELEVATED_GITHUB_TOKEN }}


### PR DESCRIPTION
# Description

This introduces https://github.com/hashicorp/backport-assistant

### `backport/website` - label

Labelling and merging a PR with this label will trigger a backport PR to be opened and automerged (see `-automerge` flag) into `stable-website`

- [x] requires `ELEVATED_GITHUB_TOKEN` w/ **repo** permissions