### PR TITLE
gentoo-guests: add nfs capability

### DIFF
--- a/plugins/guests/gentoo/cap/nfs.rb
+++ b/plugins/guests/gentoo/cap/nfs.rb
@@ -1,0 +1,15 @@
+module VagrantPlugins
+  module GuestGentoo
+    module Cap
+      class NFS
+        def self.nfs_client_install(machine)
+          comm = machine.communicate
+          comm.sudo <<-EOH.gsub(/^ {12}/, '')
+            emerge nfs-utils
+            exit $?
+          EOH
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/gentoo/plugin.rb
+++ b/plugins/guests/gentoo/plugin.rb
@@ -20,6 +20,11 @@ module VagrantPlugins
         require_relative "cap/configure_networks"
         Cap::ConfigureNetworks
       end
+
+      guest_capability(:gentoo, :nfs_client_install) do
+        require_relative "cap/nfs"
+        Cap::NFS
+      end
     end
   end
 end


### PR DESCRIPTION
This allows mounting shared directories in
gentoo guests.

This is a possible fix for #12576.

