### PR TITLE
website: Update Dockerfile

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.mirror.hashicorp.services/node:14-alpine
+FROM docker.mirror.hashicorp.services/node:14.17.0-alpine
 RUN apk add --update --no-cache git make g++ automake autoconf libtool nasm libpng-dev
 
 COPY ./package.json /website/package.json


### PR DESCRIPTION
This PR upgrades the website's Dockerfile image to `node:14.17.0-alpine`, aligned with our other sites.