### PR TITLE
chore(website): /vmware/index placeholder

### DIFF
--- a/website/content/vmware/index.mdx
+++ b/website/content/vmware/index.mdx
@@ -1,0 +1,7 @@
+---
+layout: vmware
+page_title: VMware
+description: This is a placeholder page.
+---
+
+See [/docs/providers/vmware](/docs/providers/vmware)


### PR DESCRIPTION
Adding a placeholder page at `/docs/vmware` so the build can succeed. It will never get hit as we have a redirect in place which will take users to `/docs/providers/vmware`.