### PR TITLE
website: Update Dockerfile

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.mirror.hashicorp.services/node:14-alpine
+FROM docker.mirror.hashicorp.services/node:14.17.0-alpine
 RUN apk add --update --no-cache git make g++ automake autoconf libtool nasm libpng-dev
 
 COPY ./package.json /website/package.json


### PR DESCRIPTION
This PR updates the website's Dockerfile to use the `node:14.17.0-alpine` image, in line with our other sites.