### PR TITLE
fixes bdstar for newer ubuntu versions

### DIFF
--- a/scripts/setup_tests
+++ b/scripts/setup_tests
@@ -10,10 +10,17 @@ if ! bsdtar --version
 then
   apt-get install -y bsdtar &&
     bsdtar --version || {
-      echo 'Failed to install bsdtar' >&2
-      exit 1
+      echo 'Failed to install bsdtar. Checking if it is avalialbe from another source.' >&2
     }
 fi
+if ! bsdtar --version 
+then 
+  apt-get install -y libarchive-tools &&
+    bsdtar --version || {
+      echo 'Failed to install libarchive-tools.' >&2
+      exit 1
+    }
+fi 
 
 # Install next-to-last Ruby that complies with Vagrant's version
 # constraint


### PR DESCRIPTION
For ubuntu focal 20.04, the `bastar` is replaced by `libarchive-tools`. Although the Vagrantfile specifies ubuntu bionic 18.04, it's still nice to have the script work for newer versions in case something doesn't work in bionic 18.04 (I somehow couldn't install virtualbox in 18.04, so I tried 20.04 instead).