### PR TITLE
Allow link-local IPv6 address on host-only network

### DIFF
--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -27,7 +27,10 @@ module VagrantPlugins
         # Version of VirtualBox on darwin platform that ignores restrictions
         DARWIN_IGNORE_HOSTONLY_VALIDATE_VERSION = Gem::Version.new("7.0.0")
         # Default valid range for hostonly networks
-        HOSTONLY_DEFAULT_RANGE = [IPAddr.new("192.168.56.0/21").freeze].freeze
+        HOSTONLY_DEFAULT_RANGE = [
+          IPAddr.new("192.168.56.0/21").freeze
+          IPAddr.new("fe80::/10").freeze
+        ].freeze
 
         include Vagrant::Util::NetworkIP
         include Vagrant::Util::ScopedHashOverride

--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -28,7 +28,7 @@ module VagrantPlugins
         DARWIN_IGNORE_HOSTONLY_VALIDATE_VERSION = Gem::Version.new("7.0.0")
         # Default valid range for hostonly networks
         HOSTONLY_DEFAULT_RANGE = [
-          IPAddr.new("192.168.56.0/21").freeze
+          IPAddr.new("192.168.56.0/21").freeze,
           IPAddr.new("fe80::/10").freeze
         ].freeze
 


### PR DESCRIPTION
Since VirtualBox 6.1.28, if you want to create a host-only network,
virtualbox checks if the ip is in a certain range.

According to the manual (https://www.virtualbox.org/manual/ch06.html),
ipv6 link-local addresses are allowed so add the IPv6 link-local range.