### PR TITLE
update docs: config.ssh.private_key_path if use ssh-agent will failed

### DIFF
--- a/website/content/docs/vagrantfile/ssh_settings.mdx
+++ b/website/content/docs/vagrantfile/ssh_settings.mdx
@@ -104,7 +104,7 @@ defaults are typically fine, but you can fine tune whatever you would like.
   key to use to SSH into the guest machine. By default this is the insecure private key
   that ships with Vagrant, since that is what public boxes use. If you make
   your own custom box with a custom SSH key, this should point to that
-  private key. You can also specify multiple private keys by setting this to be an array.
+  private key and set config.ssh.keys_only as false if you use ssh-agent. You can also specify multiple private keys by setting this to be an array.
   This is useful, for example, if you use the default private key to bootstrap
   the machine, but replace it with perhaps a more secure key later.
 


### PR DESCRIPTION
if user use config.ssh.private_key_path and also use ssh-agent (ex. macos maxgoedjen/secretive), user need disable config.ssh.keys_only param also, for prevent IdentitiesOnly influence.