### PR TITLE
Homepage: mention that Vagrant is free software

### DIFF
--- a/website/pages/home/index.jsx
+++ b/website/pages/home/index.jsx
@@ -92,6 +92,16 @@ $ vagrant ssh
           </TextSplit>
         </div>
       </section>
+      
+      <section className={s.freeSoftware}>
+        <div className="g-grid-container">
+          <div className={s.tag}>Free software</div>
+          <h2 className={s.h2}>Vagrant is free software</h2>
+          <p className="g-type-body">
+            Vagrant is licensed under the <a href="https://spdx.org/licenses/MIT.html">MIT license</a>.
+          </p>
+        </div>
+      </section>
 
       <section className={s.trustedAtScale}>
         <div className="g-grid-container">


### PR DESCRIPTION
As far as I can tell Vagrant is free software. This is a big deal for some people (like me). This is a big enough feature to mention it on your homepage.

Note: I could not find a detailed list of components/plugins and their licenses in your documentation. Is all of Vagrant MIT-licensed? Are some parts released under a different license?