### PR TITLE
WSL improvements for Disks with VirtualBox provider

### DIFF
--- a/plugins/providers/virtualbox/cap/configure_disks.rb
+++ b/plugins/providers/virtualbox/cap/configure_disks.rb
@@ -249,6 +249,9 @@ module VagrantPlugins
 
           guest_info = machine.provider.driver.show_vm_info
           guest_folder = File.dirname(guest_info["CfgFile"])
+          if Vagrant::Util::Platform.wsl?
+            guest_folder = File.dirname(Vagrant::Util::Platform.unix_windows_path(guest_info["CfgFile"]))
+          end
 
           disk_ext = disk_config.disk_ext
           disk_file = File.join(guest_folder, disk_config.name) + ".#{disk_ext}"


### PR DESCRIPTION
Fixes #12643 

I based this on how WSL is handled elsewhere, as well as seeing what Windows and WSL-related functions were available in `lib/vagrant/util/platform.rb`

This could be expanded to other providers, and also to handle other subsystems on windows, like cygwin. 