### PR TITLE
Fix the CI for Ruby 3.0: Stop using the last argument as kwargs in unit tests

### DIFF
--- a/test/unit/plugins/commands/package/command_test.rb
+++ b/test/unit/plugins/commands/package/command_test.rb
@@ -64,7 +64,7 @@ describe VagrantPlugins::CommandPackage::Command do
 
         it "packages default machine inside specified folder" do
           expect(package_command).to receive(:package_vm).with(
-            a_machine_named('default'), :output => "package-output-folder/default"
+            a_machine_named('default'), { output: "package-output-folder/default" }
           )
           package_command.execute
         end
@@ -96,7 +96,7 @@ describe VagrantPlugins::CommandPackage::Command do
         let(:argv){ ['--base', 'machine-id'] }
 
         it "packages vm defined within virtualbox" do
-          expect(package_command).to receive(:package_base).with(:base => 'machine-id')
+          expect(package_command).to receive(:package_base).with({ base: 'machine-id' })
           package_command.execute
         end
 

--- a/test/unit/plugins/providers/hyperv/action/read_guest_ip_test.rb
+++ b/test/unit/plugins/providers/hyperv/action/read_guest_ip_test.rb
@@ -31,7 +31,7 @@ describe VagrantPlugins::HyperV::Action::ReadGuestIP do
     end
 
     it "should set the host information into the env" do
-      expect(env).to receive(:[]=).with(:machine_ssh_info, host: "ADDRESS")
+      expect(env).to receive(:[]=).with(:machine_ssh_info, { host: "ADDRESS" })
       expect(driver).to receive(:read_guest_ip).and_return("ip" => "ADDRESS")
       subject.call(env)
     end

--- a/test/unit/vagrant/ui_test.rb
+++ b/test/unit/vagrant/ui_test.rb
@@ -379,12 +379,12 @@ describe Vagrant::UI::Prefixed do
 
   describe "#machine" do
     it "sets the target option" do
-      expect(ui).to receive(:machine).with(:foo, target: prefix)
+      expect(ui).to receive(:machine).with(:foo, { target: prefix })
       subject.machine(:foo)
     end
 
     it "preserves existing options" do
-      expect(ui).to receive(:machine).with(:foo, :bar, foo: :bar, target: prefix)
+      expect(ui).to receive(:machine).with(:foo, :bar, { foo: :bar, target: prefix })
       subject.machine(:foo, :bar, foo: :bar)
     end
   end


### PR DESCRIPTION
A few unit tests started failing with Ruby 3.0, because they were relying on
keyword arguments being converted into hashes automatically. This behavior was
deprecated in Ruby 2.7 and results in errors in Ruby 3.0 onward.

For further details:
https://rubyreferences.github.io/rubychanges/3.0.html#keyword-arguments-are-now-fully-separated-from-positional-arguments