### PR TITLE
Mentioning Parallels Provider in Docs

### DIFF
--- a/website/content/docs/providers/parallels.mdx
+++ b/website/content/docs/providers/parallels.mdx
@@ -1,0 +1,21 @@
+---
+layout: docs
+page_title: Parallels Desktop Provider
+description: |-
+  Parallels offer a free Vagrant provider to manage Parallels Desktop for Mac-based virtual machines.
+  There is a website with detailed documentation.
+---
+
+# Parallels
+
+The Parallels provider for Vagrant is officially supported by [Parallels](https://www.parallels.com) and 
+allows managing Parallels Desktop for Mac virtual machines. 
+Both Intel and Apple M1-powered Mac computers are supported. 
+
+The Parallels provider is free and open for contributions on the [GitHub](https://github.com/Parallels/vagrant-parallels).
+
+The Parallels provider is compatible with the latest versions of Parallels Desktop for Mac and works with
+ "Pro" and "Business" editions. Please note that Parallels Desktop is a third-party product
+that must be purchased and installed separately before using the provider.
+
+Learn more about the Parallels provider installation, configuration, and boxes with the [Vagrant Parallels Provider documentation](https://parallels.github.io/vagrant-parallels/docs/).

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -640,6 +640,10 @@
         ]
       },
       {
+        "title": "Parallels Provider",
+        "path": "providers/parallels"
+      },
+      {
         "title": "Custom Provider",
         "path": "providers/custom"
       }


### PR DESCRIPTION
Adding a mention of Parallels Provider to use with Vagrant. There is a short description and links to Parallels, Provider's Git, and Documentation.

Tested on node v16.14.0
<img width="1386" alt="navigation" src="https://user-images.githubusercontent.com/13949219/158051332-cb8fecdc-7c27-42a2-8a5a-88f11b3d36b7.png">
<img width="1386" alt="description" src="https://user-images.githubusercontent.com/13949219/158051335-7b1e6c43-62bb-40bc-a0bc-13befb6965c4.png">
.