### PR TITLE
Fixing typo for VAGRANT_DISABLE_WINCURL option in website docs

### DIFF
--- a/website/content/docs/other/environmental-variables.mdx
+++ b/website/content/docs/other/environmental-variables.mdx
@@ -294,7 +294,7 @@ use the embedded `ssh` executable by setting it to `0`.
 If this is set, Vagrant-go will not output a warning message about compatibility 
 with Vagrant-ruby. This does not effect the stable Ruby release of Vagrant.
 
-## `VAGRANT_WINCURL_DISABLE`
+## `VAGRANT_DISABLE_WINCURL`
 
 If set Vagrant will use the mingw build of curl which uses the installer provided
 ca-certificates bundle instead of the native Windows curl executable.


### PR DESCRIPTION
This PR is to fix a typo in the docs where the environment variable "VAGRANT_DISABLE_WINCURL" was written as "VAGRANT_WINCURL_DISABLE". The usage of this environment variable can be seen here:

https://github.com/hashicorp/vagrant-installers/blob/main/substrate/launcher/main.go#L339