### PR TITLE
Document Box requirement for "vagrant" group

### DIFF
--- a/website/content/docs/boxes/base.mdx
+++ b/website/content/docs/boxes/base.mdx
@@ -116,10 +116,11 @@ users, passwords, private keys, etc.).
 By default, Vagrant expects a "vagrant" user to SSH into the machine as.
 This user should be setup with the
 [insecure keypair](https://github.com/hashicorp/vagrant/tree/main/keys)
-that Vagrant uses as a default to attempt to SSH. Also, even though
-Vagrant uses key-based authentication by default, it is a general convention
-to set the password for the "vagrant" user to "vagrant". This lets people
-login as that user manually if they need to.
+that Vagrant uses as a default to attempt to SSH. It should belong to a
+group named "vagrant". Also, even though Vagrant uses key-based
+authentication by default, it is a general convention to set the
+password for the "vagrant" user to "vagrant". This lets people login as
+that user manually if they need to.
 
 To configure SSH access with the insecure keypair, place the public
 key into the `~/.ssh/authorized_keys` file for the "vagrant" user. Note


### PR DESCRIPTION
By default, the `vagrant rsync` command assumes that the SSH user
belongs to a group of the same name [1]:

    # Folder options
    opts[:owner] ||= ssh_info[:username]
    opts[:group] ||= ssh_info[:username]

Although consumers can override this behavior, Vagrant Boxes which
follow this convention will provide a more seamless experience. Document
the convention in the instructions for Vagrant Box authors.

[1] https://github.com/hashicorp/vagrant/blob/3d68e16f1b5d616f879d24f48dac2598acac0a38/plugins/synced_folders/rsync/helper.rb#L73-L75