### PR TITLE
Bump fake_ftp to ~> 0.3.0 & adjust tests

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -18,6 +18,9 @@ end
 # Add our patches to net-ssh
 require "vagrant/patches/net-ssh"
 
+# Add our patches to fake_ftp
+require "vagrant/patches/fake_ftp"
+
 require "optparse"
 
 module Vagrant

--- a/lib/vagrant/patches/fake_ftp.rb
+++ b/lib/vagrant/patches/fake_ftp.rb
@@ -1,0 +1,25 @@
+require "fake_ftp"
+
+module FakeFtp
+  class File
+    def initialize(name = nil, data = nil, type = nil,
+      last_modified_time = Time.now)
+      @created = Time.now
+      @name = name
+      @data = data
+      @bytes = data_is_bytes(data) ? data : data.bytes.length
+      @data = data_is_bytes(data) ? nil : data
+      @type = type
+      @last_modified_time = last_modified_time.utc
+    end
+
+    def data_is_bytes(d)
+      d.nil? || d.is_a?(Integer)
+    end
+
+    def data=(data)
+      @bytes = data_is_bytes(data) ? data : data.bytes.length
+      @data = data_is_bytes(data) ? nil : data
+    end
+  end
+end

--- a/test/unit/plugins/pushes/ftp/adapter_test.rb
+++ b/test/unit/plugins/pushes/ftp/adapter_test.rb
@@ -77,7 +77,7 @@ describe VagrantPlugins::FTPPush::FTPAdapter do
         ftp.upload("#{@dir}/file", "/file")
       end
 
-      expect(server.files).to include("file")
+      expect(server.files).to include("/file")
     end
 
     it "uploads in passive mode" do
@@ -86,7 +86,7 @@ describe VagrantPlugins::FTPPush::FTPAdapter do
         ftp.upload("#{@dir}/file", "/file")
       end
 
-      expect(server.file("file")).to be_passive
+      expect(server.file("/file")).to be_passive
     end
   end
 end

--- a/test/unit/plugins/pushes/ftp/push_test.rb
+++ b/test/unit/plugins/pushes/ftp/push_test.rb
@@ -97,7 +97,7 @@ describe VagrantPlugins::FTPPush::Push do
           subject.push
         end
 
-        expect(server.files).to eq(%w(Gemfile data.txt))
+        expect(server.files).to eq(%w(/var/www/site/Gemfile /var/www/site/data.txt))
       ensure
         FileUtils.rm_rf(pwd)
       end

--- a/test/unit/plugins/pushes/ftp/push_test.rb
+++ b/test/unit/plugins/pushes/ftp/push_test.rb
@@ -70,7 +70,7 @@ describe VagrantPlugins::FTPPush::Push do
 
     it "pushes the files to the server" do
       subject.push
-      expect(server.files).to eq(%w(Gemfile data.txt))
+      expect(server.files).to eq(%w[/var/www/site/Gemfile /var/www/site/data.txt])
     end
 
     it "raises informative exception when too many files to process" do

--- a/test/unit/vagrant/action/builtin/box_add_test.rb
+++ b/test/unit/vagrant/action/builtin/box_add_test.rb
@@ -49,7 +49,7 @@ describe Vagrant::Action::Builtin::BoxAdd, :skip_windows, :bsdtar do
       port = port1
       server = FakeFtp::Server.new(port1, port2)
     end
-    server.add_file(path.basename, path.read)
+    server.add_file(path.basename.to_s, path.read)
     server.start
     yield port
   ensure

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -47,7 +47,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rake", "~> 13.0"
   s.add_development_dependency "rspec", "~> 3.11.0"
   s.add_development_dependency "rspec-its", "~> 1.3.0"
-  s.add_development_dependency "fake_ftp", "~> 0.1.1"
+  s.add_development_dependency "fake_ftp", "~> 0.3.0"
   s.add_development_dependency "webrick", "~> 1.7.0"
 
   # The following block of code determines the files that should be included


### PR DESCRIPTION
Sadly, `fake_ftp` is unmaintained since 2021, but all other alternatives haven't been touched for even longer :-/