### PR TITLE
Add DSAAuthentication to synced_folders/rsync & add PubkeyAuthentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+- synced_folders/rsync: Adds DSAAuthentication=yes to rsh command in case that is disabled on the user's system. [GH-8183]
+
 VAGRANT-GO:
 
 ## 2.3.4 (December 9, 2022)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ FEATURES:
 
 IMPROVEMENTS:
 
+- SSH adds the configurable PubkeyAuthentication flag option in case that is disabled on the user's system. [GH-8183]
+
 BUG FIXES:
 
 - synced_folders/rsync: Adds DSAAuthentication=yes to rsh command in case that is disabled on the user's system. [GH-8183]

--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -466,6 +466,7 @@ module Vagrant
       info[:username] ||= @config.ssh.default.username
       info[:remote_user] ||= @config.ssh.default.remote_user
       info[:compression] ||= @config.ssh.default.compression
+      info[:pubkey_authentication] ||= @config.ssh.default.pubkey_authentication
       info[:dsa_authentication] ||= @config.ssh.default.dsa_authentication
       info[:extra_args] ||= @config.ssh.default.extra_args
       info[:config] ||= @config.ssh.default.config
@@ -477,6 +478,7 @@ module Vagrant
       info[:keys_only] = @config.ssh.keys_only
       info[:verify_host_key] = @config.ssh.verify_host_key
       info[:compression] = @config.ssh.compression
+      info[:pubkey_authentication] = @config.ssh.pubkey_authentication
       info[:dsa_authentication] = @config.ssh.dsa_authentication
       info[:username] = @config.ssh.username if @config.ssh.username
       info[:password] = @config.ssh.password if @config.ssh.password

--- a/lib/vagrant/util/ssh.rb
+++ b/lib/vagrant/util/ssh.rb
@@ -127,6 +127,10 @@ module Vagrant
           command_options += ["-o", "Compression=yes"]
         end
 
+        if ssh_info[:pubkey_authentication]
+          command_options += ["-o", "PubkeyAuthentication=yes"]
+        end
+
         if ssh_info[:dsa_authentication]
           command_options += ["-o", "DSAAuthentication=yes"]
         end

--- a/plugins/kernel_v2/config/ssh_connect.rb
+++ b/plugins/kernel_v2/config/ssh_connect.rb
@@ -15,6 +15,7 @@ module VagrantPlugins
       attr_accessor :paranoid
       attr_accessor :verify_host_key
       attr_accessor :compression
+      attr_accessor :pubkey_authentication
       attr_accessor :dsa_authentication
       attr_accessor :extra_args
       attr_accessor :remote_user
@@ -32,6 +33,7 @@ module VagrantPlugins
         @paranoid         = UNSET_VALUE
         @verify_host_key  = UNSET_VALUE
         @compression      = UNSET_VALUE
+        @pubkey_authentication = UNSET_VALUE
         @dsa_authentication = UNSET_VALUE
         @extra_args       = UNSET_VALUE
         @remote_user      = UNSET_VALUE
@@ -48,6 +50,7 @@ module VagrantPlugins
         @paranoid         = false if @paranoid == UNSET_VALUE
         @verify_host_key  = :never if @verify_host_key == UNSET_VALUE
         @compression      = true if @compression == UNSET_VALUE
+        @pubkey_authentication = true if @pubkey_authentication == UNSET_VALUE
         @dsa_authentication = true if @dsa_authentication == UNSET_VALUE
         @extra_args       = nil if @extra_args == UNSET_VALUE
         @config           = nil if @config == UNSET_VALUE

--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -110,6 +110,10 @@ module VagrantPlugins
         ]
         rsh += ssh_info[:extra_args] if ssh_info[:extra_args]
 
+        if ssh_info[:dsa_authentication]
+          rsh += ["-o", "DSAAuthentication=yes"]
+        end
+
         # Solaris/OpenSolaris/Illumos uses SunSSH which doesn't support the
         # IdentitiesOnly option. Also, we don't enable it if keys_only is false
         # so that SSH properly searches our identities and tries to do it itself.

--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -110,6 +110,10 @@ module VagrantPlugins
         ]
         rsh += ssh_info[:extra_args] if ssh_info[:extra_args]
 
+        if ssh_info[:pubkey_authentication]
+          rsh += ["-o", "PubkeyAuthentication=yes"]
+        end
+
         if ssh_info[:dsa_authentication]
           rsh += ["-o", "DSAAuthentication=yes"]
         end

--- a/test/unit/vagrant/util/ssh_test.rb
+++ b/test/unit/vagrant/util/ssh_test.rb
@@ -36,6 +36,7 @@ describe Vagrant::Util::SSH do
       username: "vagrant",
       private_key_path: [private_key_path],
       compression: true,
+      pubkey_authentication: true,
       dsa_authentication: true
     }}
 
@@ -87,7 +88,7 @@ describe Vagrant::Util::SSH do
 
       expect(described_class.exec(ssh_info)).to eq(nil)
       expect(Vagrant::Util::SafeExec).to have_received(:exec)
-        .with(ssh_path, "vagrant@localhost", "-p", "2222", "-o", "LogLevel=FATAL","-o", "Compression=yes", "-o", "DSAAuthentication=yes", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-i", ssh_info[:private_key_path][0])
+        .with(ssh_path, "vagrant@localhost", "-p", "2222", "-o", "LogLevel=FATAL","-o", "Compression=yes", "-o", "PubkeyAuthentication=yes", "-o", "DSAAuthentication=yes", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-i", ssh_info[:private_key_path][0])
     end
 
     context "when using '%' in a private_key_path" do
@@ -98,6 +99,7 @@ describe Vagrant::Util::SSH do
         username: "vagrant",
         private_key_path: [private_key_path],
         compression: true,
+        pubkey_authentication: true,
         dsa_authentication: true
       }}
 
@@ -106,21 +108,22 @@ describe Vagrant::Util::SSH do
         described_class.exec(ssh_info)
 
         expect(Vagrant::Util::SafeExec).to have_received(:exec)
-          .with(ssh_path, "vagrant@localhost", "-p", "2222", "-o", "LogLevel=FATAL","-o", "Compression=yes", "-o", "DSAAuthentication=yes", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-o", "IdentityFile=\"/tmp/percent%%folder\"")
+          .with(ssh_path, "vagrant@localhost", "-p", "2222", "-o", "LogLevel=FATAL","-o", "Compression=yes", "-o", "PubkeyAuthentication=yes", "-o", "DSAAuthentication=yes", "-o", "StrictHostKeyChecking=no", "-o", "UserKnownHostsFile=/dev/null", "-o", "IdentityFile=\"/tmp/percent%%folder\"")
       end
     end
 
-    context "when disabling compression or dsa_authentication flags" do
+    context "when disabling compression, pubkey_authentication or dsa_authentication flags" do
       let(:ssh_info) {{
         host: "localhost",
         port: 2222,
         username: "vagrant",
         private_key_path: [private_key_path],
         compression: false,
+        pubkey_authentication: false,
         dsa_authentication: false
       }}
 
-      it "does not include compression or dsa_authentication flags if disabled" do
+      it "does not include compression, pubkey_authentication or dsa_authentication flags if disabled" do
         allow(Vagrant::Util::SafeExec).to receive(:exec).and_return(nil)
 
         expect(described_class.exec(ssh_info)).to eq(nil)

--- a/website/content/docs/vagrantfile/ssh_settings.mdx
+++ b/website/content/docs/vagrantfile/ssh_settings.mdx
@@ -27,9 +27,16 @@ defaults are typically fine, but you can fine tune whatever you would like.
 - `config.ssh.config` (string) - Path to a custom ssh_config file to use for configuring
   the SSH connections.
 
+- `config.ssh.pubkey_authentication` (boolean) - If `false`, this setting will not include
+  `PubkeyAuthentication` when ssh'ing into a machine. If this is not set, it will
+  default to `true` and `PubkeyAuthentication=yes` will be used with ssh.
+
 - `config.ssh.dsa_authentication` (boolean) - If `false`, this setting will not include
   `DSAAuthentication` when ssh'ing into a machine. If this is not set, it will
   default to `true` and `DSAAuthentication=yes` will be used with ssh.
+
+  !> **Deprecation:** The `config.ssh.dsa_authentication` option is deprecated and will be removed
+  in a future release. Please use the `config.ssh.pubkey_authentication` option instead.
 
 - `config.ssh.export_command_template` (string) - The template used to generate
   exported environment variables in the active session. This can be useful


### PR DESCRIPTION
This adds the DSAAuthentication=yes option to rsync's rsh command when appropriate, just like done in ssh. This should fix #8183.

I've also added support for PubkeyAuthentication as its been around for 20 years now and replaces DSAAuthentication. This is most beneficial when trying to debug ssh connection issues and searching for DSAAuthentication turns up very little information.  