### PR TITLE
Enhancements for EL guests capabilities

### DIFF
--- a/plugins/guests/alma/cap/flavor.rb
+++ b/plugins/guests/alma/cap/flavor.rb
@@ -1,0 +1,23 @@
+module VagrantPlugins
+  module GuestAlma
+    module Cap
+      class Flavor
+        def self.flavor(machine)
+          # Read the version file
+          version = ""
+          machine.communicate.sudo("source /etc/os-release && printf $VERSION_ID") do |type, data|
+            if type == :stdout
+              version = data.split(".").first.to_i
+            end
+          end
+
+          if version.nil? || version < 1
+            :alma
+          else
+            "alma_#{version}".to_sym
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/alma/guest.rb
+++ b/plugins/guests/alma/guest.rb
@@ -1,0 +1,10 @@
+require_relative "../linux/guest"
+
+module VagrantPlugins
+  module GuestAlma
+    class Guest < VagrantPlugins::GuestLinux::Guest
+      # Name used for guest detection
+      GUEST_DETECTION_NAME = "almalinux".freeze
+    end
+  end
+end

--- a/plugins/guests/alma/plugin.rb
+++ b/plugins/guests/alma/plugin.rb
@@ -1,0 +1,20 @@
+require "vagrant"
+
+module VagrantPlugins
+  module GuestAlma
+    class Plugin < Vagrant.plugin("2")
+      name "Alma guest"
+      description "Alma guest support."
+
+      guest(:alma, :redhat) do
+        require_relative "guest"
+        Guest
+      end
+
+      guest_capability(:alma, :flavor) do
+        require_relative "cap/flavor"
+        Cap::Flavor
+      end
+    end
+  end
+end

--- a/plugins/guests/centos/cap/flavor.rb
+++ b/plugins/guests/centos/cap/flavor.rb
@@ -3,21 +3,24 @@ module VagrantPlugins
     module Cap
       class Flavor
         def self.flavor(machine)
-          # Read the version file
-          output = ""
-          machine.communicate.sudo("cat /etc/centos-release") do |_, data|
-            output = data
+          # Pick up version info from `/etc/os-release`. This file started to exist
+          # in CentOS 7. For versions before that (i.e. CentOS 6) just plain `:centos`
+          # should do.
+          version = nil
+          if machine.communicate.test("test -f /etc/os-release")
+            begin
+              machine.communicate.execute("source /etc/os-release && printf $VERSION_ID") do |type, data|
+                if type == :stdout
+                  version = data.split(".").first.to_i
+                end
+              end
+            rescue
+            end
           end
-
-          # Detect various flavors we care about
-          if output =~ /(CentOS)( .+)? 7/i
-            return :centos_7
-          elsif output =~ /(CentOS)( .+)? 8/i
-            return :centos_8
-          elsif output =~ /(CentOS)( .+)? 9/i
-            return :centos_9
-          else
+          if version.nil? || version < 1
             return :centos
+          else
+            return "centos_#{version}".to_sym
           end
         end
       end

--- a/plugins/guests/centos/cap/flavor.rb
+++ b/plugins/guests/centos/cap/flavor.rb
@@ -14,6 +14,8 @@ module VagrantPlugins
             return :centos_7
           elsif output =~ /(CentOS)( .+)? 8/i
             return :centos_8
+          elsif output =~ /(CentOS)( .+)? 9/i
+            return :centos_9
           else
             return :centos
           end

--- a/plugins/guests/centos/guest.rb
+++ b/plugins/guests/centos/guest.rb
@@ -1,9 +1,11 @@
+require "vagrant"
+require_relative '../linux/guest'
+
 module VagrantPlugins
   module GuestCentos
-    class Guest < Vagrant.plugin("2", :guest)
-      def detect?(machine)
-        machine.communicate.test("cat /etc/centos-release")
-      end
+    class Guest < VagrantPlugins::GuestLinux::Guest
+      # Name used for guest detection
+      GUEST_DETECTION_NAME = "centos".freeze
     end
   end
 end

--- a/plugins/guests/redhat/cap/flavor.rb
+++ b/plugins/guests/redhat/cap/flavor.rb
@@ -14,6 +14,8 @@ module VagrantPlugins
             return :rhel_7
           elsif output =~ /(Red Hat Enterprise|Scientific|Cloud|Virtuozzo)\s*Linux( .+)? release 8/i
             return :rhel_8
+          elsif output =~ /(Red Hat Enterprise|Scientific|Cloud|Virtuozzo)\s*Linux( .+)? release 9/i
+            return :rhel_9
           else
             return :rhel
           end

--- a/test/unit/plugins/guests/alma/cap/flavor_test.rb
+++ b/test/unit/plugins/guests/alma/cap/flavor_test.rb
@@ -1,0 +1,36 @@
+require_relative "../../../../base"
+
+describe "VagrantPlugins::GuestAlma::Cap::Flavor" do
+  let(:caps) do
+    VagrantPlugins::GuestAlma::Plugin
+      .components
+      .guest_capabilities[:alma]
+  end
+
+  let(:machine) { double("machine") }
+  let(:comm) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(comm)
+  end
+
+  after do
+    comm.verify_expectations!
+  end
+
+  describe ".flavor" do
+    let(:cap) { caps.get(:flavor) }
+
+    {
+      "" => :alma,
+      "8.2" => :alma_8,
+      "9" => :alma_9,
+      "invalid" => :alma
+    }.each do |str, expected|
+      it "returns #{expected} for #{str}" do
+        comm.stub_command("source /etc/os-release && printf $VERSION_ID", stdout: str)
+        expect(cap.flavor(machine)).to be(expected)
+      end
+    end
+  end
+end

--- a/test/unit/plugins/guests/centos/cap/flavor_test.rb
+++ b/test/unit/plugins/guests/centos/cap/flavor_test.rb
@@ -21,16 +21,31 @@ describe "VagrantPlugins::GuestCentos::Cap::Flavor" do
   describe ".flavor" do
     let(:cap) { caps.get(:flavor) }
 
-    {
-      "CentOS Linux 2.4 release 7" => :centos_7,
-      "CentOS Linux release 8.1.1911 (Core)" => :centos_8,
-
-      "CentOS" => :centos,
-      "banana" => :centos,
-    }.each do |str, expected|
-      it "returns #{expected} for #{str}" do
-        comm.stub_command("cat /etc/centos-release", stdout: str)
-        expect(cap.flavor(machine)).to be(expected)
+    # /etc/os-release was added in EL7+
+    context "without /etc/os-release file" do
+      {
+        "" => :centos
+      }.each do |str, expected|
+        it "returns #{expected} for #{str}" do
+          comm.stub_command("test -f /etc/os-release", exit_code: 1)
+          expect(cap.flavor(machine)).to be(expected)
+        end
+      end
+    end
+    context "with /etc/os-release file" do
+      {
+        "7" => :centos_7,
+        "8" => :centos_8,
+        "9.0" => :centos_9,
+        "9.1" => :centos_9,
+        "" => :centos,
+        "banana" => :centos,
+      }.each do |str, expected|
+        it "returns #{expected} for #{str}" do
+          comm.stub_command("test -f /etc/os-release", exit_code: 0)
+          comm.stub_command("source /etc/os-release && printf $VERSION_ID", stdout: str)
+          expect(cap.flavor(machine)).to be(expected)
+        end
       end
     end
   end


### PR DESCRIPTION
- guests: add Alma Linux guest support  
- guests: make CentOS/RHEL flavor detection more dynamic
- guests/centos: use GUEST_DETECTION_NAME='centos' to ID CentOS
- guests: RHEL 9 and CentOS stream 9 are out
