### PR TITLE
Sanitize Docker-Compose provider project name

### DIFF
--- a/plugins/providers/docker/driver/compose.rb
+++ b/plugins/providers/docker/driver/compose.rb
@@ -220,7 +220,7 @@ module VagrantPlugins
         def compose_execute(*cmd, **opts, &block)
           synchronized do
             execute("docker-compose", "-f", composition_path.to_s,
-              "-p", machine.env.cwd.basename.to_s, *cmd, **opts, &block)
+              "-p", machine.env.cwd.basename.to_s.downcase, *cmd, **opts, &block)
           end
         end
 


### PR DESCRIPTION
Docker compose project name does not allow upper case characters.
By default, Vagrant uses the current working directory as project name,
and as such there can exist upper-case characters.

As an alternative, one can use `COMPOSE_PROJECT_NAME` environment variable
to override Vagrant behaviour.

See:
* https://docs.docker.com/compose/reference/envvars/#compose_project_name