### PR TITLE
Update nfs_client.rb for rocky 9

### DIFF
--- a/plugins/guests/redhat/cap/nfs_client.rb
+++ b/plugins/guests/redhat/cap/nfs_client.rb
@@ -7,8 +7,10 @@ module VagrantPlugins
             if command -v dnf; then
               if `dnf info -q libnfs-utils > /dev/null 2>&1` ; then
                 dnf -y install nfs-utils libnfs-utils portmap
-              else
+              elif `dnf info -q nfs-utils-lib > /dev/null 2>&1` ; then
                 dnf -y install nfs-utils nfs-utils-lib portmap
+              else
+                dnf -y install nfs-utils portmap
               fi
             else
               yum -y install nfs-utils nfs-utils-lib portmap


### PR DESCRIPTION
Starting a rocky 9 box (having nfs shares) fails with: `No match for argument: nfs-utils-lib`.
Apparently Rocky 9 does not have a `nfs-utils-lib` but mounting nfs shares without nfs-utils-lib works fine.
So updating the nfs client install to only install `nfs-utils-lib` if the package is available. That way older rhel clones
should continue to work as well.