### PR TITLE
OPNsense guest plugin

### DIFF
--- a/plugins/guests/opnsense/cap/change_host_name.rb
+++ b/plugins/guests/opnsense/cap/change_host_name.rb
@@ -1,0 +1,22 @@
+module VagrantPlugins
+  module GuestOPNsense
+    module Cap
+      class ChangeHostName
+        extend Vagrant::Util::GuestHosts::BSD
+
+        def self.change_host_name(machine, name)
+          comm = machine.communicate
+
+          unless comm.test("hostname -f | grep '^#{name}$'", sudo: false, shell: "sh")
+            command = <<-EOH.gsub(/^ {14}/, '')
+              # Set the hostname and reload firewall
+              sudo sed -i '' 's@\\(<hostname>\\).*\\(</hostname>\\)@\\1#{name}\\2@g' /conf/config.xml
+              sudo /usr/local/etc/rc.reload_all
+            EOH
+            comm.sudo(command, shell: "sh")
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/opnsense/cap/change_host_name.rb
+++ b/plugins/guests/opnsense/cap/change_host_name.rb
@@ -8,9 +8,14 @@ module VagrantPlugins
           comm = machine.communicate
 
           unless comm.test("hostname -f | grep '^#{name}$'", sudo: false, shell: "sh")
+            basename = name.split(".", 2)[0]
+            domain = name.split(".", 2).drop(1).join('.') || "localdomain"
+
+            # Set the hostname and reload firewall
+            # sudo required because only root user has permissions for following tasks
             command = <<-EOH.gsub(/^ {14}/, '')
-              # Set the hostname and reload firewall
-              sudo sed -i '' 's@\\(<hostname>\\).*\\(</hostname>\\)@\\1#{name}\\2@g' /conf/config.xml
+              sudo sed -i '' 's@\\(<hostname>\\).*\\(</hostname>\\)@\\1#{basename}\\2@g' /conf/config.xml
+              sudo sed -i '' 's@\\(<domain>\\).*\\(</domain>\\)@\\1#{domain}\\2@g' /conf/config.xml
               sudo /usr/local/etc/rc.reload_all
             EOH
             comm.sudo(command, shell: "sh")

--- a/plugins/guests/opnsense/guest.rb
+++ b/plugins/guests/opnsense/guest.rb
@@ -1,0 +1,14 @@
+require 'vagrant/util/template_renderer'
+
+module VagrantPlugins
+  module GuestOPNsense
+    # A basic Vagrant system implementation for "OPNsense".
+    #
+    # Contributed by Fabio Bertagna <bertagna@puzzle.ch>
+    class Guest < Vagrant.plugin("2", :guest)
+      def detect?(machine)
+        machine.communicate.test("opnsense-version", {shell: "sh"})
+      end
+    end
+  end
+end

--- a/plugins/guests/opnsense/plugin.rb
+++ b/plugins/guests/opnsense/plugin.rb
@@ -1,0 +1,16 @@
+require "vagrant"
+
+module VagrantPlugins
+  module GuestOPNsense
+    class Plugin < Vagrant.plugin("2")
+      name "OPNsense guest"
+      description "OPNsense guest support."
+
+      guest(:opnsense, :bsd) do
+        require_relative "guest"
+        Guest
+      end
+
+    end
+  end
+end

--- a/plugins/guests/opnsense/plugin.rb
+++ b/plugins/guests/opnsense/plugin.rb
@@ -11,6 +11,11 @@ module VagrantPlugins
         Guest
       end
 
+      guest_capability(:opnsense, :change_host_name) do
+        require_relative "cap/change_host_name"
+        Cap::ChangeHostName
+      end
+
     end
   end
 end

--- a/test/unit/plugins/guests/opnsense/cap/change_host_name_test.rb
+++ b/test/unit/plugins/guests/opnsense/cap/change_host_name_test.rb
@@ -1,0 +1,52 @@
+require_relative "../../../../base"
+
+describe "VagrantPlugins::GuestOPNsense::Cap::ChangeHostName" do
+  let(:described_class) do
+    VagrantPlugins::GuestOPNsense::Plugin
+      .components
+      .guest_capabilities[:opnsense]
+      .get(:change_host_name)
+  end
+
+  let(:machine) { double("machine") }
+  let(:comm) { VagrantTests::DummyCommunicator::Communicator.new(machine) }
+  let(:name) { "banana-rama.example.com" }
+  let(:basename) { "banana-rama" }
+  let(:check_command) { "hostname -f | grep '^#{name}$'" }
+  let(:modify_hostname_command) {
+    %Q(sudo sed -i '' 's@\\(<hostname>\\).*\\(</hostname>\\)@\\1#{basename}\\2@g' /conf/config.xml
+    sudo /usr/local/etc/rc.reload_all
+).gsub(/^ {14}/, '').gsub(/^ {4}/, '')
+  }
+
+  before do
+    allow(machine).to receive(:communicate).and_return(comm)
+  end
+
+  after do
+    comm.verify_expectations!
+  end
+
+  describe ".change_host_name" do
+    context "minimal network config" do
+
+      it "sets the hostname" do
+        comm.stub_command("#{check_command}", exit_code: 1)
+
+        described_class.change_host_name(machine, name)
+        expect(comm.received_commands[0]).to eq("#{check_command}")
+        expect(comm.received_commands[1]).to eq("#{modify_hostname_command}")
+      end
+
+      it "does not change the hostname if already set" do
+        comm.stub_command("#{check_command}", exit_code: 0)
+
+        described_class.change_host_name(machine, name)
+        expect(comm.received_commands[0]).to eq("#{check_command}")
+        # sudo command should not be executed so only one command in the communicator
+        expect(comm.received_commands.length).to eq(1)
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
## Description 
Even though OPNsense is based on FreeBSD, hostname settings are not managed via the `/etc/rc.conf`. To correctly configure  hostname (and domainname)  in OPNSense the `/conf/config.xml` has to be updated with the desired values. After that the Firewall has to be reloaded with the `/usr/local/etc/rc.reload_all` command. This ensures that the changes in the config file are applyed through the whole system.

### Example
1. Vagrantfile:
    ```
    Vagrant.configure("2") do |config|
      config.vm.box = "fbertagna/opnsense"
      config.vm.box_version = "22.1.2"
      config.vm.hostname = "opnsense.vagrant.test"
    end
    ```

2. `vagrant up`
3.  Firewall is configured:
![Screenshot from 2022-07-28 15-40-39](https://user-images.githubusercontent.com/33524186/181574201-4caeb4eb-5a35-4043-8deb-6dd173b64891.png)

See #12817 