### PR TITLE
Only patch fake_ftp when running tests

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -18,9 +18,6 @@ end
 # Add our patches to net-ssh
 require "vagrant/patches/net-ssh"
 
-# Add our patches to fake_ftp
-require "vagrant/patches/fake_ftp"
-
 require "optparse"
 
 module Vagrant

--- a/test/unit/base.rb
+++ b/test/unit/base.rb
@@ -10,6 +10,9 @@ require "rspec/its"
 require "vagrant"
 require "vagrant/util/platform"
 
+# Include patches for fake ftp
+require "vagrant/patches/fake_ftp"
+
 # Add the test directory to the load path
 $:.unshift File.expand_path("../../", __FILE__)
 


### PR DESCRIPTION
The fake_ftp patches should only be applied when running tests. Since
the library is a development dependency only, it will not be available
for loading from a release.
