### PR TITLE
Include multiple build types

### DIFF
--- a/.ci/build.sh
+++ b/.ci/build.sh
@@ -23,18 +23,53 @@ wrap aws s3 cp "${gem}" "${ASSETS_PRIVATE_BUCKET}/${repository}/vagrant-main.gem
 # Install submodules
 wrap git submodule update --init --recursive \
      "Failed to install git submodules"
-# Build our binary
-wrap make \
-     "Failed to build the Vagrant go binary"
+
+# Build our binaries
+
+# Build linux amd64 binary
+wrap make bin/linux \
+     "Failed to build the Vagrant go linux amd64 binary"
 
 # Rename our binary
-wrap mv vagrant vagrant-go \
-     "Failed to rename vagrant binary"
+wrap mv vagrant vagrant-go_linux_amd64 \
+     "Failed to rename vagrant linux amd64 binary"
 
 # Zip the binary
-wrap zip vagrant-go vagrant-go \
-     "Failed to compress go binary"
+wrap zip vagrant-go_linux_amd64 vagrant-go_linux_amd64 \
+     "Failed to compress go linux amd64 binary"
 
 # Store the binary asset
-wrap aws s3 cp vagrant-go.zip "${ASSETS_PRIVATE_BUCKET}/${repository}/vagrant-go-main.zip" \
-     "Failed to store Vagrant Go main build"
+wrap aws s3 cp vagrant-go_linux_amd64.zip "${ASSETS_PRIVATE_BUCKET}/${repository}/vagrant-go_main_linux_amd64.zip" \
+     "Failed to store Vagrant Go linux amd64 main build"
+
+# Build linux 386 binary
+wrap make bin/linux-386 \
+     "Failed to build the Vagrant go linux 386 binary"
+
+# Rename our binary
+wrap mv vagrant vagrant-go_linux_386 \
+     "Failed to rename vagrant linux 386 binary"
+
+# Zip the binary
+wrap zip vagrant-go_linux_386 vagrant-go_linux_386 \
+     "Failed to compress go linux 386 binary"
+
+# Store the binary asset
+wrap aws s3 cp vagrant-go_linux_386.zip "${ASSETS_PRIVATE_BUCKET}/${repository}/vagrant-go_main_linux_386.zip" \
+     "Failed to store Vagrant Go linux 386 main build"
+
+# Build darwin binary
+wrap make bin/darwin \
+     "Failed to build the Vagrant go darwin amd64 binary"
+
+# Rename our binary
+wrap mv vagrant vagrant-go_darwin_amd64 \
+     "Failed to rename vagrant darwin amd64 binary"
+
+# Zip the binary
+wrap zip vagrant-go_darwin_amd64 vagrant-go_darwin_amd64 \
+     "Failed to compress go darwin amd64 binary"
+
+# Store the binary asset
+wrap aws s3 cp vagrant-go_darwin_amd64.zip "${ASSETS_PRIVATE_BUCKET}/${repository}/vagrant-go_main_darwin_amd64.zip" \
+     "Failed to store Vagrant Go darwin amd64 main build"

--- a/.ci/release.sh
+++ b/.ci/release.sh
@@ -35,22 +35,55 @@ gem=$(printf "%s" "${g}")
 vagrant_version="$(gem specification "${gem}" version)"
 vagrant_version="${vagrant_version##*version: }"
 
-# Build the go binary
-wrap make \
-    "Failed to build the Vagrant go binary"
+# Install submodules
+wrap git submodule update --init --recursive \
+     "Failed to install git submodules"
 
-wrap mv vagrant vagrant-go \
-    "Failed to rename Vagrant go binary"
-wrap zip vagrant-go vagrant-go \
-    "Failed to compress go binary"
+# Build our binaries
+
+# Build linux amd64 binary
+wrap make bin/linux \
+     "Failed to build the Vagrant go linux amd64 binary"
+
+# Rename our binary
+wrap mv vagrant vagrant-go_linux_amd64 \
+     "Failed to rename vagrant linux amd64 binary"
+
+# Zip the binary
+wrap zip "vagrant-go_${vagrant_version}_linux_amd64" vagrant-go_linux_amd64 \
+     "Failed to compress go linux amd64 binary"
+
+# Build linux 386 binary
+wrap make bin/linux-386 \
+     "Failed to build the Vagrant go linux 386 binary"
+
+# Rename our binary
+wrap mv vagrant vagrant-go_linux_386 \
+     "Failed to rename vagrant linux 386 binary"
+
+# Zip the binary
+wrap zip "vagrant-go_${vagrant_version}_linux_386" vagrant-go_linux_386 \
+     "Failed to compress go linux 386 binary"
+
+# Build darwin binary
+wrap make bin/darwin \
+     "Failed to build the Vagrant go darwin amd64 binary"
+
+# Rename our binary
+wrap mv vagrant vagrant-go_darwin_amd64 \
+     "Failed to rename vagrant darwin amd64 binary"
+
+# Zip the binary
+wrap zip "vagrant-go_${vagrant_version}_darwin_amd64" vagrant-go_darwin_amd64 \
+     "Failed to compress go darwin amd64 binary"
 
 wrap mkdir release-assets \
     "Failed to create release assets directory"
 
 wrap mv vagrant*.gem release-assets \
     "Failed to move Vagrant RubyGem asset to release asset directory"
-wrap mv vagrant-go.zip release-assets \
-    "Failed to move Vagrant go asset to release asset directory"
+wrap mv vagrant-go*.zip release-assets \
+    "Failed to move Vagrant go assets to release asset directory"
 
 # We want to release into the builders repository so
 # update the repository variable with the desired destination

--- a/.github/workflows/spectesting.yml
+++ b/.github/workflows/spectesting.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   setup-packet:
+    if: github.repository == 'hashicorp/vagrant-acceptance'
     runs-on: self-hosted
     name: Build Packet Instance
     steps:
@@ -21,6 +22,7 @@ jobs:
           VAGRANT_CI_LOADER_BUCKET: ${{ secrets.VAGRANT_CI_LOADER_BUCKET }}
 
   setup-hosts:
+    if: github.repository == 'hashicorp/vagrant-acceptance'
     runs-on: self-hosted
     name: Vagrant-Spec Start Hosts
     needs: setup-packet
@@ -34,7 +36,7 @@ jobs:
         uses: actions/checkout@v1
         with:
           submodules: 'recursive'
-      - name: Create packet host for tests (provider ${{ matrix.providers }})
+      - name: Create hosts for tests (provider ${{ matrix.providers }})
         run: ./.ci/spec/create-hosts.sh
         working-directory: ${{github.workspace}}
         env:
@@ -45,6 +47,7 @@ jobs:
           VAGRANT_CI_LOADER_BUCKET: ${{ secrets.VAGRANT_CI_LOADER_BUCKET }}
 
   spec-tests:
+    if: github.repository == 'hashicorp/vagrant-acceptance'
     runs-on: self-hosted
     name: Vagrant-Spec Tests
     needs: setup-hosts

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,3 @@
-# A lot of this Makefile right now is temporary since we have a private
-# repo so that we can more sanely create
 ASSETFS_PATH?=internal/server/gen/bindata_ui.go
 
 GIT_COMMIT=$$(git rev-parse --short HEAD)
@@ -20,14 +18,18 @@ debug: # debug creates an executable with optimizations off, suitable for debugg
 
 .PHONY: bin/windows
 bin/windows: # create windows binaries
-	GOOS=linux GOARCH=amd64 go build -o ./internal/assets/ceb/ceb ./cmd/vagrant-entrypoint
-	cd internal/assets && go-bindata -pkg assets -o prod.go -tags assetsembedded ./ceb
+	@test -s "thirdparty/proto/api-common-protos/.git" || { echo "git submodules not initialized, run 'git submodule update --init --recursive' and try again"; exit 1; }#
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=$(CGO_ENABLED) go build -ldflags $(GOLDFLAGS) -tags assetsembedded -o ./vagrant.exe ./cmd/vagrant
 
 .PHONY: bin/linux
 bin/linux: # create Linux binaries
 	@test -s "thirdparty/proto/api-common-protos/.git" || { echo "git submodules not initialized, run 'git submodule update --init --recursive' and try again"; exit 1; }
 	GOOS=linux GOARCH=amd64 $(MAKE) bin
+
+.PHONY: bin/linux-386
+bin/linux-386: # create Linux binaries
+	@test -s "thirdparty/proto/api-common-protos/.git" || { echo "git submodules not initialized, run 'git submodule update --init --recursive' and try again"; exit 1; }
+	GOOS=linux GOARCH=386 $(MAKE) bin
 
 .PHONY: bin/darwin
 bin/darwin: # create Darwin binaries


### PR DESCRIPTION
Updates the build job to generate vagrant-go binaries
for linux-amd64/386 and darwin-amd64.
