### PR TITLE
Update go version configuration in setup

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '>=1.17.11'
+          go-version-file: go.mod
       - name: Build RubyGem and binary
         run: ./.ci/build.sh
         working-directory: ${{github.workspace}}

--- a/.github/workflows/go-spectest.yml
+++ b/.github/workflows/go-spectest.yml
@@ -30,7 +30,7 @@ jobs:
           # to be based off a tag
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{matrix.go}}
       - name: Setup Ruby

--- a/.github/workflows/go-testing.yml
+++ b/.github/workflows/go-testing.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Code Checkout
         uses: actions/checkout@v2
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
           go-version: ${{matrix.go}}
       - name: Setup Ruby

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '>=1.17.11'
+          go-version-file: go.mod
       - name: Create Builders Release
         run: ./.ci/release.sh
         working-directory: ${{github.workspace}}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/vagrant
 
-go 1.13
+go 1.17
 
 require (
 	cloud.google.com/go/storage v1.18.2 // indirect


### PR DESCRIPTION
Updates the setup-go action to use v3 in all
jobs using it. For the build and release jobs,
which only need a single version setup, use
the defined version within the go.mod file.
