### PR TITLE
Updated the private_network.mdx file to improve clarity for beginners

### DIFF
--- a/website/content/docs/networking/private_network.mdx
+++ b/website/content/docs/networking/private_network.mdx
@@ -40,7 +40,7 @@ end
 This will automatically assign an IP address from the reserved address space.
 The IP address can be determined by using `vagrant ssh` to SSH into the
 machine and using the appropriate command line tool to find the IP,
-such as `ifconfig`.
+such as `ifconfig` or `ip addr show`.
 
 ## Static IP
 
@@ -58,14 +58,14 @@ It is up to the users to make sure that the static IP does not collide
 with any other machines on the same network.
 
 While you can choose any IP you would like, you _should_ use an IP from
-the [reserved private address space](https://en.wikipedia.org/wiki/Private_network#Private_IPv4_address_spaces). These IPs are guaranteed to never be publicly routable,
+the [reserved private address range](https://en.wikipedia.org/wiki/Private_network#Private_IPv4_address_spaces). These IPs are guaranteed to never be publicly routable,
 and most routers actually block traffic from going to them from the
 outside world.
 
 For some operating systems, additional configuration options for the static
 IP address are available such as setting the default gateway or MTU.
 
-~> **Warning!** Do not choose an IP that overlaps with any
+~> **Warning!** Do not choose a static IP that overlaps with any
 other IP space on your system. This can cause the network to not be
 reachable.
 
@@ -101,7 +101,7 @@ not work with every provider.
 ## Disable Auto-Configuration
 
 If you want to manually configure the network interface yourself, you
-can disable Vagrant's auto-configure feature by specifying `auto_config`:
+can disable Vagrant's auto-configure feature by specifying the `auto_config` field as false:
 
 ```ruby
 Vagrant.configure("2") do |config|
@@ -112,7 +112,7 @@ end
 
 If you already started the Vagrant environment before setting `auto_config`,
 the files it initially placed there will stay there. You will have to remove
-those files manually or destroy and recreate the machine.
+those files manually or destroy and recreate the machine by running `vagrant destroy` followed by `vagrant up`.
 
 The files created by Vagrant depend on the OS. For example, for many
 Linux distros, this is `/etc/network/interfaces`. In general you should


### PR DESCRIPTION
Contributed to improving the clarity of certain sentences that would help beginners -Added the word 'static' before ip and specified the commands to destroy and recreate the Vagrant environment post changing the 'auto-config' field. Added the 'ip addr show' command as ifconfig has been deprecated and thus missing by default on some modern Linux distributions.