### PR TITLE
Fixed issue provisioning ubuntu 22.04 python-dev has no install candidate

### DIFF
--- a/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
@@ -37,7 +37,7 @@ INLINE_CRIPT
 
             def self.pip_setup(machine, pip_install_cmd = "")
               machine.communicate.sudo "apt-get update -y -qq"
-              machine.communicate.sudo "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev python-dev"
+              machine.communicate.sudo "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev python-dev-is-python3"
               Pip::get_pip machine, pip_install_cmd
             end
 

--- a/test/unit/plugins/provisioners/ansible/cap/guest/shared/pip_ansible_install_examples.rb
+++ b/test/unit/plugins/provisioners/ansible/cap/guest/shared/pip_ansible_install_examples.rb
@@ -33,8 +33,7 @@ shared_examples_for "Ansible setup via pip on Debian-based systems" do
       expect(communicator).to receive(:sudo).once.ordered.
         with("apt-get update -y -qq")
       expect(communicator).to receive(:sudo).once.ordered.
-        with("DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev python-dev")
-      expect(communicator).to receive(:sudo).once.ordered.
+        with("DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev python-dev-is-python3
         with("pip install --upgrade ansible")
 
       subject.ansible_install(machine, :pip, "", "", pip_install_cmd)
@@ -44,7 +43,7 @@ shared_examples_for "Ansible setup via pip on Debian-based systems" do
       expect(communicator).to receive(:sudo).once.ordered.
         with("apt-get update -y -qq")
       expect(communicator).to receive(:sudo).once.ordered.
-        with("DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev python-dev")
+        with("DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev python-dev-is-python3")
       expect(communicator).to receive(:sudo).once.ordered.
         with("pip install")
 


### PR DESCRIPTION
Ran into this issue today dug through the code and resolved it with the following minor change. didn't see this reported in the issue list so if there is another plan to resolve this please close and i will wait for the updated version. Thanks