### PR TITLE
Relax overly strict grpc-tools version requirement

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_dependency "winrm-fs", ">= 1.3.4", "< 2.0"
 
   # Needed for go generate to use grpc_tools_ruby_protoc
-  s.add_development_dependency "grpc-tools", "~> 1.41.1"
+  s.add_development_dependency "grpc-tools", "~> 1.41"
 
   # Constraint rake to properly handle deprecated method usage
   # from within rspec


### PR DESCRIPTION
`"~> 1.41.1"` limits us to 1.41 which is already a year old now, relaxing this to `"~> 1.41"` allows us to pick up fresher and maintained releases.

@phinze you introduced this strict pin in a5f0064a86222ba55f0e162e16581ce1af8aaa69, any specific reason for going with this release?