### PR TITLE
Provider flag

### DIFF
--- a/internal/core/project.go
+++ b/internal/core/project.go
@@ -392,10 +392,13 @@ func (p *Project) DefaultProvider(opts *core.DefaultProviderOptions) (string, er
 		if opts.CheckUsable {
 			logger.Debug("Checking usable on provider", "provider", pp.Name)
 			pluginImpl := plug.Plugin.(core.Provider)
-			usable, _ := pluginImpl.Usable()
+			usable, err := pluginImpl.Usable()
 			if !usable {
 				logger.Debug("Skipping unusable provider", "provider", pp.Name)
 				continue
+			}
+			if err != nil {
+				return "", err
 			}
 		}
 


### PR DESCRIPTION
Fixes: https://github.com/hashicorp/vagrant/issues/12870 
Depends on: https://github.com/hashicorp/vagrant-plugin-sdk/pull/189

- Adds provider validation to the Vagrantfile core module
- Sets the target provider when provided to the Vagrantfile service
- Makes the provider in the Ruby service  always raise errors when running a `usable?` check

Now when running Vagrant:
```
# Invalid provider
 % ./vagrant up --provider sadg

! Running of task up failed unexpectedly
  
! Error: rpc error: code = Unknown desc = failed to locate plugin `sadg`

# Unusable provider
% ./vagrant up --provider hyperv

! The Hyper-V provider only works on Windows. Please try to
  use another provider.

# Default provider (in this case virtualbox)
% ./vagrant up                  

  Bringing machine 'one' up with 'virtualbox' provider...
```