### PR TITLE
(#12884) Use default ssh.private_key_path when ssh.keys_only = false

### DIFF
--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -501,7 +501,7 @@ module Vagrant
       if !info[:private_key_path] && !info[:password]
         if @config.ssh.private_key_path
           info[:private_key_path] = @config.ssh.private_key_path
-        elsif info[:keys_only]
+        else
           info[:private_key_path] = @env.default_private_key_path
         end
       end

--- a/test/unit/vagrant/machine_test.rb
+++ b/test/unit/vagrant/machine_test.rb
@@ -777,6 +777,16 @@ describe Vagrant::Machine do
         )
       end
 
+      it "should return the default private key path with keys_only = false" do
+        provider_ssh_info[:private_key_path] = nil
+        instance.config.ssh.private_key_path = nil
+        instance.config.ssh.keys_only = false
+
+        expect(instance.ssh_info[:private_key_path]).to eq(
+          [instance.env.default_private_key_path.to_s]
+        )
+      end
+
       it "should not set any default private keys if a password is specified" do
         provider_ssh_info[:private_key_path] = nil
         instance.config.ssh.private_key_path = nil


### PR DESCRIPTION
Per config.ssh documentation, `ssh.private_key_path` should use the default key path when not set. `ssh.keys_only = false` as worded does not prevent key based auth, it simply does not _limit_ to key based auth; setting `ssh.keys_only = false` should not change the default behavior for `ssh.private_key_path`.

Fixes #12884 