### PR TITLE
Raise error if required metadata.json box fields are not present

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -168,6 +168,10 @@ module Vagrant
       error_key(:box_metadata_corrupted)
     end
 
+    class BoxMetadataMissingRequiredFields < VagrantError
+      error_key(:box_metadata_missing_required_fields)
+    end
+
     class BoxMetadataDownloadError < VagrantError
       error_key(:box_metadata_download_error)
     end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -615,6 +615,12 @@ en:
         The metadata associated with the box '%{name}' appears corrupted.
         This is most often caused by a disk issue or system crash. Please
         remove the box, re-add it, and try again.
+      box_metadata_missing_required_fields: |-
+        The metadata associated with the box '%{name}' appears to be missing
+        the required field '%{required_field}'. Please ensure `metadata.json`
+        has all required fields.
+
+        Required fields: %{all_fields}
       box_metadata_download_error: |-
         There was an error while downloading the metadata for this box.
         The error message is shown below:

--- a/test/unit/vagrant/box_test.rb
+++ b/test/unit/vagrant/box_test.rb
@@ -45,6 +45,19 @@ describe Vagrant::Box, :skip_windows do
     end
 
     # Verify the metadata
+    expect { subject.metadata }.
+        to raise_error(Vagrant::Errors::BoxMetadataMissingRequiredFields)
+  end
+
+  it "provides the metadata associated with a box" do
+    data = { "provider" => "bar" }
+
+    # Write the metadata
+    directory.join("metadata.json").open("w") do |f|
+      f.write(JSON.generate(data))
+    end
+
+    # Verify the metadata
     expect(subject.metadata).to eq(data)
   end
 


### PR DESCRIPTION
A Vagrant box must include a [`metadata.json`](https://www.vagrantup.com/docs/boxes/format) file which contains (at least) information about the box provider. This PR adds validation to ensure that is the case and raises an error if there is no provider entry in `metadata.json`


fixes: https://github.com/hashicorp/vagrant/issues/12829