### PR TITLE
Ensure last line from extracting the SSH_AUTH_SOCK is not nil

### DIFF
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -645,7 +645,7 @@ module VagrantPlugins
               if auth_socket != ""
                 # Make sure we only read the last line which should be
                 # the $SSH_AUTH_SOCK env var we printed.
-                auth_socket = auth_socket.split("\n").last.chomp
+                auth_socket = auth_socket.split("\n").last.to_s.chomp
               end
 
               if auth_socket == ""


### PR DESCRIPTION
Fixes https://github.com/hashicorp/vagrant/issues/12849

Since this fixes a flaky issue, it's a little challenging to reproduce. One way is to slightly change the command that is breaking to force it to be in the desired "broken" state. This diff will do that by forcing the `SSH_AUTH_SOCK` env var on the guest to be empty. 

```
diff --git a/plugins/communicators/ssh/communicator.rb b/plugins/communicators/ssh/communicator.rb
index 1d45096bb..47cd75b58 100644
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -636,7 +636,7 @@ module VagrantPlugins
             # the SSH_AUTH_SOCK env var is not preserved.
             if @connection_ssh_info[:forward_agent] && sudo
               auth_socket = ""
-              execute("echo; printf $SSH_AUTH_SOCK") do |type, data|
+              execute("export SSH_AUTH_SOCK=; echo; printf \n$SSH_AUTH_SOCK") do |type, data|
                 if type == :stdout
                   auth_socket += data
                 end
```