### PR TITLE
Update NFS exports usage

### DIFF
--- a/plugins/hosts/linux/cap/nfs.rb
+++ b/plugins/hosts/linux/cap/nfs.rb
@@ -177,10 +177,11 @@ module VagrantPlugins
               exports_path = Pathname.new(NFS_EXPORTS_PATH)
 
               # Write contents out to temporary file
-              new_exports_file = Tempfile.create('vagrant')
+              new_exports_path = File.join(Dir.tmpdir, "vagrant-exports")
+              FileUtils.rm_f(new_exports_path)
+              new_exports_file = File.open(new_exports_path, "w+")
               new_exports_file.puts(new_exports_content)
               new_exports_file.close
-              new_exports_path = new_exports_file.path
 
               # Ensure new file mode and uid/gid match existing file to replace
               existing_stat = File.stat(NFS_EXPORTS_PATH)
@@ -209,7 +210,7 @@ module VagrantPlugins
                   stdout: result.stdout
               end
             ensure
-              if File.exist?(new_exports_path)
+              if !new_exports_path.nil? && File.exist?(new_exports_path)
                 File.unlink(new_exports_path)
               end
             end

--- a/website/content/docs/synced-folders/nfs.mdx
+++ b/website/content/docs/synced-folders/nfs.mdx
@@ -152,7 +152,7 @@ All of the snippets below require Vagrant version 1.7.3 or higher.
 ~> **Use the appropriate group for your user** Depending on how your machine is
 configured, you might need to use a different group than the ones listed in the examples below.
 
-For OS X, sudoers should have this entry:
+For macOS, sudoers should have this entry:
 
 ```
 Cmnd_Alias VAGRANT_EXPORTS_ADD = /usr/bin/tee -a /etc/exports
@@ -161,11 +161,11 @@ Cmnd_Alias VAGRANT_EXPORTS_REMOVE = /usr/bin/sed -E -e /*/ d -ibak /etc/exports
 %admin ALL=(root) NOPASSWD: VAGRANT_EXPORTS_ADD, VAGRANT_NFSD, VAGRANT_EXPORTS_REMOVE
 ```
 
-For Ubuntu Linux , sudoers should look like this:
+For Linux , sudoers should look like this:
 
 ```
-Cmnd_Alias VAGRANT_EXPORTS_CHOWN = /bin/chown 0\:0 /tmp/*
-Cmnd_Alias VAGRANT_EXPORTS_MV = /bin/mv -f /tmp/* /etc/exports
+Cmnd_Alias VAGRANT_EXPORTS_CHOWN = /bin/chown 0\:0 /tmp/vagrant-exports
+Cmnd_Alias VAGRANT_EXPORTS_MV = /bin/mv -f /tmp/vagrant-exports /etc/exports
 Cmnd_Alias VAGRANT_NFSD_CHECK = /etc/init.d/nfs-kernel-server status
 Cmnd_Alias VAGRANT_NFSD_START = /etc/init.d/nfs-kernel-server start
 Cmnd_Alias VAGRANT_NFSD_APPLY = /usr/sbin/exportfs -ar
@@ -176,8 +176,8 @@ For Fedora Linux, sudoers might look like this (given your user
 belongs to the vagrant group):
 
 ```
-Cmnd_Alias VAGRANT_EXPORTS_CHOWN = /bin/chown 0\:0 /tmp/*
-Cmnd_Alias VAGRANT_EXPORTS_MV = /bin/mv -f /tmp/* /etc/exports
+Cmnd_Alias VAGRANT_EXPORTS_CHOWN = /bin/chown 0\:0 /tmp/vagrant-exports
+Cmnd_Alias VAGRANT_EXPORTS_MV = /bin/mv -f /tmp/vagrant-exports /etc/exports
 Cmnd_Alias VAGRANT_NFSD_CHECK = /usr/bin/systemctl status --no-pager nfs-server.service
 Cmnd_Alias VAGRANT_NFSD_START = /usr/bin/systemctl start nfs-server.service
 Cmnd_Alias VAGRANT_NFSD_APPLY = /usr/sbin/exportfs -ar
@@ -188,8 +188,8 @@ For SUSE Linux, sudoers might look like this (given your user
 belongs to the vagrant group):
 
 ```
-Cmnd_Alias VAGRANT_CHOWN = /usr/bin/chown 0\:0 /tmp/vagrant[a-z0-9-]*
-Cmnd_Alias VAGRANT_MV = /usr/bin/mv -f /tmp/vagrant[a-z0-9-]* /etc/exports
+Cmnd_Alias VAGRANT_CHOWN = /usr/bin/chown 0\:0 /tmp/vagrant-exports
+Cmnd_Alias VAGRANT_MV = /usr/bin/mv -f /tmp/vagrant-exports /etc/exports
 Cmnd_Alias VAGRANT_START = /usr/bin/systemctl start --no-pager nfs-server
 Cmnd_Alias VAGRANT_STATUS = /usr/bin/systemctl status --no-pager nfs-server
 Cmnd_Alias VAGRANT_APPLY = /usr/sbin/exportfs -ar


### PR DESCRIPTION
Update the NFS exports write capability to use
a static file path when creating and moving the
updated file. Update documentation to match updated
implementation.
