### PR TITLE
Provide helpful error message on invalid version

### DIFF
--- a/lib/vagrant/box_collection.rb
+++ b/lib/vagrant/box_collection.rb
@@ -276,7 +276,12 @@ module Vagrant
 
       # Build up the requirements we have
       requirements = version.to_s.split(",").map do |v|
-        Gem::Requirement.new(v.strip)
+        begin
+          Gem::Requirement.new(v.strip)
+        rescue Gem::Requirement::BadRequirementError
+          raise Errors::BoxVersionInvalid,
+                version: v.strip
+        end
       end
 
       with_collection_lock do

--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -244,6 +244,10 @@ module Vagrant
       error_key(:failed, "vagrant.actions.box.verify")
     end
 
+    class BoxVersionInvalid < VagrantError
+      error_key(:box_version_invalid)
+    end
+
     class BundlerDisabled < VagrantError
       error_key(:bundler_disabled)
     end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -719,6 +719,15 @@ en:
         such as from the public Vagrant Server.
       box_update_no_name: |-
         This machine doesn't have a box. Won't update anything.
+      box_version_invalid: |-
+        The format of box version provided (%{version}) is incorrect. The
+        version must follow the semantic versioning format or semantic
+        versioning compatible constraint format. Examples of valid values:
+
+          2.0
+          2.1.4
+          >= 2
+          < 3.0.0
       bundler_disabled: |-
         Vagrant's built-in bundler management mechanism is disabled because
         Vagrant is running in an external bundler environment. In these

--- a/test/unit/vagrant/box_collection_test.rb
+++ b/test/unit/vagrant/box_collection_test.rb
@@ -197,6 +197,11 @@ describe Vagrant::BoxCollection, :skip_windows do
   end
 
   describe "#find" do
+    it "fails with custom error on invalid version" do
+      expect { subject.find("foo", :i_dont_exist, "v1.2.2") }.
+        to raise_error(Vagrant::Errors::BoxVersionInvalid)
+    end
+
     it "returns nil if the box does not exist" do
       expect(subject.find("foo", :i_dont_exist, ">= 0")).to be_nil
     end


### PR DESCRIPTION
When a box version (or constraint) is provided with an invalid
format, rescue the error and return a customized error with
information for the user explaining the problem.

Fixes #12848
