### PR TITLE
Replace deprecated File.exists? with File.exist?.

### DIFF
--- a/lib/vagrant/util/install_cli_autocomplete.rb
+++ b/lib/vagrant/util/install_cli_autocomplete.rb
@@ -29,7 +29,7 @@ module Vagrant
         @logger.info("Searching for config in home #{home}")
         @config_paths.each do |path|
           config_file = File.join(home, path)
-          if File.exists?(config_file)
+          if File.exist?(config_file)
             @logger.info("Found config file #{config_file}")
             return config_file
           end

--- a/plugins/hosts/gentoo/host.rb
+++ b/plugins/hosts/gentoo/host.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
   module HostGentoo
     class Host < Vagrant.plugin("2", :host)
       def detect?(env)
-        File.exists?("/etc/gentoo-release")
+        File.exist?("/etc/gentoo-release")
       end
     end
   end

--- a/plugins/hosts/slackware/host.rb
+++ b/plugins/hosts/slackware/host.rb
@@ -4,7 +4,7 @@ module VagrantPlugins
   module HostSlackware
     class Host < Vagrant.plugin("2", :host)
       def detect?(env)
-        return File.exists?("/etc/slackware-version") ||
+        return File.exist?("/etc/slackware-version") ||
           !Dir.glob("/usr/lib/setup/Plamo-*").empty?
       end
     end

--- a/plugins/provisioners/ansible/provisioner/host.rb
+++ b/plugins/provisioners/ansible/provisioner/host.rb
@@ -185,7 +185,7 @@ module VagrantPlugins
 
           inventory_file = Pathname.new(File.join(inventory_path, 'vagrant_ansible_inventory'))
           @@lock.synchronize do
-            if !File.exists?(inventory_file) or inventory_content != File.read(inventory_file)
+            if !File.exist?(inventory_file) or inventory_content != File.read(inventory_file)
               begin
                 # ansible dir inventory will ignore files starting with '.'
                 inventory_tmpfile = Tempfile.new('.vagrant_ansible_inventory', inventory_path)

--- a/plugins/provisioners/chef/config/chef_zero.rb
+++ b/plugins/provisioners/chef/config/chef_zero.rb
@@ -81,7 +81,7 @@ module VagrantPlugins
             errors << I18n.t("vagrant.config.chef.nodes_path_empty")
           else
             missing_paths = Array.new
-            nodes_path.each { |dir| missing_paths << dir[1] if !File.exists? dir[1] }
+            nodes_path.each { |dir| missing_paths << dir[1] if !File.exist? dir[1] }
             # If it exists at least one path on disk it's ok for Chef provisioning
             if missing_paths.size == nodes_path.size
               errors << I18n.t("vagrant.config.chef.nodes_path_missing", path: missing_paths.to_s)

--- a/test/unit/plugins/provisioners/ansible/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/ansible/provisioner_test.rb
@@ -181,7 +181,7 @@ VF
     it "generates an inventory with all active machines" do
       expect(Vagrant::Util::Subprocess).to receive(:execute).with('ansible-playbook', any_args) { |*args|
         expect(config.inventory_path).to be_nil
-        expect(File.exists?(generated_inventory_file)).to be(true)
+        expect(File.exist?(generated_inventory_file)).to be(true)
         inventory_content = File.read(generated_inventory_file)
         _ssh = config.compatibility_mode == VagrantPlugins::Ansible::COMPATIBILITY_MODE_V2_0 ? "" : "_ssh"
         if with_user
@@ -697,7 +697,7 @@ VF
       it "generates an inventory with winrm connection settings" do
         expect(Vagrant::Util::Subprocess).to receive(:execute).with('ansible-playbook', any_args) { |*args|
           expect(config.inventory_path).to be_nil
-          expect(File.exists?(generated_inventory_file)).to be(true)
+          expect(File.exist?(generated_inventory_file)).to be(true)
           inventory_content = File.read(generated_inventory_file)
 
           expect(inventory_content).to include("machine1 ansible_connection=winrm ansible_ssh_host=127.0.0.1 ansible_ssh_port=55986 ansible_ssh_user='winner' ansible_ssh_pass='winword'\n")
@@ -731,7 +731,7 @@ VF
         expect(Vagrant::Util::Subprocess).to receive(:execute).with('ansible-playbook', any_args) { |*args|
           expect(args).to include("--inventory-file=#{existing_file}")
           expect(args).not_to include("--inventory-file=#{generated_inventory_file}")
-          expect(File.exists?(generated_inventory_file)).to be(false)
+          expect(File.exist?(generated_inventory_file)).to be(false)
         }.and_return(default_execute_result)
       end
 


### PR DESCRIPTION
The method File.exists? is [deprecated](https://ruby-doc.org/core-2.5.0/File.html).

In the release of Ruby 3.2.0 it is [removed](https://github.com/ruby/ruby/commit/bf97415c02b11a8949f715431aca9eeb6311add2).

Replace File.exists? with File.exist?.