### PR TITLE
 Support colored input prompts

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/hashicorp/go-version v1.3.0
 	github.com/hashicorp/hcl/v2 v2.11.1
 	github.com/hashicorp/nomad/api v0.0.0-20200814140818-42de70466a9d
-	github.com/hashicorp/vagrant-plugin-sdk v0.0.0-20220919180735-d47bfe003e94
+	github.com/hashicorp/vagrant-plugin-sdk v0.0.0-20220928204300-c0e4b14e08c5
 	github.com/imdario/mergo v0.3.11
 	github.com/improbable-eng/grpc-web v0.13.0
 	github.com/kr/text v0.2.0

--- a/go.sum
+++ b/go.sum
@@ -367,6 +367,8 @@ github.com/hashicorp/vagrant-plugin-sdk v0.0.0-20220919180525-50c632cd450d h1:Tq
 github.com/hashicorp/vagrant-plugin-sdk v0.0.0-20220919180525-50c632cd450d/go.mod h1:zA5vDskG3gH306C+obL+yURiUiLMAlx52yqO8MC2r9w=
 github.com/hashicorp/vagrant-plugin-sdk v0.0.0-20220919180735-d47bfe003e94 h1:CGq9dOg/kK0ihxx81H59xEHGfTvRs0ls8qCL3Bujdgo=
 github.com/hashicorp/vagrant-plugin-sdk v0.0.0-20220919180735-d47bfe003e94/go.mod h1:zA5vDskG3gH306C+obL+yURiUiLMAlx52yqO8MC2r9w=
+github.com/hashicorp/vagrant-plugin-sdk v0.0.0-20220928204300-c0e4b14e08c5 h1:xxwRPE6ISOz4CFFJlk3DmDD+4ZBt7iO9YiGwk4W/CYY=
+github.com/hashicorp/vagrant-plugin-sdk v0.0.0-20220928204300-c0e4b14e08c5/go.mod h1:zA5vDskG3gH306C+obL+yURiUiLMAlx52yqO8MC2r9w=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce h1:7UnVY3T/ZnHUrfviiAgIUjg2PXxsQfs5bphsG8F7Keo=
 github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/lib/vagrant/protobufs/proto/vagrant_plugin_sdk/plugin_pb.rb
+++ b/lib/vagrant/protobufs/proto/vagrant_plugin_sdk/plugin_pb.rb
@@ -342,6 +342,7 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       optional :prompt, :string, 1
       optional :style, :string, 2
       optional :secret, :bool, 3
+      optional :color, :string, 4
     end
     add_message "hashicorp.vagrant.sdk.TerminalUI.Event.InputResp" do
       optional :input, :string, 1


### PR DESCRIPTION
This pr picks up the changes from https://github.com/hashicorp/vagrant-plugin-sdk/pull/193 for supporting colored input.

- [x] update protos
- [x] bump sdk

depends on https://github.com/hashicorp/vagrant-plugin-sdk/pull/193