### PR TITLE
Added network type from ip address resolution to virtualbox provider

### DIFF
--- a/lib/vagrant/util/ip_network_type_resolver.rb
+++ b/lib/vagrant/util/ip_network_type_resolver.rb
@@ -1,0 +1,22 @@
+require "ipaddr"
+require_relative "../errors"
+
+module Vagrant
+  module Util
+    class IpNetworkTypeResolver
+      def self.resolve(ip)
+        begin
+          ipaddr = IPAddr.new(ip)
+          if ipaddr.ipv4?
+            :static
+          else
+            :static6
+          end
+        rescue IPAddr::Error => e
+          raise Vagrant::Errors::NetworkAddressInvalid,
+            address: ip
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
The PR addresses issue mentioned in issue [#12839](https://github.com/hashicorp/vagrant/issues/12839).
Existing test scenarios pass and new one is added to affirm that resolution works.