### PR TITLE
Fix downloader user agent

### DIFF
--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -21,7 +21,7 @@ module Vagrant
       # are properly tracked.
       #
       #     Vagrant/1.7.4 (+https://www.vagrantup.com; ruby2.1.0)
-      USER_AGENT = "Vagrant/#{VERSION} (+https://www.vagrantup.com; #{RUBY_ENGINE}#{RUBY_VERSION}) #{ENV['VAGRANT_USER_AGENT_PROVISIONAL_STRING']}".freeze
+      USER_AGENT = "Vagrant/#{VERSION} (+https://www.vagrantup.com; #{RUBY_ENGINE}#{RUBY_VERSION}) #{ENV['VAGRANT_USER_AGENT_PROVISIONAL_STRING']}".strip.freeze
 
       # Hosts that do not require notification on redirect
       SILENCED_HOSTS = [

--- a/test/unit/vagrant/util/downloader_test.rb
+++ b/test/unit/vagrant/util/downloader_test.rb
@@ -22,6 +22,12 @@ describe Vagrant::Util::Downloader do
     allow(Vagrant).to receive(:in_installer?).and_return(false)
   end
 
+  describe "USER_AGENT" do
+    it "should not include a trailing space" do
+      expect(described_class.const_get(:USER_AGENT)).not_to end_with(" ")
+    end
+  end
+
   describe "#download!" do
     let(:curl_options) {
       ["-q", "--fail", "--location", "--max-redirs", "10",


### PR DESCRIPTION
Prevents a space from being included on the
end of the user agent string for the downloader.

Fixes #12921
