### PR TITLE
ci: add minimum GitHub token permissions for workflows

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,6 +7,9 @@ on:
       - closed
       - labeled
 
+permissions:
+  contents: read
+
 jobs:
   backport:
     if: github.event.pull_request.merged

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
       - 'CHANGELOG.md'
       - 'website/**'
 
+permissions:
+  contents: read
+
 jobs:
   build-gem:
     if: github.repository == 'hashicorp/vagrant'

--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -4,6 +4,9 @@ on:
       - 'main'
       - 'spec-test-*'
 
+permissions:
+  contents: read
+
 jobs:
   sync-acceptance:
     if: github.repository == 'hashicorp/vagrant'

--- a/.github/workflows/go-spectest.yml
+++ b/.github/workflows/go-spectest.yml
@@ -13,6 +13,9 @@ on:
   # Allows manual trigger on arbitrary branches via GitHub UI/API
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   vagrant-spec-tests:
     runs-on: ubuntu-18.04

--- a/.github/workflows/go-testing.yml
+++ b/.github/workflows/go-testing.yml
@@ -20,6 +20,9 @@ on:
       - 'go.mod'
       - 'go.sum'
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests-go:
     runs-on: ubuntu-18.04

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -4,8 +4,14 @@ on:
   schedule:
     - cron: '50 1 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   lock:
+    permissions:
+      issues: write  # for dessant/lock-threads to lock issues
+      pull-requests: write  # for dessant/lock-threads to lock PRs
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
       - 'CHANGELOG.md'
       - 'website/**'
 
+permissions:
+  contents: read
+
 jobs:
   trigger-release:
     name: Trigger Installers Build

--- a/.github/workflows/spectesting.yml
+++ b/.github/workflows/spectesting.yml
@@ -7,6 +7,9 @@ on:
     # Run nightly on weekdays at 05:00 UTC or midnight-ish in US time zones
     - cron: '0 5 * * 1-5'
 
+permissions:
+  contents: read
+
 jobs:
   setup-packet:
     if: github.repository == 'hashicorp/vagrant-acceptance'

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -25,6 +25,9 @@ on:
       - 'vagrant.gemspec'
       - 'Rakefile'
 
+permissions:
+  contents: read
+
 jobs:
   unit-tests-ruby:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
### Description
This PR adds minimum token permissions for the GITHUB_TOKEN in GitHub Actions workflows using [secure-workflows](https://github.com/step-security/secure-workflows).

The GitHub Actions workflow has a GITHUB_TOKEN with write access to multiple scopes. Here is an example of the permissions in one of the workflow runs:
https://github.com/hashicorp/vagrant/actions/runs/3167057422/jobs/5157250614#step:1:19

After this change, the scopes will be reduced to the minimum needed for the following workflows:

- backport.yml
- build.yml
- code.yml
- go-spectest.yml
- go-testing.yml
- lock.yml
- release.yml
- spectesting.yml
- testing.yml


### Motivation and Context

- This is a security best practice, so if the GITHUB_TOKEN is compromised due to a vulnerability or compromised Action, the damage will be reduced.
- [GitHub recommends](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token) defining minimum GITHUB_TOKEN permissions.
- The Open Source Security Foundation (OpenSSF) [Scorecards](https://github.com/ossf/scorecard) also treats not setting token permissions as a high-risk issue. This change will help increase the Scorecard score for this repository.

Signed-off-by: Ashish Kurmi <akurmi@stepsecurity.io>