### PR TITLE
Enabling ext4 as supported for synced folders within WSL

### DIFF
--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -551,10 +551,12 @@ module Vagrant
         # Mount pattern for extracting local mount information
         MOUNT_PATTERN = /^(?<device>.+?) on (?<mount>.+?) type (?<type>.+?) \((?<options>.+)\)/.freeze
 
+        # List of supported file systems for WSL
+        WSL_MOUNT_TYPES = ['drvfs', '9p', 'ext4']
+
         # Get list of local mount paths that are DrvFs file systems
         #
         # @return [Array<String>]
-        # @todo(chrisroberts): Constantize types for check
         def wsl_drvfs_mounts
           if !defined?(@_wsl_drvfs_mounts)
             @_wsl_drvfs_mounts = []
@@ -562,7 +564,7 @@ module Vagrant
               result = Util::Subprocess.execute("mount")
               result.stdout.each_line do |line|
                 info = line.match(MOUNT_PATTERN)
-                if info && (info[:type] == "drvfs" || info[:type] == "9p")
+                if info && WSL_MOUNT_TYPES.include?(info[:type])
                   @_wsl_drvfs_mounts << info[:mount]
                 end
               end

--- a/test/unit/plugins/kernel_v2/config/vm_test.rb
+++ b/test/unit/plugins/kernel_v2/config/vm_test.rb
@@ -9,6 +9,9 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
 
   let(:provider) { double("provider") }
   let(:machine) { double("machine", provider: provider, provider_name: "provider", name: "default") }
+  let(:fs_config){ double("fs_config", vm: double("fs_vm", allowed_synced_folder_types: nil)) }
+  let(:synced_folder_impl) { double("synced_folder_impl", new: double("synced_folder_inst", usable?: true, _initialize: true)) }
+  let(:synced_folders ) { {sf_impl: [synced_folder_impl, 1] } }
 
   def assert_invalid
     errors = subject.validate(machine)
@@ -37,12 +40,16 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
     allow(machine).to receive(:env).and_return(env)
     allow(machine).to receive(:provider_config).and_return(nil)
     allow(machine).to receive(:provider_options).and_return({})
+    allow(machine).to receive(:config).and_return(fs_config)
     allow(machine).to receive_message_chain(:synced_folders, :types).and_return( {} )
     allow(provider).to receive(:capability?).with(:validate_disk_ext).and_return(true)
     allow(provider).to receive(:capability).with(:validate_disk_ext, "vdi").and_return(true)
     allow(provider).to receive(:capability?).with(:set_default_disk_ext).and_return(true)
     allow(provider).to receive(:capability).with(:set_default_disk_ext).and_return("vdi")
 
+    allow(synced_folder_impl).to receive(:respond_to?).with(:wsl_allow_non_drvfs?).and_return(true)
+    allow(synced_folder_impl).to receive(:wsl_allow_non_drvfs?).and_return(true)
+    allow(Vagrant.plugin("2").manager).to receive(:synced_folders).and_return(synced_folders)
     subject.box = "foo"
   end
 
@@ -759,10 +766,8 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
     context "WSL host paths" do
       let(:valid_path){ "/mnt/c/path" }
       let(:invalid_path){ "/home/vagrant/path" }
-      let(:synced_folder_impl){ double("synced_folder_impl", new: double("synced_folder_inst", usable?: true, _initialize: true)) }
-      let(:fs_config){ double("fs_config", vm: double("fs_vm", allowed_synced_folder_types: nil)) }
       let(:plugin){ double("plugin", manager: manager) }
-      let(:manager){ double("manager", synced_folders: {sf_impl: [synced_folder_impl, 1]}) }
+      let(:manager){ double("manager", synced_folders: synced_folders) }
 
       let(:stub_pathname){ double("stub_pathname", directory?: true, relative?: false) }
 
@@ -772,8 +777,9 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
         allow(Vagrant::Util::Platform).to receive(:wsl?).and_return(true)
         allow(Vagrant::Util::Platform).to receive(:wsl_drvfs_path?).with(valid_path).and_return(true)
         allow(Vagrant::Util::Platform).to receive(:wsl_drvfs_path?).with(invalid_path).and_return(false)
-        allow(machine).to receive(:config).and_return(fs_config)
         allow(Vagrant).to receive(:plugin).with("2").and_return(plugin)
+        allow(synced_folder_impl).to receive(:respond_to?).with(:wsl_allow_non_drvfs?).and_return(true)
+        allow(synced_folder_impl).to receive(:wsl_allow_non_drvfs?).and_return(false)
         subject.synced_folder(".", "/vagrant", disabled: true)
       end
 

--- a/test/unit/vagrant/util/platform_test.rb
+++ b/test/unit/vagrant/util/platform_test.rb
@@ -500,6 +500,8 @@ none on /run/shm type tmpfs (rw,nosuid,nodev,noatime)
 none on /run/user type tmpfs (rw,nosuid,nodev,noexec,noatime,mode=755)
 binfmt_misc on /proc/sys/fs/binfmt_misc type binfmt_misc (rw,noatime)
 C: on /mnt/c type drvfs (rw,noatime)
+drvfs on /mnt/d type 9p (rw,noatime,dirsync,anme=drvfs;path=D:\\)
+/dev/sdc on /mnt/e type ext4 (rw,relatime,data=ordered)
 EOF
       }
 
@@ -509,7 +511,7 @@ EOF
       end
 
       it "should locate DrvFs mount path" do
-        expect(subject.wsl_drvfs_mounts).to eq(["/mnt/c"])
+        expect(subject.wsl_drvfs_mounts).to eq(["/mnt/c", "/mnt/d", "/mnt/e"])
       end
 
       context "when no DrvFs mounts exist" do


### PR DESCRIPTION
Since WSL2 allows for mounting proper Linux file systems, this PR is allowing shared folders from ext4 mounts
Inspired by #12056