### PR TITLE
Redirect the Hyper-V URL to the official Microsoft Hyper-V Doc

### DIFF
--- a/website/content/docs/providers/index.mdx
+++ b/website/content/docs/providers/index.mdx
@@ -10,7 +10,7 @@ description: |-
 # Providers
 
 While Vagrant ships out of the box with support for [VirtualBox](https://www.virtualbox.org),
-[Hyper-V](https://en.wikipedia.org/wiki/Hyper-V), and [Docker](https://www.docker.io),
+[Hyper-V](https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/about/), and [Docker](https://www.docker.io),
 Vagrant has the ability to manage other types of machines as well. This is done
 by using other _providers_ with Vagrant.
 


### PR DESCRIPTION
The [existing Hyper-V URL](https://en.wikipedia.org/wiki/Hyper-V) in the [Providers](https://developer.hashicorp.com/vagrant/docs/providers) page redirects to the Wikipedia page while VirtualBox and Docker URLs redirect to the official Docs. Maybe it's methodical to redirect the [Hyper-V](https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/about/) URL to the official Microsoft [Hyper-V documentation](https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/about/) as well. Hence suggesting the change in URL to the official doc -[https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/about/](https://learn.microsoft.com/en-us/virtualization/hyper-v-on-windows/about/)