### PR TITLE
website: reset redirects file

### DIFF
--- a/website/redirects.js
+++ b/website/redirects.js
@@ -1,122 +1,15 @@
-// REDIRECTS FILE
-
-// See the README file in this directory for documentation. Please do not
-// modify or delete existing redirects without first verifying internally.
-// Next.js redirect documentation: https://nextjs.org/docs/api-reference/next.config.js/redirects
-
-module.exports = [
-  { source: '/home', destination: '/', permanent: true },
-  { source: '/support', destination: '/', permanent: true },
-  { source: '/sponsors', destination: '/', permanent: true },
-  { source: '/about', destination: '/intro', permanent: true },
-  {
-    source: '/v1/:path*',
-    destination: 'https://docs-v1.vagrantup.com/:path*',
-    permanent: true,
-  },
-  {
-    source: '/blog/:path*',
-    destination: 'https://hashicorp.com/blog/:path*',
-    permanent: true,
-  },
-  {
-    source: '/download-archive/:path*',
-    destination: 'https://releases.hashicorp.com/vagrant',
-    permanent: true,
-  },
-  { source: '/intro/index', destination: '/intro', permanent: true },
-  { source: '/docs/index', destination: '/docs', permanent: true },
-  {
-    source: '/docs/virtualbox/:path*',
-    destination: '/docs/providers/virtualbox/:path*',
-    permanent: true,
-  },
-  {
-    source: '/docs/vmware/:path*',
-    destination: '/docs/providers/vmware/:path*',
-    permanent: true,
-  },
-  {
-    source: '/docs/docker/:path*',
-    destination: '/docs/providers/docker/:path*',
-    permanent: true,
-  },
-  {
-    source: '/docs/hyperv/:path*',
-    destination: '/docs/providers/hyperv/:path*',
-    permanent: true,
-  },
-  {
-    source: '/docs/vagrant-cloud',
-    destination: '/vagrant-cloud',
-    permanent: true,
-  },
-  {
-    source: '/docs/vagrant-cloud/:path*',
-    destination: '/vagrant-cloud/:path*',
-    permanent: true,
-  },
-  // Redirect "getting started" guides to Learn
-  {
-    source: '/(docs|intro)/getting-started',
-    destination:
-      'https://learn.hashicorp.com/collections/vagrant/getting-started',
-    permanent: true,
-  },
-  {
-    source: '/(docs|intro)/getting-started/project_setup',
-    destination:
-      'https://learn.hashicorp.com/tutorials/vagrant/getting-started-project-setup?in=vagrant/getting-started',
-    permanent: true,
-  },
-  {
-    source: '/(docs|intro)/getting-started/synced_folders',
-    destination:
-      'https://learn.hashicorp.com/tutorials/vagrant/getting-started-synced-folders?in=vagrant/getting-started',
-    permanent: true,
-  },
-  {
-    source: '/(docs|intro)/getting-started/:path*',
-    destination:
-      'https://learn.hashicorp.com/tutorials/vagrant/getting-started-:path*',
-    permanent: true,
-  },
-  {
-    source: '/docs/why-vagrant',
-    destination: '/intro#why-vagrant',
-    permanent: true,
-  },
-  {
-    source: '/boxes',
-    destination: 'https://app.vagrantup.com/boxes',
-    permanent: true,
-  },
-  {
-    source: '/boxes/search',
-    destination: 'https://app.vagrantup.com/boxes/search',
-    permanent: true,
-  },
-  {
-    source: '/downloads\\.(html?)?',
-    destination: '/downloads',
-    permanent: true,
-  },
-  {
-    source: '/download',
-    destination: '/downloads',
-    permanent: true,
-  },
-  {
-    source: '/vmware',
-    destination: '/docs/providers/vmware',
-    permanent: true,
-  },
-  {
-    source: '/vmware/reseller',
-    destination: '/docs/providers/vmware',
-    permanent: true,
-  },
-  // disallow '.html' or '/index.html' in favor of cleaner, simpler paths
-  { source: '/:path*/index', destination: '/:path*', permanent: true },
-  { source: '/:path*.html', destination: '/:path*', permanent: true },
-]
+/**
+ * Define your custom redirects within this file.
+ *
+ * See the README file in this directory for documentation. Please do not
+ * modify or delete existing redirects without first verifying internally.
+ *
+ * Vercel's redirect documentation:
+ * https://nextjs.org/docs/api-reference/next.config.js/redirects
+ *
+ * Relative paths with fragments (#) are not supported.
+ * For destinations with fragments, use an absolute URL.
+ *
+ * Playground for testing url pattern matching: https://npm.runkit.com/path-to-regexp
+ */
+ module.exports = []

--- a/website/redirects.js
+++ b/website/redirects.js
@@ -11,5 +11,20 @@
  * For destinations with fragments, use an absolute URL.
  *
  * Playground for testing url pattern matching: https://npm.runkit.com/path-to-regexp
+ *
+ * Note that redirects defined in a product's redirects file are applied to
+ * the developer.hashicorp.com domain, which is where the documentation content
+ * is rendered. Redirect sources should be prefixed with the product slug
+ * to ensure they are scoped to the product's section. Any redirects that are
+ * not prefixed with a product slug will be ignored.
  */
- module.exports = []
+ module.exports = [
+  /*
+  Example redirect:
+  {
+    source: '/vagrant/docs/internal-docs/my-page',
+    destination: '/vagrant/docs/internals/my-page',
+    permanent: true,
+  },
+  */
+]


### PR DESCRIPTION
This PR resets the redirects file to an empty array. Redirects that previously lived in this file have been moved to the `hashicorp/dev-portal` repository in https://github.com/hashicorp/dev-portal/pull/1277.

Note that docs-related redirects should still be added to this file.