### PR TITLE
Relax rspec dependency to ~> 3.11

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -49,7 +49,7 @@ Gem::Specification.new do |s|
   # Constraint rake to properly handle deprecated method usage
   # from within rspec
   s.add_development_dependency "rake", "~> 13.0"
-  s.add_development_dependency "rspec", "~> 3.11.0"
+  s.add_development_dependency "rspec", "~> 3.11"
   s.add_development_dependency "rspec-its", "~> 1.3.0"
   s.add_development_dependency "fake_ftp", "~> 0.3.0"
   s.add_development_dependency "webrick", "~> 1.7.0"


### PR DESCRIPTION
No need to be so overly strict, this is a test dependency, so failures will surface immediately.