### PR TITLE
Force LANG when executing commands

### DIFF
--- a/plugins/providers/virtualbox/driver/base.rb
+++ b/plugins/providers/virtualbox/driver/base.rb
@@ -460,7 +460,9 @@ module VagrantPlugins
           end
 
           # Append in the options for subprocess
-          command << { notify: [:stdout, :stderr] }
+          # NOTE: We include the LANG env var set to C to prevent command output
+          #       from being localized
+          command << { notify: [:stdout, :stderr], env: {LANG: "C"}}
 
           Vagrant::Util::Busy.busy(int_callback) do
             Vagrant::Util::Subprocess.execute(@vboxmanage_path, *command, &block)

--- a/test/unit/plugins/providers/virtualbox/support/shared/virtualbox_driver_version_5_x_examples.rb
+++ b/test/unit/plugins/providers/virtualbox/support/shared/virtualbox_driver_version_5_x_examples.rb
@@ -22,11 +22,11 @@ shared_examples "a version 5.x virtualbox driver" do |options|
 
     it "enables SharedFoldersEnableSymlinksCreate if true" do
       expect(subprocess).to receive(:execute).
-        with("VBoxManage", "setextradata", anything, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/folder", "1", {:notify=>[:stdout, :stderr]}).
+        with("VBoxManage", "setextradata", anything, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/folder", "1", {:env => {:LANG => "C"}, :notify=>[:stdout, :stderr]}).
         and_return(subprocess_result(exit_code: 0))
 
       expect(subprocess).to receive(:execute).
-        with("VBoxManage", "sharedfolder", "add", anything, "--name", "folder", "--hostpath", "/Users/brian/vagrant-folder", {:notify=>[:stdout, :stderr]}).
+        with("VBoxManage", "sharedfolder", "add", anything, "--name", "folder", "--hostpath", "/Users/brian/vagrant-folder", {:env => {:LANG => "C"}, :notify=>[:stdout, :stderr]}).
         and_return(subprocess_result(exit_code: 0))
       subject.share_folders(folders)
 
@@ -34,11 +34,11 @@ shared_examples "a version 5.x virtualbox driver" do |options|
 
     it "enables automount if option is true" do
       expect(subprocess).to receive(:execute).
-        with("VBoxManage", "setextradata", anything, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/folder", "1", {:notify=>[:stdout, :stderr]}).
+        with("VBoxManage", "setextradata", anything, "VBoxInternal2/SharedFoldersEnableSymlinksCreate/folder", "1", {:env => {:LANG => "C"}, :notify=>[:stdout, :stderr]}).
         and_return(subprocess_result(exit_code: 0))
 
       expect(subprocess).to receive(:execute).
-        with("VBoxManage", "sharedfolder", "add", anything, "--name", "folder", "--hostpath", "/Users/brian/vagrant-folder", "--automount", {:notify=>[:stdout, :stderr]}).
+        with("VBoxManage", "sharedfolder", "add", anything, "--name", "folder", "--hostpath", "/Users/brian/vagrant-folder", "--automount", {:env => {:LANG => "C"}, :notify=>[:stdout, :stderr]}).
         and_return(subprocess_result(exit_code: 0))
       subject.share_folders(folders_automount)
 
@@ -46,7 +46,7 @@ shared_examples "a version 5.x virtualbox driver" do |options|
 
     it "disables SharedFoldersEnableSymlinksCreate if false" do
       expect(subprocess).to receive(:execute).
-        with("VBoxManage", "sharedfolder", "add", anything, "--name", "folder", "--hostpath", "/Users/brian/vagrant-folder", {:notify=>[:stdout, :stderr]}).
+        with("VBoxManage", "sharedfolder", "add", anything, "--name", "folder", "--hostpath", "/Users/brian/vagrant-folder", {:env => {:LANG => "C"}, :notify=>[:stdout, :stderr]}).
         and_return(subprocess_result(exit_code: 0))
       subject.share_folders(folders_disabled)
 


### PR DESCRIPTION
This forces the LANG enviroment variable to be set to `"C"` when
executing VBoxManage commands. Doing this prevents localization of
output which causes failures of the VirtualBox driver when scanning
for information.

Fixes #12968
