### PR TITLE
VirtualBox hostnet addressing

### DIFF
--- a/plugins/providers/virtualbox/driver/version_7_0.rb
+++ b/plugins/providers/virtualbox/driver/version_7_0.rb
@@ -33,7 +33,7 @@ module VagrantPlugins
             addr = begin
                      IPAddr.new(i[:ip]).mask(i[:netmask])
                    rescue IPAddr::Error => err
-                     @logger.debug("skipping bridged interface due to parse error #{err} (#{i}) ")
+                     @logger.warn("skipping bridged interface due to parse error #{err} (#{i}) ")
                      nil
                    end
             addr.nil? ||
@@ -113,8 +113,7 @@ module VagrantPlugins
             opts[:upper] = options[:dhcp_upper]
           else
             addr = IPAddr.new(options[:adapter_ip])
-            opts[:upper] = opts[:lower] =
-            addr.mask(opts[:netmask]).to_range.first.to_s
+            opts[:upper] = opts[:lower] = addr.mask(opts[:netmask]).to_range.first.to_s
           end
 
           name_idx = read_host_only_networks.map { |hn|

--- a/plugins/providers/virtualbox/driver/version_7_0.rb
+++ b/plugins/providers/virtualbox/driver/version_7_0.rb
@@ -30,8 +30,14 @@ module VagrantPlugins
 
           # Prune any hostonly interfaces in the list
           ifaces.delete_if { |i|
-            addr = IPAddr.new(i[:ip]).mask(i[:netmask])
-            hostonly_ifaces.include?(addr)
+            addr = begin
+                     IPAddr.new(i[:ip]).mask(i[:netmask])
+                   rescue IPAddr::Error => err
+                     @logger.debug("skipping bridged interface due to parse error #{err} (#{i}) ")
+                     nil
+                   end
+            addr.nil? ||
+              hostonly_ifaces.include?(addr)
           }
 
           ifaces
@@ -107,7 +113,8 @@ module VagrantPlugins
             opts[:upper] = options[:dhcp_upper]
           else
             addr = IPAddr.new(options[:adapter_ip])
-            opts[:upper] = opts[:lower] = addr.mask(opts[:netmask]).to_range.first.to_s
+            opts[:upper] = opts[:lower] =
+            addr.mask(opts[:netmask]).to_range.first.to_s
           end
 
           name_idx = read_host_only_networks.map { |hn|
@@ -154,21 +161,32 @@ module VagrantPlugins
           # reformat the information to line up with how
           # the interfaces is structured
           read_host_only_networks.map do |net|
-            addr = IPAddr.new(net[:lowerip])
+            addr = begin
+                     IPAddr.new(net[:lowerip])
+                   rescue IPAddr::Error => err
+                     @logger.warn("invalid host only network lower IP encountered: #{err} (#{net})")
+                     next
+                   end
+            # Address of the interface will be the lower bound of the range or
+            # the first available address in the subnet
+            if addr == addr.mask(net[:networkmask])
+              addr = addr.succ
+            end
+
             net[:netmask] = net[:networkmask]
             if addr.ipv4?
-              net[:ip] = addr.mask(net[:netmask]).succ.to_s
+              net[:ip] = addr.to_s
               net[:ipv6] = ""
             else
               net[:ip] = ""
-              net[:ipv6] = addr.mask(net[:netmwask]).succ.to_s
+              net[:ipv6] = addr.to_s
               net[:ipv6_prefix] = net[:netmask]
             end
 
             net[:status] = net[:state] == "Enabled" ? "Up" : "Down"
 
             net
-          end
+          end.compact
         end
 
         def read_network_interfaces


### PR DESCRIPTION
Rescue any address errors logging them and ignoring the address. Update
how the host address is determined based on the network configuration.
Host address will be either the lowest address assignable via dhcp
configuration or first address available within the configured subnet.

Fixes #12996