### PR TITLE
Import the security module for access check

### DIFF
--- a/plugins/providers/hyperv/scripts/utils/VagrantVM/VagrantVM.psm1
+++ b/plugins/providers/hyperv/scripts/utils/VagrantVM/VagrantVM.psm1
@@ -1,6 +1,21 @@
 # Always stop when errors are encountered unless instructed not to
 $ErrorActionPreference = "Stop"
 
+# Check the version of Powershell currently in use. If it's
+# under 7.3.0 we need to restrict the maximum version of the
+# security module to prevent errors.
+# Source: https://github.com/PowerShell/PowerShell/issues/18530
+$checkVersion = $PSVersionTable.PSVersion
+if($checkVersion -eq "") {
+    $checkVersion = $(Get-Host).Version
+}
+
+if([System.Version]$checkVersion -lt [System.Version]"7.3.0") {
+    Import-Module Microsoft.Powershell.Security -MaximumVersion 3.0.0.0
+} else {
+    Import-Module Microsoft.Powershell.Security
+}
+
 # Vagrant VM creation functions
 
 function New-VagrantVM {


### PR DESCRIPTION
The 7.3.0 release of powershell cleaned up some stray things that
should require the import of the security module to be available.
It causes issues with pre-7.3 versions of powershell that attempt
to load the newer module so we run a check and restrict the module
version based on the powershell version.

Powershell change: https://github.com/PowerShell/PowerShell/pull/16355
Module import issue described here: https://github.com/PowerShell/PowerShell/issues/18530#issuecomment-1312446352

Fixes #12998
