### PR TITLE
Add workaround for Debian 10 and older

### DIFF
--- a/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
@@ -37,12 +37,11 @@ INLINE_CRIPT
 
             def self.pip_setup(machine, pip_install_cmd = "")
               machine.communicate.sudo "apt-get update -y -qq"
-              debian_version = machine.communicate.execute "lsb_release -rs", error_check: false
-              if debian_version > 10
-                machine.communicate.sudo "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev python-dev-is-python3"
-              else
-                machine.communicate.sudo "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev"
+              python_dev_pkg = "python-dev"
+              if machine.communicate.test "apt-cache show python-dev-is-python3"
+                python_dev_pkg = "python-dev-is-python3"
               end
+              machine.communicate.sudo "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev #{python_dev_pkg}"
               Pip::get_pip machine, pip_install_cmd
             end
 

--- a/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
+++ b/plugins/provisioners/ansible/cap/guest/debian/ansible_install.rb
@@ -37,7 +37,12 @@ INLINE_CRIPT
 
             def self.pip_setup(machine, pip_install_cmd = "")
               machine.communicate.sudo "apt-get update -y -qq"
-              machine.communicate.sudo "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev python-dev-is-python3"
+              debian_version = machine.communicate.execute "lsb_release -rs", error_check: false
+              if debian_version > 10
+                machine.communicate.sudo "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev python-dev-is-python3"
+              else
+                machine.communicate.sudo "DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev"
+              end
               Pip::get_pip machine, pip_install_cmd
             end
 

--- a/test/unit/plugins/provisioners/ansible/cap/guest/debian/ansible_install_test.rb
+++ b/test/unit/plugins/provisioners/ansible/cap/guest/debian/ansible_install_test.rb
@@ -23,6 +23,7 @@ describe VagrantPlugins::Ansible::Cap::Guest::Debian::AnsibleInstall do
   before do
     allow(machine).to receive(:communicate).and_return(communicator)
     allow(communicator).to receive(:execute).and_return(true)
+    allow(communicator).to receive(:test).and_return(false)
   end
 
   describe "#ansible_install" do

--- a/test/unit/plugins/provisioners/ansible/cap/guest/shared/pip_ansible_install_examples.rb
+++ b/test/unit/plugins/provisioners/ansible/cap/guest/shared/pip_ansible_install_examples.rb
@@ -2,6 +2,8 @@
 shared_examples_for "Ansible setup via pip" do
 
   describe "when install_mode is :pip" do
+    before { allow(communicator).to receive(:test) }
+
     it "installs pip and calls Cap::Guest::Pip::pip_install" do
       expect(communicator).to receive(:sudo).at_least(1).times.ordered
       expect(VagrantPlugins::Ansible::Cap::Guest::Pip).to receive(:pip_install).once.ordered.
@@ -12,6 +14,8 @@ shared_examples_for "Ansible setup via pip" do
   end
 
   describe "when install_mode is :pip_args_only" do
+    before { allow(communicator).to receive(:test) }
+
     it "installs pip and calls Cap::Guest::Pip::pip_install with 'pip_args' parameter" do
       pip_args = "-r /vagrant/requirements.txt"
 
@@ -27,13 +31,14 @@ end
 shared_examples_for "Ansible setup via pip on Debian-based systems" do
 
   describe "installs required Debian packages and..." do
+    before { allow(communicator).to receive(:test) }
     pip_install_cmd = "foo"
 
     it "calls Cap::Guest::Pip::get_pip with 'pip' install_mode" do
       expect(communicator).to receive(:sudo).
         with("apt-get update -y -qq")
       expect(communicator).to receive(:sudo).
-        with("DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev python-dev-is-python3")
+        with("DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev python-dev")
       expect(communicator).to receive(:sudo).
         with("pip install --upgrade ansible")
 
@@ -44,11 +49,37 @@ shared_examples_for "Ansible setup via pip on Debian-based systems" do
       expect(communicator).to receive(:sudo).
         with("apt-get update -y -qq")
       expect(communicator).to receive(:sudo).
-        with("DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev python-dev-is-python3")
+        with("DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev python-dev")
       expect(communicator).to receive(:sudo).
         with("pip install")
 
       subject.ansible_install(machine, :pip_args_only, "", "", pip_install_cmd)
+    end
+
+    context "when python-dev-is-python3 package is available" do
+      before { allow(communicator).to receive(:test).with("apt-cache show python-dev-is-python3").and_return(true) }
+
+      it "calls Cap::Guest::Pip::get_pip with 'pip' install_mode" do
+        expect(communicator).to receive(:sudo).
+          with("apt-get update -y -qq")
+        expect(communicator).to receive(:sudo).
+          with("DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev python-dev-is-python3")
+        expect(communicator).to receive(:sudo).
+          with("pip install --upgrade ansible")
+
+        subject.ansible_install(machine, :pip, "", "", pip_install_cmd)
+      end
+
+      it "calls Cap::Guest::Pip::get_pip with 'pip_args_only' install_mode" do
+        expect(communicator).to receive(:sudo).
+          with("apt-get update -y -qq")
+        expect(communicator).to receive(:sudo).
+          with("DEBIAN_FRONTEND=noninteractive apt-get install -y -qq --option \"Dpkg::Options::=--force-confold\" build-essential curl git libssl-dev libffi-dev python-dev-is-python3")
+        expect(communicator).to receive(:sudo).
+          with("pip install")
+
+        subject.ansible_install(machine, :pip_args_only, "", "", pip_install_cmd)
+      end
     end
 
   end


### PR DESCRIPTION
This is the somewhat native and probably not the most elegant solution to fix #13016.
But using the guide [Installing Vagrant from Source](https://developer.hashicorp.com/vagrant/docs/installation/source), I tested my changes and vagrant is able to install pip and ansible without any errors and run ansible subsequently.