### PR TITLE
Add timestamp to Rsync Folder output during Rsync-Auto

### DIFF
--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -196,7 +196,7 @@ module VagrantPlugins
         command_opts[:workdir] = machine.env.root_path.to_s
 
         machine.ui.info(I18n.t(
-          "vagrant.rsync_folder", guestpath: guestpath, hostpath: hostpath))
+          "vagrant.rsync_folder", guestpath: guestpath, hostpath: hostpath, sync_time: DateTime.now.strftime("%d/%m/%Y %H:%M")))
         if excludes.length > 1
           machine.ui.info(I18n.t(
             "vagrant.rsync_folder_excludes", excludes: excludes.inspect))

--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -196,7 +196,7 @@ module VagrantPlugins
         command_opts[:workdir] = machine.env.root_path.to_s
 
         machine.ui.info(I18n.t(
-          "vagrant.rsync_folder", guestpath: guestpath, hostpath: hostpath, sync_time: DateTime.now.strftime("%d/%m/%Y %H:%M")))
+          "vagrant.rsync_folder", guestpath: guestpath, hostpath: hostpath, synctime: DateTime.now.strftime("%d/%m/%Y %H:%M")))
         if excludes.length > 1
           machine.ui.info(I18n.t(
             "vagrant.rsync_folder_excludes", excludes: excludes.inspect))

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -266,7 +266,7 @@ en:
       machine rebooting or being halted. Please make sure the machine is
       running, and modify a file to try again.
     rsync_folder: |-
-      Rsyncing folder: %{hostpath} => %{guestpath}
+      Rsyncing folder [ %{synctime} ]: %{hostpath} => %{guestpath}
     rsync_folder_excludes: "  - Exclude: %{excludes}"
     rsync_installing: "Installing rsync to the VM..."
     rsync_proxy_machine: |-


### PR DESCRIPTION
This is a small patch to add output when rsync-auto is running to indicate when changes were rsync'd across to the guest.

This is to help understand if you're recent changes have been copied across as sometimes when you are making lots of changes it's hard to tell with the terminal output.

![Screenshot 2022-12-06 at 2 26 46 pm](https://user-images.githubusercontent.com/3860091/205806435-39bc0117-e927-445e-a9ef-2630abf88910.png)
