### PR TITLE
Isolate loading dependencies for serve command

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -39,10 +39,26 @@ module VagrantPlugins
   OptionParser = Vagrant::OptionParser
 end
 
+# Load in our helpers and utilities
 require "vagrant/shared_helpers"
 require "rubygems"
 require "vagrant/util"
 require "vagrant/plugin/manager"
+
+# Update the load path so our protos can be located
+$LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs").to_s
+$LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs/proto").to_s
+$LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs/proto/vagrant_plugin_sdk").to_s
+
+# Load our protos so they are available
+require 'vagrant/protobufs/proto/vagrant_server/server_pb'
+require 'vagrant/protobufs/proto/vagrant_server/server_services_pb'
+require 'vagrant/protobufs/proto/ruby_vagrant/ruby-server_pb'
+require 'vagrant/protobufs/proto/ruby_vagrant/ruby-server_services_pb'
+require 'vagrant/protobufs/proto/vagrant_plugin_sdk/plugin_pb'
+require 'vagrant/protobufs/proto/vagrant_plugin_sdk/plugin_services_pb'
+require 'vagrant/protobufs/proto/plugin/grpc_broker_pb'
+require 'vagrant/protobufs/proto/plugin/grpc_broker_services_pb'
 
 # Enable logging if it is requested. We do this before
 # anything else so that we can setup the output before

--- a/lib/vagrant/shared_helpers.rb
+++ b/lib/vagrant/shared_helpers.rb
@@ -235,19 +235,6 @@ module Vagrant
   # @return [true]
   def self.enable_server_mode!
     if !server_mode?
-      $LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs").to_s
-      $LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs/proto").to_s
-      $LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs/proto/vagrant_plugin_sdk").to_s
-
-      require 'vagrant/protobufs/proto/vagrant_server/server_pb'
-      require 'vagrant/protobufs/proto/vagrant_server/server_services_pb'
-      require 'vagrant/protobufs/proto/ruby_vagrant/ruby-server_pb'
-      require 'vagrant/protobufs/proto/ruby_vagrant/ruby-server_services_pb'
-      require 'vagrant/protobufs/proto/vagrant_plugin_sdk/plugin_pb'
-      require 'vagrant/protobufs/proto/vagrant_plugin_sdk/plugin_services_pb'
-      require 'vagrant/protobufs/proto/plugin/grpc_broker_pb'
-      require 'vagrant/protobufs/proto/plugin/grpc_broker_services_pb'
-
       SERVER_MODE_CALLBACKS.each(&:call)
       Util::HCLogOutputter.new("hclog")
       Log4r::Outputter["hclog"].formatter = Util::HCLogFormatter.new

--- a/lib/vagrant/shared_helpers.rb
+++ b/lib/vagrant/shared_helpers.rb
@@ -235,6 +235,19 @@ module Vagrant
   # @return [true]
   def self.enable_server_mode!
     if !server_mode?
+      $LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs").to_s
+      $LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs/proto").to_s
+      $LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs/proto/vagrant_plugin_sdk").to_s
+
+      require 'vagrant/protobufs/proto/vagrant_server/server_pb'
+      require 'vagrant/protobufs/proto/vagrant_server/server_services_pb'
+      require 'vagrant/protobufs/proto/ruby_vagrant/ruby-server_pb'
+      require 'vagrant/protobufs/proto/ruby_vagrant/ruby-server_services_pb'
+      require 'vagrant/protobufs/proto/vagrant_plugin_sdk/plugin_pb'
+      require 'vagrant/protobufs/proto/vagrant_plugin_sdk/plugin_services_pb'
+      require 'vagrant/protobufs/proto/plugin/grpc_broker_pb'
+      require 'vagrant/protobufs/proto/plugin/grpc_broker_services_pb'
+
       SERVER_MODE_CALLBACKS.each(&:call)
       Util::HCLogOutputter.new("hclog")
       Log4r::Outputter["hclog"].formatter = Util::HCLogFormatter.new

--- a/plugins/commands/serve/command.rb
+++ b/plugins/commands/serve/command.rb
@@ -1,20 +1,4 @@
-$LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs").to_s
-$LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs/proto").to_s
-$LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs/proto/vagrant_plugin_sdk").to_s
-
-require 'vagrant/protobufs/proto/vagrant_server/server_pb'
-require 'vagrant/protobufs/proto/vagrant_server/server_services_pb'
-require 'vagrant/protobufs/proto/ruby_vagrant/ruby-server_pb'
-require 'vagrant/protobufs/proto/ruby_vagrant/ruby-server_services_pb'
-require 'vagrant/protobufs/proto/vagrant_plugin_sdk/plugin_pb'
-require 'vagrant/protobufs/proto/vagrant_plugin_sdk/plugin_services_pb'
-require 'vagrant/protobufs/proto/plugin/grpc_broker_pb'
-require 'vagrant/protobufs/proto/plugin/grpc_broker_services_pb'
-
 require "optparse"
-require 'grpc'
-require 'grpc/health/checker'
-require 'grpc/health/v1/health_services_pb'
 
 module VagrantPlugins
   module CommandServe
@@ -34,6 +18,17 @@ module VagrantPlugins
       attr_accessor :broker
       attr_accessor :server
       attr_reader :cache
+
+      # Loads the required dependencies for this command. This is isolated
+      # into a method so that the dependencies can be loaded just in time when
+      # the command is actually executed.
+      def load_dependencies!
+        return if @dependencies_loaded
+        require 'grpc'
+        require 'grpc/health/checker'
+        require 'grpc/health/v1/health_services_pb'
+        @dependencies_loaded = true
+      end
     end
     @cache = Util::Cacher.new
 
@@ -49,6 +44,9 @@ module VagrantPlugins
       end
 
       def execute
+        # Load dependencies before we start
+        CommandServe.load_dependencies!
+
         options = {
           bind: DEFAULT_BIND,
           min_port: DEFAULT_PORT_RANGE.first,


### PR DESCRIPTION
Only load the dependencies needed for the serve command if the serve
command is being run. This allows Vagrant to properly load on platforms
where some of the dependency libraries may not be available due to
incompatibilities or being EOL.

Fixes #12997
