### PR TITLE
Fix #13029 and add --local to plugin init failure command

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1213,7 +1213,7 @@ en:
         versions of dependencies. To fix this problem please remove and re-install
         all plugins. Vagrant can attempt to do this automatically by running:
 
-          vagrant plugin expunge --reinstall
+          vagrant plugin expunge --reinstall --local
 
         Or you may want to try updating the installed plugins to their latest
         versions:


### PR DESCRIPTION
Adds --local so that users with local plugins installed can benefit from this message instead of causing confusion