### PR TITLE
Isolate protobuf message loading to server mode

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -45,21 +45,6 @@ require "rubygems"
 require "vagrant/util"
 require "vagrant/plugin/manager"
 
-# Update the load path so our protos can be located
-$LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs").to_s
-$LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs/proto").to_s
-$LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs/proto/vagrant_plugin_sdk").to_s
-
-# Load our protos so they are available
-require 'vagrant/protobufs/proto/vagrant_server/server_pb'
-require 'vagrant/protobufs/proto/vagrant_server/server_services_pb'
-require 'vagrant/protobufs/proto/ruby_vagrant/ruby-server_pb'
-require 'vagrant/protobufs/proto/ruby_vagrant/ruby-server_services_pb'
-require 'vagrant/protobufs/proto/vagrant_plugin_sdk/plugin_pb'
-require 'vagrant/protobufs/proto/vagrant_plugin_sdk/plugin_services_pb'
-require 'vagrant/protobufs/proto/plugin/grpc_broker_pb'
-require 'vagrant/protobufs/proto/plugin/grpc_broker_services_pb'
-
 # Enable logging if it is requested. We do this before
 # anything else so that we can setup the output before
 # any logging occurs.

--- a/lib/vagrant/plugin/v2/config.rb
+++ b/lib/vagrant/plugin/v2/config.rb
@@ -15,11 +15,6 @@ module Vagrant
 
         UNSET_VALUE = :__UNSET__VALUE__
 
-        if Vagrant.server_mode?
-          GENERAL_CONFIG_CLS = Hashicorp::Vagrant::Sdk::Vagrantfile::GeneralConfig
-          SYMBOL_PROTO = Hashicorp::Vagrant::Sdk::Args::Symbol
-        end
-
         # This is called as a last-minute hook that allows the configuration
         # object to finalize itself before it will be put into use. This is
         # a useful place to do some defaults in the case the user didn't

--- a/lib/vagrant/shared_helpers.rb
+++ b/lib/vagrant/shared_helpers.rb
@@ -235,6 +235,7 @@ module Vagrant
   # @return [true]
   def self.enable_server_mode!
     if !server_mode?
+      load_vagrant_proto!
       SERVER_MODE_CALLBACKS.each(&:call)
       Util::HCLogOutputter.new("hclog")
       Log4r::Outputter["hclog"].formatter = Util::HCLogFormatter.new
@@ -255,6 +256,26 @@ module Vagrant
       l.level = Log4r::ERROR
     end
     @_server_mode = true
+  end
+
+  # Load the vagrant proto messages
+  def self.load_vagrant_proto!
+    return if @_vagrant_proto_loaded
+    # Update the load path so our protos can be located
+    $LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs").to_s
+    $LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs/proto").to_s
+    $LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs/proto/vagrant_plugin_sdk").to_s
+
+    # Load our protos so they are available
+    require 'vagrant/protobufs/proto/vagrant_server/server_pb'
+    require 'vagrant/protobufs/proto/vagrant_server/server_services_pb'
+    require 'vagrant/protobufs/proto/ruby_vagrant/ruby-server_pb'
+    require 'vagrant/protobufs/proto/ruby_vagrant/ruby-server_services_pb'
+    require 'vagrant/protobufs/proto/vagrant_plugin_sdk/plugin_pb'
+    require 'vagrant/protobufs/proto/vagrant_plugin_sdk/plugin_services_pb'
+    require 'vagrant/protobufs/proto/plugin/grpc_broker_pb'
+    require 'vagrant/protobufs/proto/plugin/grpc_broker_services_pb'
+    @_vagrant_proto_loaded = true
   end
 
   SERVER_MODE_CALLBACKS = [

--- a/test/unit/base.rb
+++ b/test/unit/base.rb
@@ -13,6 +13,9 @@ require "vagrant/util/platform"
 # Include patches for fake ftp
 require "vagrant/patches/fake_ftp"
 
+# Be sure our proto messages are available
+Vagrant.load_vagrant_proto!
+
 # Add the test directory to the load path
 $:.unshift File.expand_path("../../", __FILE__)
 


### PR DESCRIPTION
Prevent protobuf loading when not in server mode. This allows proper
loading on platforms which don't have support for the protobuf
libraries.

The initial modifications only isolated the grpc related libraries
with the protobuf messages still be required so constants were
available. This change modifies that so the protos are also restricted
to being loaded only when in server mode.

Fixes #12997
