### PR TITLE
ansible/provisioner_test: fix for ruby32 Kernel#=~ removal

### DIFF
--- a/test/unit/plugins/provisioners/ansible/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/ansible/provisioner_test.rb
@@ -91,7 +91,7 @@ VF
         expect(args[1]).to eq("--connection=ssh")
         expect(args[2]).to eq("--timeout=30")
 
-        inventory_count = args.count { |x| x =~ /^--inventory-file=.+$/ }
+        inventory_count = args.count { |x| x.respond_to?(:=~) && x =~ /^--inventory-file=.+$/ }
         expect(inventory_count).to be > 0
 
         expect(args[args.length-2]).to eq("playbook.yml")
@@ -100,9 +100,9 @@ VF
 
     it "sets --limit argument" do
       expect(Vagrant::Util::Subprocess).to receive(:execute).with('ansible-playbook', any_args) { |*args|
-        all_limits = args.select { |x| x =~ /^(--limit=|-l)/ }
+        all_limits = args.select { |x| x.respond_to?(:=~) && x =~ /^(--limit=|-l)/ }
         if config.raw_arguments
-          raw_limits = config.raw_arguments.select { |x| x =~ /^(--limit=|-l)/ }
+          raw_limits = config.raw_arguments.select { |x| x.respond_to?(:=~) && x =~ /^(--limit=|-l)/ }
           expect(all_limits.length - raw_limits.length).to eq(1)
           expect(all_limits.last).to eq(raw_limits.last)
         else


### PR DESCRIPTION
Kernel#=~ has done nothing and just has returned nil, and now with ruby3.2 this deprecated method is removed.

So for $ bundle exec rake under ruby 3.2, check if variable really accepts =~ method first.

Fixes #13028 .