### PR TITLE
Update connection settings when using a password to connect ssh

### DIFF
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -404,7 +404,7 @@ module VagrantPlugins
 
         # Set some valid auth methods. We disable the auth methods that
         # we're not using if we don't have the right auth info.
-        auth_methods = ["none", "hostbased"]
+        auth_methods = ["none", "hostbased", "keyboard-interactive"]
         auth_methods << "publickey" if ssh_info[:private_key_path]
         auth_methods << "password" if ssh_info[:password]
 
@@ -460,6 +460,10 @@ module VagrantPlugins
                   connect_opts[:keepalive] = true
                   connect_opts[:keepalive_interval] = 5
                 end
+                
+                if ssh_info[:password]
+                  connect_opts[:non_interactive] = true
+                end
 
                 @logger.info("Attempting to connect to SSH...")
                 @logger.info("  - Host: #{ssh_info[:host]}")
@@ -469,7 +473,7 @@ module VagrantPlugins
                 @logger.info("  - Key Path: #{ssh_info[:private_key_path]}")
                 @logger.debug("  - connect_opts: #{connect_opts}")
 
-                Net::SSH.start(ssh_info[:host], ssh_info[:username], connect_opts)
+                Net::SSH.start(ssh_info[:host], ssh_info[:username], **connect_opts)
               ensure
                 # Make sure we output the connection log
                 @logger.debug("== Net-SSH connection debug-level log START ==")

--- a/test/unit/plugins/communicators/ssh/communicator_test.rb
+++ b/test/unit/plugins/communicators/ssh/communicator_test.rb
@@ -664,7 +664,7 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
       it "includes `none` and `hostbased` auth methods" do
         expect(Net::SSH).to receive(:start).with(
           nil, nil, hash_including(
-            auth_methods: ["none", "hostbased"]
+            auth_methods: ["none", "hostbased", "keyboard-interactive"]
           )
         ).and_return(true)
         communicator.send(:connect)
@@ -780,7 +780,7 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
       it "includes `publickey` auth method" do
         expect(Net::SSH).to receive(:start).with(
           anything, anything, hash_including(
-            auth_methods: ["none", "hostbased", "publickey"]
+            auth_methods: ["none", "hostbased", "keyboard-interactive", "publickey"]
           )
         ).and_return(true)
         communicator.send(:connect)
@@ -809,7 +809,7 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
       it "has password defined" do
         expect(Net::SSH).to receive(:start).with(
           anything, anything, hash_including(
-            password: 'vagrant'
+            password: 'vagrant', non_interactive: true
           )
         ).and_return(true)
         communicator.send(:connect)
@@ -818,7 +818,7 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
       it "includes `password` auth method" do
         expect(Net::SSH).to receive(:start).with(
           anything, anything, hash_including(
-            auth_methods: ["none", "hostbased", "password"]
+            auth_methods: ["none", "hostbased", "keyboard-interactive", "password"]
           )
         ).and_return(true)
         communicator.send(:connect)
@@ -860,7 +860,7 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
       it "includes `publickey` and `password` auth methods" do
         expect(Net::SSH).to receive(:start).with(
           anything, anything, hash_including(
-            auth_methods: ["none", "hostbased", "publickey", "password"]
+            auth_methods: ["none", "hostbased", "keyboard-interactive", "publickey", "password"]
           )
         ).and_return(true)
         communicator.send(:connect)

--- a/test/unit/plugins/communicators/winssh/communicator_test.rb
+++ b/test/unit/plugins/communicators/winssh/communicator_test.rb
@@ -328,7 +328,7 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
       it "includes `none` and `hostbased` auth methods" do
         expect(Net::SSH).to receive(:start).with(
           nil, nil, hash_including(
-            auth_methods: ["none", "hostbased"]
+            auth_methods: ["none", "hostbased", "keyboard-interactive"]
           )
         ).and_return(connection)
         communicator.send(:connect)
@@ -420,7 +420,7 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
       it "includes `publickey` auth method" do
         expect(Net::SSH).to receive(:start).with(
           anything, anything, hash_including(
-            auth_methods: ["none", "hostbased", "publickey"]
+            auth_methods: ["none", "hostbased", "keyboard-interactive", "publickey"]
           )
         ).and_return(connection)
         communicator.send(:connect)
@@ -458,7 +458,7 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
       it "includes `password` auth method" do
         expect(Net::SSH).to receive(:start).with(
           anything, anything, hash_including(
-            auth_methods: ["none", "hostbased", "password"]
+            auth_methods: ["none", "hostbased", "keyboard-interactive", "password"]
           )
         ).and_return(connection)
         communicator.send(:connect)
@@ -500,7 +500,7 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
       it "includes `publickey` and `password` auth methods" do
         expect(Net::SSH).to receive(:start).with(
           anything, anything, hash_including(
-            auth_methods: ["none", "hostbased", "publickey", "password"]
+            auth_methods: ["none", "hostbased", "keyboard-interactive", "publickey", "password"]
           )
         ).and_return(connection)
         communicator.send(:connect)


### PR DESCRIPTION
When connecting over ssh using net-ssh use the non_interactive argument must be set when authenticating with a password.

The "keyboard-interactive" options may be used as a default auth method, like in the net-ssh defaults (ref: https://github.com/net-ssh/net-ssh/blob/8a176a6ea0db1b59a21834df806a257a0b76e943/lib/net/ssh/config.rb#L52)

fixes https://github.com/hashicorp/vagrant/issues/13008