### PR TITLE
Add a file mutex when downloading box files.

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -485,7 +485,8 @@ module Vagrant
           mutex_path = d.destination + MUTEX_SUFFIX
           if File.file?(mutex_path)
             raise Errors::DownloadAlreadyInProgress,
-              dest_path: d.destination
+              dest_path: d.destination,
+              lock_file_path: mutex_path
           end
 
           begin

--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -376,6 +376,10 @@ module Vagrant
       error_key(:dotfile_upgrade_json_error)
     end
 
+    class DownloadAlreadyInProgress < VagrantError
+      error_key(:download_already_in_progress_error)
+    end
+
     class DownloaderError < VagrantError
       error_key(:downloader_error)
     end

--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -924,6 +924,10 @@ module Vagrant
       error_key(:uploader_interrupted)
     end
 
+    class VagrantLocked < VagrantError
+      error_key(:vagrant_locked)
+    end
+
     class VagrantInterrupt < VagrantError
       error_key(:interrupted)
     end

--- a/lib/vagrant/util.rb
+++ b/lib/vagrant/util.rb
@@ -20,6 +20,7 @@ module Vagrant
     autoload :Experimental,              'vagrant/util/experimental'
     autoload :FileChecksum,              'vagrant/util/file_checksum'
     autoload :FileMode,                  'vagrant/util/file_mode'
+    autoload :FileMutex,                 'vagrant/util/file_mutex'
     autoload :GuestHosts,                'vagrant/util/guest_hosts'
     autoload :GuestInspection,           'vagrant/util/guest_inspection'
     autoload :HashWithIndifferentAccess, 'vagrant/util/hash_with_indifferent_access'

--- a/lib/vagrant/util/file_mutex.rb
+++ b/lib/vagrant/util/file_mutex.rb
@@ -1,0 +1,29 @@
+module Vagrant
+  module Util
+    class FileMutex
+      def initialize(mutex_path)
+        @mutex_path = mutex_path
+      end
+
+      def with_lock(&block)
+        lock
+        block.call
+      ensure
+        unlock
+      end
+
+      def lock
+        if File.file?(@mutex_path)
+          raise Errors::VagrantLocked,
+            lock_file_path: @mutex_path
+        end
+        
+        File.write(@mutex_path, "")
+      end
+
+      def unlock
+        File.delete(@mutex_path)
+      end
+    end
+  end
+end

--- a/lib/vagrant/util/file_mutex.rb
+++ b/lib/vagrant/util/file_mutex.rb
@@ -22,7 +22,7 @@ module Vagrant
       end
 
       def unlock
-        File.delete(@mutex_path)
+        File.delete(@mutex_path) if File.file?(@mutex_path)
       end
     end
   end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -901,6 +901,7 @@ en:
         a file to the same location.
 
         Download path: %{dest_path}
+        Lock file path: %{lock_file_path}
       downloader_error: |-
         An error occurred while downloading the remote file. The error
         message, if any, is reproduced below. Please fix this error and try

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -895,6 +895,12 @@ en:
         support.
 
         State file path: %{state_file}
+      download_already_in_progress_error: |-
+        Download to global Vagrant location already in progress. This
+        may be caused by other Vagrant processes attempting to download
+        a file to the same location.
+
+        Download path: %{dest_path}
       downloader_error: |-
         An error occurred while downloading the remote file. The error
         message, if any, is reproduced below. Please fix this error and try

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1675,6 +1675,11 @@ en:
       uploader_interrupted: |-
         The upload was interrupted by an external signal. It did not
         complete.
+      vagrant_locked: |-
+        The requested Vagrant action is locked. This may be caused
+        by other Vagrant processes attempting to do a similar action.
+
+        Lock file path: %{lock_file_path}
       vagrantfile_exists: |-
         `Vagrantfile` already exists in this directory. Remove it before
         running `vagrant init`.

--- a/test/unit/vagrant/action/builtin/box_add_test.rb
+++ b/test/unit/vagrant/action/builtin/box_add_test.rb
@@ -86,12 +86,16 @@ describe Vagrant::Action::Builtin::BoxAdd, :skip_windows, :bsdtar do
 
   context "the download location is locked" do
     let(:box_path) { iso_env.box2_file(:virtualbox) }
+    let(:mutex_path) {  env[:tmp_path].join("box" + Digest::SHA1.hexdigest("file://" + box_path.to_s) + ".lock").to_s }
 
     before do
-      mutex_path = env[:tmp_path].join("box" + Digest::SHA1.hexdigest("file://" + box_path.to_s) + ".lock").to_s
-      File.write(mutex_path, "")
+      # Lock file
+      @f = File.open(mutex_path, "w+") 
+      @f.flock(File::LOCK_EX|File::LOCK_NB) 
     end
-
+  
+    after { @f.close }
+    
     it "raises a download error" do
       env[:box_name] = "foo"
       env[:box_url] = box_path.to_s

--- a/test/unit/vagrant/action/builtin/box_add_test.rb
+++ b/test/unit/vagrant/action/builtin/box_add_test.rb
@@ -102,29 +102,6 @@ describe Vagrant::Action::Builtin::BoxAdd, :skip_windows, :bsdtar do
   end
 
   context "with box file directly" do
-    it "creates and cleans up a lock file" do
-      box_path = iso_env.box2_file(:virtualbox)
-
-      env[:box_name] = "foo"
-      env[:box_url] = box_path.to_s
-
-      
-      expect(box_collection).to receive(:add).with(any_args) { |path, name, version, opts|
-        expect(checksum(path)).to eq(checksum(box_path))
-        expect(name).to eq("foo")
-        expect(version).to eq("0")
-        expect(opts[:metadata_url]).to be_nil
-        true
-      }.and_return(box)
-
-      expect(app).to receive(:call).with(env)
-
-      mutex_path = env[:tmp_path].join("box" + Digest::SHA1.hexdigest("file://" + box_path.to_s) + ".lock").to_s
-      expect(File).to receive(:write).with(mutex_path, "")
-      expect(File).to receive(:delete).with(mutex_path)
-      subject.call(env)
-    end
-
     it "adds it" do
       box_path = iso_env.box2_file(:virtualbox)
 

--- a/test/unit/vagrant/util/file_mutex_test.rb
+++ b/test/unit/vagrant/util/file_mutex_test.rb
@@ -1,0 +1,49 @@
+require File.expand_path("../../../base", __FILE__)
+require 'vagrant/util/file_mutex'
+
+describe Vagrant::Util::FileMutex do
+  include_context "unit"
+
+  let(:temp_dir) { Dir.mktmpdir("vagrant-test-util-mutex_test") }
+
+  after do
+    FileUtils.rm_rf(temp_dir)
+  end
+
+  it "should create a lock file" do
+    mutex_path = temp_dir + "test.lock"
+    instance = described_class.new(mutex_path)
+    instance.lock
+    expect(File).to exist(mutex_path)
+  end
+
+  it "should create and delete lock file" do
+    mutex_path = temp_dir + "test.lock"
+    instance = described_class.new(mutex_path)
+    instance.lock
+    instance.unlock
+    expect(File).to_not exist(mutex_path)
+  end
+
+  it "should not raise an error if the lock file does not exist" do
+    mutex_path = temp_dir + "test.lock"
+    instance = described_class.new(mutex_path)
+    instance.unlock
+    expect(File).to_not exist(mutex_path)
+  end
+
+  it "should run a function with a lock" do
+    mutex_path = temp_dir + "test.lock"
+    instance = described_class.new(mutex_path)
+    instance.with_lock { true }
+    expect(File).to_not exist(mutex_path)
+  end
+
+  it "should fail running a function when locked" do
+    mutex_path = temp_dir + "test.lock"
+    instance = described_class.new(mutex_path)
+    instance.lock
+    expect {instance.with_lock { true }}.
+      to raise_error(Vagrant::Errors::VagrantLocked)
+  end
+end


### PR DESCRIPTION
Box's are global to Vagrant. Multiple Vagrant process can all access the box directory for both downloading and extracting boxes. A file mutex will ensure that multiple Vagrant process will not trample each other if they are trying to download the same box.

Now if multiple Vagrant process are trying to download the same box the process started first will successfully download and add the box. The second will display an error message:

```
-> % vagrant up

Bringing machine 'default' up with 'virtualbox' provider...
==> default: Box 'centos/stream8' could not be found. Attempting to find and install...
    default: Box Provider: virtualbox
    default: Box Version: >= 0
==> default: Loading metadata for box 'centos/stream8'
    default: URL: https://vagrantcloud.com/centos/stream8
==> default: Adding box 'centos/stream8' (v20210210.0) for provider: virtualbox
    default: Downloading: https://vagrantcloud.com/centos/boxes/stream8/versions/20210210.0/providers/virtualbox.box
==> default: Box download is resuming from prior download progress
Download to global Vagrant location already in progress. This
may be caused by other Vagrant processes attempting to download
a file to the same location.

Download path: /Users/sophia/.vagrant.d/tmp/box5fb30816ce1dcffcbdb0d582d356f3626d7cc595
Lock file path: /Users/sophia/.vagrant.d/tmp/box5fb30816ce1dcffcbdb0d582d356f3626d7cc595.lock
```

fixes: https://github.com/hashicorp/vagrant/issues/12880