### PR TITLE
Process rsync exclude regex less

### DIFF
--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -27,18 +27,15 @@ module VagrantPlugins
 
         if exclude.start_with?("/")
           start_anchor = true
-          exclude      = exclude[1..-1]
         end
 
-        exclude = "#{exclude}/" if !exclude.end_with?("/")
-        exclude = "^#{exclude}"
-        exclude += ".*" if !start_anchor
+        exclude = "#{exclude}/" if !exclude.end_with?("/") if start_anchor
+        exclude = "^#{exclude}" if start_anchor
+        exclude += ".*" if (!start_anchor && !exclude.end_with?("*"))
 
         # This is not an ideal solution, but it's a start. We can improve and
         # keep unit tests passing in the future.
         exclude = exclude.gsub("**", "|||GLOBAL|||")
-        exclude = exclude.gsub("*", "|||PATH|||")
-        exclude = exclude.gsub("|||PATH|||", "[^/]*")
         exclude = exclude.gsub("|||GLOBAL|||", ".*")
 
         Regexp.new(exclude)

--- a/test/unit/plugins/synced_folders/rsync/helper_test.rb
+++ b/test/unit/plugins/synced_folders/rsync/helper_test.rb
@@ -32,23 +32,31 @@ describe VagrantPlugins::SyncedFolderRSync::RsyncHelper do
     let(:path) { "/foo/bar" }
 
     it "converts a directory match" do
+      expected_regex = /foo\/.*/
       expect(described_class.exclude_to_regexp("foo/")).
-        to eq(/^foo\/.[^\/]*/)
+        to eq(/foo\/.*/)
+      expect(path).to match(expected_regex)
     end
 
     it "converts the start anchor" do
+      expected_regex = /^\/foo\//
       expect(described_class.exclude_to_regexp("/foo")).
-        to eq(/^foo\//)
+        to eq(expected_regex)
+      expect(path).to match(expected_regex)
     end
 
     it "converts the **" do
+      expected_regex = /fo.*o.*/
       expect(described_class.exclude_to_regexp("fo**o")).
-        to eq(/^fo.*o\/.[^\/]*/)
+        to eq(expected_regex)
+      expect(path).to match(expected_regex)
     end
 
     it "converts the *" do
+      expected_regex = /fo*o.*/
       expect(described_class.exclude_to_regexp("fo*o")).
-        to eq(/^fo[^\/]*o\/.[^\/]*/)
+        to eq(expected_regex)
+      expect(path).to match(expected_regex)
     end
   end
 


### PR DESCRIPTION
This change will prepend "^" and append "/" if a start anchor is detected in the regex string. This allows users to specify relative paths to exclude.

It also removes replacing occurences of "*" with "[^/]*". "*" already expresses itself accurately.

This fixes `vagrant rsync-auto --poll`. Previously for a Vagrantfile
```
Vagrant.configure("2") do |config|
  config.vm.box = "hashicorp/bionic64"
  config.vm.synced_folder ".", "/vagrant", type: "rsync",
    rsync__exclude: [".git/", "data/", "data/*", "data/**"]
end
```
with a `data` folder 
```
ls -lah | grep data
dr-x------   3 root    staff    96B Jan 19 16:27 data
```

The following error would be produced
```
% vagrant rsync-auto --poll

==> default: Doing an initial rsync...
==> default: Rsyncing folder: /Users/sophia/project/vagrant/ => /vagrant
==> default:   - Exclude: [".vagrant/", ".git/", "data/", "data/*", "data/**", "data/postgres"]
==> default: Watching: /Users/sophia/project/vagrant
E, [2023-01-19T16:29:36.126752 #86023] ERROR -- : Exception rescued in listen-run_thread:
Errno::EACCES: Permission denied @ dir_initialize - /Users/sophia/project/vagrant/data
<internal:dir>:98:in `open'
/Users/sophia/miniconda3/envs/vagrant-agogo/lib/ruby/3.1.0/pathname.rb:446:in `foreach'
/Users/sophia/miniconda3/envs/vagrant-agogo/lib/ruby/3.1.0/pathname.rb:446:in `children'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/directory.rb:83:in `_children'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/directory.rb:18:in `scan'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/change.rb:60:in `invalidate'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/directory.rb:73:in `_change'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/directory.rb:30:in `block in scan'
/Users/sophia/miniconda3/envs/vagrant-agogo/lib/ruby/3.1.0/set.rb:511:in `each_key'
/Users/sophia/miniconda3/envs/vagrant-agogo/lib/ruby/3.1.0/set.rb:511:in `each'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/directory.rb:27:in `scan'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/change.rb:60:in `invalidate'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/adapter/base.rb:108:in `_queue_change'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/adapter/polling.rb:36:in `_process_event'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/adapter/base.rb:44:in `block (2 levels) in configure'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/adapter/polling.rb:26:in `block (2 levels) in _run'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/adapter/polling.rb:25:in `each'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/adapter/polling.rb:25:in `block in _run'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/adapter/polling.rb:23:in `loop'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/adapter/polling.rb:23:in `_run'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/adapter/base.rb:79:in `block in start'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/thread.rb:26:in `rescue_and_log'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/thread.rb:18:in `block in new'
--- Thread.new ---
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/adapter/base.rb:75:in `start'
/Users/sophia/miniconda3/envs/vagrant-agogo/lib/ruby/3.1.0/forwardable.rb:238:in `start'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/listener.rb:71:in `block in <class:Listener>'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/fsm.rb:124:in `instance_eval'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/fsm.rb:124:in `call'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/fsm.rb:105:in `transition_with_callbacks!'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/fsm.rb:72:in `transition'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/listener.rb:92:in `start'
/Users/sophia/project/vagrant/plugins/synced_folders/rsync/command/rsync_auto.rb:171:in `block in execute'
/Users/sophia/project/vagrant/lib/vagrant/util/busy.rb:19:in `busy'
/Users/sophia/project/vagrant/plugins/synced_folders/rsync/command/rsync_auto.rb:170:in `execute'
/Users/sophia/project/vagrant/lib/vagrant/cli.rb:67:in `execute'
/Users/sophia/project/vagrant/lib/vagrant/environment.rb:301:in `cli'
/Users/sophia/project/vagrant/bin/vagrant:248:in `<top (required)>'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/bin/vagrant:25:in `load'
/Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/bin/vagrant:25:in `<main>'
/Users/sophia/project/vagrant/plugins/synced_folders/rsync/command/rsync_auto.rb:172:in `pop': No live threads left. Deadlock? (fatal)
3 threads, 3 sleeps current:0x00007fae1efd50a0 main thread:0x00007fae48004080
* #<Thread:0x00000001101fcd98 sleep_forever>
   rb_thread_t:0x00007fae48004080 native:0x000000011605f600 int:0
   
* #<Thread:0x000000011487b120@Timeout stdlib thread /Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/timeout-0.3.1/lib/timeout.rb:101 sleep_forever>
   rb_thread_t:0x00007fae1efd50a0 native:0x00007000037bd000 int:0
   
* #<Thread:0x000000011527a7e8@listen-wait_thread /Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/gems/listen-3.8.0/lib/listen/thread.rb:17 sleep_forever>
   rb_thread_t:0x00007faddf694e60 native:0x0000700003bc3000 int:0
   
        from /Users/sophia/project/vagrant/plugins/synced_folders/rsync/command/rsync_auto.rb:172:in `block in execute'
        from /Users/sophia/project/vagrant/lib/vagrant/util/busy.rb:19:in `busy'
        from /Users/sophia/project/vagrant/plugins/synced_folders/rsync/command/rsync_auto.rb:170:in `execute'
        from /Users/sophia/project/vagrant/lib/vagrant/cli.rb:67:in `execute'
        from /Users/sophia/project/vagrant/lib/vagrant/environment.rb:301:in `cli'
        from /Users/sophia/project/vagrant/bin/vagrant:248:in `<top (required)>'
        from /Users/sophia/miniconda3/envs/vagrant-agogo/share/rubygems/bin/vagrant:25:in `load'
```