### PR TITLE
Use netssh builtin keep alive functionality

### DIFF
--- a/test/unit/plugins/communicators/ssh/communicator_test.rb
+++ b/test/unit/plugins/communicators/ssh/communicator_test.rb
@@ -669,6 +669,32 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
         ).and_return(true)
         communicator.send(:connect)
       end
+
+      context "keep ssh connection alive" do
+        let(:ssh) do
+          double("ssh",
+            timeout: 1,
+            host: nil,
+            port: 5986,
+            guest_port: 5986,
+            pty: false,
+            keep_alive: true,
+            insert_key: insert_ssh_key,
+            export_command_template: export_command_template,
+            shell: 'bash -l'
+          )
+        end
+
+        it "sets keepalive settings" do
+          expect(Net::SSH).to receive(:start).with(
+            nil, nil, hash_including(
+              keepalive: true,
+              keepalive_interval: 5
+            )
+          ).and_return(true)
+          communicator.send(:connect)
+        end
+      end
     end
 
     context "with keys_only disabled and verify_host_key enabled" do


### PR DESCRIPTION
This PR moves away from manually doing a SSH keep alive in another thread and instead depends on Netssh's keep alive feature. 

I'm pretty hesitant of touching this kind of [code that's been around forever](https://github.com/hashicorp/vagrant/commit/7fa9892b754b5aef7877a10a87cf875089c5f92c) but it looks like when this was implemented net-ssh was at version [2.6.6](https://github.com/hashicorp/vagrant/blob/7fa9892b754b5aef7877a10a87cf875089c5f92c/vagrant.gemspec#L22). Looks like keepalive functionality wasn't added until [2.7.0](https://github.com/net-ssh/net-ssh/blob/master/CHANGES.txt#L347). 


Fixes https://github.com/hashicorp/vagrant/issues/12783