### PR TITLE
Removes check for hyperv being enabled when verifying virtualbox is usable on windows.

### DIFF
--- a/plugins/providers/virtualbox/action/check_virtualbox.rb
+++ b/plugins/providers/virtualbox/action/check_virtualbox.rb
@@ -16,12 +16,6 @@ module VagrantPlugins
           # which will break us out of execution of the middleware sequence.
           Driver::Meta.new.verify!
 
-          if Vagrant::Util::Platform.windows? && Vagrant::Util::Platform.windows_hyperv_enabled?
-            @logger.error("Virtualbox and Hyper-V cannot be used together at the same time on Windows and will result in a system crash.")
-
-            raise Vagrant::Errors::HypervVirtualBoxError
-          end
-
           # Carry on.
           @app.call(env)
         end


### PR DESCRIPTION
Virtualbox has supported running with hyperv since version 6.0.0 https://www.virtualbox.org/wiki/Changelog-6.0. (Virtualbox 6.0 is currently EOL) So, this check is no longer required.

This change is required for Virtualbox to work on Windows after https://github.com/hashicorp/vagrant/pull/11933 has been merged. https://github.com/hashicorp/vagrant/pull/11933 fixes the `windows_hyperv_enabled?` function.

Note, this removes the only use of `windows_hyperv_enabled?` in the Vagrant code base. Since this is a publicly available function I don't think it's appropriate to fully remove it for a point release.