### PR TITLE
docs: change frontmatter key from script to description

### DIFF
--- a/website/content/docs/plugins/provisioners.mdx
+++ b/website/content/docs/plugins/provisioners.mdx
@@ -1,7 +1,7 @@
 ---
 layout: docs
 page_title: Custom Provisioners - Plugin Development
-script: |-
+description: |-
   This page documents how to add new provisioners to Vagrant, allowing Vagrant
   to automatically install software and configure software using a custom
   provisioner. Prior to reading this, you should be familiar with the plugin


### PR DESCRIPTION
Updating the frontmatter of `website/content/docs/plugins/provisioners.mdx`. I'm pretty sure it should be `description`, not `script`. 💭 