### PR TITLE
Build updates

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@ on:
       - 'CHANGELOG.md'
       - 'website/**'
 
+concurrency: build
+
 permissions:
   contents: write
 


### PR DESCRIPTION
Properly cleanup previous build artifacts, include commit ID
information, and prevent multiple build workflows from running
at once.
