### PR TITLE
Adding a mention of Parallels Provider to use with Vagrant. There is a short description and links to Parallels, Provider's Git, and Documentation.

### DIFF
--- a/website/content/docs/providers/parallels.mdx
+++ b/website/content/docs/providers/parallels.mdx
@@ -1,0 +1,21 @@
+---
+layout: docs
+page_title: Parallels Desktop Provider
+description: |-
+  Parallels offer a free Vagrant provider to manage Parallels Desktop for Mac-based virtual machines.
+  There is a website with detailed documentation.
+---
+
+# Parallels
+
+The Parallels provider for Vagrant is officially supported by [Parallels](https://www.parallels.com) and
+allows managing Parallels Desktop for Mac virtual machines.
+Both Intel and Apple M1-powered Mac computers are supported.
+
+The Parallels provider is free and open for contributions on the [GitHub](https://github.com/Parallels/vagrant-parallels).
+
+The Parallels provider is compatible with the latest versions of Parallels Desktop for Mac and works with
+ "Pro" and "Business" editions. Please note that Parallels Desktop is a third-party product
+that must be purchased and installed separately before using the provider.
+
+Learn more about the Parallels provider installation, configuration, and boxes with the [Vagrant Parallels Provider documentation](https://parallels.github.io/vagrant-parallels/docs/).

--- a/website/content/docs/providers/parallels.mdx
+++ b/website/content/docs/providers/parallels.mdx
@@ -19,3 +19,4 @@ The Parallels provider is compatible with the latest versions of Parallels Deskt
 that must be purchased and installed separately before using the provider.
 
 Learn more about the Parallels provider installation, configuration, and boxes with the [Vagrant Parallels Provider documentation](https://parallels.github.io/vagrant-parallels/docs/).
+

--- a/website/data/docs-nav-data.json
+++ b/website/data/docs-nav-data.json
@@ -644,6 +644,10 @@
         ]
       },
       {
+        "title": "Parallels Provider",
+        "path": "providers/parallels"
+      },
+      {
         "title": "Custom Provider",
         "path": "providers/custom"
       }


### PR DESCRIPTION
Tested on node v16.14.0
![image](https://user-images.githubusercontent.com/17143029/235604003-2b18f3bd-897f-4d08-b059-73ea87799e50.png)

![image](https://user-images.githubusercontent.com/17143029/235604046-13eea4b4-3e12-4040-a6a4-601b07589ac0.png)

navigation
description