### PR TITLE
Remove protobuf related loading from config

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -10,15 +10,6 @@ require "vagrant/util/presence"
 require "vagrant/util/experimental"
 require "vagrant/util/map_command_options"
 
-$LOAD_PATH << Vagrant.source_root.join("lib/vagrant/protobufs/proto").to_s
-
-require "vagrant/protobufs/proto/protostructure_pb"
-require "vagrant/protobufs/proto/vagrant_plugin_sdk/plugin_pb"
-require "vagrant/protobufs/proto/vagrant_plugin_sdk/plugin_services_pb"
-
-# Include mappers
-require Vagrant.source_root.join("plugins/commands/serve/command").to_s
-
 require File.expand_path("../vm_provisioner", __FILE__)
 require File.expand_path("../vm_subvm", __FILE__)
 require File.expand_path("../disk", __FILE__)


### PR DESCRIPTION
The final proto related constants were removed in #13031 but the proto
loading still remained. This removes the loading to prevent protos from
being loaded when not in server mode.
