### PR TITLE
Ignore inactive docker containers when assigning ports

### DIFF
--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -140,6 +140,9 @@ module VagrantPlugins
         all_containers.each do |c|
           container_info = inspect_container(c)
 
+          active = container_info["State"]["Running"]
+          next unless active # Ignore used ports on inactive containers
+
           if container_info["HostConfig"]["PortBindings"]
             port_bindings = container_info["HostConfig"]["PortBindings"]
             next if port_bindings.empty? # Nothing defined, but not nil either


### PR DESCRIPTION
Checks to make sure that a docker container is running before determining whether or not the port is in use. This prevents the a port on an inactive container from being treated as if it is use.

Fixes #13110 #12797