### PR TITLE
docker: sync folders before preparing nfs settings

### DIFF
--- a/plugins/providers/docker/action.rb
+++ b/plugins/providers/docker/action.rb
@@ -231,6 +231,7 @@ module VagrantPlugins
             b2.use HostMachineSyncFolders
             b2.use PrepareNFSValidIds
             b2.use SyncedFolderCleanup
+            b2.use SyncedFolders
             b2.use PrepareNFSSettings
             b2.use PrepareNetworks
             b2.use Login
@@ -248,7 +249,6 @@ module VagrantPlugins
                   b3.use ForwardedPorts # This action converts the `ports` param into proper network configs
                   b3.use PrepareForwardedPortCollisionParams
                   b3.use HandleForwardedPortCollisions
-                  b3.use SyncedFolders
                   b3.use Pull
                   b3.use Create
                   b3.use WaitForRunning
@@ -268,7 +268,6 @@ module VagrantPlugins
               end
             else
               # We're in a run command, so we do things a bit differently.
-              b2.use SyncedFolders
               b2.use Create
             end
           end


### PR DESCRIPTION
Re-order the `SyncedFolders` to occur before `PrepareNFSSettings`, ensuring that the host & machine ips are set appropriately. 

Fixes https://github.com/hashicorp/vagrant/issues/12430 