### PR TITLE
Close the file handler after the lock acquired

### DIFF
--- a/lib/vagrant/util/file_mutex.rb
+++ b/lib/vagrant/util/file_mutex.rb
@@ -17,9 +17,10 @@ module Vagrant
       end
 
       def lock
-        f = File.open(@mutex_path, "w+") 
-        if f.flock(File::LOCK_EX|File::LOCK_NB) === false
-          raise Errors::VagrantLocked, lock_file_path: @mutex_path
+        File.open(@mutex_path, "w+")  do |f|
+          if f.flock(File::LOCK_EX|File::LOCK_NB) === false
+            raise Errors::VagrantLocked, lock_file_path: @mutex_path
+          end
         end
       end
 


### PR DESCRIPTION
In Windows environments, the vagrant process fails to delete the lock file in 'unlock' with below error.

```
C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-2.3.5/lib/vagrant/util/file_mutex.rb:29:in `delete': Permission denied @ apply2files - C:/Users/mnaok/.vagrant.d/tmp/box46c81917947598abc6ffe65447243ef52cc7c736.lock (Errno::EACCES)
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-2.3.5/lib/vagrant/util/file_mutex.rb:29:in `unlock'
        from C:/HashiCorp/Vagrant/embedded/gems/gems/vagrant-2.3.5/lib/vagrant/util/file_mutex.rb:15:in `with_lock'
...
```

Opened file handler causes this error.
Closing the file handler after lock acquisition fixes this error.