### PR TITLE
Update locale preference for the virtualbox driver

### DIFF
--- a/plugins/providers/virtualbox/driver/base.rb
+++ b/plugins/providers/virtualbox/driver/base.rb
@@ -475,7 +475,7 @@ module VagrantPlugins
         private
 
         # List of LANG values to attempt to use
-        LANG_VARIATIONS = %w(C C.UTF-8 C.utf8 en_US.UTF-8 en_US.utf8 POSIX).map(&:freeze).freeze
+        LANG_VARIATIONS = %w(C.UTF-8 C.utf8 en_US.UTF-8 en_US.utf8 C POSIX).map(&:freeze).freeze
 
         # By default set the LANG to C. If the host has the locale command
         # available, check installed locales and verify C is included (or

--- a/test/unit/plugins/providers/virtualbox/driver/base.rb
+++ b/test/unit/plugins/providers/virtualbox/driver/base.rb
@@ -42,6 +42,22 @@ describe VagrantPlugins::ProviderVirtualBox::Driver::Base do
           it "should use C for the lang" do
             expect(subject.send(:env_lang)).to eq({LANG: "C"})
           end
+
+          context "when stdout includes UTF-8 variants of C" do
+            let(:stdout) { "#{base}C\nC.UTF-8" }
+
+            it "should use the UTF-8 variant" do
+              expect(subject.send(:env_lang)).to eq({LANG: "C.UTF-8"})
+            end
+          end
+
+          context "when stdout includes utf8 variants of C" do
+            let(:stdout) { "#{base}C\nC.utf8" }
+
+            it "should use the utf8 variant" do
+              expect(subject.send(:env_lang)).to eq({LANG: "C.utf8"})
+            end
+          end
         end
 
         context "when stdout does not include C" do


### PR DESCRIPTION
Update the locale preference list to prefer UTF-8 variations of `C` when
available.

Fixes #13145
