### PR TITLE
Fix ssh keyboard interactive login

### DIFF
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -404,7 +404,7 @@ module VagrantPlugins
 
         # Set some valid auth methods. We disable the auth methods that
         # we're not using if we don't have the right auth info.
-        auth_methods = ["none"]
+        auth_methods = ["none", "hostbased"]
         auth_methods << "publickey" if ssh_info[:private_key_path]
         auth_methods << "password" if ssh_info[:password]
         auth_methods << "keyboard-interactive"

--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -404,9 +404,10 @@ module VagrantPlugins
 
         # Set some valid auth methods. We disable the auth methods that
         # we're not using if we don't have the right auth info.
-        auth_methods = ["none", "hostbased", "keyboard-interactive"]
+        auth_methods = ["none"]
         auth_methods << "publickey" if ssh_info[:private_key_path]
         auth_methods << "password" if ssh_info[:password]
+        auth_methods << "keyboard-interactive"
 
         # Build the options we'll use to initiate the connection via Net::SSH
         common_connect_opts = {


### PR DESCRIPTION
The PR https://github.com/hashicorp/vagrant/pull/13052 has introduced the "keyboard-interactive" option for SSH connections.
However, the order of preference is crucial, and when using this option, even if a valid SSH key is available, the connection still prompts for a password.