### PR TITLE
Bump all GitHub Actions and pin; avoid deprecated Node 12

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/go-spectest.yml
+++ b/.github/workflows/go-spectest.yml
@@ -23,18 +23,18 @@ jobs:
     name: Vagrant acceptance tests
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           submodules: 'recursive'
           # Also fetch all tags, since we need our version number in the build
           # to be based off a tag
           fetch-depth: 0
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: ${{matrix.go}}
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@7d546f4868fb108ed378764d873683f920672ae2 # v1.149.0
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true

--- a/.github/workflows/go-testing.yml
+++ b/.github/workflows/go-testing.yml
@@ -30,13 +30,13 @@ jobs:
     name: Vagrant unit tests on Go
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
         with:
           go-version: ${{matrix.go}}
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@7d546f4868fb108ed378764d873683f920672ae2 # v1.149.0
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -11,7 +11,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: dessant/lock-threads@v2
+      - uses: dessant/lock-threads@c1b35aecc5cdb1a34539d14196df55838bb2f836 # v4.0.0
         with:
           github-token: ${{ github.token }}
           issue-lock-inactive-days: '30'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Trigger Build
         run: ./.ci/release
         env:

--- a/.github/workflows/spectesting.yml
+++ b/.github/workflows/spectesting.yml
@@ -29,7 +29,7 @@ jobs:
             kv/data/teams/vagrant/packet project_id | packet_project_id;
             kv/data/teams/vagrant/packet ssh_key_content | packet_ssh_key_content;
       - name: Code Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Create packet instance
         run: ./.ci/spec/create-packet.sh
         working-directory: ${{github.workspace}}
@@ -50,7 +50,7 @@ jobs:
         providers: ['virtualbox', 'docker']
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           submodules: 'recursive'
       - name: Create hosts for tests (provider ${{ matrix.providers }})
@@ -104,7 +104,7 @@ jobs:
           VAGRANT_DOCKER_IMAGES: ${{matrix.docker_images}}
       - name: Upload log
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         with:
           name: vagrant-spec-${{matrix.providers}}.log
           path: ${{ github.workspace }}/vagrant-spec.log

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -35,9 +35,9 @@ jobs:
     name: Vagrant unit tests on Ruby ${{ matrix.ruby }}
     steps:
       - name: Code Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
       - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
+        uses: ruby/setup-ruby@7d546f4868fb108ed378764d873683f920672ae2 # v1.149.0
         with:
           ruby-version: ${{matrix.ruby}}
           bundler-cache: true


### PR DESCRIPTION
Commit is the result of running HashiCorp's internal pinning tool, for all GitHub Actions workflows in the repo.

https://github.blog/changelog/2023-05-04-github-actions-all-actions-will-run-on-node16-instead-of-node12/

Note, this unsolicited PR is a courtesy and has not been tested before submission.  The PR should be evaluated and merged by its responsible team.