### PR TITLE
Enable deprecated key type and host key algorithm

### DIFF
--- a/lib/vagrant/util/ssh.rb
+++ b/lib/vagrant/util/ssh.rb
@@ -146,6 +146,13 @@ module Vagrant
             "-o", "UserKnownHostsFile=/dev/null"]
         end
 
+        if !ssh_info[:disable_deprecated_algorithms]
+          command_options += [
+            "-o", "PubkeyAcceptedKeyTypes=+ssh-rsa",
+            "-o", "HostKeyAlgorithms=+ssh-rsa",
+          ]
+        end
+
         # If we're not in plain mode and :private_key_path is set attach the private key path(s).
         if !plain_mode && options[:private_key_path]
           options[:private_key_path].each do |path|

--- a/plugins/commands/ssh_config/command.rb
+++ b/plugins/commands/ssh_config/command.rb
@@ -55,7 +55,8 @@ module VagrantPlugins
             proxy_command: ssh_info[:proxy_command],
             ssh_command:   ssh_info[:ssh_command],
             forward_env:   ssh_info[:forward_env],
-            config:        ssh_info[:config]
+            config:        ssh_info[:config],
+            disable_deprecated_algorithms: ssh_info[:disable_deprecated_algorithms]
           }
 
           # Render the template and output directly to STDOUT

--- a/plugins/kernel_v2/config/ssh_connect.rb
+++ b/plugins/kernel_v2/config/ssh_connect.rb
@@ -18,6 +18,7 @@ module VagrantPlugins
       attr_accessor :dsa_authentication
       attr_accessor :extra_args
       attr_accessor :remote_user
+      attr_accessor :disable_deprecated_algorithms
 
       def initialize
         @host             = UNSET_VALUE
@@ -35,6 +36,7 @@ module VagrantPlugins
         @dsa_authentication = UNSET_VALUE
         @extra_args       = UNSET_VALUE
         @remote_user      = UNSET_VALUE
+        @disable_deprecated_algorithms = UNSET_VALUE
       end
 
       def finalize!
@@ -51,6 +53,7 @@ module VagrantPlugins
         @dsa_authentication = true if @dsa_authentication == UNSET_VALUE
         @extra_args       = nil if @extra_args == UNSET_VALUE
         @config           = nil if @config == UNSET_VALUE
+        @disable_deprecated_algorithms = false if @disable_deprecated_algorithms == UNSET_VALUE
         @connect_timeout  = DEFAULT_SSH_CONNECT_TIMEOUT if @connect_timeout == UNSET_VALUE
 
         if @private_key_path && !@private_key_path.is_a?(Array)

--- a/templates/commands/ssh_config/config.erb
+++ b/templates/commands/ssh_config/config.erb
@@ -36,3 +36,7 @@ Host <%= host_key %>
 <% if proxy_command -%>
   ProxyCommand <%= proxy_command %>
 <% end -%>
+<% if !disable_deprecated_algorithms -%>
+  PubkeyAcceptedKeyTypes +ssh-rsa
+  HostKeyAlgorithms +ssh-rsa
+<% end -%>

--- a/test/unit/plugins/commands/ssh_config/command_test.rb
+++ b/test/unit/plugins/commands/ssh_config/command_test.rb
@@ -56,6 +56,8 @@ Host #{machine.name}
   IdentityFile /home/vagrant/.private/keys.key
   IdentitiesOnly yes
   LogLevel FATAL
+  PubkeyAcceptedKeyTypes +ssh-rsa
+  HostKeyAlgorithms +ssh-rsa
       SSHCONFIG
     end
 
@@ -178,5 +180,31 @@ Host #{machine.name}
 
       expect(output).to include("Include /custom/ssh/config")
     end
+
+    it "includes enabling ssh-rsa key types and host algorithms" do
+      output = ""
+      allow(subject).to receive(:safe_puts) do |data|
+        output += data if data
+      end
+
+      subject.execute
+
+      expect(output).to include("PubkeyAcceptedKeyTypes +ssh-rsa")
+      expect(output).to include("HostKeyAlgorithms +ssh-rsa")
+    end
+
+    it "does not enable ssh-rsa key types and host algorithms when disabled" do
+      allow(machine).to receive(:ssh_info) { ssh_info.merge(disable_deprecated_algorithms: true) }
+      output = ""
+      allow(subject).to receive(:safe_puts) do |data|
+        output += data if data
+      end
+
+      subject.execute
+
+      expect(output).not_to include("PubkeyAcceptedKeyTypes +ssh-rsa")
+      expect(output).not_to include("HostKeyAlgorithms +ssh-rsa")
+    end
+
   end
 end

--- a/website/content/docs/vagrantfile/ssh_settings.mdx
+++ b/website/content/docs/vagrantfile/ssh_settings.mdx
@@ -27,6 +27,10 @@ defaults are typically fine, but you can fine tune whatever you would like.
 - `config.ssh.config` (string) - Path to a custom ssh_config file to use for configuring
   the SSH connections.
 
+- `config.ssh.disable_deprecated_algorithms` (boolean) - If `true`, this setting will
+  not configure the SSH client to allow connecting to a host using ssh-rsa key types
+  and host key algorithms. Defaults to false.
+
 - `config.ssh.dsa_authentication` (boolean) - If `false`, this setting will not include
   `DSAAuthentication` when ssh'ing into a machine. If this is not set, it will
   default to `true` and `DSAAuthentication=yes` will be used with ssh.


### PR DESCRIPTION
Recent versions of OpenSSH remove support of ssh-rsa key types and host
key algorithms from the default conection configuration. Set options to
enable them and provide a configuration option which can disable them if
required.

Fixes #13124
