### PR TITLE
Remove keyboard-interactive authentication method

### DIFF
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -404,7 +404,7 @@ module VagrantPlugins
 
         # Set some valid auth methods. We disable the auth methods that
         # we're not using if we don't have the right auth info.
-        auth_methods = ["none", "hostbased", "keyboard-interactive"]
+        auth_methods = ["none", "hostbased"]
         auth_methods << "publickey" if ssh_info[:private_key_path]
         auth_methods << "password" if ssh_info[:password]
 
@@ -461,10 +461,6 @@ module VagrantPlugins
                   connect_opts[:keepalive_interval] = 5
                 end
                 
-                if ssh_info[:password]
-                  connect_opts[:non_interactive] = true
-                end
-
                 @logger.info("Attempting to connect to SSH...")
                 @logger.info("  - Host: #{ssh_info[:host]}")
                 @logger.info("  - Port: #{ssh_info[:port]}")

--- a/test/unit/plugins/communicators/ssh/communicator_test.rb
+++ b/test/unit/plugins/communicators/ssh/communicator_test.rb
@@ -664,7 +664,7 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
       it "includes `none` and `hostbased` auth methods" do
         expect(Net::SSH).to receive(:start).with(
           nil, nil, hash_including(
-            auth_methods: ["none", "hostbased", "keyboard-interactive"]
+            auth_methods: ["none", "hostbased"]
           )
         ).and_return(true)
         communicator.send(:connect)
@@ -780,7 +780,7 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
       it "includes `publickey` auth method" do
         expect(Net::SSH).to receive(:start).with(
           anything, anything, hash_including(
-            auth_methods: ["none", "hostbased", "keyboard-interactive", "publickey"]
+            auth_methods: ["none", "hostbased", "publickey"]
           )
         ).and_return(true)
         communicator.send(:connect)
@@ -809,7 +809,7 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
       it "has password defined" do
         expect(Net::SSH).to receive(:start).with(
           anything, anything, hash_including(
-            password: 'vagrant', non_interactive: true
+            password: 'vagrant'
           )
         ).and_return(true)
         communicator.send(:connect)
@@ -818,7 +818,7 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
       it "includes `password` auth method" do
         expect(Net::SSH).to receive(:start).with(
           anything, anything, hash_including(
-            auth_methods: ["none", "hostbased", "keyboard-interactive", "password"]
+            auth_methods: ["none", "hostbased", "password"]
           )
         ).and_return(true)
         communicator.send(:connect)
@@ -860,7 +860,7 @@ describe VagrantPlugins::CommunicatorSSH::Communicator do
       it "includes `publickey` and `password` auth methods" do
         expect(Net::SSH).to receive(:start).with(
           anything, anything, hash_including(
-            auth_methods: ["none", "hostbased", "keyboard-interactive", "publickey", "password"]
+            auth_methods: ["none", "hostbased", "publickey", "password"]
           )
         ).and_return(true)
         communicator.send(:connect)

--- a/test/unit/plugins/communicators/winssh/communicator_test.rb
+++ b/test/unit/plugins/communicators/winssh/communicator_test.rb
@@ -328,7 +328,7 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
       it "includes `none` and `hostbased` auth methods" do
         expect(Net::SSH).to receive(:start).with(
           nil, nil, hash_including(
-            auth_methods: ["none", "hostbased", "keyboard-interactive"]
+            auth_methods: ["none", "hostbased"]
           )
         ).and_return(connection)
         communicator.send(:connect)
@@ -420,7 +420,7 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
       it "includes `publickey` auth method" do
         expect(Net::SSH).to receive(:start).with(
           anything, anything, hash_including(
-            auth_methods: ["none", "hostbased", "keyboard-interactive", "publickey"]
+            auth_methods: ["none", "hostbased", "publickey"]
           )
         ).and_return(connection)
         communicator.send(:connect)
@@ -458,7 +458,7 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
       it "includes `password` auth method" do
         expect(Net::SSH).to receive(:start).with(
           anything, anything, hash_including(
-            auth_methods: ["none", "hostbased", "keyboard-interactive", "password"]
+            auth_methods: ["none", "hostbased", "password"]
           )
         ).and_return(connection)
         communicator.send(:connect)
@@ -500,7 +500,7 @@ describe VagrantPlugins::CommunicatorWinSSH::Communicator do
       it "includes `publickey` and `password` auth methods" do
         expect(Net::SSH).to receive(:start).with(
           anything, anything, hash_including(
-            auth_methods: ["none", "hostbased", "keyboard-interactive", "publickey", "password"]
+            auth_methods: ["none", "hostbased", "publickey", "password"]
           )
         ).and_return(connection)
         communicator.send(:connect)


### PR DESCRIPTION
The keyboard-interactive authentication method was added due to a
mis-reading hashicorp/vagrant#13008. In that issue it was reported
that Vagrant wasn't properly connecting to a guest using password
based authentication. However, upon further inspection of the debug
output provided in that issue, the root cause was the guest sshd not
being properly configured to allow password authentication.

The keyboard-interactive authentication method has been backed out as
properly configured Vagrant boxes do not require interaction for
authentication. This also resolves an issue introduced by the placement
of the keyboard-interactive auth method which can result in authentication
hanging waiting for user input before reaching key based authentication.

Fixes #13171 #13191 
