### PR TITLE
update ansible installation and faq links

### DIFF
--- a/website/content/docs/provisioning/ansible.mdx
+++ b/website/content/docs/provisioning/ansible.mdx
@@ -17,9 +17,9 @@ If you are not familiar with Ansible and Vagrant already, we recommend starting 
 
 ## Setup Requirements
 
-- **[Install Ansible](https://docs.ansible.com/intro_installation.html#installing-the-control-machine) on your Vagrant host**.
+- **[Install Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) on your Vagrant host**.
 
-- Your Vagrant host should ideally provide a recent version of OpenSSH that [supports ControlPersist](https://docs.ansible.com/faq.html#how-do-i-get-ansible-to-reuse-connections-enable-kerberized-ssh-or-have-ansible-pay-attention-to-my-local-ssh-config-file).
+- Your Vagrant host should ideally provide a recent version of OpenSSH that [supports ControlPersist](https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-get-ansible-to-reuse-connections-enable-kerberized-ssh-or-have-ansible-pay-attention-to-my-local-ssh-config-file).
 
 If installing Ansible directly on the Vagrant host is not an option in your development environment, you might be looking for the [Ansible Local provisioner](/vagrant/docs/provisioning/ansible_local) alternative.
 


### PR DESCRIPTION
I noticed that these links to the Ansible installation instructions and FAQs were broken. It seems that the "Installing the Control Machine" section no longer exists in the linked docs.