### PR TITLE
Handle skipped required tests

### DIFF
--- a/.github/workflows/go-spectest-skipped.yml
+++ b/.github/workflows/go-spectest-skipped.yml
@@ -1,0 +1,22 @@
+name: Vagrant Go acceptance tests
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'builtin/**'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'go.mod'
+      - 'go.sum'
+
+jobs:
+  vagrant-spec-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: ['3.0', '3.1', '3.2']
+    name: Vagrant acceptance tests (Ruby ${{ matrix.ruby }})
+    steps:
+      - name: Stubbed for skip
+        run: "echo 'No testing required in changeset'"

--- a/.github/workflows/go-spectest.yml
+++ b/.github/workflows/go-spectest.yml
@@ -1,3 +1,4 @@
+name: Vagrant Go acceptance tests
 on:
   push:
     branches:
@@ -18,9 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['^1.16']
-        ruby: ['3.1']
-    name: Vagrant acceptance tests
+        ruby: ['3.0', '3.1', '3.2']
+    name: Vagrant acceptance tests (Ruby ${{ matrix.ruby }})
     steps:
       - name: Code Checkout
         uses: actions/checkout@v3
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{matrix.go}}
+          go-version-file: go.mod
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -41,7 +41,7 @@ jobs:
       - name: Build Vagrant
         run:  |
           git config --global url."https://${HASHIBOT_USERNAME}:${HASHIBOT_TOKEN}@github.com".insteadOf "https://github.com"
-          make bin/linux
+          make
         env:
           HASHIBOT_USERNAME: ${{ secrets.HASHIBOT_USERNAME }}
           HASHIBOT_TOKEN: ${{ secrets.HASHIBOT_TOKEN }}
@@ -52,6 +52,6 @@ jobs:
           VAGRANT_SPEC_BOX: "hashicorp/bionic64"
       - name: Run vagrant-spec
         run: |
-          VAGRANT_PATH="$GITHUB_WORKSPACE/vagrant" bundle exec vagrant-spec test --components=cli/version --config test/vagrant-spec/configs/vagrant-spec.config.virtualbox.rb
+          VAGRANT_PATH="$GITHUB_WORKSPACE/bin/vagrant-go" bundle exec vagrant-spec test --components=cli/version --config test/vagrant-spec/configs/vagrant-spec.config.virtualbox.rb
         env:
           VAGRANT_SPEC_BOX: "hashicorp/bionic64"

--- a/.github/workflows/go-testing-skipped.yml
+++ b/.github/workflows/go-testing-skipped.yml
@@ -1,0 +1,21 @@
+on:
+  pull_request:
+    branches:
+      - main
+    ignored-paths:
+      - 'builtin/**'
+      - 'cmd/**'
+      - 'internal/**'
+      - 'go.mod'
+      - 'go.sum'
+
+jobs:
+  unit-tests-go:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: ['3.0', '3.1', '3.2']
+    name: Vagrant unit tests on Go (Ruby ${{ matrix.ruby }})
+    steps:
+      - name: Stubbed for skip
+        run: "echo 'No testing required in changeset'"

--- a/.github/workflows/go-testing.yml
+++ b/.github/workflows/go-testing.yml
@@ -1,3 +1,4 @@
+name: Vagrant Go unit tests
 on:
   push:
     branches:
@@ -25,16 +26,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['^1.16']
-        ruby: ['3.0', '3.1']
-    name: Vagrant unit tests on Go
+        ruby: ['3.0', '3.1', '3.2']
+    name: Vagrant unit tests on Go (Ruby ${{ matrix.ruby }})
     steps:
       - name: Code Checkout
         uses: actions/checkout@v3
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: ${{matrix.go}}
+          go-version-file: go.mod
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/testing-skipped.yml
+++ b/.github/workflows/testing-skipped.yml
@@ -1,0 +1,26 @@
+name: Vagrant Ruby Tests
+on:
+  pull_request:
+    branches:
+      - main
+    ignored-paths:
+      - 'bin/**'
+      - 'lib/**'
+      - 'plugins/**'
+      - 'test/**'
+      - 'Gemfile'
+      - 'templates/**'
+      - 'vagrant.gemspec'
+      - 'Rakefile'
+
+jobs:
+  unit-tests-ruby:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      matrix:
+        ruby: [ '3.0', '3.1', '3.2' ]
+    name: Vagrant unit tests on Ruby ${{ matrix.ruby }}
+    steps:
+      - name: Stubbed for skip
+        run: "echo 'No testing required in changeset'"

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,3 +1,4 @@
+name: Vagrant Ruby Tests
 on:
   push:
     branches:


### PR DESCRIPTION
Required tests that are skipped based on path matching need to have an
inverse match with the same name that always succeeds to allow the tests
to be marked as passing.

This approach is described in [this article](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/troubleshooting-required-status-checks#handling-skipped-but-required-checks).
