### PR TITLE
Add architecture support

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -140,6 +140,8 @@ if File.exist?(File.expand_path("vagrant/vagrant_ssl.so", __dir__))
   rescue => err
     global_logger.warn("unexpected failure loading ssl providers, attempting to continue (#{err})")
   end
+else
+  global_logger.warn("vagrant ssl helper was not found, continuing...")
 end
 
 # We need these components always so instead of an autoload we

--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -329,6 +329,17 @@ module Vagrant
             provider_url = authed_urls[0]
           end
 
+          # The architecture name used when adding the box should be
+          # the value extracted from the metadata provider
+          arch_name = metadata_provider.architecture
+
+          # In the special case where the architecture name is "unknown" and
+          # it is listed as the default architecture, unset the architecture
+          # name so it is installed without architecture information
+          if arch_name == "unknown" && metadata_provider.default_architecture
+            arch_name = nil
+          end
+
           box_add(
             [[provider_url, metadata_provider.url]],
             metadata.name,
@@ -338,7 +349,7 @@ module Vagrant
             env,
             checksum: metadata_provider.checksum,
             checksum_type: metadata_provider.checksum_type,
-            architecture: metadata_provider.architecture,
+            architecture: arch_name,
           )
         end
 

--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -338,7 +338,7 @@ module Vagrant
             env,
             checksum: metadata_provider.checksum,
             checksum_type: metadata_provider.checksum_type,
-            architecture: architecture,
+            architecture: metadata_provider.architecture,
           )
         end
 
@@ -420,7 +420,7 @@ module Vagrant
               force: env[:box_force],
               metadata_url: md_url,
               providers: provider,
-              architecture: env[:box_architecture]
+              architecture: opts[:architecture]
             )
           ensure
             # Make sure we delete the temporary file after we add it,

--- a/lib/vagrant/action/builtin/box_remove.rb
+++ b/lib/vagrant/action/builtin/box_remove.rb
@@ -15,112 +15,162 @@ module Vagrant
 
         def call(env)
           box_name     = env[:box_name]
-          box_provider = env[:box_provider]
-          box_provider = box_provider.to_sym if box_provider
+          box_architecture = env[:box_architecture] if env[:box_architecture]
+          box_provider = env[:box_provider].to_sym if env[:box_provider]
           box_version  = env[:box_version]
           box_remove_all_versions = env[:box_remove_all_versions]
+          box_remove_all_providers = env[:box_remove_all_providers]
+          box_remove_all_architectures = env[:box_remove_all_architectures]
 
-          boxes = {}
-          env[:box_collection].all.each do |n, v, p|
-            boxes[n] ||= {}
-            boxes[n][p] ||= []
-            boxes[n][p] << v
+          box_info = Util::HashWithIndifferentAccess.new
+          env[:box_collection].all.each do |name, version, provider, architecture|
+            next if name != box_name
+            box_info[version] ||= Util::HashWithIndifferentAccess.new
+            box_info[version][provider] ||= []
+            box_info[version][provider] << architecture
           end
 
-          all_box = boxes[box_name]
-          if !all_box
+          # If there's no box info, then the box doesn't exist here
+          if box_info.empty?
             raise Errors::BoxRemoveNotFound, name: box_name
           end
 
-          all_versions = nil
-          if !box_provider
-            if all_box.length == 1
-              # There is only one provider, just use that.
-              all_versions = all_box.values.first
-              box_provider = all_box.keys.first
-            else
-              raise Errors::BoxRemoveMultiProvider,
-                name: box_name,
-                providers: all_box.keys.map(&:to_s).sort.join(", ")
-            end
-          else
-            all_versions = all_box[box_provider]
-            if !all_versions
-              raise Errors::BoxRemoveProviderNotFound,
-                name: box_name,
-                provider: box_provider.to_s,
-                providers: all_box.keys.map(&:to_s).sort.join(", ")
-            end
-          end
-
-          if !box_version
-            if all_versions.length == 1
-              # There is only one version, just use that.
-              box_version = all_versions.first
-            elsif not box_remove_all_versions
-              # There are multiple versions, we can't choose.
+          # Filtering only matters if not removing all versions
+          if !box_remove_all_versions
+            # If no version was provided, and not removing all versions,
+            # only allow one version to proceed
+            if !box_version && box_info.size > 1
               raise Errors::BoxRemoveMultiVersion,
                 name: box_name,
-                provider: box_provider.to_s,
-                versions: all_versions.sort.map { |k| " * #{k}" }.join("\n")
+                versions: box_info.keys.sort.map { |k| " * #{k}" }.join("\n")
             end
-          elsif !all_versions.include?(box_version)
-            raise Errors::BoxRemoveVersionNotFound,
-              name: box_name,
-              provider: box_provider.to_s,
-              version: box_version,
-              versions: all_versions.sort.map { |k| " * #{k}" }.join("\n")
+
+            # If a version was provided, make sure it exists
+            if box_version
+              if !box_info.keys.include?(box_version)
+                raise Errors::BoxRemoveVersionNotFound,
+                  name: box_name,
+                  version: box_version,
+                  versions: box_info.keys.sort.map { |k| " * #{k}" }.join("\n")
+              else
+                box_info.delete_if { |k, _| k != box_version }
+              end
+            end
+
+            # Only a single version remains
+            box_version = box_info.keys.first
+
+            # Further filtering only matters if not removing all providers
+            if !box_remove_all_providers
+              # If no provider was given, check if there are more
+              # than a single provider for the version
+              if !box_provider && box_info.values.first.size > 1
+                raise Errors::BoxRemoveMultiProvider,
+                  name: box_name,
+                  version: box_version,
+                  providers: box_info.values.first.keys.map(&:to_s).sort.join(", ")
+              end
+
+              # If a provider was given, check the version has it
+              if box_provider
+                if !box_info.values.first.key?(box_provider)
+                  raise Errors::BoxRemoveProviderNotFound,
+                    name: box_name,
+                    version: box_version,
+                    provider: box_provider.to_s,
+                    providers: box_info.values.first.keys.map(&:to_s).sort.join(", ")
+                else
+                  box_info.values.first.delete_if { |k, _| k.to_s != box_provider.to_s }
+                end
+              end
+
+              # Only a single provider remains
+              box_provider = box_info.values.first.keys.first
+
+              # Further filtering only matters if not removing all architectures
+              if !box_remove_all_architectures
+                # If no architecture was given, check if there are more
+                # than a single architecture for the provider in version
+                if !box_architecture && box_info.values.first.values.first.size > 1
+                  raise Errors::BoxRemoveMultiArchitecture,
+                    name: box_name,
+                    version: box_version,
+                    provider: box_provider.to_s,
+                    architectures: box_info.values.first.values.first.sort.join(", ")
+                end
+
+                # If architecture was given, check the provider for the version has it
+                if box_architecture
+                  if !box_info.values.first.values.first.include?(box_architecture)
+                    raise Errors::BoxRemoveArchitectureNotFound,
+                      name: box_name,
+                      version: box_version,
+                      provider: box_provider.to_s,
+                      architecture: box_architecture,
+                      architectures: box_info.values.first.values.first.sort.join(", ")
+                  else
+                    box_info.values.first.values.first.delete_if { |v| v != box_architecture }
+                  end
+                end
+              end
+            end
           end
 
-          versions_to_remove = [box_version]
-          versions_to_remove = all_versions if box_remove_all_versions
+          box_info.each do |version, provider_info|
+            provider_info.each do |provider, architecture_info|
+              provider = provider.to_sym
+              architecture_info.each do |architecture|
+                box = env[:box_collection].find(
+                  box_name, provider, version, architecture
+                )
 
-          versions_to_remove.sort.each do |version_to_remove|
-            box = env[:box_collection].find(
-              box_name, box_provider, box_version)
+                # Verify that this box is not in use by an active machine,
+                # otherwise warn the user.
+                users = box.in_use?(env[:machine_index]) || []
+                users = users.find_all { |u| u.valid?(env[:home_path]) }
+                if !users.empty?
+                  # Build up the output to show the user.
+                  users = users.map do |entry|
+                    "#{entry.name} (ID: #{entry.id})"
+                  end.join("\n")
 
-            # Verify that this box is not in use by an active machine,
-            # otherwise warn the user.
-            users = box.in_use?(env[:machine_index]) || []
-            users = users.find_all { |u| u.valid?(env[:home_path]) }
-            if !users.empty?
-              # Build up the output to show the user.
-              users = users.map do |entry|
-                "#{entry.name} (ID: #{entry.id})"
-              end.join("\n")
+                  force_key = :force_confirm_box_remove
+                  message   = I18n.t(
+                    "vagrant.commands.box.remove_in_use_query",
+                    name: box.name,
+                    architecture: box.architecture,
+                    provider: box.provider,
+                    version: box.version,
+                    users: users) + " "
 
-              force_key = :force_confirm_box_remove
-              message   = I18n.t(
-                "vagrant.commands.box.remove_in_use_query",
-                name: box.name,
-                provider: box.provider,
-                version: box.version,
-                users: users) + " "
+                  # Ask the user if we should do this
+                  stack = Builder.new.tap do |b|
+                    b.use Confirm, message, force_key
+                  end
 
-              # Ask the user if we should do this
-              stack = Builder.new.tap do |b|
-                b.use Confirm, message, force_key
-              end
+                  # Keep used boxes, even if "force" is applied
+                  keep_used_boxes = env[:keep_used_boxes]
 
-              # Keep used boxes, even if "force" is applied
-              keep_used_boxes = env[:keep_used_boxes]
+                  result = env[:action_runner].run(stack, env)
+                  if !result[:result] || keep_used_boxes
+                    # They said "no", so continue with the next box
+                    next
+                  end
+                end
 
-              result = env[:action_runner].run(stack, env)
-              if !result[:result] || keep_used_boxes
-                # They said "no", so continue with the next box
-                next
+                env[:ui].info(I18n.t("vagrant.commands.box.removing",
+                  name: box.name,
+                  architecture: box.architecture,
+                  provider: box.provider,
+                  version: box.version))
+
+                box.destroy!
+                env[:box_collection].clean(box.name)
+
+                # Passes on the removed box to the rest of the middleware chain
+                env[:box_removed] = box
               end
             end
-
-            env[:ui].info(I18n.t("vagrant.commands.box.removing",
-                                name: box.name,
-                                provider: box.provider,
-                                version: box.version))
-            box.destroy!
-            env[:box_collection].clean(box.name)
-
-            # Passes on the removed box to the rest of the middleware chain
-            env[:box_removed] = box
           end
 
           @app.call(env)

--- a/lib/vagrant/action/builtin/handle_box.rb
+++ b/lib/vagrant/action/builtin/handle_box.rb
@@ -87,6 +87,7 @@ module Vagrant
             env[:action_runner].run(Vagrant::Action.action_box_add, env.merge({
               box_name: machine.config.vm.box,
               box_url: machine.config.vm.box_url || machine.config.vm.box,
+              box_architecture: machine.config.vm.box_architecture,
               box_server_url: machine.config.vm.box_server_url,
               box_provider: box_formats,
               box_version: machine.config.vm.box_version,

--- a/lib/vagrant/box_collection.rb
+++ b/lib/vagrant/box_collection.rb
@@ -170,28 +170,26 @@ module Vagrant
             @logger.debug("Box directory: #{box_dir}")
 
             # This is the final directory we'll move it to
-            provider_dir = box_dir.join(provider.to_s)
-            final_dir = provider_dir
-            @logger.debug("Provider directory: #{provider_dir}")
-            # If architecture is set, unpack into architecture specific directory
             if architecture
               arch = architecture
               arch = Util::Platform.architecture if architecture == :auto
-              final_dir = provider_dir.join(arch)
+              box_dir = box_dir.join(arch)
             end
+            provider_dir = box_dir.join(provider.to_s)
+            @logger.debug("Provider directory: #{provider_dir}")
 
-            if final_dir.exist?
+            if provider_dir.exist?
               @logger.debug("Removing existing provider directory...")
-              final_dir.rmtree
+              provider_dir.rmtree
             end
 
             # Move to final destination
-            final_dir.mkpath
+            provider_dir.mkpath
 
             # Recursively move individual files from the temporary directory
             # to the final location. We do this instead of moving the entire
             # directory to avoid issues on Windows. [GH-1424]
-            copy_pairs = [[final_temp_dir, final_dir]]
+            copy_pairs = [[final_temp_dir, provider_dir]]
             while !copy_pairs.empty?
               from, to = copy_pairs.shift
               from.children(true).each do |f|
@@ -248,34 +246,52 @@ module Vagrant
             next if versiondir.basename.to_s.start_with?(".")
 
             version = versiondir.basename.to_s
+            # Ensure version of box is correct before continuing
+            if !Gem::Version.correct?(version)
+              ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
+              ui.warn(I18n.t("vagrant.box_version_malformed",
+                             version: version, box_name: box_name))
+              @logger.debug("Invalid version #{version} for box #{box_name}")
+              next
+            end
 
-            versiondir.children(true).each do |provider|
-              # Ensure version of box is correct before continuing
-              if !Gem::Version.correct?(version)
-                ui = Vagrant::UI::Prefixed.new(Vagrant::UI::Colored.new, "vagrant")
-                ui.warn(I18n.t("vagrant.box_version_malformed",
-                              version: version, box_name: box_name))
-                @logger.debug("Invalid version #{version} for box #{box_name}")
+            versiondir.children(true).each do |architecture_or_provider|
+              # If the entry is not a directory, it is invalid and should be ignored
+              if !architecture_or_provider.directory?
+                @logger.debug("Invalid box #{box_name} (v#{version}) - invalid item: #{architecture_or_provider}")
                 next
               end
 
-              # Verify this is a potentially valid box. If it looks
-              # correct enough then include it.
-              if provider.directory? && provider.join("metadata.json").file?
-                provider_name = provider.basename.to_s.to_sym
+              # Now the directory can be assumed to be the architecture
+              architecture_name = architecture_or_provider.basename.to_s.to_sym
+
+              # Cycle through directories to find providers
+              architecture_or_provider.children(true).each do |provider|
+                if !provider.directory?
+                  @logger.debug("Invalid box #{box_name} (v#{version}, #{architecture_name}) - invalid item: #{provider}")
+                  next
+                end
+
+                # If the entry contains a metadata file, add it
+                if provider.join("metadata.json").file?
+                  provider_name = provider.basename.to_s.to_sym
+                  @logger.debug("Box: #{box_name} (#{provider_name} (#{architecture_name}), #{version})")
+                  results << [box_name, version, provider_name, architecture_name]
+                end
+              end
+
+              # If the base entry contains a metadata file, then it was
+              # added prior to architecture support and is a provider directory.
+              # If it contains a metadata file, include it with the results only
+              # if an entry hasn't already been included for the local system's
+              # architecture
+              if architecture_or_provider.join("metadata.json").file?
+                provider_name = architecture_or_provider.basename.to_s.to_sym
+                if results.include?([box_name, version, provider_name, Util::Platform.architecture.to_sym])
+                  next
+                end
                 @logger.debug("Box: #{box_name} (#{provider_name}, #{version})")
                 results << [box_name, version, provider_name, nil]
-              elsif provider.directory?
-                provider.children(true).each do |architecture|
-                  provider_name = provider.basename.to_s.to_sym
-                  if architecture.directory? && architecture.join("metadata.json").file?
-                    architecture_name = architecture.basename.to_s.to_sym
-                    @logger.debug("Box: #{box_name} (#{provider_name} (#{architecture_name}), #{version})")
-                    results << [box_name, version, provider_name, architecture_name]
-                  end
-                end
-              else
-                @logger.debug("Invalid box #{box_name}, ignoring: #{provider}")
               end
             end
           end
@@ -341,25 +357,41 @@ module Vagrant
           end
 
           versiondir = box_directory.join(version_dir_map[v.to_s])
-          providers.each do |provider|
-            provider_dir = versiondir.join(provider.to_s)
-            next if !provider_dir.directory?
-            # If architecture is defined then the box should be within
-            # a subdirectory. However, if box_architecture value is :auto
-            # and the box provider directory exists but the architecture
-            # directory does not, we will use the box provider directory. This
-            # allows Vagrant to work correctly with boxes which were added
-            # prior to the addition of architecture support
-            final_dir = provider_dir
-            if architecture
-              arch_dir = provider_dir.join(architecture.to_s)
-              next if !arch_dir.directory? && box_architecture != :auto
-            end
-            final_dir = arch_dir if arch_dir && arch_dir.directory?
 
-            # If the final directory does not contain a `metadata.json` file, then
-            # skip this directory
-            next if !final_dir.join("metadata.json").exist?
+          providers.each do |provider|
+            providerdir = versiondir.join(architecture.to_s).join(provider.to_s)
+
+            # If the architecture was automatically set to the host
+            # architecture, then a match on the architecture subdirectory
+            # or the provider directory (which is a box install prior to
+            # architecture support) is valid
+            if box_architecture == :auto
+              if !providerdir.directory?
+                providerdir = versiondir.join(provider.to_s)
+              end
+
+              if providerdir.join("metadata.json").file?
+                @logger.info("Box found: #{name} (#{provider})")
+
+                metadata_url = nil
+                metadata_url_file = box_directory.join("metadata_url")
+                metadata_url = metadata_url_file.read if metadata_url_file.file?
+
+                if metadata_url && @hook
+                  hook_env     = @hook.call(
+                    :authenticate_box_url, box_urls: [metadata_url])
+                  metadata_url = hook_env[:box_urls].first
+                end
+
+                return Box.new(
+                  name, provider, version_dir_map[v.to_s], providerdir,
+                  architecture: architecture, metadata_url: metadata_url, hook: @hook
+                )
+              end
+            end
+
+            # If there is no metadata file found, skip
+            next if !providerdir.join("metadata.json").file?
 
             @logger.info("Box found: #{name} (#{provider})")
 
@@ -374,7 +406,7 @@ module Vagrant
             end
 
             return Box.new(
-              name, provider, version_dir_map[v.to_s], final_dir,
+              name, provider, version_dir_map[v.to_s], providerdir,
               architecture: architecture, metadata_url: metadata_url, hook: @hook
             )
           end

--- a/lib/vagrant/box_collection.rb
+++ b/lib/vagrant/box_collection.rb
@@ -357,6 +357,10 @@ module Vagrant
             end
             final_dir = arch_dir if arch_dir && arch_dir.directory?
 
+            # If the final directory does not contain a `metadata.json` file, then
+            # skip this directory
+            next if !final_dir.join("metadata.json").exist?
+
             @logger.info("Box found: #{name} (#{provider})")
 
             metadata_url = nil

--- a/lib/vagrant/box_metadata.rb
+++ b/lib/vagrant/box_metadata.rb
@@ -38,7 +38,7 @@ module Vagrant
       @description = @raw["description"]
       @version_map = (@raw["versions"] || []).map do |v|
         begin
-          [Gem::Version.new(v["version"]), v]
+          [Gem::Version.new(v["version"]), Version.new(v)]
         rescue ArgumentError
           raise Errors::BoxMetadataMalformedVersion,
             version: v["version"].to_s
@@ -61,11 +61,27 @@ module Vagrant
 
       providers = nil
       providers = Array(opts[:provider]).map(&:to_sym) if opts[:provider]
+      # NOTE: The :auto value is not expanded here since no architecture
+      #       value comparisons are being done within this method
+      architecture = opts.fetch(:architecture, :auto)
 
       @version_map.keys.sort.reverse.each do |v|
         next if !requirements.all? { |r| r.satisfied_by?(v) }
-        version = Version.new(@version_map[v])
-        next if (providers & version.providers).empty? if providers
+        version = @version_map[v]
+        valid_providers = version.providers
+
+        # If filtering by provider(s), apply filter
+        valid_providers &= providers if providers
+
+        # Skip if no valid providers are found
+        next if valid_providers.empty?
+
+        # Skip if no valid provider includes support
+        # the desired architecture
+        next if architecture && valid_providers.none? { |p|
+          version.provider(p, architecture)
+        }
+
         return version
       end
 
@@ -79,20 +95,25 @@ module Vagrant
     #
     # @return[Array<String>]
     def versions(**opts)
-      provider = nil
+      architecture = opts[:architecture]
       provider = opts[:provider].to_sym if opts[:provider]
 
-      if provider
-        @version_map.select do |version, raw|
-          if raw["providers"]
-            raw["providers"].detect do |p|
-              p["name"].to_sym == provider
-            end
-          end
-        end.keys.sort.map(&:to_s)
-      else
-        @version_map.keys.sort.map(&:to_s)
+      # Return full version list if no filters provided
+      if provider.nil? && architecture.nil?
+        return @version_map.keys.sort.map(&:to_s)
       end
+
+      # If a specific provider is not provided, filter
+      # only on architecture
+      if provider.nil?
+        return @version_map.select { |_, version|
+          !version.providers(architecture).empty?
+        }.keys.sort.map(&:to_s)
+      end
+
+      @version_map.select { |_, version|
+        version.provider(provider, architecture)
+      }.keys.sort.map(&:to_s)
     end
 
     # Represents a single version within the metadata.
@@ -106,26 +127,81 @@ module Vagrant
         return if !raw
 
         @version = raw["version"]
-        @provider_map = (raw["providers"] || []).map do |p|
-          [p["name"].to_sym, p]
+        @providers = raw.fetch("providers", []).map do |data|
+          Provider.new(data)
         end
-        @provider_map = Hash[@provider_map]
+        @provider_map = @providers.group_by(&:name)
+        @provider_map = Util::HashWithIndifferentAccess.new(@provider_map)
       end
 
       # Returns a [Provider] for the given name, or nil if it isn't
       # supported by this version.
-      def provider(name)
-        p = @provider_map[name.to_sym]
-        return nil if !p
-        Provider.new(p)
+      def provider(name, architecture=nil)
+        name = name.to_sym
+        arch_name = architecture
+        arch_name = Util::Platform.architecture if arch_name == :auto
+        arch_name = arch_name.to_s if arch_name
+
+        # If the provider doesn't exist in the map, return immediately
+        return if !@provider_map.key?(name)
+
+        # If the arch_name value is set, filter based
+        # on architecture and return match if found. If
+        # no match is found and architecture wasn't automatically
+        # detected, return nil as an explicit match is
+        # being requested
+        if arch_name
+          match = @provider_map[name].detect do |p|
+            p.architecture == arch_name
+          end
+
+          return match if match || architecture != :auto
+        end
+
+        # If the passed architecture value was :auto and no explicit
+        # match for the architecture was found, check for a provider
+        # that is flagged as the default architecture, and has an
+        # architecture value of "unknown"
+        #
+        # NOTE: This preserves expected behavior with legacy boxes
+        if architecture == :auto
+          match = @provider_map[name].detect do |p|
+            p.architecture == "unknown" &&
+              p.default_architecture
+          end
+
+          return match if match
+        end
+
+        # If the architecture value is set to nil, then just return
+        # whatever is defined as the default architecture
+        if architecture.nil?
+          match = @provider_map[name].detect(&:default_architecture)
+
+          return match if match
+        end
+
+        # The metadata consumed may not include architecture information,
+        # in which case the match would just be the single provider
+        # defined within the provider map for the name
+        if @provider_map[name].size == 1 && !@provider_map[name].first.architecture_support?
+          return @provider_map[name].first
+        end
+
+        # Otherwise, there is no match
+        nil
       end
 
       # Returns the providers that are available for this version
       # of the box.
       #
       # @return [Array<Symbol>]
-      def providers
-        @provider_map.keys.map(&:to_sym)
+      def providers(architecture=nil)
+        return @provider_map.keys.map(&:to_sym) if architecture.nil?
+
+        @provider_map.keys.find_all { |k|
+          provider(k, architecture)
+        }.map(&:to_sym)
       end
     end
 
@@ -152,11 +228,27 @@ module Vagrant
       # @return [String]
       attr_accessor :checksum_type
 
+      # The architecture of the box
+      #
+      # @return [String]
+      attr_accessor :architecture
+
+      # Marked as the default architecture
+      #
+      # @return [Boolean, NilClass]
+      attr_accessor :default_architecture
+
       def initialize(raw, **_)
         @name = raw["name"]
         @url  = raw["url"]
         @checksum = raw["checksum"]
         @checksum_type = raw["checksum_type"]
+        @architecture = raw["architecture"]
+        @default_architecture = raw["default_architecture"]
+      end
+
+      def architecture_support?
+        !@default_architecture.nil?
       end
     end
   end

--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -199,6 +199,10 @@ module Vagrant
       error_key(:box_not_found_with_provider)
     end
 
+    class BoxNotFoundWithProviderArchitecture < VagrantError
+      error_key(:box_not_found_with_provider_architecture)
+    end
+
     class BoxNotFoundWithProviderAndVersion < VagrantError
       error_key(:box_not_found_with_provider_and_version)
     end
@@ -211,12 +215,20 @@ module Vagrant
       error_key(:box_remove_not_found)
     end
 
+    class BoxRemoveArchitectureNotFound < VagrantError
+      error_key(:box_remove_architecture_not_found)
+    end
+
     class BoxRemoveProviderNotFound < VagrantError
       error_key(:box_remove_provider_not_found)
     end
 
     class BoxRemoveVersionNotFound < VagrantError
       error_key(:box_remove_version_not_found)
+    end
+
+    class BoxRemoveMultiArchitecture < VagrantError
+      error_key(:box_remove_multi_architecture)
     end
 
     class BoxRemoveMultiProvider < VagrantError
@@ -237,6 +249,10 @@ module Vagrant
 
     class BoxUpdateMultiProvider < VagrantError
       error_key(:box_update_multi_provider)
+    end
+
+    class BoxUpdateMultiArchitecture < VagrantError
+      error_key(:box_update_multi_architecture)
     end
 
     class BoxUpdateNoMetadata < VagrantError

--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -326,6 +326,7 @@ module Vagrant
           entry.local_data_path = @env.local_data_path
           entry.name = @name.to_s
           entry.provider = @provider_name.to_s
+          entry.architecture = @architecture
           entry.state = "preparing"
           entry.vagrantfile_path = @env.root_path
           entry.vagrantfile_name = @env.vagrantfile_name
@@ -334,6 +335,7 @@ module Vagrant
             entry.extra_data["box"] = {
               "name"     => @box.name,
               "provider" => @box.provider.to_s,
+              "architecture" => @box.architecture,
               "version"  => @box.version.to_s,
             }
           end
@@ -587,6 +589,7 @@ module Vagrant
         entry.extra_data["box"] = {
           "name"     => @box.name,
           "provider" => @box.provider.to_s,
+          "architecture" => @box.architecture,
           "version"  => @box.version.to_s,
         }
       end

--- a/lib/vagrant/machine_index.rb
+++ b/lib/vagrant/machine_index.rb
@@ -30,6 +30,7 @@ module Vagrant
   #       "uuid": {
   #         "name": "foo",
   #         "provider": "vmware_fusion",
+  #         "architecture": "amd64",
   #         "data_path": "/path/to/data/dir",
   #         "vagrantfile_path": "/path/to/Vagrantfile",
   #         "state": "running",
@@ -381,6 +382,11 @@ module Vagrant
       # @return [String]
       attr_accessor :provider
 
+      # The name of the architecture.
+      #
+      # @return [String]
+      attr_accessor :architecture
+
       # The last known state of this machine.
       #
       # @return [String]
@@ -427,6 +433,7 @@ module Vagrant
         @local_data_path  = raw["local_data_path"]
         @name             = raw["name"]
         @provider         = raw["provider"]
+        @architecture     = raw["architecture"]
         @state            = raw["state"]
         @full_state       = raw["full_state"]
         @vagrantfile_name = raw["vagrantfile_name"]
@@ -510,6 +517,7 @@ module Vagrant
           "local_data_path"  => @local_data_path.to_s,
           "name"             => @name,
           "provider"         => @provider,
+          "architecture"     => @architecture,
           "state"            => @state,
           "vagrantfile_name" => @vagrantfile_name,
           "vagrantfile_path" => @vagrantfile_path.to_s,

--- a/lib/vagrant/util.rb
+++ b/lib/vagrant/util.rb
@@ -46,7 +46,7 @@ module Vagrant
     autoload :Numeric,                   'vagrant/util/numeric'
     autoload :Platform,                  'vagrant/util/platform'
     autoload :Powershell,                'vagrant/util/powershell'
-    autoload :Presence,                   'vagrant/util/presence'
+    autoload :Presence,                  'vagrant/util/presence'
     autoload :Retryable,                 'vagrant/util/retryable'
     autoload :SafeChdir,                 'vagrant/util/safe_chdir'
     autoload :SafeEnv,                   'vagrant/util/safe_env'

--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -17,6 +17,29 @@ module Vagrant
     class Platform
       class << self
 
+        # Detect architecture of host system
+        #
+        # @return [String]
+        def architecture
+          if !defined?(@_host_architecture)
+            if ENV["VAGRANT_HOST_ARCHITECTURE"].to_s != ""
+              return @_host_architecture = ENV["VAGRANT_HOST_ARCHITECTURE"]
+            end
+
+            @_host_architecture = case RbConfig::CONFIG["target_cpu"]
+              when "x86_64"
+                "amd64"
+              when "i386"
+                "386"
+              when "arm64", "aarch64"
+                "arm64"
+              else
+                RbConfig::CONFIG["target_cpu"]
+              end
+          end
+          @_host_architecture
+        end
+
         def logger
           if !defined?(@_logger)
             @_logger = Log4r::Logger.new("vagrant::util::platform")

--- a/lib/vagrant/vagrantfile.rb
+++ b/lib/vagrant/vagrantfile.rb
@@ -202,7 +202,7 @@ module Vagrant
 
         # Load the box Vagrantfile, if there is one
         if !config.vm.box.to_s.empty? && boxes
-          box = boxes.find(config.vm.box, box_formats, config.vm.box_version)
+          box = boxes.find(config.vm.box, box_formats, config.vm.box_version, config.vm.box_architecture)
           if box
             box_vagrantfile = find_vagrantfile(box.directory)
             if box_vagrantfile && !config.vm.ignore_box_vagrantfile

--- a/plugins/commands/box/command/add.rb
+++ b/plugins/commands/box/command/add.rb
@@ -12,7 +12,9 @@ module VagrantPlugins
         include DownloadMixins
 
         def execute
-          options = {}
+          options = {
+            architecture: :auto,
+          }
 
           opts = OptionParser.new do |o|
             o.banner = "Usage: vagrant box add [options] <name, url, or path>"
@@ -32,6 +34,10 @@ module VagrantPlugins
 
             o.on("--location-trusted", "Trust 'Location' header from HTTP redirects and use the same credentials for subsequent urls as for the initial one") do |l|
                 options[:location_trusted] = l
+            end
+
+            o.on("-a", "--architecture ARCH", String, "Architecture the box should satisfy") do |a|
+              options[:architecture] = a
             end
 
             o.on("--provider PROVIDER", String, "Provider the box should satisfy") do |p|
@@ -82,6 +88,7 @@ module VagrantPlugins
             box_url: url,
             box_name: options[:name],
             box_provider: options[:provider],
+            box_architecture: options[:architecture],
             box_version: options[:version],
             box_checksum_type: options[:checksum_type],
             box_checksum: options[:checksum],

--- a/plugins/commands/box/command/remove.rb
+++ b/plugins/commands/box/command/remove.rb
@@ -21,6 +21,9 @@ module VagrantPlugins
               options[:force] = f
             end
 
+            o.on("-a", "--architecture ARCH", String, "The specific architecture for the box to remove") do |a|
+              options[:architecture] = a
+            end
             o.on("--provider PROVIDER", String,
                  "The specific provider type for the box to remove") do |p|
               options[:provider] = p
@@ -33,6 +36,14 @@ module VagrantPlugins
 
             o.on("--all", "Remove all available versions of the box") do |a|
               options[:all] = a
+            end
+
+            o.on("--all-providers", "Remove all providers within a version of the box") do |a|
+              options[:all_providers] = a
+            end
+
+            o.on("--all-architectures", "Remove all architectures within a provider a version of the box") do |a|
+              options[:all_architectures] = a
             end
           end
 
@@ -54,10 +65,13 @@ module VagrantPlugins
 
           @env.action_runner.run(Vagrant::Action.action_box_remove, {
             box_name:     argv[0],
+            box_architecture: options[:architecture],
             box_provider: options[:provider],
             box_version:  options[:version],
             force_confirm_box_remove: options[:force],
             box_remove_all_versions: options[:all],
+            box_remove_all_providers: options[:all_providers],
+            box_remove_all_architectures: options[:all_architectures]
           })
 
           # Success, exit status 0

--- a/plugins/commands/cloud/box/show.rb
+++ b/plugins/commands/cloud/box/show.rb
@@ -11,7 +11,12 @@ module VagrantPlugins
           include Util
 
           def execute
-            options = {quiet: true, versions: []}
+            options = {
+              architectures: [],
+              providers: [],
+              quiet: true,
+              versions: [],
+            }
 
             opts = OptionParser.new do |o|
               o.banner = "Usage: vagrant cloud box show [options] organization/box-name"
@@ -21,8 +26,14 @@ module VagrantPlugins
               o.separator "Options:"
               o.separator ""
 
+              o.on("--architectures ARCH", String, "Filter results by architecture support (can be defined multiple times)") do |a|
+                options[:architectures].push(a).uniq!
+              end
               o.on("--versions VERSION", String, "Display box information for a specific version (can be defined multiple times)") do |v|
-                options[:versions] << v
+                options[:versions].push(v).uniq!
+              end
+              o.on("--providers PROVIDER", String, "Filter results by provider support (can be defined multiple times)") do |pv|
+                options[:providers].push(pv).uniq!
               end
               o.on("--[no-]auth", "Authenticate with Vagrant Cloud if required before searching") do |l|
                 options[:quiet] = !l
@@ -40,7 +51,7 @@ module VagrantPlugins
             @client = client_login(@env, options.slice(:quiet))
             org, box_name = argv.first.split('/', 2)
 
-            show_box(org, box_name, @client&.token, options.slice(:versions))
+            show_box(org, box_name, @client&.token, options.slice(:architectures, :providers, :versions))
           end
 
           # Display the requested box to the user
@@ -57,26 +68,61 @@ module VagrantPlugins
               access_token: access_token
             )
             with_box(account: account, org: org, box: box_name) do |box|
-              if box && !Array(options[:versions]).empty?
-                box = box.versions.find_all{ |v| options[:versions].include?(v.version) }
-              else
-                box = [box]
-              end
+              list = [box]
 
-              if !box.empty?
-                box.each do |b|
-                  format_box_results(b, @env)
+              # If specific version(s) provided, filter out the version
+              list = list.first.versions.find_all { |v|
+                options[:versions].include?(v.version)
+              } if !Array(options[:versions]).empty?
+
+              # If specific provider(s) provided, filter out the provider(s)
+              list = list.find_all { |item|
+                if item.is_a?(VagrantCloud::Box)
+                  item.versions.any? { |v|
+                    v.providers.any? { |p|
+                      options[:providers].include?(p.name)
+                    }
+                  }
+                else
+                  item.providers.any? { |p|
+                    options[:providers].include?(p.name)
+                  }
+                end
+              } if !Array(options[:providers]).empty?
+
+              list = list.find_all { |item|
+                if item.is_a?(VagrantCloud::Box)
+                  item.versions.any? { |v|
+                    v.providers.any? { |p|
+                      options[:architectures].include?(p.architecture)
+                    }
+                  }
+                else
+                  item.providers.any? { |p|
+                    options[:architectures].include?(p.architecture)
+                  }
+                end
+              } if !Array(options[:architectures]).empty?
+
+              if !list.empty?
+                list.each do |b|
+                  format_box_results(b, @env, options.slice(:providers, :architectures))
                   @env.ui.output("")
                 end
                 0
               else
                 @env.ui.warn(I18n.t("cloud_command.box.show_filter_empty",
-                  version: options[:version], org: org, box_name: box_name))
+                  org: org,
+                  box_name: box_name,
+                  architectures: Array(options[:architectures]).empty? ? "N/A" : Array(options[:architectures]).join(", "),
+                  providers: Array(options[:providers]).empty? ? "N/A" : Array(options[:providers]).join(", "),
+                  versions: Array(options[:versions]).empty? ? "N/A" : Array(options[:versions]).join(", ")
+                ))
                 1
               end
             end
           rescue VagrantCloud::Error => e
-            @env.ui.error(I18n.t("cloud_command.errors.box.show_fail", org: org,box_name:box_name))
+            @env.ui.error(I18n.t("cloud_command.errors.box.show_fail", org: org, box_name:box_name))
             @env.ui.error(e.message)
             1
           end

--- a/plugins/commands/cloud/client/client.rb
+++ b/plugins/commands/cloud/client/client.rb
@@ -168,6 +168,11 @@ EOH
 
       def with_error_handling(&block)
         yield
+      rescue VagrantCloud::Error::ClientError => e
+        @logger.debug("vagrantcloud request error:")
+        @logger.debug(e.message)
+        @logger.debug(e.backtrace.join("\n"))
+        raise Errors::Unexpected, error: e.message
       rescue Excon::Error::Unauthorized
         @logger.debug("Unauthorized!")
         raise Errors::Unauthorized

--- a/plugins/commands/cloud/locales/en.yml
+++ b/plugins/commands/cloud/locales/en.yml
@@ -39,13 +39,25 @@ en:
             Box Description:       %{description}
         box_short_desc: |-
             Box Short Description: %{short_description}
+        checksum_type: |-
+            Checksum Type:         %{checksum_type}
+        checksum_value: |-
+            Checksum Value:        %{checksum_value}
+        architecture: |-
+            Box Architecture:      %{architecture}
+        default_architecture: |-
+            Default Architecture:  true
         version_desc: |-
             Version Description:   %{version_description}
     continue: |-
       Do you wish to continue? [y/N]
     box:
       show_filter_empty: |-
-        No version matched %{version} for %{org}/%{box_name}
+        No matches found for %{org}/%{box_name}
+        Filters applied:
+          Architectures: %{architectures}
+          Providers:     %{providers}
+          Versions:      %{versions}
       create_success: |-
         Created box %{org}/%{box_name}
       delete_success: |-
@@ -68,12 +80,19 @@ en:
         Uploading box file for '%{org}/%{box_name}' (v%{version}) for provider: '%{provider}'
       upload_success: |-
         Uploaded provider %{provider} on %{org}/%{box_name} for version %{version}
+      delete_multiple_architectures: |-
+        Multiple architectures detected for %{provider} on %{org}/%{box_name}:
+
+      delete_architectures_prompt: |-
+        Please enter the architecture name to delete:
       delete_warn: |-
-        This will completely remove provider %{provider} on version %{version} from %{box} on Vagrant Cloud. This cannot be undone.
+        This will completely remove provider %{provider} with architecture %{architecture}
+        on version %{version} from %{box} on Vagrant Cloud. This cannot be undone.
       create_success: |-
-        Created provider %{provider} on %{org}/%{box_name} for version %{version}
+        Created provider %{provider} with %{architecture} architecture on %{org}/%{box_name} for version %{version}
       delete_success: |-
-        Deleted provider %{provider} on %{org}/%{box_name} for version %{version}
+        Deleted provider %{provider} with %{architecture} architecture on %{org}/%{box_name}
+        for version %{version}
       update_success: |-
         Updated provider %{provider} on %{org}/%{box_name} for version %{version}
       not_found: |-
@@ -122,13 +141,13 @@ en:
           Failed to locate account information
       provider:
         create_fail: |-
-          Failed to create provider %{provider} on box %{org}/%{box_name} for version %{version}
+          Failed to create '%{architecture}' variant of %{provider} provider for version %{version} of the %{org}/%{box_name} box
         update_fail: |-
-          Failed to update provider %{provider} on box %{org}/%{box_name} for version %{version}
+          Failed to update '%{architecture}' variant of %{provider} provider for version %{version} of the %{org}/%{box_name} box
         delete_fail: |-
-          Failed to delete provider %{provider} on box %{org}/%{box_name} for version %{version}
+          Failed to delete '%{architecture}' variant of %{provider} provider for version %{version} of the %{org}/%{box_name} box
         upload_fail: |-
-          Failed to upload provider %{provider} on box %{org}/%{box_name} for version %{version}
+          Failed to upload '%{architecture}' variant of %{provider} provider for version %{version} of the %{org}/%{box_name} box
       version:
         create_fail: |-
           Failed to create version %{version} on box %{org}/%{box_name}

--- a/plugins/commands/cloud/provider/delete.rb
+++ b/plugins/commands/cloud/provider/delete.rb
@@ -14,7 +14,7 @@ module VagrantPlugins
             options = {}
 
             opts = OptionParser.new do |o|
-              o.banner = "Usage: vagrant cloud provider delete [options] organization/box-name provider-name version"
+              o.banner = "Usage: vagrant cloud provider delete [options] organization/box-name provider-name version [architecture]"
               o.separator ""
               o.separator "Deletes a provider entry on Vagrant Cloud"
               o.separator ""
@@ -28,7 +28,7 @@ module VagrantPlugins
             # Parse the options
             argv = parse_options(opts)
             return if !argv
-            if argv.count != 3
+            if argv.count < 3 || argv.count > 4
               raise Vagrant::Errors::CLIInvalidUsage,
                 help: opts.help.chomp
             end
@@ -36,18 +36,47 @@ module VagrantPlugins
             org, box_name = argv.first.split('/', 2)
             provider_name = argv[1]
             version = argv[2]
+            architecture = argv[3]
+
+            @client = client_login(@env)
+            account = VagrantCloud::Account.new(
+              custom_server: api_server_url,
+              access_token: @client.token
+            )
+
+            if architecture.nil?
+              architecture = select_provider_architecture(account, org, box_name, version, provider_name)
+            end
 
             @env.ui.warn(I18n.t("cloud_command.provider.delete_warn",
-              provider: provider_name, version:version, box: argv.first))
+              architecture: architecture, provider: provider_name, version: version, box: argv.first))
 
             if !options[:force]
               cont = @env.ui.ask(I18n.t("cloud_command.continue"))
               return 1 if cont.strip.downcase != "y"
             end
 
-            @client = client_login(@env)
+            delete_provider(org, box_name, version, provider_name, architecture, account, options)
+          end
 
-            delete_provider(org, box_name, version, provider_name, @client.token, options)
+          def select_provider_architecture(account, org, box, version, provider)
+            with_version(account: account, org: org, box: box, version: version) do |box_version|
+              list = box_version.providers.map(&:architecture)
+              return list.first if list.size == 1
+
+              @env.ui.info(I18n.t("cloud_command.provider.delete_multiple_architectures",
+                org: org, box_name: box, provider: provider))
+              list.each do |provider_name|
+                @env.ui.info(" * #{provider_name}")
+              end
+              selected = nil
+              while selected.nil?
+                user_input = @env.ui.ask(I18n.t("cloud_command.provider.delete_architectures_prompt") + " ")
+                selected = user_input if list.include?(user_input)
+              end
+
+              return selected
+            end
           end
 
           # Delete a provider for the box version
@@ -56,23 +85,20 @@ module VagrantPlugins
           # @param [String] box Box name
           # @param [String] version Box version
           # @param [String] provider Provider name
-          # @param [String] access_token User Vagrant Cloud access token
+          # @param [String] architecture Architecture of guest
+          # @param [VagrantCloud::Account] account VagrantCloud account
           # @param [Hash] options Currently unused
           # @return [Integer]
-          def delete_provider(org, box, version, provider, access_token, options={})
-            account = VagrantCloud::Account.new(
-              custom_server: api_server_url,
-              access_token: access_token
-            )
-            with_provider(account: account, org: org, box: box, version: version, provider: provider) do |p|
+          def delete_provider(org, box, version, provider, architecture, account, options={})
+            with_provider(account: account, org: org, box: box, version: version, provider: provider, architecture: architecture) do |p|
               p.delete
               @env.ui.error(I18n.t("cloud_command.provider.delete_success",
-                provider: provider, org: org, box_name: box, version: version))
+                architecture: architecture, provider: provider, org: org, box_name: box, version: version))
               0
             end
           rescue VagrantCloud::Error => e
             @env.ui.error(I18n.t("cloud_command.errors.provider.delete_fail",
-              provider: provider, org: org, box_name: box, version: version))
+              architecture: architecture, provider: provider, org: org, box_name: box, version: version))
             @env.ui.error(e)
             1
           end

--- a/plugins/commands/cloud/provider/update.rb
+++ b/plugins/commands/cloud/provider/update.rb
@@ -14,25 +14,31 @@ module VagrantPlugins
             options = {}
 
             opts = OptionParser.new do |o|
-              o.banner = "Usage: vagrant cloud provider update [options] organization/box-name provider-name version [url]"
+              o.banner = "Usage: vagrant cloud provider update [options] organization/box-name provider-name version architecture [url]"
               o.separator ""
               o.separator "Updates a provider entry on Vagrant Cloud"
               o.separator ""
               o.separator "Options:"
               o.separator ""
 
+              o.on("-a", "--architecture ARCH", String, "Update architecture value of guest box") do |a|
+                options[:architecture] = a
+              end
               o.on("-c", "--checksum CHECKSUM_VALUE", String, "Checksum of the box for this provider. --checksum-type option is required.") do |c|
                 options[:checksum] = c
               end
               o.on("-C", "--checksum-type TYPE", String, "Type of checksum used (md5, sha1, sha256, sha384, sha512). --checksum option is required.") do |c|
                 options[:checksum_type] = c
               end
+              o.on("--[no-]default-architecture", "Mark as default architecture for specific provider") do |d|
+                options[:default_architecture] = d
+              end
             end
 
             # Parse the options
             argv = parse_options(opts)
             return if !argv
-            if argv.count < 3 || argv.count > 4
+            if argv.count < 4 || argv.count > 5
               raise Vagrant::Errors::CLIInvalidUsage,
                 help: opts.help.chomp
             end
@@ -42,9 +48,10 @@ module VagrantPlugins
             org, box_name = argv.first.split('/', 2)
             provider_name = argv[1]
             version = argv[2]
-            url = argv[3]
+            architecture = argv[3]
+            url = argv[4]
 
-            update_provider(org, box_name, version, provider_name, url, @client.token, options)
+            update_provider(org, box_name, version, provider_name, architecture, url, @client.token, options)
           end
 
           # Update a provider for the box version
@@ -53,12 +60,13 @@ module VagrantPlugins
           # @param [String] box Box name
           # @param [String] version Box version
           # @param [String] provider Provider name
+          # @param [String] architecture Architecture of guest
           # @param [String] access_token User Vagrant Cloud access token
           # @param [Hash] options
           # @option options [String] :checksum Checksum of the box asset
           # @option options [String] :checksum_type Type of the checksum
           # @return [Integer]
-          def update_provider(org, box, version, provider, url, access_token, options)
+          def update_provider(org, box, version, provider, architecture, url, access_token, options)
             if !url
               @env.ui.warn(I18n.t("cloud_command.upload.no_url"))
             end
@@ -67,21 +75,23 @@ module VagrantPlugins
               access_token: access_token
             )
 
-            with_provider(account: account, org: org, box: box, version: version, provider: provider) do |p|
+            with_provider(account: account, org: org, box: box, version: version, provider: provider, architecture: architecture) do |p|
               p.checksum = options[:checksum] if options.key?(:checksum)
               p.checksum_type = options[:checksum_type] if options.key?(:checksum_type)
+              p.architecture = options[:architecture] if options.key?(:architecture)
+              p.default_architecture = options[:default_architecture] if options.key?(:default_architecture)
               p.url = url if !url.nil?
               p.save
 
               @env.ui.success(I18n.t("cloud_command.provider.update_success",
-                provider: provider, org: org, box_name: box, version: version))
+                architecture: architecture, provider: provider, org: org, box_name: box, version: version))
 
               format_box_results(p, @env)
               0
             end
           rescue VagrantCloud::Error => e
             @env.ui.error(I18n.t("cloud_command.errors.provider.update_fail",
-              provider: provider, org: org, box_name: box, version: version))
+              architecture: architecture, provider: provider, org: org, box_name: box, version: version))
             @env.ui.error(e.message)
             1
           end

--- a/plugins/commands/cloud/search.rb
+++ b/plugins/commands/cloud/search.rb
@@ -21,6 +21,9 @@ module VagrantPlugins
             o.separator "Options:"
             o.separator ""
 
+            o.on("-a", "--architecture ARCH", "Filter search results to a single architecture. Defaults to all.") do |a|
+              options[:architecture] = a
+            end
             o.on("-j", "--json", "Formats results in JSON") do |j|
               options[:json] = j
             end
@@ -78,7 +81,7 @@ module VagrantPlugins
             custom_server: api_server_url,
             access_token: access_token
           )
-          params = {query: query}.merge(options.slice(:provider, :sort, :order, :limit, :page))
+          params = {query: query}.merge(options.slice(:architecture, :provider, :sort, :order, :limit, :page))
           result = account.searcher.search(**params)
 
           if result.boxes.empty?

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -32,6 +32,7 @@ module VagrantPlugins
       attr_accessor :base_address
       attr_accessor :boot_timeout
       attr_accessor :box
+      attr_accessor :box_architecture
       attr_accessor :ignore_box_vagrantfile
       attr_accessor :box_check_update
       attr_accessor :box_url
@@ -69,6 +70,7 @@ module VagrantPlugins
         @base_address                  = UNSET_VALUE
         @boot_timeout                  = UNSET_VALUE
         @box                           = UNSET_VALUE
+        @box_architecture              = UNSET_VALUE
         @ignore_box_vagrantfile        = UNSET_VALUE
         @box_check_update              = UNSET_VALUE
         @box_download_ca_cert          = UNSET_VALUE
@@ -509,6 +511,11 @@ module VagrantPlugins
         @base_address = nil if @base_address == UNSET_VALUE
         @boot_timeout = 300 if @boot_timeout == UNSET_VALUE
         @box = nil if @box == UNSET_VALUE
+        @box_architecture = :auto if @box_architecture == UNSET_VALUE
+        # If box architecture value was set, force to string
+        if @box_architecture && @box_architecture != :auto
+          @box_architecture = @box_architecture.to_s
+        end
         @ignore_box_vagrantfile = false if @ignore_box_vagrantfile == UNSET_VALUE
 
         if @box_check_update == UNSET_VALUE

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -4,6 +4,5 @@ require 'rspec/core/rake_task'
 namespace :test do
   RSpec::Core::RakeTask.new(:unit) do |t|
     t.pattern = "test/unit/**/*_test.rb"
-    t.rspec_opts = "--color --format documentation"
   end
 end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -659,6 +659,13 @@ en:
         the box are shown below:
 
         %{providers}
+      box_not_found_with_provider_architecture: |-
+        The box '%{name}' for the provider '%{provider}' isn't installed
+        for the architecture '%{architecture}'. Please double-check and
+        try again. The installed architectures for the box are shown
+        below:
+
+        %{architectures}
       box_not_found_with_provider_and_version: |-
         The box '%{name}' (v%{version}) with provider '%{provider}'
         could not be found. Please double check and try again. You
@@ -669,35 +676,51 @@ en:
         Provider expected: %{expected}
         Provider of box: %{actual}
       box_remove_multi_provider: |-
-        You requested to remove the box '%{name}'. This box has
-        multiple providers. You must explicitly select a single
-        provider to remove with `--provider`.
+        You requested to remove the box '%{name}' version '%{version}'. This
+        box has multiple providers. You must explicitly select a single provider to
+        remove with `--provider` or specify the `--all-providers` flag to remove
+        all providers.
 
         Available providers: %{providers}
       box_remove_multi_version: |-
-        You requested to remove the box '%{name}' with provider
-        '%{provider}'. This box has multiple versions. You must
-        explicitly specify which version you want to remove with
-        the `--box-version` flag or specify the `--all` flag to remove all
-        versions. The available versions for this box are:
+        You requested to remove the box '%{name}'. This box has multiple
+        versions. You must explicitly specify which version you want to
+        remove with the `--box-version` flag or specify the `--all` flag
+        to remove all versions. The available versions for this box are:
 
         %{versions}
       box_remove_not_found: |-
         The box you requested to be removed could not be found. No
         boxes named '%{name}' could be found.
       box_remove_provider_not_found: |-
-        You requested to remove the box '%{name}' with provider
-        '%{provider}'. The box '%{name}' exists but not with
-        the provider specified. Please double-check and try again.
+        You requested to remove the box '%{name}' version '%{version}'
+        with provider '%{provider}'. The box '%{name}' exists but not
+        with the provider specified. Please double-check and try again.
 
         The providers for this are: %{providers}
       box_remove_version_not_found: |-
-        You requested to remove the box '%{name}' version '%{version}' with
-        provider '%{provider}', but that specific version of the box is
-        not installed. Please double-check and try again. The available versions
-        for this box are:
+        You requested to remove the box '%{name}' version '%{version}',
+        but that specific version of the box is not installed. Please
+        double-check and try again. The available versions for this box
+        are:
 
         %{versions}
+      box_remove_multi_architecture: |-
+        You requested to remove the box '%{name}' version '%{version}'
+        with provider '%{provider}'. This box has multiple architectures.
+        You must explicitly select a single architecture to remove with
+        `--architecture` or specify the `--all-architectures` flag to
+        remove all architectures. The available architectures for this
+        box are:
+
+        %{architectures}
+      box_remove_architecture_not_found: |-
+        You requested to remove the box '%{name}' version '%{version}'
+        with provider '%{provider}' and architecture '%{architecture}' but
+        that specific architecture is not installed. Please double-check
+        and try again. The available architectures are:
+
+        %{architectures}
       box_server_not_set: |-
         A URL to a Vagrant Cloud server is not set, so boxes cannot be added with a
         shorthand ("mitchellh/precise64") format. You may also be seeing this
@@ -710,9 +733,15 @@ en:
       box_update_multi_provider: |-
         You requested to update the box '%{name}'. This box has
         multiple providers. You must explicitly select a single
-        provider to remove with `--provider`.
+        provider to update with `--provider`.
 
         Available providers: %{providers}
+      box_update_multi_architecture: |-
+        You requested to update the box '%{name}' (v%{version}) with provider
+        '%{provider}'. This box has multiple architectures. You must explicitly
+        select a single architecture to update with `--architecture`.
+
+        Available architectures: %{architectures}
       box_update_no_box: |-
         Box '%{name}' not installed, can't check for updates.
       box_update_no_metadata: |-
@@ -2188,10 +2217,10 @@ en:
       box:
         no_installed_boxes: "There are no installed boxes! Use `vagrant box add` to add some."
         remove_in_use_query: |-
-          Box '%{name}' (v%{version}) with provider '%{provider}' appears
-          to still be in use by at least one Vagrant environment. Removing
-          the box could corrupt the environment. We recommend destroying
-          these environments first:
+          Box '%{name}' (v%{version}) with provider '%{provider}' and
+          architectures '%{architecture}' appears to still be in use by
+          at least one Vagrant environment. Removing the box could corrupt
+          the environment. We recommend destroying these environments first:
 
           %{users}
 

--- a/test/unit/base.rb
+++ b/test/unit/base.rb
@@ -41,7 +41,7 @@ VAGRANT_TEST_CWD = Dir.mktmpdir("vagrant-test-cwd")
 
 # Configure RSpec
 RSpec.configure do |c|
-  #c.formatter = :progress
+  c.formatter = :progress
   c.color_mode = :on
 
   if Vagrant::Util::Platform.windows?

--- a/test/unit/plugins/commands/box/command/add_test.rb
+++ b/test/unit/plugins/commands/box/command/add_test.rb
@@ -67,4 +67,16 @@ describe VagrantPlugins::CommandBox::Command::Add do
         to raise_error(Vagrant::Errors::CLIInvalidUsage)
     end
   end
+
+  context "with architecture flag" do
+    let(:argv) { ["foo", "--architecture", "test-arch"] }
+
+    it "executes the runner with box architecture set" do
+      expect(action_runner).to receive(:run) do |_, opts|
+        expect(opts[:box_architecture]).to eq("test-arch")
+      end
+
+      subject.execute
+    end
+  end
 end

--- a/test/unit/plugins/commands/box/command/remove_test.rb
+++ b/test/unit/plugins/commands/box/command/remove_test.rb
@@ -81,4 +81,40 @@ describe VagrantPlugins::CommandBox::Command::Remove do
         to raise_error(Vagrant::Errors::CLIInvalidUsage)
     end
   end
+
+  context "with architecture flag" do
+    let(:argv) { ["foo", "--architecture", "test-arch"] }
+
+    it "should execute runner with box architecture set" do
+      expect(action_runner).to receive(:run) do |_, opts|
+        expect(opts[:box_architecture]).to eq("test-arch")
+      end
+
+      subject.execute
+    end
+  end
+
+  context "with all providers flag" do
+    let(:argv) { ["foo", "--all-providers"] }
+
+    it "should execute runner with all providers enabled" do
+      expect(action_runner).to receive(:run) do |_, opts|
+        expect(opts[:box_remove_all_providers]).to be(true)
+      end
+
+      subject.execute
+    end
+  end
+
+  context "with all architectures flag" do
+    let(:argv) { ["foo", "--all-architectures"] }
+
+    it "should execute runner with all architectures enabled" do
+      expect(action_runner).to receive(:run) do |_, opts|
+        expect(opts[:box_remove_all_architectures]).to be(true)
+      end
+
+      subject.execute
+    end
+  end
 end

--- a/test/unit/plugins/commands/cloud/box/show_test.rb
+++ b/test/unit/plugins/commands/cloud/box/show_test.rb
@@ -40,7 +40,7 @@ describe VagrantPlugins::CloudCommand::BoxCommand::Command::Show do
     end
 
     it "should display the box results" do
-      expect(subject).to receive(:format_box_results).with(box, env)
+      expect(subject).to receive(:format_box_results).with(box, env, {})
       subject.show_box(org_name, box_name, access_token, options)
     end
 
@@ -62,7 +62,7 @@ describe VagrantPlugins::CloudCommand::BoxCommand::Command::Show do
       end
 
       it "should print the version details" do
-        expect(subject).to receive(:format_box_results).with(box_version, env)
+        expect(subject).to receive(:format_box_results).with(box_version, env, {})
         subject.show_box(org_name, box_name, access_token, options)
       end
 
@@ -141,6 +141,34 @@ describe VagrantPlugins::CloudCommand::BoxCommand::Command::Show do
         it "should show box with version option set" do
           expect(subject).to receive(:show_box).
             with(org_name, box_name, access_token, hash_including(versions: [version_option]))
+          subject.execute
+        end
+      end
+
+      context "with architectures flag set" do
+        let(:arch_option) { "test-arch" }
+
+        before { argv.push("--architectures").push(arch_option) }
+
+        it "shouild show box with architectures option set" do
+          expect(subject).to receive(:show_box) do |*_, opts|
+            expect(opts[:architectures]).to eq([arch_option])
+          end
+
+          subject.execute
+        end
+      end
+
+      context "with providers flag set" do
+        let(:provider_option) { "test-provider" }
+
+        before { argv.push("--providers").push(provider_option) }
+
+        it "shilud show box with providers option set" do
+          expect(subject).to receive(:show_box) do |*_, opts|
+            expect(opts[:providers]).to eq([provider_option])
+          end
+
           subject.execute
         end
       end

--- a/test/unit/plugins/commands/cloud/search_test.rb
+++ b/test/unit/plugins/commands/cloud/search_test.rb
@@ -45,6 +45,7 @@ describe VagrantPlugins::CloudCommand::Command::Search do
     end
 
     context "with valid options" do
+      let(:architecture) { double("architecture") }
       let(:provider) { double("provider") }
       let(:sort) { double("sort") }
       let(:order) { double("order") }
@@ -52,6 +53,7 @@ describe VagrantPlugins::CloudCommand::Command::Search do
       let(:page) { double("page") }
 
       let(:options) { {
+        architecture: architecture,
         provider: provider,
         sort: sort,
         order: order,

--- a/test/unit/plugins/kernel_v2/config/vm_test.rb
+++ b/test/unit/plugins/kernel_v2/config/vm_test.rb
@@ -116,6 +116,34 @@ describe VagrantPlugins::Kernel_V2::VMConfig do
     end
   end
 
+  describe "#box_architecture" do
+    it "is not required" do
+      subject.box_architecture = nil
+      subject.finalize!
+      assert_valid
+    end
+
+    it "is :auto by default" do
+      subject.finalize!
+      assert_valid
+      expect(subject.box_architecture).to eq(:auto)
+    end
+
+    it "can be set to custom value" do
+      subject.box_architecture = "test-arch"
+      subject.finalize!
+      assert_valid
+      expect(subject.box_architecture).to eq("test-arch")
+    end
+
+    it "is converted to string" do
+      subject.box_architecture = :test_arch
+      subject.finalize!
+      assert_valid
+      expect(subject.box_architecture).to eq("test_arch")
+    end
+  end
+
   context "#box_check_update" do
     it "defaults to true" do
       with_temp_env("VAGRANT_BOX_UPDATE_CHECK_DISABLE" => "") do

--- a/test/unit/plugins/providers/virtualbox/driver/version_7_0_test.rb
+++ b/test/unit/plugins/providers/virtualbox/driver/version_7_0_test.rb
@@ -810,24 +810,6 @@ LowerIP:         192.168.22.0
 UpperIP:         192.168.22.0
 VBoxNetworkName: hostonly-vagrantnet-vbox2)
 
-VBOX_HOSTONLYNETS=%(Name:            vagrantnet-vbox1
-GUID:            10000000-0000-0000-0000-000000000000
-
-State:           Enabled
-NetworkMask:     255.255.255.0
-LowerIP:         192.168.61.0
-UpperIP:         192.168.61.0
-VBoxNetworkName: hostonly-vagrantnet-vbox1
-
-Name:            vagrantnet-vbox2
-GUID:            20000000-0000-0000-0000-000000000000
-
-State:           Enabled
-NetworkMask:     255.255.255.0
-LowerIP:         192.168.22.0
-UpperIP:         192.168.22.0
-VBoxNetworkName: hostonly-vagrantnet-vbox2)
-
 VBOX_RANGE_HOSTONLYNETS=%(Name:            vagrantnet-vbox1
 GUID:            10000000-0000-0000-0000-000000000000
 

--- a/test/unit/support/isolated_environment.rb
+++ b/test/unit/support/isolated_environment.rb
@@ -100,8 +100,11 @@ module Unit
     # @param [String] provider
     # @return [Pathname]
     def box3(name, version, provider, **opts)
+      args = [name, version, provider.to_s]
+      args << opts[:architecture].to_s if opts[:architecture]
+
       # Create the directory for the box
-      box_dir = boxes_dir.join(name, version, provider.to_s)
+      box_dir = boxes_dir.join(*args)
       box_dir.mkpath
 
       # Create the metadata.json for it

--- a/test/unit/support/isolated_environment.rb
+++ b/test/unit/support/isolated_environment.rb
@@ -100,8 +100,9 @@ module Unit
     # @param [String] provider
     # @return [Pathname]
     def box3(name, version, provider, **opts)
-      args = [name, version, provider.to_s]
+      args = [name, version]
       args << opts[:architecture].to_s if opts[:architecture]
+      args << provider.to_s
 
       # Create the directory for the box
       box_dir = boxes_dir.join(*args)

--- a/test/unit/vagrant/action/builtin/box_add_test.rb
+++ b/test/unit/vagrant/action/builtin/box_add_test.rb
@@ -1033,7 +1033,7 @@ describe Vagrant::Action::Builtin::BoxAdd, :skip_windows, :bsdtar do
           subject.call(env)
         end
 
-        it "adds the latest version of a box with only one provider and no unknown architecture set as default" do
+        it "adds the latest version of a box with only one provider and unknown architecture set as default" do
           box_path = iso_env.box2_file(:virtualbox)
           tf = Tempfile.new(["vagrant-box-latest-version", ".json"]).tap do |f|
             f.write(
@@ -1072,7 +1072,7 @@ describe Vagrant::Action::Builtin::BoxAdd, :skip_windows, :bsdtar do
             expect(name).to eq("foo/bar")
             expect(version).to eq("0.7")
             expect(opts[:metadata_url]).to eq("file://#{tf.path}")
-            expect(opts[:architecture]).to eq("unknown")
+            expect(opts[:architecture]).to be_nil
             true
           }.and_return(box)
 

--- a/test/unit/vagrant/action/builtin/box_add_test.rb
+++ b/test/unit/vagrant/action/builtin/box_add_test.rb
@@ -1024,7 +1024,7 @@ describe Vagrant::Action::Builtin::BoxAdd, :skip_windows, :bsdtar do
             expect(name).to eq("foo/bar")
             expect(version).to eq("0.7")
             expect(opts[:metadata_url]).to eq("file://#{tf.path}")
-            expect(opts[:architecture]).to eq(:auto)
+            expect(opts[:architecture]).to eq("test-arch")
             true
           }.and_return(box)
 
@@ -1072,7 +1072,7 @@ describe Vagrant::Action::Builtin::BoxAdd, :skip_windows, :bsdtar do
             expect(name).to eq("foo/bar")
             expect(version).to eq("0.7")
             expect(opts[:metadata_url]).to eq("file://#{tf.path}")
-            expect(opts[:architecture]).to eq(:auto)
+            expect(opts[:architecture]).to eq("unknown")
             true
           }.and_return(box)
 
@@ -1130,6 +1130,7 @@ describe Vagrant::Action::Builtin::BoxAdd, :skip_windows, :bsdtar do
         end
 
         it "adds the latest version of a box with only one provider and default architecture" do
+          allow(Vagrant::Util::Platform).to receive(:architecture).and_return("default-arch")
           box_path = iso_env.box2_file(:virtualbox)
           tf = Tempfile.new(["vagrant-box-latest-version", ".json"]).tap do |f|
             f.write(
@@ -1145,7 +1146,7 @@ describe Vagrant::Action::Builtin::BoxAdd, :skip_windows, :bsdtar do
                       {
                         name: "virtualbox",
                         url: "#{box_path}",
-                        architecture: "amd64",
+                        architecture: "default-arch",
                         default_architecture: true,
                       },
                       {
@@ -1168,7 +1169,7 @@ describe Vagrant::Action::Builtin::BoxAdd, :skip_windows, :bsdtar do
             expect(name).to eq("foo/bar")
             expect(version).to eq("0.7")
             expect(opts[:metadata_url]).to eq("file://#{tf.path}")
-            expect(opts[:architecture]).to be_nil
+            expect(opts[:architecture]).to eq("default-arch")
             true
           }.and_return(box)
 

--- a/test/unit/vagrant/box_collection_test.rb
+++ b/test/unit/vagrant/box_collection_test.rb
@@ -36,11 +36,11 @@ describe Vagrant::BoxCollection, :skip_windows, :bsdtar do
       # Verify some output
       results = subject.all
       expect(results.length).to eq(5)
-      expect(results.include?(["foo", "1.0", :virtualbox])).to be
-      expect(results.include?(["foo", "1.0", :vmware])).to be
-      expect(results.include?(["bar", "0", :ec2])).to be
-      expect(results.include?(["foo/bar", "1.0", :virtualbox])).to be
-      expect(results.include?(["foo:colon", "1.0", :virtualbox])).to be
+      expect(results).to include(["foo", "1.0", :virtualbox, nil])
+      expect(results).to include(["foo", "1.0", :vmware, nil])
+      expect(results).to include(["bar", "0", :ec2, nil])
+      expect(results).to include(["foo/bar", "1.0", :virtualbox, nil])
+      expect(results).to include(["foo:colon", "1.0", :virtualbox, nil])
     end
 
     it "should return the boxes and their providers even if box has wrong version" do
@@ -57,11 +57,11 @@ describe Vagrant::BoxCollection, :skip_windows, :bsdtar do
       # Verify some output
       results = subject.all
       expect(results.length).to eq(4)
-      expect(results.include?(["foo", "1.0", :virtualbox])).not_to be
-      expect(results.include?(["foo", "1.0", :vmware])).to be
-      expect(results.include?(["bar", "0", :ec2])).to be
-      expect(results.include?(["foo/bar", "1.0", :virtualbox])).to be
-      expect(results.include?(["foo:colon", "1.0", :virtualbox])).to be
+      expect(results).not_to include(["foo", "1.0", :virtualbox, nil])
+      expect(results).to include(["foo", "1.0", :vmware, nil])
+      expect(results).to include(["bar", "0", :ec2, nil])
+      expect(results).to include(["foo/bar", "1.0", :virtualbox, nil])
+      expect(results).to include(["foo:colon", "1.0", :virtualbox, nil])
     end
 
     it 'does not raise an exception when a file appears in the boxes dir' do
@@ -175,7 +175,7 @@ describe Vagrant::BoxCollection, :skip_windows, :bsdtar do
       # Make sure the results still exist
       results = subject.all
       expect(results.length).to eq(1)
-      expect(results.include?(["foo", "1.0", :vmware])).to be
+      expect(results).to include(["foo", "1.0", :vmware, nil])
     end
 
     it "doesn't remove the directory if a version exists" do
@@ -195,7 +195,7 @@ describe Vagrant::BoxCollection, :skip_windows, :bsdtar do
       # Make sure the results still exist
       results = subject.all
       expect(results.length).to eq(1)
-      expect(results.include?(["foo", "1.0", :virtualbox])).to be
+      expect(results).to include(["foo", "1.0", :virtualbox, nil])
     end
   end
 

--- a/test/unit/vagrant/box_metadata_test.rb
+++ b/test/unit/vagrant/box_metadata_test.rb
@@ -9,34 +9,32 @@ describe Vagrant::BoxMetadata do
   include_context "unit"
 
   let(:raw) do
-    <<-RAW
-      {
-        "name": "foo",
-        "description": "bar",
-        "versions": [
-          {
-            "version": "1.0.0",
-            "providers": [
-              { "name": "virtualbox" },
-              { "name": "vmware" }
-            ]
-          },
-          {
-            "version": "1.1.5",
-            "providers": [
-              { "name": "virtualbox" }
-            ]
-          },
-          {
-            "version": "1.1.0",
-            "providers": [
-              { "name": "virtualbox" },
-              { "name": "vmware" }
-            ]
-          }
-        ]
-      }
-    RAW
+    {
+      name: "foo",
+      description: "bar",
+      versions: [
+        {
+          version: "1.0.0",
+          providers: [
+            { name: "virtualbox" },
+            { name: "vmware" }
+          ],
+        },
+        {
+          version: "1.1.5",
+          providers: [
+            { name: "virtualbox" }
+          ]
+        },
+        {
+          version: "1.1.0",
+          providers: [
+            { name: "virtualbox" },
+            { name: "vmware" }
+          ]
+        }
+      ]
+    }.to_json
   end
 
   subject { described_class.new(raw) }
@@ -53,9 +51,7 @@ describe Vagrant::BoxMetadata do
 
   context "with poorly formatted JSON" do
     let(:raw) {
-      <<-RAW
-      { "name": "foo", }
-      RAW
+      {name: "foo"}.to_json + ","
     }
 
     it "raises an exception" do
@@ -66,15 +62,14 @@ describe Vagrant::BoxMetadata do
 
   context "with poorly formatted version" do
     let(:raw) {
-      <<-RAW
-      { "name": "foo",
-        "versions": [
+      {
+        name: "foo",
+        versions: [
           {
-            "version": "I AM NOT VALID"
+            version: "I AM NOT VALID"
           }
         ]
-      }
-      RAW
+      }.to_json
     }
 
     it "raises an exception" do
@@ -123,6 +118,213 @@ describe Vagrant::BoxMetadata do
       expect(subject.versions(provider: :vmware)).to eq(
         ["1.0.0", "1.1.0"])
     end
+  end
+
+  context "with architecture" do
+    let(:raw) do
+      {
+        name: "foo",
+        description: "bar",
+        versions: [
+          {
+            version: "1.0.0",
+            providers: [
+              {
+                name: "virtualbox",
+                default_architecture: true,
+                architecture: "amd64"
+              },
+              {
+                name: "virtualbox",
+                default_architecture: false,
+                architecture: "arm64"
+              },
+              {
+                name: "vmware",
+                default_architecture: true,
+                architecture: "arm64"
+              },
+              {
+                name: "vmware",
+                default_architecture: false,
+                architecture: "amd64"
+              }
+            ],
+          },
+          {
+            version: "1.1.5",
+            providers: [
+              {
+                name: "virtualbox",
+                architecture: "amd64",
+                default_architecture: true,
+              }
+            ]
+          },
+          {
+            version: "1.1.6",
+            providers: [
+              {
+                name: "virtualbox",
+                architecture: "arm64",
+                default_architecture: true,
+              },
+            ]
+          },
+          {
+            version: "1.1.0",
+            providers: [
+              {
+                name: "virtualbox",
+                architecture: "amd64",
+                default_architecture: true,
+              },
+              {
+                name: "vmware",
+                architecture: "amd64",
+                default_architecture: true,
+              }
+            ]
+          },
+          {
+            version: "2.0.0",
+            providers: [
+              {
+                name: "vmware",
+                architecture: "arm64",
+                default_architecture: true,
+              }
+            ]
+          }
+        ]
+      }.to_json
+    end
+
+    subject { described_class.new(raw) }
+
+    before { allow(Vagrant::Util::Platform).to receive(:architecture).and_return("amd64") }
+
+    describe "#version" do
+      it "matches an exact version" do
+        result = subject.version("1.0.0")
+        expect(result).to_not be_nil
+        expect(result).to be_kind_of(Vagrant::BoxMetadata::Version)
+        expect(result.version).to eq("1.0.0")
+      end
+
+      it "matches a constraint with latest matching version" do
+        result = subject.version(">= 1.0")
+        expect(result).to_not be_nil
+        expect(result).to be_kind_of(Vagrant::BoxMetadata::Version)
+        expect(result.version).to eq("1.1.5")
+      end
+
+      it "matches complex constraints" do
+        result = subject.version(">= 0.9, ~> 1.0.0")
+        expect(result).to_not be_nil
+        expect(result).to be_kind_of(Vagrant::BoxMetadata::Version)
+        expect(result.version).to eq("1.0.0")
+      end
+
+      context "with provider filter" do
+        it "matches the constraint that has the given provider" do
+          result = subject.version(">= 0", provider: :vmware)
+          expect(result).to_not be_nil
+          expect(result).to be_kind_of(Vagrant::BoxMetadata::Version)
+          expect(result.version).to eq("1.1.0")
+        end
+
+        it "matches the exact version that has the given provider" do
+          result = subject.version("1.0.0", provider: :virtualbox)
+          expect(result).to_not be_nil
+          expect(result).to be_kind_of(Vagrant::BoxMetadata::Version)
+          expect(result.version).to eq("1.0.0")
+        end
+
+        it "does not match exact version that has given provider but not host architecture" do
+          result = subject.version("1.1.6", provider: :virtualbox)
+          expect(result).to be_nil
+        end
+
+        context "with architecture filter" do
+          it "matches the exact version that has provider with host architecture when using :auto" do
+            result = subject.version("1.0.0", provider: :virtualbox, architecture: :auto)
+            expect(result).to_not be_nil
+            expect(result).to be_kind_of(Vagrant::BoxMetadata::Version)
+            expect(result.version).to eq("1.0.0")
+          end
+
+          it "matches the exact version that has provider with defined host architecture" do
+            result = subject.version("1.0.0", provider: :virtualbox, architecture: "arm64")
+            expect(result).to_not be_nil
+            expect(result).to be_kind_of(Vagrant::BoxMetadata::Version)
+            expect(result.version).to eq("1.0.0")
+          end
+
+          it "does not match the exact version that has provider with defined host architecture" do
+            result = subject.version("1.0.0", provider: :virtualbox, architecture: "ppc64")
+            expect(result).to be_nil
+          end
+        end
+      end
+
+      context "with architecture filter" do
+        it "matches a constraint that has the detected host architecture" do
+          result = subject.version("> 0", architecture: :auto)
+          expect(result).to be_kind_of(Vagrant::BoxMetadata::Version)
+          expect(result.version).to eq("1.1.5")
+        end
+
+        it "matches a constraint that has the provided architecture" do
+          result = subject.version("> 0", architecture: "arm64")
+          expect(result).to be_kind_of(Vagrant::BoxMetadata::Version)
+          expect(result.version).to eq("2.0.0")
+        end
+
+        it "matches exact version that has the provided architecture" do
+          result = subject.version("1.0.0", architecture: "arm64")
+          expect(result).to be_kind_of(Vagrant::BoxMetadata::Version)
+          expect(result.version).to eq("1.0.0")
+        end
+
+        it "does not match exact version that does not have provided architecture" do
+          result = subject.version("2.0.0", architecture: "amd64")
+          expect(result).to be_nil
+        end
+      end
+    end
+
+    describe "#versions" do
+      it "returns the versions it contained" do
+        expect(subject.versions).
+          to eq(["1.0.0", "1.1.0", "1.1.5", "1.1.6", "2.0.0"])
+      end
+
+      context "with provider filter" do
+        it "filters versions" do
+          expect(subject.versions(provider: :vmware)).
+            to eq(["1.0.0", "1.1.0", "2.0.0"])
+        end
+      end
+
+      context "with architecture filter" do
+        it "filters versions" do
+          expect(subject.versions(architecture: "arm64")).
+            to eq(["1.0.0", "1.1.6", "2.0.0"])
+        end
+
+        it "returns none when no matching architecture available" do
+          expect(subject.versions(architecture: "other")).
+            to be_empty
+        end
+
+        it "filters based on host architecture when :auto used" do
+          expect(subject.versions(architecture: :auto)).
+            to eq(subject.versions(architecture: "amd64"))
+        end
+      end
+    end
+
   end
 end
 
@@ -201,6 +403,30 @@ describe Vagrant::BoxMetadata::Provider do
     it "is nil if not set" do
       expect(subject.checksum).to be_nil
       expect(subject.checksum_type).to be_nil
+    end
+  end
+
+  describe "architecture" do
+    it "is set properly" do
+      raw["architecture"] = "test-arch"
+
+      expect(subject.architecture).to eq("test-arch")
+    end
+
+    it "is nil if not set" do
+      expect(subject.architecture).to be_nil
+    end
+  end
+
+  describe "#architecture_support?" do
+    it "is false if architecture is not supported" do
+      expect(subject.architecture_support?).to be(false)
+    end
+
+    it "is true if architecture is supported" do
+      raw["default_architecture"] = false
+
+      expect(subject.architecture_support?).to be(true)
     end
   end
 end

--- a/test/unit/vagrant/machine_test.rb
+++ b/test/unit/vagrant/machine_test.rb
@@ -26,6 +26,7 @@ describe Vagrant::Machine do
     double("box").tap do |b|
       allow(b).to receive(:name).and_return("foo")
       allow(b).to receive(:provider).and_return(:dummy)
+      allow(b).to receive(:architecture)
       allow(b).to receive(:version).and_return("1.0")
     end
   end
@@ -580,6 +581,7 @@ describe Vagrant::Machine do
       box = double("box")
       allow(box).to receive(:name).and_return("foo")
       allow(box).to receive(:provider).and_return(:bar)
+      allow(box).to receive(:architecture)
       allow(box).to receive(:version).and_return("1.2.3")
       subject.box = box
 
@@ -599,6 +601,7 @@ describe Vagrant::Machine do
       expect(entry.extra_data["box"]).to eq({
         "name"     => box.name,
         "provider" => box.provider.to_s,
+        "architecture" => nil,
         "version"  => box.version,
       })
       env.machine_index.release(entry)

--- a/test/unit/vagrant/util/platform_test.rb
+++ b/test/unit/vagrant/util/platform_test.rb
@@ -11,6 +11,70 @@ describe Vagrant::Util::Platform do
   after { described_class.reset! }
   subject { described_class }
 
+  describe "#architecture" do
+    let(:cpu_string) { "unknown" }
+
+    before do
+      allow(RbConfig::CONFIG).
+        to receive(:[]).with("target_cpu").
+             and_return(cpu_string)
+    end
+
+    context "when cpu is x86_64" do
+      let(:cpu_string) { "x86_64" }
+
+      it "should be mapped to amd64" do
+        expect(described_class.architecture).to eq("amd64")
+      end
+    end
+
+    context "when cpu is i386" do
+      let(:cpu_string) { "i386" }
+
+      it "should be mapped to 386" do
+        expect(described_class.architecture).to eq("386")
+      end
+    end
+
+    context "when cpu is arm64" do
+      let(:cpu_string) { "arm64" }
+
+      it "should be arm64" do
+        expect(described_class.architecture).to eq("arm64")
+      end
+    end
+
+    context "when cpu is aarch64" do
+      let(:cpu_string) { "aarch64" }
+
+      it "should be mapped to arm64" do
+        expect(described_class.architecture).to eq("arm64")
+      end
+    end
+
+    context "when cpu is unmapped value" do
+      let(:cpu_string) { "custom-cpu" }
+
+      it "should be returned as-is" do
+        expect(described_class.architecture).to eq(cpu_string)
+      end
+    end
+
+    context "when environment variable override is set" do
+      let(:host_override) { "custom-host-override" }
+
+      before do
+        allow(ENV).to receive(:[]).
+                        with("VAGRANT_HOST_ARCHITECTURE").
+                        and_return(host_override)
+      end
+
+      it "should return the custom override" do
+        expect(subject.architecture).to eq(host_override)
+      end
+    end
+  end
+
   describe "#cygwin_path" do
     let(:path) { "C:\\msys2\\home\\vagrant" }
     let(:updated_path) { "/home/vagrant" }

--- a/test/unit/vagrant/vagrantfile_test.rb
+++ b/test/unit/vagrant/vagrantfile_test.rb
@@ -266,6 +266,44 @@ describe Vagrant::Vagrantfile do
       expect(box.version).to eq("1.3")
     end
 
+    it "configures with the custom box architecture" do
+      register_provider("foo")
+      configure do |config|
+        config.vm.box = "base"
+        config.vm.box_architecture = "custom-arch"
+      end
+
+      results = subject.machine_config(:default, :foo, boxes)
+      config = results[:config]
+      expect(config.vm.box).to eq("base")
+      expect(config.vm.box_architecture).to eq("custom-arch")
+    end
+
+    it "configures with the default box architecture" do
+      register_provider("foo")
+      configure do |config|
+        config.vm.box = "base"
+      end
+
+      results = subject.machine_config(:default, :foo, boxes)
+      config = results[:config]
+      expect(config.vm.box).to eq("base")
+      expect(config.vm.box_architecture).to eq(:auto)
+    end
+
+    it "configures box architecture to nil" do
+      register_provider("foo")
+      configure do |config|
+        config.vm.box = "base"
+        config.vm.box_architecture = nil
+      end
+
+      results = subject.machine_config(:default, :foo, boxes)
+      config = results[:config]
+      expect(config.vm.box).to eq("base")
+      expect(config.vm.box_architecture).to be_nil
+    end
+
     it "configures with box config of other supported formats" do
       register_provider("foo", nil, box_format: "bar")
 

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rexml", "~> 3.2"
   s.add_dependency "rgl", "~> 0.5.10"
   s.add_dependency "rubyzip", "~> 2.3.2"
-  s.add_dependency "vagrant_cloud", "> 3.0.5", "< 3.1"
+  s.add_dependency "vagrant_cloud", "~> 3.1.0"
   s.add_dependency "wdm", "~> 0.1.1"
   s.add_dependency "winrm", ">= 2.3.6", "< 3.0"
   s.add_dependency "winrm-elevated", ">= 1.2.3", "< 2.0"

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rexml", "~> 3.2"
   s.add_dependency "rgl", "~> 0.5.10"
   s.add_dependency "rubyzip", "~> 2.3.2"
-  s.add_dependency "vagrant_cloud", "~> 3.0.5"
+  s.add_dependency "vagrant_cloud", "> 3.0.5", "< 3.1"
   s.add_dependency "wdm", "~> 0.1.1"
   s.add_dependency "winrm", ">= 2.3.6", "< 3.0"
   s.add_dependency "winrm-elevated", ">= 1.2.3", "< 2.0"

--- a/website/content/docs/boxes/box_repository.mdx
+++ b/website/content/docs/boxes/box_repository.mdx
@@ -50,7 +50,9 @@ It is a JSON document, structured in the following way:
           "name": "virtualbox",
           "url": "http://example.com/bionic64_010_virtualbox.box",
           "checksum_type": "sha1",
-          "checksum": "foo"
+          "checksum": "foo",
+          "architecture": "amd64",
+          "default_architecture": true
         }
       ]
     }
@@ -59,7 +61,8 @@ It is a JSON document, structured in the following way:
 ```
 
 As you can see, the JSON document can describe multiple versions of a box,
-multiple providers, and can add/remove providers in different versions.
+multiple providers, and can add/remove providers/architectures in different
+versions.
 
 This JSON file can be passed directly to `vagrant box add` from the
 local filesystem using a file path or via a URL, and Vagrant will

--- a/website/content/docs/vagrantfile/machine_settings.mdx
+++ b/website/content/docs/vagrantfile/machine_settings.mdx
@@ -42,6 +42,13 @@ the name of the synced folder plugin.
   of an installed box or a shorthand name of a box in
   [HashiCorp's Vagrant Cloud](/vagrant/vagrant-cloud).
 
+- `config.vm.box_architecture` (string) - The architecture of the box to be used.
+  Supported architecture values: "386", "amd64", "arm", "arm64", "ppc64le", "ppc64",
+  "mips64le", "mips64", "mipsle", "mips", and "s390x". The special value `:auto` will
+  detect the host architecture and fetch the appropriate box, if available. When the
+  value is set to `nil`, it will fetch the box flagged as the default architecture.
+  Defaults to `:auto`.
+
 - `config.vm.box_check_update` (boolean) - If true, Vagrant will check for updates to
   the configured box on every `vagrant up`. If an update is found, Vagrant
   will tell the user. By default this is true. Updates will only be checked


### PR DESCRIPTION
This PR adds box architecture support. It introduces a new setting to
the vm configuration within the Vagrantfile:

```ruby
Vagrant.configure("2") do |config|
  config.vm.box = "box-name"
  config.vm.box_architecture = "amd64"
end
```

In most circumstances, this setting will not be needed. By default it
is set to a special value of `:auto`. The behavior when set to `:auto` is
as follows: Vagrant will determine the architecture of the host and automatically 
request it from the box repository. If architecture information is available in 
the repository metadata and a matching architecture was not found, Vagrant will
look for a box with an architecture of "unknown" and flagged as the default
architecture. This behavior allows Vagrant to continue working correctly with
boxes currently published on Vagrant Cloud that do not include architecture
information. 

The `box_architecture` setting can also be set to `nil`, which will prevent
any architecture filtering being performed, and the box flagged as the default
architecture will be used.

The box collection will now unpack boxes based on architecture. Special handling
is done when `box_architecture` is set to `:auto` which prevents Vagrant from
not properly detecting boxes installed without architecture support. 

The `vagrant cloud` commands have been updated to include architecture support
where required. These updates are dependent on hashicorp/vagrant_cloud#82

Fixes: #12610
