### PR TITLE
Remove duplicate appending of "6" to network type

### DIFF
--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -299,8 +299,6 @@ module VagrantPlugins
             elsif ip.ipv6?
               options[:netmask] ||= 64
 
-              # Append a 6 to the end of the type
-              options[:type] = "#{options[:type]}6".to_sym
             else
               raise IPAddr::AddressFamilyError, 'unknown address family'
             end


### PR DESCRIPTION
To distinct between IPv4 and IPv6 configuration, a "6" was added to the network configuration type if an IPv6 address should be configured. This is now duplicate, as with pull [13024](https://github.com/hashicorp/vagrant/pull/13024) the same thing is already done prior and more globally, thus leading to a duplicate "6" at the end of the network config type, i.e. "static66".  
  
Tested on my local system without breakage using a "private_network" config, but I was unable to extensively test this.