### PR TITLE
Update CPU mapping values

### DIFF
--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -27,10 +27,10 @@ module Vagrant
             end
 
             @_host_architecture = case RbConfig::CONFIG["target_cpu"]
-              when "x86_64"
+              when "amd64", "x86_64", "x64"
                 "amd64"
-              when "i386"
-                "386"
+              when "386", "i386", "x86"
+                "i386"
               when "arm64", "aarch64"
                 "arm64"
               else

--- a/test/unit/vagrant/util/platform_test.rb
+++ b/test/unit/vagrant/util/platform_test.rb
@@ -28,11 +28,27 @@ describe Vagrant::Util::Platform do
       end
     end
 
+    context "when cpu is x64" do
+      let(:cpu_string) { "x64" }
+
+      it "should be mapped to amd64" do
+        expect(described_class.architecture).to eq("amd64")
+      end
+    end
+
     context "when cpu is i386" do
       let(:cpu_string) { "i386" }
 
+      it "should be mapped to i386" do
+        expect(described_class.architecture).to eq("i386")
+      end
+    end
+
+    context "when cpu is 386" do
+      let(:cpu_string) { "386" }
+
       it "should be mapped to 386" do
-        expect(described_class.architecture).to eq("386")
+        expect(described_class.architecture).to eq("i386")
       end
     end
 


### PR DESCRIPTION
Specifically for Windows hosts, the target CPU string will report as
`x64`, not `x86_64`. Include the value in the mapping to get the
properly value.

Fixes #13274
