### PR TITLE
docker-podman: stricter container ID regex to avoid bad matches

### DIFF
--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -36,7 +36,7 @@ module VagrantPlugins
             # Check for podman format when it is emulating docker CLI.
             # Podman outputs the full hash of the container on
             # the last line after a successful build.
-            match = result.split.select { |str| str.match?(/[0-9a-z]{64}/) }.last
+            match = result.split.select { |str| str.match?(/^[0-9a-z]{64}/) }.last
             return match[0..7] unless match.nil?
           else
             matches = result.scan(/Successfully built (.+)$/i).last

--- a/test/unit/plugins/providers/docker/driver_test.rb
+++ b/test/unit/plugins/providers/docker/driver_test.rb
@@ -208,7 +208,7 @@ describe VagrantPlugins::DockerProvider::Driver do
     end
 
     context "using podman emulating docker CLI" do
-      let(:stdout) { "1a2b3c4d5e6f7g8h9i10j11k12l13m14n16o17p18q19r20s21t22u23v24w25x2" }
+      let(:stdout) { "1a2b3c4d5e6f7g8h9i10j11k12l13m14n16o17p18q19r20s21t22u23v24w25x2\nCopying config sha256:368a084ba17dcba88f5b23acfa47481131010219524fd9c41af87d709a04845b" }
 
       it "builds a container with podman emulating docker CLI" do
         allow(subject).to receive(:podman?).and_return(true)


### PR DESCRIPTION
In testing an environment using the docker provider backed by podman-docker, I kept running into a problem where the first time I tried to bring up a container it would fail because it tried to use 'sha256:3' as the container ID. A second attempt to bring up the container would always succeed.

On inspection, I think this is happening because, for some reason, the output from the 'docker build' command had a line:

Copying config sha256:368a084ba17dcba88f5b23acfa47481131010219524fd9c41af87d709a04845b

*after* the line it wants to match on (a line containing just the final container ID). This happens almost every time on one host I'm testing on (which is a Fedora 38 host); it doesn't seem to happen on the other host (which is Fedora 39). I'm not sure why. But we can fix it by just tightening the regex a bit, to only match on a line that *starts* with a 64-character alphanumeric string, not any line that contains one.