### PR TITLE
Fix box collection sorting

### DIFF
--- a/lib/vagrant/box_collection.rb
+++ b/lib/vagrant/box_collection.rb
@@ -299,7 +299,12 @@ module Vagrant
       end
       # Sort the list to group like providers and properly ordered versions
       results.sort_by! do |box_result|
-        [box_result[0], box_result[2], Gem::Version.new(box_result[1]), box_result[3]]
+        [
+          box_result[0],
+          box_result[2],
+          Gem::Version.new(box_result[1]),
+          box_result[3] || :""
+        ]
       end
       results
     end

--- a/test/unit/vagrant/box_collection_test.rb
+++ b/test/unit/vagrant/box_collection_test.rb
@@ -111,6 +111,17 @@ describe Vagrant::BoxCollection, :skip_windows, :bsdtar do
         end.not_to raise_error
       end
 
+      context "with architectures defined" do
+        before do
+          environment.box3("foo-VAGRANTSLASH-bar", "1.0", :virtualbox, architecture: :arm64)
+        end
+
+        it "should sort boxes by name" do
+          result = subject.all.map(&:first).uniq
+          expect(result).to eq(["bar", "foo", "foo/bar", "foo:colon"])
+        end
+      end
+
       it "should sort boxes by version" do
         box_list = subject.all.find_all do |box_info|
           box_info[0] == "foo" && box_info[2].to_s == "virtualbox"


### PR DESCRIPTION
When the box collection includes a common box entry which contains
architecture information, and another entry that does not it will
result in an error when sorting due to comparison with a nil value. 
Force a common type when sorting to prevent this error.

Fixes #13314
