### PR TITLE
fix(typo): Fix minor typo in Vagrantfile.erb template

### DIFF
--- a/templates/commands/init/Vagrantfile.erb
+++ b/templates/commands/init/Vagrantfile.erb
@@ -56,7 +56,7 @@ Vagrant.configure("2") do |config|
 
   # Disable the default share of the current code directory. Doing this
   # provides improved isolation between the vagrant box and your host
-  # by making sure your Vagrantfile isn't accessable to the vagrant box.
+  # by making sure your Vagrantfile isn't accessible to the vagrant box.
   # If you use this you may want to enable additional shared subfolders as
   # shown above.
   # config.vm.synced_folder ".", "/vagrant", disabled: true


### PR DESCRIPTION
This PR fixes a minor typo in the Vagrantfile.erb template:
`accessable` -> `accessible`