### PR TITLE
Open private key file in binary mode when writing

### DIFF
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -251,7 +251,7 @@ module VagrantPlugins
 
           # Write out the private key in the data dir so that the
           # machine automatically picks it up.
-          @machine.data_dir.join("private_key").open("w+") do |f|
+          @machine.data_dir.join("private_key").open("wb+") do |f|
             f.write(priv)
           end
 


### PR DESCRIPTION
Prevent newlines from being converted to CRLF when writing private key
to file.

Fixes #13284
