### PR TITLE
Update vagrant_cloud dependency constraint

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rexml", "~> 3.2"
   s.add_dependency "rgl", "~> 0.5.10"
   s.add_dependency "rubyzip", "~> 2.3.2"
-  s.add_dependency "vagrant_cloud", "~> 3.1.0"
+  s.add_dependency "vagrant_cloud", "~> 3.1.1"
   s.add_dependency "wdm", "~> 0.1.1"
   s.add_dependency "winrm", ">= 2.3.6", "< 3.0"
   s.add_dependency "winrm-elevated", ">= 1.2.3", "< 2.0"


### PR DESCRIPTION
Updates the vagrant_cloud dependency constraint to a minimum of 3.1.1
which includes a path prefixing fix that resolves an issue affect direct
uploads to Vagrant Cloud.

Fixes #13319
