### PR TITLE
Fix undefined method `size' for nil:NilClass in network_defined?

### DIFF
--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -349,7 +349,8 @@ module VagrantPlugins
         network_info = inspect_network(all_networks)
         network_info.each do |network|
           config = network["IPAM"]["Config"]
-          if (config.size > 0 &&
+          if (defined?(config.size) &&
+            config.size > 0 &&
             config.first["Subnet"] == subnet_string)
             @logger.debug("Found existing network #{network["Name"]} already configured with #{subnet_string}")
             return network["Name"]


### PR DESCRIPTION
This fixes a bug in the docker provider where Vagrant crashes on checking config.size when it is nil. The fix is just checking if config.size is defined?() before checking the value of it.

Here is the error message:
```
 ❯ vagrant up --provision-with basetools,docker,vault,consul,nomad --provider docker
Bringing machine 'hashiqube0.service.consul' up with 'docker' provider...
==> hashiqube0.service.consul: Creating and configuring docker networks...
/opt/vagrant/embedded/gems/gems/vagrant-2.4.0/plugins/providers/docker/driver.rb:352:in `block in network_defined?': undefined method `size' for nil:NilClass (NoMethodError)

          if (config.size > 0 &&
                    ^^^^^
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/plugins/providers/docker/driver.rb:350:in `each'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/plugins/providers/docker/driver.rb:350:in `network_defined?'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/plugins/providers/docker/action/prepare_networks.rb:140:in `process_private_network'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/plugins/providers/docker/action/prepare_networks.rb:343:in `block (3 levels) in call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/plugins/providers/docker/action/prepare_networks.rb:333:in `each'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/plugins/providers/docker/action/prepare_networks.rb:333:in `each_with_index'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/plugins/providers/docker/action/prepare_networks.rb:333:in `block (2 levels) in call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/environment.rb:649:in `lock'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/plugins/providers/docker/action/prepare_networks.rb:331:in `block in call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/plugins/providers/docker/action/prepare_networks.rb:330:in `synchronize'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/plugins/providers/docker/action/prepare_networks.rb:330:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/plugins/providers/docker/action/prepare_nfs_settings.rb:18:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/builtin/synced_folders.rb:90:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/builtin/delayed.rb:22:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/builtin/synced_folder_cleanup.rb:31:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/plugins/synced_folders/nfs/action_cleanup.rb:28:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/plugins/providers/docker/action/prepare_nfs_valid_ids.rb:17:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/plugins/providers/docker/action/host_machine_sync_folders.rb:26:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/plugins/providers/docker/action/host_machine_build_dir.rb:29:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:117:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/builtin/env_set.rb:22:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:117:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/builder.rb:183:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/runner.rb:104:in `block in run'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/util/busy.rb:22:in `busy'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/runner.rb:104:in `run'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/builtin/call.rb:56:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:117:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/builtin/provision.rb:83:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:117:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/builder.rb:183:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/runner.rb:104:in `block in run'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/util/busy.rb:22:in `busy'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/runner.rb:104:in `run'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/builtin/call.rb:56:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:117:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/builder.rb:183:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/runner.rb:104:in `block in run'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/util/busy.rb:22:in `busy'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/runner.rb:104:in `run'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/builtin/call.rb:56:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:117:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:117:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/builder.rb:183:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/runner.rb:104:in `block in run'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/util/busy.rb:22:in `busy'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/runner.rb:104:in `run'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/builtin/call.rb:56:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/plugins/providers/docker/action/host_machine.rb:21:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/builtin/config_validate.rb:28:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:117:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:117:in `block in finalize_action'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/builder.rb:183:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/runner.rb:104:in `block in run'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/util/busy.rb:22:in `busy'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/runner.rb:104:in `run'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/builtin/call.rb:56:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/warden.rb:38:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/builder.rb:183:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/runner.rb:104:in `block in run'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/util/busy.rb:22:in `busy'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/action/runner.rb:104:in `run'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/machine.rb:247:in `action_raw'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/machine.rb:216:in `block in action'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/environment.rb:649:in `lock'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/machine.rb:202:in `call'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/machine.rb:202:in `action'
	from /opt/vagrant/embedded/gems/gems/vagrant-2.4.0/lib/vagrant/batch_action.rb:89:in `block (2 levels) in run'

```