### PR TITLE
Fix#13342 adapt docker provider build for containerd storage

### DIFF
--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -32,6 +32,10 @@ module VagrantPlugins
         # from standard docker
         matches = result.scan(/writing image .+:([^\s]+)/i).last
         if !matches
+          # Check for outout of docker using containerd backend store
+          matches = result.scan(/exporting manifest list .+:([^\s]+)/i).last
+        end
+        if !matches
           if podman?
             # Check for podman format when it is emulating docker CLI.
             # Podman outputs the full hash of the container on

--- a/test/unit/plugins/providers/docker/driver_test.rb
+++ b/test/unit/plugins/providers/docker/driver_test.rb
@@ -207,6 +207,16 @@ describe VagrantPlugins::DockerProvider::Driver do
       end
     end
 
+    context "using buildkit with containerd backend output" do
+      let(:stdout) { "exporting manifest list sha256:1a2b3c4d done" }
+
+      it "builds a container with buildkit docker (containerd)" do
+        container_id = subject.build("/tmp/fakedir")
+
+        expect(container_id).to eq(cid)
+      end
+    end
+
     context "using podman emulating docker CLI" do
       let(:stdout) { "1a2b3c4d5e6f7g8h9i10j11k12l13m14n16o17p18q19r20s21t22u23v24w25x2" }
 


### PR DESCRIPTION
Fixes https://github.com/hashicorp/vagrant/issues/13342 adding another regex for the docker log format with containerd storage enabled.

Another approach would be to use the `--iidfile` parameter of docker build to have the id written to a file. This would be less brittle than trying to keep up with different docker/podman log outputs. A working prototype is here https://github.com/tnaroska/vagrant/commit/c8073cf440e401b35ce0a4ce78bd73e8ac33b7c7 This would require more elaborate changes in the unit tests though.