### PR TITLE
Adding warning for IPv6 ending with 1

### DIFF
--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -923,7 +923,7 @@ module VagrantPlugins
               end
             end
 
-            if options[:ip] && options[:ip].end_with?(".1") && (options[:type] || "").to_sym != :dhcp
+            if options[:ip] && options[:ip].end_with?(".1") || options[:ip].end_with?(":1") && (options[:type] || "").to_sym != :dhcp
               machine.ui.warn(I18n.t(
                 "vagrant.config.vm.network_ip_ends_in_one"))
             end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -2160,7 +2160,7 @@ en:
         name_invalid: |-
           The sub-VM name '%{name}' is invalid. Please don't use special characters.
         network_ip_ends_in_one: |-
-          You assigned a static IP ending in ".1" to this machine.
+          You assigned a static IP ending in ".1" or ":1" to this machine.
           This is very often used by the router and can cause the
           network to not work properly. If the network doesn't work
           properly, try changing this IP.


### PR DESCRIPTION
After struggling quite some time I figured out I had an issue caused by setting an IPv6 ending with :1 

The network_ip_ends_in_one warning message is use for IPv4 to warn user about this matter, I would like to add this warning to IPv6 to avoid some painful debug time to future IPv6 users
