### PR TITLE
Check if the docker config is nil, fixes #13371

### DIFF
--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -348,10 +348,10 @@ module VagrantPlugins
 
         network_info = inspect_network(all_networks)
         network_info.each do |network|
-          config = Array(network["IPAM"]["Config"])
-          if ( config &&
-            config.size > 0 &&
-            config.first["Subnet"] == subnet_string)
+          next if !network["IPAM"]
+          config = network["IPAM"]["Config"]
+          next if !config || config.size < 1
+          if (config.first["Subnet"] == subnet_string)
             @logger.debug("Found existing network #{network["Name"]} already configured with #{subnet_string}")
             return network["Name"]
           end

--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -348,9 +348,8 @@ module VagrantPlugins
 
         network_info = inspect_network(all_networks)
         network_info.each do |network|
-          next if !network["IPAM"]
-          config = network["IPAM"]["Config"]
-          next if !config || config.size < 1
+          config = Array(network.dig("IPAM", "Config"))
+          next if config.empty? || !config.first.is_a?(Hash)
           if (config.first["Subnet"] == subnet_string)
             @logger.debug("Found existing network #{network["Name"]} already configured with #{subnet_string}")
             return network["Name"]

--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -349,7 +349,8 @@ module VagrantPlugins
         network_info = inspect_network(all_networks)
         network_info.each do |network|
           config = Array(network["IPAM"]["Config"])
-          if (config.size > 0 &&
+          if ( config &&
+            config.size > 0 &&
             config.first["Subnet"] == subnet_string)
             @logger.debug("Found existing network #{network["Name"]} already configured with #{subnet_string}")
             return network["Name"]

--- a/test/unit/plugins/providers/docker/driver_test.rb
+++ b/test/unit/plugins/providers/docker/driver_test.rb
@@ -729,6 +729,50 @@ describe VagrantPlugins::DockerProvider::Driver do
         expect { subject.network_defined?(subnet_string) }.not_to raise_error
       end
     end
+
+    context "when IPAM information is missing" do
+      let(:docker_network_struct) do
+        [
+          {
+            "Name": "bridge",
+            "Id": "ae74f6cc18bbcde86326937797070b814cc71bfc4a6d8e3e8cf3b2cc5c7f4a7d",
+            "Created": "2019-03-20T14:10:06.313314662-07:00",
+            "Scope": "local",
+            "Driver": "bridge",
+            "EnableIPv6": false,
+            "Internal": false,
+            "Attachable": false,
+            "Ingress": false,
+            "ConfigFrom": {
+              "Network": ""
+            },
+            "ConfigOnly": false,
+            "Containers": {
+              "a1ee9b12bcea8268495b1f43e8d1285df1925b7174a695075f6140adb9415d87": {
+                "Name": "vagrant-sandbox_docker-1_1553116237",
+                "EndpointID": "fc1b0ed6e4f700cf88bb26a98a0722655191542e90df3e3492461f4d1f3c0cae",
+                "MacAddress": "02:42:ac:11:00:02",
+                "IPv4Address": "172.17.0.2/16",
+                "IPv6Address": ""
+              },
+              "Options": {
+                "com.docker.network.bridge.default_bridge": "true",
+                "com.docker.network.bridge.enable_icc": "true",
+                "com.docker.network.bridge.enable_ip_masquerade": "true",
+                "com.docker.network.bridge.host_binding_ipv4": "0.0.0.0",
+                "com.docker.network.bridge.name": "docker0",
+                "com.docker.network.driver.mtu": "1500"
+              },
+              "Labels": {}
+            },
+          }
+        ].to_json
+      end
+
+      it "should not raise an error" do
+        expect { subject.network_defined?(subnet_string) }.not_to raise_error
+      end
+    end
   end
 
   describe '#network_containing_address' do


### PR DESCRIPTION
Sometimes the host network has a nil config, causing a crash on vagrant up when checking the docker networks.

See #13371 for more details of the bug this fixes