### PR TITLE
provisioner/ansible: Fix ansible version gathering in host provisioner

### DIFF
--- a/plugins/provisioners/ansible/provisioner/host.rb
+++ b/plugins/provisioners/ansible/provisioner/host.rb
@@ -113,7 +113,7 @@ module VagrantPlugins
         def gather_ansible_version
           raw_output = ''
           command = ['python3', '-c',
-                     "\"import importlib.metadata; print('ansible ' + importlib.metadata.version('ansible'))\""]
+                     "import importlib.metadata; print('ansible ' + importlib.metadata.version('ansible'))"]
 
           command << {
             notify: [:stdout, :stderr]

--- a/test/unit/plugins/provisioners/ansible/provisioner_test.rb
+++ b/test/unit/plugins/provisioners/ansible/provisioner_test.rb
@@ -77,7 +77,7 @@ VF
   def self.it_should_check_ansible_version
     it "execute 'Python ansible version check before executing 'ansible-playbook'" do
       expect(Vagrant::Util::Subprocess).to receive(:execute)
-        .once.with('python3', '-c', "\"import importlib.metadata; print('ansible ' + importlib.metadata.version('ansible'))\"", { notify: %i[
+        .once.with('python3', '-c', "import importlib.metadata; print('ansible ' + importlib.metadata.version('ansible'))", { notify: %i[
                      stdout stderr
                    ] })
       expect(Vagrant::Util::Subprocess).to receive(:execute)
@@ -1054,7 +1054,7 @@ VF
         expect(Vagrant::Util::Subprocess).to receive(:execute)
           .once
           .with('python3', '-c',
-                "\"import importlib.metadata; print('ansible ' + importlib.metadata.version('ansible'))\"", { notify: %i[stdout stderr] })
+                "import importlib.metadata; print('ansible ' + importlib.metadata.version('ansible'))", { notify: %i[stdout stderr] })
           .and_return(default_execute_result)
         expect(Vagrant::Util::Subprocess).to receive(:execute)
           .once


### PR DESCRIPTION
When not forcing `ansible.compatibility_mode`, Vagrant tries to gather the Ansible version using the `gather_ansible_version` function.

This seems to be incorrectly quoted / escaped.

Fixes https://github.com/hashicorp/vagrant/issues/13234

The noted fix from the issue is being implemented in this PR.

Before:
```bash
 vagrant provision
==> hostname: Running provisioner: ansible...
Vagrant gathered an unknown Ansible version:


and falls back on the compatibility mode '1.8'.
```
after:
```bash
 vagrant provision
==> hostname: Running provisioner: ansible...
    hostname: Running ansible-playbook...
```

Tested with the following versions on MacOS;
`ansible [core 2.15.8]`
`python version = 3.9.16`
`Vagrant 2.4.1` and `Vagrant 2.4.0`

```python
Python 3.9.16 (main, Jun  6 2023, 11:35:35)
[Clang 14.0.3 (clang-1403.0.22.14.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import importlib.metadata; print('ansible ' + importlib.metadata.version('ansible'))
ansible 8.7.0
>>> import importlib.metadata; print('ansible ' + importlib.metadata.version('ansible-core'))
ansible 2.15.8
```