### PR TITLE
Add HCP-Vagrant docs section with Migration Guide & Troubleshooting pages

### DIFF
--- a/website/content/vagrant-cloud/hcp-vagrant/migration-guide.mdx
+++ b/website/content/vagrant-cloud/hcp-vagrant/migration-guide.mdx
@@ -28,13 +28,13 @@ The collection that holds a user’s boxes, the registry name is incorporated in
 
 ~> Note: An HCP registry is analogous to an Organization in Vagrant Cloud. A given HCP project may have an unlimited number of registries.
 
-##### [HCP organizations](https://developer.hashicorp.com/hcp/docs/hcp/admin/orgs)
+##### HCP Organizations
 
-Parent-level entities that can have up to ten projects.A single HCP account can be a member of multiple organizations, as an invited user, but can only create and own a single organization.
+[HCP organizations](/hcp/docs/hcp/admin/orgs) are parent-level entities that can have up to ten projects.A single HCP account can be a member of multiple organizations, as an invited user, but can only create and own a single organization.
 
-##### [HCP projects](https://developer.hashicorp.com/hcp/docs/hcp/admin/projects)
+##### HCP Projects
 
-Allow organization owners to segment resources by team, environment, etc. Resources such as HCP Vagrant Registries, Hashicorp Virtual Private Networks (HPN). Each organization is assigned a `default-project` at creation and may have up to 10 projects.
+[HCP projects](/hcp/docs/hcp/admin/orgs) allow organization owners to segment resources by team, environment, etc. Resources such as HCP Vagrant Registries, Hashicorp Virtual Private Networks (HPN). Each organization is assigned a `default-project` at creation and may have up to 10 projects.
 
 #### Create an HCP Vagrant Account
 

--- a/website/content/vagrant-cloud/hcp-vagrant/migration-guide.mdx
+++ b/website/content/vagrant-cloud/hcp-vagrant/migration-guide.mdx
@@ -1,0 +1,149 @@
+---
+layout: vagrant-cloud
+page_title: Migrating to HCP Vagrant
+description: "Step by step guide to using Vagrant Cloud's HCP Vagrant Migration Tools"
+---
+
+# Migrating to HCP Vagrant
+
+~> Note: Vagrant Cloud will be migrated to HCP Vagrant at the end of July 2024.
+
+## Overview
+
+HCP [Vagrant Registry](https://portal.cloud.hashicorp.com/vagrant/discover), like Vagrant Cloud, is a public, searchable index of Vagrant boxes that allows box owners to host and share artifacts.
+
+To take advantage of shared infrastructure and platform investments available on the Hashicorp Cloud Platform (HCP), Hashicorp is migrating all existing boxes to HCP Vagrant Registry and retiring the current Vagrant Cloud rails app at the end of July 2024.
+
+Migrated organizations will be permanently accessible at their original Vagrant Cloud URLs and won’t require changes to user workflows. Migrated registries will have access to the modern HCP Vagrant UI, an improved search experience, and free private boxes.
+
+Those who take no action will have their boxes migrated as part of the site wide migration. The Vagrant team will maintain redirects to ensure users can expect all existing URLs and workflows to operate as usual after migration regardless of how boxes are migrated.
+
+## Prerequisites
+
+Before you continue with this guide, you should familiarize yourself with a few new resource management concepts in HCP and HCP Vagrant Registry.
+
+###### Registries
+
+The collection that holds a user’s boxes, the registry name is incorporated into the first half of resource names, e.g `hashicorp/atlas`
+
+~> Note: An HCP registry is analogous to an Organization in Vagrant Cloud. A given HCP project may have an unlimited number of registries.
+
+##### [HCP organizations](https://developer.hashicorp.com/hcp/docs/hcp/admin/orgs)
+
+Parent-level entities that can have up to ten projects.A single HCP account can be a member of multiple organizations, as an invited user, but can only create and own a single organization.
+
+##### [HCP projects](https://developer.hashicorp.com/hcp/docs/hcp/admin/projects)
+
+Allow organization owners to segment resources by team, environment, etc. Resources such as HCP Vagrant Registries, Hashicorp Virtual Private Networks (HPN). Each organization is assigned a `default-project` at creation and may have up to 10 projects.
+
+#### Create an HCP Vagrant Account
+
+To use the Vagrant Cloud migration tool you must define an organization and project within an HCP account and be signed into an active session on that account.
+
+Your HCP account must use the email address associated with your Vagrant Cloud account.Check under `Settings→ Profile` if you are unsure what email address you use for Vagrant Cloud.
+
+1. Sign up for a (free) [HCP account](https://portal.cloud.hashicorp.com/orgs/create), with your primary Vagrant Cloud organization email address. You must verify your account and sign in to HCP.
+2. At first log-in, use the wizard to create an HCP organization.
+3. Once you have created an organization you will be dropped into the dashboard for your `default-project`
+   - If you desire, you can create an additional project from the Projects Page.
+     - To get there, click `Projects` in the breadcrumbs at the top of the Dashboard page.
+     - A single organization may have up to 10 projects and each of those projects can have an unlimited number of [Registries](#registries) and Boxes.
+4. Now that you have a project in an HCP Account that uses the same email address as your Vagrant Cloud account, you’re ready to start migrating boxes!
+
+## Migrate to HCP Vagrant Registry
+
+#### 1. Sign in to both accounts and open the migration tool
+
+Once you have signed into both your HCP and Vagrant Cloud accounts, you can access the [migration tool](https://app.vagrantup.com/migration)
+
+To auto-populate the migration tool with a specific Vagrant Cloud `Organization` click on the `Migrate to HCP` button in the top right corner of your [settings](https://app.vagrantup.com/settings) page .
+
+#### 2. Select a Vagrant Cloud organization to migrate
+
+Select a single organization to migrate or select the `Migrate all organizations` checkbox to migrate them all at once to a single HCP Project.
+
+You may select any of the organizations listed in the Vagrant Cloud organization drop-down, even if a specific organization was pre-populated after navigating to the migration tool from your [Settings](https://app.vagrantup.com/settings) page.
+
+##### 3. Select a destination project in HCP
+
+If you have multiple projects in HCP, select the desired project from the HCP Project drop-down. If you have not created a second project the `default-project` will be auto-selected.
+
+When preparing for migration it is worth noting the following:
+
+- Your Vagrant Cloud Organization will be put into a read-only state and marked `Migrating` until the migration is complete. During this time boxes will be available in searches and to download, but write functionality like uploading new boxes, releasing versions, and managing settings for your Vagrant Cloud Organization will be unavailable.
+- Your new HCP Registry will not be available until the migration is complete.
+- When you migrate your default organization your Profile Settings (user name, gravatar url, etc) will no longer be available to manage in Vagrant Cloud and should be managed from your [HCP Settings](https://portal.cloud.hashicorp.com/account-settings).
+
+#### 4. Start the migration
+
+After you press the `Migrate` button you will be redirected to a status page that will keep you updated on the progress of your migration.
+
+#### 5. Visit your Registry in HCP
+
+Once your migration is complete you can view your new Registry in HCP!
+
+You can see your registries by clicking on[ Vagrant Registry](https://portal.cloud.hashicorp.com/services/vagrant/registries) in the side panel or by visiting [https://portal.cloud.hashicorp.com/services/vagrant/registries](https://portal.cloud.hashicorp.com/services/vagrant/registries).
+
+It is important to note that while a migrated organization will no longer be available in Vagrant Cloud the status of the migration will be visible from the `Status` tab on the [Migration](https://app.vagrantup.com/migration) page.
+
+## Conclusion
+
+If for some reason you are unable to access your new HCP Registry or your migration does not complete in a timely fashion check our [Troubleshooting Guide ](/vagrant/vagrant-cloud/hcp-vagrant/troubleshooting)or contact us at [support@hashicorp.com](mailto:support@hashicorp.com) with the subject `Vagrant Migration`. Our team will be happy to help you complete your migration or reset your organization state.
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/website/content/vagrant-cloud/hcp-vagrant/migration-guide.mdx
+++ b/website/content/vagrant-cloud/hcp-vagrant/migration-guide.mdx
@@ -1,12 +1,15 @@
 ---
 layout: vagrant-cloud
-page_title: Migrate to HCP Vagrant Registry 
+page_title: Migrate to HCP Vagrant Registry
 description: "Use Vagrant Cloud's migration tools to move all your artifacts to HashiCorp Cloud Platform (HCP)."
 ---
 
-# Migrate to HCP Vagrant Registry 
+# Migrate to HCP Vagrant Registry
 
 ~> Note: Vagrant Cloud will be migrated to HCP Vagrant Registry at the end of July 2024.
+Your Vagrant Cloud Organization will be put into a read-only state and marked `Migrating` until the migration is complete. During this time boxes will be available in searches and to download, but write functionality like uploading new boxes, releasing versions, and managing settings for your Vagrant Cloud Organization will be unavailable. Your new HCP Registry will not be available until the migration is complete.
+
+When you migrate your default organization your Profile Settings (user name, gravatar url, etc) will no longer be available to manage in Vagrant Cloud and should be managed from your [HCP Settings](https://portal.cloud.hashicorp.com/account-settings).
 
 ## Overview
 
@@ -57,7 +60,7 @@ To auto-populate the migration tool with a specific Vagrant Cloud `Organization`
 
 #### 2. Select a Vagrant Cloud organization to migrate
 
-Select a single organization from the dropdown to migrate or select the checkbox `Migrate all organizations`  to migrate them all at once to a single HCP Project.
+Select a single organization from the dropdown to migrate or select the checkbox `Migrate all organizations` to migrate them all at once to a single HCP Project.
 
 You can select any of the organizations listed in the Vagrant Cloud organization dropdown, even if a specific organization was pre-populated.
 
@@ -85,62 +88,4 @@ It is important to note that while a migrated organization will no longer be ava
 
 ## Conclusion
 
-If for some reason you are unable to access your new HCP Registry or your migration does not complete in a timely fashion check our [Troubleshooting Guide ](/vagrant/vagrant-cloud/hcp-vagrant/troubleshooting)or contact us at [support@hashicorp.com](mailto:support@hashicorp.com) with the subject `Vagrant Migration`. Our team will be happy to help you complete your migration or reset your organization state.
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
+If for some reason you are unable to access your new HCP Registry or your migration does not complete successfully, review the [Migration Troubleshooting] (/vagrant/vagrant-cloud/hcp-vagrant/troubleshooting) guide or contact us at [support@hashicorp.com](mailto:support@hashicorp.com) with the subject `HCP Vagrant Migration`. Our team will be happy to help you complete your migration or reset your organization state.

--- a/website/content/vagrant-cloud/hcp-vagrant/migration-guide.mdx
+++ b/website/content/vagrant-cloud/hcp-vagrant/migration-guide.mdx
@@ -15,7 +15,7 @@ When you migrate your default organization your Profile Settings (user name, gra
 
 HCP [Vagrant Registry](https://portal.cloud.hashicorp.com/vagrant/discover), like Vagrant Cloud, is a public, searchable index of Vagrant boxes that allows box owners to host and share artifacts.
 
-To take advantage of shared infrastructure and platform investments available on the Hashicorp Cloud Platform (HCP), Hashicorp is migrating all existing boxes to HCP Vagrant Registry and retiring the current Vagrant Cloud rails app at the end of July 2024.
+To take advantage of shared infrastructure and platform investments available on the Hashicorp Cloud Platform (HCP), Hashicorp is migrating all existing boxes to HCP Vagrant Registry and retiring the current Vagrant Cloud application at the end of July 2024.
 
 Migrated organizations will be permanently accessible at their original Vagrant Cloud URLs and won’t require changes to user workflows. Migrated registries will have access to the modern HCP Vagrant Registry UI, an improved search experience, and free private boxes.
 
@@ -56,13 +56,9 @@ Your HCP account must use the email address associated with your Vagrant Cloud a
 
 Once you have signed into both your HCP and Vagrant Cloud accounts, you can access the [migration tool](https://app.vagrantup.com/migration).
 
-To auto-populate the migration tool with a specific Vagrant Cloud `Organization` click on the `Migrate to HCP` button in the top right corner of your [settings](https://app.vagrantup.com/settings) page.
-
 #### 2. Select a Vagrant Cloud organization to migrate
 
 Select a single organization from the dropdown to migrate or select the checkbox `Migrate all organizations` to migrate them all at once to a single HCP Project.
-
-You can select any of the organizations listed in the Vagrant Cloud organization dropdown, even if a specific organization was pre-populated.
 
 ##### 3. Select a destination project in HCP
 
@@ -88,4 +84,6 @@ It is important to note that while a migrated organization will no longer be ava
 
 ## Conclusion
 
-If for some reason you are unable to access your new HCP Registry or your migration does not complete successfully, review the [Migration Troubleshooting] (/vagrant/vagrant-cloud/hcp-vagrant/troubleshooting) guide or contact us at [support@hashicorp.com](mailto:support@hashicorp.com) with the subject `HCP Vagrant Migration`. Our team will be happy to help you complete your migration or reset your organization state.
+If for some reason you are unable to access your new HCP Registry or your migration does not complete successfully, review the [Migration Troubleshooting] (/vagrant/vagrant-cloud/hcp-vagrant/troubleshooting) guide or contact us at [support+vagrantcloud@hashicorp.com](mailto:support@hashicorp.com) with the subject `HCP Vagrant Migration`. Our team will be happy to help you complete your migration or reset your organization state.
+
+

--- a/website/content/vagrant-cloud/hcp-vagrant/migration-guide.mdx
+++ b/website/content/vagrant-cloud/hcp-vagrant/migration-guide.mdx
@@ -1,12 +1,12 @@
 ---
 layout: vagrant-cloud
-page_title: Migrating to HCP Vagrant
-description: "Step by step guide to using Vagrant Cloud's HCP Vagrant Migration Tools"
+page_title: Migrate to HCP Vagrant Registry 
+description: "Use Vagrant Cloud's migration tools to move all your artifacts to HashiCorp Cloud Platform (HCP)."
 ---
 
-# Migrating to HCP Vagrant
+# Migrate to HCP Vagrant Registry 
 
-~> Note: Vagrant Cloud will be migrated to HCP Vagrant at the end of July 2024.
+~> Note: Vagrant Cloud will be migrated to HCP Vagrant Registry at the end of July 2024.
 
 ## Overview
 
@@ -14,7 +14,7 @@ HCP [Vagrant Registry](https://portal.cloud.hashicorp.com/vagrant/discover), lik
 
 To take advantage of shared infrastructure and platform investments available on the Hashicorp Cloud Platform (HCP), Hashicorp is migrating all existing boxes to HCP Vagrant Registry and retiring the current Vagrant Cloud rails app at the end of July 2024.
 
-Migrated organizations will be permanently accessible at their original Vagrant Cloud URLs and won’t require changes to user workflows. Migrated registries will have access to the modern HCP Vagrant UI, an improved search experience, and free private boxes.
+Migrated organizations will be permanently accessible at their original Vagrant Cloud URLs and won’t require changes to user workflows. Migrated registries will have access to the modern HCP Vagrant Registry UI, an improved search experience, and free private boxes.
 
 Those who take no action will have their boxes migrated as part of the site wide migration. The Vagrant team will maintain redirects to ensure users can expect all existing URLs and workflows to operate as usual after migration regardless of how boxes are migrated.
 
@@ -24,49 +24,46 @@ Before you continue with this guide, you should familiarize yourself with a few 
 
 ###### Registries
 
-The collection that holds a user’s boxes, the registry name is incorporated into the first half of resource names, e.g `hashicorp/atlas`
+The collection that holds a user’s boxes, the registry name is incorporated into the first half of resource names. For example, `hashicorp/atlas`.
 
 ~> Note: An HCP registry is analogous to an Organization in Vagrant Cloud. A given HCP project may have an unlimited number of registries.
 
 ##### HCP Organizations
 
-[HCP organizations](/hcp/docs/hcp/admin/orgs) are parent-level entities that can have up to ten projects.A single HCP account can be a member of multiple organizations, as an invited user, but can only create and own a single organization.
+[HCP organizations](/hcp/docs/hcp/admin/orgs) are parent-level entities that can have up to ten projects. A single HCP account can be a member of multiple organizations, as an invited user, but can only create and own a single organization.
 
 ##### HCP Projects
 
 [HCP projects](/hcp/docs/hcp/admin/orgs) allow organization owners to segment resources by team, environment, etc. Resources such as HCP Vagrant Registries, Hashicorp Virtual Private Networks (HPN). Each organization is assigned a `default-project` at creation and may have up to 10 projects.
 
-#### Create an HCP Vagrant Account
+#### Create an HCP Vagrant Registry account
 
-To use the Vagrant Cloud migration tool you must define an organization and project within an HCP account and be signed into an active session on that account.
+To use the Vagrant Cloud migration tool, you must define an organization and project within an HCP account and be signed into an active session on that account.
 
-Your HCP account must use the email address associated with your Vagrant Cloud account.Check under `Settings→ Profile` if you are unsure what email address you use for Vagrant Cloud.
+Your HCP account must use the email address associated with your Vagrant Cloud account. Check under `Settings → Profile` if you are unsure what email address you use for Vagrant Cloud.
 
-1. Sign up for a (free) [HCP account](https://portal.cloud.hashicorp.com/orgs/create), with your primary Vagrant Cloud organization email address. You must verify your account and sign in to HCP.
+1. Sign up for a (free) [HCP account](https://portal.cloud.hashicorp.com/orgs/create), with your primary Vagrant Cloud organization email address. You must verify your account and sign into HCP.
 2. At first log-in, use the wizard to create an HCP organization.
-3. Once you have created an organization you will be dropped into the dashboard for your `default-project`
-   - If you desire, you can create an additional project from the Projects Page.
-     - To get there, click `Projects` in the breadcrumbs at the top of the Dashboard page.
-     - A single organization may have up to 10 projects and each of those projects can have an unlimited number of [Registries](#registries) and Boxes.
-4. Now that you have a project in an HCP Account that uses the same email address as your Vagrant Cloud account, you’re ready to start migrating boxes!
+3. On creation of your organization, you will be directed to the dashboard for your `default-project`. You can create an additional project from the Projects page.
+4. Now that you have a project in an HCP Account that uses the same email address as your Vagrant Cloud account, you can begin the migration process.
 
 ## Migrate to HCP Vagrant Registry
 
 #### 1. Sign in to both accounts and open the migration tool
 
-Once you have signed into both your HCP and Vagrant Cloud accounts, you can access the [migration tool](https://app.vagrantup.com/migration)
+Once you have signed into both your HCP and Vagrant Cloud accounts, you can access the [migration tool](https://app.vagrantup.com/migration).
 
-To auto-populate the migration tool with a specific Vagrant Cloud `Organization` click on the `Migrate to HCP` button in the top right corner of your [settings](https://app.vagrantup.com/settings) page .
+To auto-populate the migration tool with a specific Vagrant Cloud `Organization` click on the `Migrate to HCP` button in the top right corner of your [settings](https://app.vagrantup.com/settings) page.
 
 #### 2. Select a Vagrant Cloud organization to migrate
 
-Select a single organization to migrate or select the `Migrate all organizations` checkbox to migrate them all at once to a single HCP Project.
+Select a single organization from the dropdown to migrate or select the checkbox `Migrate all organizations`  to migrate them all at once to a single HCP Project.
 
-You may select any of the organizations listed in the Vagrant Cloud organization drop-down, even if a specific organization was pre-populated after navigating to the migration tool from your [Settings](https://app.vagrantup.com/settings) page.
+You can select any of the organizations listed in the Vagrant Cloud organization dropdown, even if a specific organization was pre-populated.
 
 ##### 3. Select a destination project in HCP
 
-If you have multiple projects in HCP, select the desired project from the HCP Project drop-down. If you have not created a second project the `default-project` will be auto-selected.
+If you have multiple projects in HCP, select the project you want from the HCP Project dropdown. If you have not created a second project the `default-project` will be auto-selected.
 
 When preparing for migration it is worth noting the following:
 
@@ -80,9 +77,9 @@ After you press the `Migrate` button you will be redirected to a status page tha
 
 #### 5. Visit your Registry in HCP
 
-Once your migration is complete you can view your new Registry in HCP!
+Once your migration is complete you can view your new Registry in HCP.
 
-You can see your registries by clicking on[ Vagrant Registry](https://portal.cloud.hashicorp.com/services/vagrant/registries) in the side panel or by visiting [https://portal.cloud.hashicorp.com/services/vagrant/registries](https://portal.cloud.hashicorp.com/services/vagrant/registries).
+To view your registries , click on [Vagrant Registry](https://portal.cloud.hashicorp.com/services/vagrant/registries) in the side panel or by visiting [https://portal.cloud.hashicorp.com/services/vagrant/registries](https://portal.cloud.hashicorp.com/services/vagrant/registries).
 
 It is important to note that while a migrated organization will no longer be available in Vagrant Cloud the status of the migration will be visible from the `Status` tab on the [Migration](https://app.vagrantup.com/migration) page.
 

--- a/website/content/vagrant-cloud/hcp-vagrant/troubleshooting.mdx
+++ b/website/content/vagrant-cloud/hcp-vagrant/troubleshooting.mdx
@@ -18,20 +18,3 @@ In the rare case that an inoperable box was successfully uploaded (e.g legacy bo
 
 If a migration fails, a `retry` icon will appear beside the name of that organization on the [migration status](https://app.beta.vagrantup.com/migration/status) page. Failed migrations can be retried once.
 In the event of a second failure, contact us at [support@hashicorp.com](mailto:support@hashicorp.com) with the subject `Vagrant Migration`. Our team will be happy to help you complete your migration or reset your organization state.
-
-
-
-
-
-
-
- 
-
-
-
-
-
-
-
-
-

--- a/website/content/vagrant-cloud/hcp-vagrant/troubleshooting.mdx
+++ b/website/content/vagrant-cloud/hcp-vagrant/troubleshooting.mdx
@@ -1,6 +1,6 @@
 ---
 layout: vagrant-cloud
-page_title: Troubleshooting
+page_title: Migration Troubleshooting
 description: 'HCP Migration troubleshooting guide'
 ---
 

--- a/website/content/vagrant-cloud/hcp-vagrant/troubleshooting.mdx
+++ b/website/content/vagrant-cloud/hcp-vagrant/troubleshooting.mdx
@@ -16,5 +16,5 @@ In the rare case that an inoperable box was successfully uploaded (e.g legacy bo
 
 ### Retrying Migrations
 
-If a migration fails, a `retry` icon will appear beside the name of that organization on the [migration status](https://app.beta.vagrantup.com/migration/status) page. Failed migrations can be retried once.
-In the event of a second failure, contact us at [support@hashicorp.com](mailto:support@hashicorp.com) with the subject `Vagrant Migration`. Our team will be happy to help you complete your migration or reset your organization state.
+If a migration fails, a `retry` icon will appear beside the name of that organization on the [migration status](https://app.vagrantup.com/migration/status) page. Failed migrations can be retried once.
+In the event of a second failure, contact us at [support+vagrantcloud@hashicorp.com](mailto:support@hashicorp.com) with the subject `Vagrant Migration`. Our team will be happy to help you complete your migration or reset your organization state.

--- a/website/content/vagrant-cloud/hcp-vagrant/troubleshooting.mdx
+++ b/website/content/vagrant-cloud/hcp-vagrant/troubleshooting.mdx
@@ -1,0 +1,37 @@
+---
+layout: vagrant-cloud
+page_title: Troubleshooting
+description: 'HCP Migration troubleshooting guide'
+---
+
+# Troubleshooting
+
+### Inactive HCP Session
+
+You may see a warning in the Migration Wizard if your HCP Session is inactive. The wizard will attempt to reload your page automatically within 5 seconds or you may attempt to refresh your session by reloading manually. The error will persist if you are not logged into HCP, log in from another window and refresh.
+
+### Missing Boxes or Registries
+
+In the rare case that an inoperable box was successfully uploaded (e.g legacy box improperly ported from Atlas) that box will not be migrated to HCP Vagrant. Any failed boxes will be listed in the Migration Status page.
+
+### Retrying Migrations
+
+If a migration fails, a `retry` icon will appear beside the name of that organization on the [migration status](https://app.beta.vagrantup.com/migration/status) page. Failed migrations can be retried once.
+In the event of a second failure, contact us at [support@hashicorp.com](mailto:support@hashicorp.com) with the subject `Vagrant Migration`. Our team will be happy to help you complete your migration or reset your organization state.
+
+
+
+
+
+
+
+ 
+
+
+
+
+
+
+
+
+

--- a/website/data/alert-banner.js
+++ b/website/data/alert-banner.js
@@ -9,8 +9,7 @@ export const ALERT_BANNER_ACTIVE = false
 export default {
   tag: 'Blog post',
   url: 'https://www.hashicorp.com/blog/a-new-chapter-for-hashicorp',
-  text:
-    'HashiCorp shares have begun trading on the Nasdaq. Read the blog from our founders, Mitchell Hashimoto and Armon Dadgar.',
+  text: 'HashiCorp shares have begun trading on the Nasdaq. Read the blog from our founders, Mitchell Hashimoto and Armon Dadgar.',
   linkText: 'Read the post',
   // Set the expirationDate prop with a datetime string (e.g. '2020-01-31T12:00:00-07:00')
   // if you'd like the component to stop showing at or after a certain date

--- a/website/data/vagrant-cloud-nav-data.json
+++ b/website/data/vagrant-cloud-nav-data.json
@@ -3,11 +3,11 @@
     "title": "HCP Vagrant",
     "routes": [
       {
-        "title": "HCP Vagrant Migration Guide",
+        "title": "HCP Vagrant Registry Migration Guide",
         "path": "hcp-vagrant/migration-guide"
       },
       {
-        "title": "Troubleshooting",
+        "title": "Migration Troubleshooting",
         "path": "hcp-vagrant/troubleshooting"
       }
     ]

--- a/website/data/vagrant-cloud-nav-data.json
+++ b/website/data/vagrant-cloud-nav-data.json
@@ -1,5 +1,18 @@
 [
   {
+    "title": "HCP Vagrant",
+    "routes": [
+      {
+        "title": "HCP Vagrant Migration Guide",
+        "path": "hcp-vagrant/migration-guide"
+      },
+      {
+        "title": "Troubleshooting",
+        "path": "hcp-vagrant/troubleshooting"
+      }
+    ]
+  },
+  {
     "title": "Boxes",
     "routes": [
       {


### PR DESCRIPTION
This PR adds two doc pages.

I made a few changes from the google doc specifically
- adding a note banner to the top of the migration guide to highlight our impending site migration
- dropped the screenshots. First because resolving the image path was frustrating but primarily because that would bring the guide more into alignment with the rest of the docs site and because the migration tool is so straight forward that the screenshots weren't terribly helpful.