### PR TITLE
fix spacing on 1st paragraph & migration note

### DIFF
--- a/website/content/vagrant-cloud/hcp-vagrant/migration-guide.mdx
+++ b/website/content/vagrant-cloud/hcp-vagrant/migration-guide.mdx
@@ -7,6 +7,7 @@ description: "Use Vagrant Cloud's migration tools to move all your artifacts to 
 # Migrate to HCP Vagrant Registry
 
 ~> Note: Vagrant Cloud will be migrated to HCP Vagrant Registry at the end of July 2024.
+
 Your Vagrant Cloud Organization will be put into a read-only state and marked `Migrating` until the migration is complete. During this time boxes will be available in searches and to download, but write functionality like uploading new boxes, releasing versions, and managing settings for your Vagrant Cloud Organization will be unavailable. Your new HCP Registry will not be available until the migration is complete.
 
 When you migrate your default organization your Profile Settings (user name, gravatar url, etc) will no longer be available to manage in Vagrant Cloud and should be managed from your [HCP Settings](https://portal.cloud.hashicorp.com/account-settings).
@@ -85,5 +86,3 @@ It is important to note that while a migrated organization will no longer be ava
 ## Conclusion
 
 If for some reason you are unable to access your new HCP Registry or your migration does not complete successfully, review the [Migration Troubleshooting] (/vagrant/vagrant-cloud/hcp-vagrant/troubleshooting) guide or contact us at [support+vagrantcloud@hashicorp.com](mailto:support@hashicorp.com) with the subject `HCP Vagrant Migration`. Our team will be happy to help you complete your migration or reset your organization state.
-
-


### PR DESCRIPTION
I forgot a space between the website migration note and the 1st paragraph. This fixes that