### PR TITLE
Add base64 to the gemspec

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version     = ">= 3.0", "< 3.4"
   s.required_rubygems_version = ">= 1.3.6"
 
+  s.add_dependency "base64"
   s.add_dependency "bcrypt_pbkdf", "~> 1.1"
   s.add_dependency "childprocess", "~> 4.1.0"
   s.add_dependency "ed25519", "~> 1.3.0"


### PR DESCRIPTION
base64 will no longer be the default gem in the Ruby 3.4, without this patch following warning message may come from ruby 3.3+

    /opt/vagrant/lib/vagrant/util/powershell.rb:4: warning: base64 was
    loaded from the standard library, but will no longer be part of the
    default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec.

See https://github.com/thinreports/thinreports-generator/pull/134