### PR TITLE
virtualbox version detection: handle WARNING lines

### DIFF
--- a/plugins/providers/virtualbox/driver/meta.rb
+++ b/plugins/providers/virtualbox/driver/meta.rb
@@ -197,7 +197,11 @@ module VagrantPlugins
             end
           end
 
-          parts = output.split("_")
+          version_line = output.each_line.find do |line|
+            !line.start_with?("WARNING:")
+          end
+
+          parts = version_line.split("_")
           return nil if parts.empty?
           parts[0].split("r")[0]
         end

--- a/plugins/providers/virtualbox/driver/meta.rb
+++ b/plugins/providers/virtualbox/driver/meta.rb
@@ -201,7 +201,7 @@ module VagrantPlugins
             !line.start_with?("WARNING:")
           end
 
-          parts = version_line.split("_")
+          parts = version_line.to_s.split("_")
           return nil if parts.empty?
           parts[0].split("r")[0]
         end


### PR DESCRIPTION
As reported in https://www.virtualbox.org/ticket/22060, starting with Virtualbox 7.0.16 running:
```
$ vboxmanage --version
WARNING: Environment variable LOGNAME or USER does not correspond to effective user id.
7.0.18r162988
```
the warning line is written to stdout which is an issue since the parsing of the version is used in the provider code to use the correct class to handle following communication with Virtualbox.

This PR improves the version detection by parsing the version in the first line that does not start with `WARNING:`.