### PR TITLE
Migration guide link typo

### DIFF
--- a/website/content/vagrant-cloud/hcp-vagrant/migration-guide.mdx
+++ b/website/content/vagrant-cloud/hcp-vagrant/migration-guide.mdx
@@ -85,4 +85,4 @@ It is important to note that while a migrated organization will no longer be ava
 
 ## Conclusion
 
-If for some reason you are unable to access your new HCP Registry or your migration does not complete successfully, review the [Migration Troubleshooting] (/vagrant/vagrant-cloud/hcp-vagrant/troubleshooting) guide or contact us at [support+vagrantcloud@hashicorp.com](mailto:support@hashicorp.com) with the subject `HCP Vagrant Migration`. Our team will be happy to help you complete your migration or reset your organization state.
+If for some reason you are unable to access your new HCP Registry or your migration does not complete successfully, review the [Migration Troubleshooting](/vagrant/vagrant-cloud/hcp-vagrant/troubleshooting) guide or contact us at [support+vagrantcloud@hashicorp.com](mailto:support@hashicorp.com) with the subject `HCP Vagrant Migration`. Our team will be happy to help you complete your migration or reset your organization state.


### PR DESCRIPTION
In the conclusion the link to the troubleshooting guide had a space in it. Hopefully that's the only issue.