### PR TITLE
fix openwrt nfs synched folders

### DIFF
--- a/plugins/synced_folders/unix_mount_helpers.rb
+++ b/plugins/synced_folders/unix_mount_helpers.rb
@@ -97,7 +97,7 @@ module VagrantPlugins
       def emit_upstart_notification(machine, guest_path)
         # Emit an upstart event if we can
         machine.communicate.sudo <<-EOH.gsub(/^ {12}/, "")
-            if command -v /sbin/init && /sbin/init 2>/dev/null --version | grep upstart; then
+            if test -x /sbin/initctl && command -v /sbin/init && /sbin/init 2>/dev/null --version | grep upstart; then
               /sbin/initctl emit --no-wait vagrant-mounted MOUNTPOINT=#{guest_path}
             fi
           EOH


### PR DESCRIPTION
in openwrt, /sbin/init --version does not print the version, instead it calls init, which breaks the running system

this was already fixed in https://github.com/hashicorp/vagrant/pull/7813 but somehow was lost in later code changes