### PR TITLE
Pass docker exec_options to executor as kwargs

### DIFF
--- a/plugins/providers/docker/command/exec.rb
+++ b/plugins/providers/docker/command/exec.rb
@@ -94,7 +94,7 @@ module VagrantPlugins
             Vagrant::Util::SafeExec.exec(exec_cmd[0], *exec_cmd[1..-1])
           else
             output = ""
-            machine.provider.driver.execute(*exec_cmd, exec_options) do |type, data|
+            machine.provider.driver.execute(*exec_cmd, **exec_options) do |type, data|
               output += data
             end
 

--- a/test/unit/plugins/providers/docker/command/exec_test.rb
+++ b/test/unit/plugins/providers/docker/command/exec_test.rb
@@ -55,6 +55,17 @@ describe VagrantPlugins::DockerProvider::Command::Exec do
         subject.exec_command(machine, command, options)
       end
     end
+    describe "with options" do
+      let(:command) { ["ls"] }
+      let(:options) { {etc: "something"} }
+
+      it "passes the options successfully" do
+        driver = instance_double("Driver")
+        expect(driver).to receive(:execute).with("docker", "exec", nil, "ls", {etc: "something"})
+        allow(machine.provider).to receive(:driver) { driver }
+        subject.exec_command(machine, command, options)
+      end
+    end
     describe "without a command" do
       let(:argv) { [] }
 


### PR DESCRIPTION
Updates the passing of `exec_options` as kwargs to the docker local executor, where passing without the `**` was deprecated in Ruby 2.7 and broke in 3.0. Without the double splat, the hash was passed as an element in the `exec_cmd` (splatted) array.

fixes #13388