### PR TITLE
Match docker image id on full output from list when building

### DIFF
--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -125,8 +125,8 @@ module VagrantPlugins
       end
 
       def image?(id)
-        result = execute('docker', 'images', '-q').to_s
-        result =~ /^#{Regexp.escape(id)}$/
+        result = execute('docker', 'images', '-q', '--no-trunc').to_s
+        result =~ /\b#{Regexp.escape(id)}\b/
       end
 
       # Reads all current docker containers and determines what ports

--- a/test/unit/plugins/providers/docker/driver_test.rb
+++ b/test/unit/plugins/providers/docker/driver_test.rb
@@ -351,6 +351,34 @@ describe VagrantPlugins::DockerProvider::Driver do
     end
   end
 
+  describe '#image?' do
+    let(:result) { subject.image?(cid) }
+
+    it 'performs the check on all images list' do
+      subject.image?(cid)
+      expect(cmd_executed).to match(/docker images \-q \--no-trunc/)
+    end
+
+    context 'when image id exists' do
+      let(:stdout) { "foo\n#{cid}\nbar" }
+
+      it { expect(result).to be_truthy }
+    end
+
+    context 'when sha265 image id exists' do
+      let(:stdout) { "sha256:foo\nsha256:#{cid}\nsha256:bar" }
+
+      it { expect(result).to be_truthy }
+    end
+
+    context 'when image does not exist' do
+      let(:stdout) { "foo\n#{cid}extra\nbar" }
+
+      it { expect(result).to be_falsey }
+    end
+  end
+
+
   describe '#pull' do
     it 'should pull images' do
       subject.pull('foo')


### PR DESCRIPTION
When checking if a docker image exists or should be rebuilt during a `vagrant up`, check the image presence against the full  & not truncated list of docker images ids (`docker images -q --no-trunc`). Adjusts the regex matching to account for additional characters in the not truncated output, which has been added as a test case. 

fixes #13384 