### PR TITLE
Use `nfsd update` command for restart 

### DIFF
--- a/plugins/hosts/bsd/cap/nfs.rb
+++ b/plugins/hosts/bsd/cap/nfs.rb
@@ -13,7 +13,7 @@ module VagrantPlugins
       class NFS
         def self.nfs_export(environment, ui, id, ips, folders)
           nfs_exports_template = environment.host.capability(:nfs_exports_template)
-          nfs_restart_command  = environment.host.capability(:nfs_restart_command)
+          nfs_update_command  = environment.host.capability(:nfs_update_command)
           logger = Log4r::Logger.new("vagrant::hosts::bsd")
 
           nfs_checkexports! if File.file?("/etc/exports")
@@ -117,9 +117,8 @@ module VagrantPlugins
               "#{sudo_command}/usr/bin/tee -a /etc/exports >/dev/null")
           end
 
-          # We run restart here instead of "update" just in case nfsd
-          # is not starting
-          system(*nfs_restart_command)
+          # Attempt to update nfsd
+          system(*nfs_update_command)
         end
 
         def self.nfs_exports_template(environment)
@@ -161,6 +160,10 @@ module VagrantPlugins
 
         def self.nfs_restart_command(environment)
           ["sudo", "nfsd", "restart"]
+        end
+
+        def self.nfs_update_command(environment)
+          ["sudo", "nfsd", "update"]
         end
 
         protected

--- a/plugins/hosts/bsd/cap/nfs.rb
+++ b/plugins/hosts/bsd/cap/nfs.rb
@@ -13,6 +13,8 @@ module VagrantPlugins
       class NFS
         def self.nfs_export(environment, ui, id, ips, folders)
           nfs_exports_template = environment.host.capability(:nfs_exports_template)
+          nfs_restart_command  = environment.host.capability(:nfs_restart_command)
+          nfs_status_command  = environment.host.capability(:nfs_status_command)
           nfs_update_command  = environment.host.capability(:nfs_update_command)
           logger = Log4r::Logger.new("vagrant::hosts::bsd")
 
@@ -117,8 +119,12 @@ module VagrantPlugins
               "#{sudo_command}/usr/bin/tee -a /etc/exports >/dev/null")
           end
 
-          # Attempt to update nfsd
-          system(*nfs_update_command)
+          # Check if nfsd is running, and update or restart depending on the result
+          if nfs_running?(nfs_status_command)
+            system(*nfs_update_command)
+          else
+            system(*nfs_restart_command)
+          end
         end
 
         def self.nfs_exports_template(environment)
@@ -158,12 +164,20 @@ module VagrantPlugins
           raise Vagrant::Errors::NFSCantReadExports
         end
 
+        def self.nfs_running?(check_command)
+          Vagrant::Util::Subprocess.execute(*check_command).exit_code == 0
+        end
+
         def self.nfs_restart_command(environment)
           ["sudo", "nfsd", "restart"]
         end
 
         def self.nfs_update_command(environment)
           ["sudo", "nfsd", "update"]
+        end
+
+        def self.nfs_status_command(environment)
+          ["sudo", "nfsd", "status"]
         end
 
         protected

--- a/plugins/hosts/bsd/plugin.rb
+++ b/plugins/hosts/bsd/plugin.rb
@@ -44,6 +44,11 @@ module VagrantPlugins
         Cap::NFS
       end
 
+      host_capability("bsd", "nfs_status_command") do
+        require_relative "cap/nfs"
+        Cap::NFS
+      end
+
       host_capability("bsd", "resolve_host_path") do
         require_relative "cap/path"
         Cap::Path

--- a/plugins/hosts/bsd/plugin.rb
+++ b/plugins/hosts/bsd/plugin.rb
@@ -39,6 +39,11 @@ module VagrantPlugins
         Cap::NFS
       end
 
+      host_capability("bsd", "nfs_update_command") do
+        require_relative "cap/nfs"
+        Cap::NFS
+      end
+
       host_capability("bsd", "resolve_host_path") do
         require_relative "cap/path"
         Cap::Path

--- a/plugins/synced_folders/nfs/synced_folder.rb
+++ b/plugins/synced_folders/nfs/synced_folder.rb
@@ -103,12 +103,12 @@ module VagrantPlugins
         mount_folders = {}
         folders.each do |id, opts|
           mount_folders[id] = opts.dup if opts[:guestpath]
-        end
 
-        machine.ui.detail(I18n.t("vagrant.actions.vm.nfs.mounting_entry",
-          guestpath: opts[:guestpath],
-          hostpath: opts[:hostpath]
-        ))
+          machine.ui.detail(I18n.t("vagrant.actions.vm.nfs.mounting_entry",
+            guestpath: opts[:guestpath],
+            hostpath: opts[:hostpath]
+          ))
+        end
 
         # Mount them!
         if machine.guest.capability?(:nfs_pre)


### PR DESCRIPTION
Updates the `nfs_restart_command` for darwin hosts to use `update` instead of `restart`, after mac Sonoma update. Also adjusts the nfs mount log to run within the block, so it can access the opts hash. 

fixes #13364