### PR TITLE
Fix double digits Ansible version match

### DIFF
--- a/plugins/provisioners/ansible/provisioner/base.rb
+++ b/plugins/provisioners/ansible/provisioner/base.rb
@@ -393,7 +393,7 @@ gathered version stdout version:
               _, @gathered_version, _ = ansible_version_pattern.captures
               @gathered_version.strip!
               if @gathered_version
-                @gathered_version_major = @gathered_version.match(/(\d)\..+$/).captures[0].to_i
+                @gathered_version_major = @gathered_version.match(/(\d+)\..+$/).captures[0].to_i
               end
             end
           end


### PR DESCRIPTION
Vagrant does an Ansible version check in the Ansible provisioner to determine which compatibility mode to use. The latest version of Ansible is Ansible 10 and this check fails in Vagrant when using Ansible 10.

```
% python3 -c "import importlib.metadata; print('ansible ' + importlib.metadata.version('ansible'))"
ansible 10.3.0
```

This is the first time that double digits are used in an Ansible major version. The regex that is used to determine the major version in Vagrant only checks a single digit. So in this case it matches to 0, which in turn will trigger compatibility mode 1.8 instead of 2.0. Compatibility mode 1.8 uses [sudo](https://github.com/hashicorp/vagrant/blob/main/plugins/provisioners/ansible/provisioner/base.rb#L28) in the command, instead of [become](https://github.com/hashicorp/vagrant/blob/main/plugins/provisioners/ansible/provisioner/base.rb#L37) which is needed by recent Ansible versions.

```
% vagrant provision
==> server01.exonetcloud.nl: Running provisioner: ansible...
    server01.exonetcloud.nl: Running ansible-playbook...
usage: ansible-playbook [-h] [--version] [-v] [--private-key PRIVATE_KEY_FILE]
                        [-u REMOTE_USER] [-c CONNECTION] [-T TIMEOUT]
                        [--ssh-common-args SSH_COMMON_ARGS]
                        [--sftp-extra-args SFTP_EXTRA_ARGS]
                        [--scp-extra-args SCP_EXTRA_ARGS]
                        [--ssh-extra-args SSH_EXTRA_ARGS]
                        [-k | --connection-password-file CONNECTION_PASSWORD_FILE]
                        [--force-handlers] [--flush-cache] [-b]
                        [--become-method BECOME_METHOD]
                        [--become-user BECOME_USER]
                        [-K | --become-password-file BECOME_PASSWORD_FILE]
                        [-t TAGS] [--skip-tags SKIP_TAGS] [-C] [-D]
                        [-i INVENTORY] [--list-hosts] [-l SUBSET]
                        [-e EXTRA_VARS] [--vault-id VAULT_IDS]
                        [-J | --vault-password-file VAULT_PASSWORD_FILES]
                        [-f FORKS] [-M MODULE_PATH] [--syntax-check]
                        [--list-tasks] [--list-tags] [--step]
                        [--start-at-task START_AT_TASK]
                        playbook [playbook ...]
ansible-playbook: error: unrecognized arguments: --sudo
```

This PR updates the regex to check all digits before the first dot, so the major version is set to 10 instead of 0 and the correct compatibility mode is selected.