### PR TITLE
Fixed message when mounting nfs folders

### DIFF
--- a/plugins/synced_folders/nfs/synced_folder.rb
+++ b/plugins/synced_folders/nfs/synced_folder.rb
@@ -103,12 +103,12 @@ module VagrantPlugins
         mount_folders = {}
         folders.each do |id, opts|
           mount_folders[id] = opts.dup if opts[:guestpath]
-        end
 
-        machine.ui.detail(I18n.t("vagrant.actions.vm.nfs.mounting_entry",
-          guestpath: opts[:guestpath],
-          hostpath: opts[:hostpath]
-        ))
+          machine.ui.detail(I18n.t("vagrant.actions.vm.nfs.mounting_entry",
+            guestpath: opts[:guestpath],
+            hostpath: opts[:hostpath]
+          ))
+        end
 
         # Mount them!
         if machine.guest.capability?(:nfs_pre)


### PR DESCRIPTION
Solve error: undefined local variable or method `opts'
This commit fix problem related to commit b26482d23c9a4b5958bf3084fbc2d687a81d1e3d