### PR TITLE
Update provider/virtualbox to allow paused state when booting vm

### DIFF
--- a/plugins/providers/virtualbox/action.rb
+++ b/plugins/providers/virtualbox/action.rb
@@ -92,7 +92,7 @@ module VagrantPlugins
           b.use Customize, "pre-boot"
           b.use Boot
           b.use Customize, "post-boot"
-          b.use WaitForCommunicator, [:starting, :running]
+          b.use WaitForCommunicator, [:starting, :running, :paused]
           b.use Call, IsEnvSet, :cloud_init do |env, b2|
             if env[:result]
               b2.use CloudInitWait

--- a/test/unit/vagrant/action/builtin/wait_for_communicator_test.rb
+++ b/test/unit/vagrant/action/builtin/wait_for_communicator_test.rb
@@ -1,0 +1,58 @@
+require File.expand_path("../../../../base", __FILE__)
+
+describe Vagrant::Action::Builtin::WaitForCommunicator do
+  let(:app) { lambda { |env| } }
+  let(:ui) { lambda { |env| } }
+  let(:env) { { machine: machine, ui: ui } }
+
+  let(:vm) do
+    double("vm",
+      communicator: nil
+    )
+  end
+
+  # Configuration mock
+  let(:config) { double("config", vm: vm) }
+
+  # Communicate mock
+  let(:communicate) { double("communicate") }
+
+  let(:state) { double("state") }
+
+  let(:ui) { Vagrant::UI::Silent.new }
+
+  let(:machine) do
+    double("machine",
+      config: config,
+      communicate: communicate, 
+      state: state,)
+  end
+
+  before do 
+    allow(vm).to receive(:boot_timeout).and_return(1)
+    allow(communicate).to receive(:wait_for_ready).with(1).and_return(true)
+  end
+
+  it "raise an error if a bad state is encountered" do
+    allow(state).to receive(:id).and_return(:stopped)
+    
+    expect { described_class.new(app, env, [:running]).call(env) }.
+    to raise_error(Vagrant::Errors::VMBootBadState)
+  end
+
+  it "raise an error if the vm doesn't boot" do
+    allow(communicate).to receive(:wait_for_ready).and_return(false)
+    allow(state).to receive(:id).and_return(:running)
+    
+    expect { described_class.new(app, env, [:running]).call(env) }.
+    to raise_error(Vagrant::Errors::VMBootTimeout)
+  end
+
+  it "succeed when a valid state is encountered" do
+    allow(communicate).to receive(:wait_for_ready).and_return(true)
+    allow(state).to receive(:id).and_return(:running)
+    
+    expect { described_class.new(app, env, [:running]).call(env) }.
+    to_not raise_error
+  end
+end


### PR DESCRIPTION
When a virtualbox vm is booting initially, allow it to enter the `:paused` state and wait until a new state is entered or the boot_timeout is reached. This allows the GUI menu to be accessed and state selected before it errors, but to still error as expected if the outcome of the selection moves the vm to an invalid state. This matches how previous versions of virtualbox behaved, before the `:paused` state was introduced.

Also adds some simple tests for `WaitForCommunicator`, which came up as I was investigating different ways to address the issue

fixes #13410