### PR TITLE
Add logger and ostruct to the gemspec

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -16,6 +16,8 @@ Gem::Specification.new do |s|
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "base64", "~> 0.2.0"
+  s.add_dependency "logger", "~> 1.6.1"
+  s.add_dependency "ostruct", "~> 0.1.0"
   s.add_dependency "bcrypt_pbkdf", "~> 1.1"
   s.add_dependency "childprocess", "~> 4.1.0"
   s.add_dependency "ed25519", "~> 1.3.0"


### PR DESCRIPTION
logger and ostruct will no longer be the default gem in the Ruby 3.5, without this patch following warning message may come from ruby 3.3+

```
/opt/vagrant/lib/vagrant/patches/net-ssh.rb:4: warning: logger was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add logger to your Gemfile or gemspec to silence this warning.
/usr/lib/ruby/3.3.0/json/common.rb:3: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```
