### PR TITLE
Bump winrm constraint

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rubyzip", "~> 2.3.2"
   s.add_dependency "vagrant_cloud", "~> 3.1.1"
   s.add_dependency "wdm", "~> 0.1.1"
-  s.add_dependency "winrm", ">= 2.3.6", "< 3.0"
+  s.add_dependency "winrm", ">= 2.3.9", "< 3.0"
   s.add_dependency "winrm-elevated", ">= 1.2.3", "< 2.0"
   s.add_dependency "winrm-fs", ">= 1.3.5", "< 2.0"
 


### PR DESCRIPTION
This fixes snakecase errors that may be encountered with the
winrm communicator.
