### PR TITLE
Fix ansible major version extraction

### DIFF
--- a/plugins/provisioners/ansible/provisioner/base.rb
+++ b/plugins/provisioners/ansible/provisioner/base.rb
@@ -393,7 +393,7 @@ gathered version stdout version:
               _, @gathered_version, _ = ansible_version_pattern.captures
               @gathered_version.strip!
               if @gathered_version
-                @gathered_version_major = @gathered_version.match(/(\d)\..+$/).captures[0].to_i
+                @gathered_version_major = @gathered_version.match(/(\d+)\..+$/).captures[0].to_i
               end
             end
           end


### PR DESCRIPTION
While working on a test environment created with vagrant 2.4.1 and the ansible local provisioner I noticed that my provisioning was no longer working since ansible version `10`. See this [issue](https://github.com/eclipse-opendut/opendut/issues/307) for details.

### Error encountered
  ```
  vagrant up --provision --debug
  ```
  vagrant version `2.4.1` detects ansible version `10.5.0` and then chooses ansible compatibility mode with version `1.8` for some reason.
  ```
   INFO ssh: Execute: python3 -c "import importlib.metadata; print('ansible ' + importlib.metadata.version('ansible'))" (sudo=false)       
  DEBUG ssh: stderr: 41e57d38-b4f7-4e46-9c38-13873d338b86-vagrant-ssh                                                                      
  DEBUG ssh: Exit status: 0                                                                                                                
   INFO ansible_guest: Vagrant has automatically selected the compatibility mode '1.8'                                                     
  according to the Ansible version installed (10.5.0).                                                                                     
  ```
  Ansible then adds the no longer existing sudo flag and fails:
  ```
  INFO ssh: Execute: cd /vagrant && PYTHONUNBUFFERED=1 ANSIBLE_FORCE_COLOR=true ANSIBLE_ROLES_PATH='/vagrant/.ci/docker/vagrant/local_roles/:
  /vagrant/.ci/docker/vagrant/downloaded_roles' ansible-playbook --limit="opendut-vm" --inventory-file=/tmp/vagrant-ansible/inventory --extra-
  vars=\{\"opendut_repo_root\":\"/vagrant\"\} --sudo --tags=all --skip-tags=desktop,firefox /vagrant/.ci/docker/vagrant/playbook.yml (sudo=fal
  se)                                                                                                                                         
  DEBUG ssh: stderr: 41e57d38-b4f7-4e46-9c38-13873d338b86-vagrant-ssh                                                                         
  [...]
  ansible-playbook: error: unrecognized arguments: --sudo
  ```

### Root cause

Curious to the cause of this behavior I found a method that is extracting the ansible major version from a string. Now the regular expression apparently captures only the last digit of the first number before a dot. This is not exactly the intended behavior.

* The following snippet resolves version `0` but it should resolve version `10`
  ```
  version_string="ansible 10.5.0"
  ansible_version_pattern = version_string.match(/(^ansible\s+)(.+)$/)
  _, @gathered_version, _ = ansible_version_pattern.captures
  @gathered_version.match(/(\d)\..+$/).captures[0].to_i
  ```

This subsequently leads to vagrant dropping to a compatibility mode that fails the ansible playbook execution. 

Since this is such a minor code change I thought a quick fix is highly appreciated. Looking forward to your thoughts and comments on this.

* Alternative without regex
```
@gathered_version.split(".")[0].to_i
```