### PR TITLE
Force encoding on command output strings

### DIFF
--- a/plugins/providers/virtualbox/driver/base.rb
+++ b/plugins/providers/virtualbox/driver/base.rb
@@ -442,8 +442,8 @@ module VagrantPlugins
             if errored
               raise Vagrant::Errors::VBoxManageError,
                 command: command.inspect,
-                stderr:  r.stderr,
-                stdout:  r.stdout
+                stderr:  r.stderr.to_s.force_encoding("UTF-8"),
+                stdout:  r.stdout.to_s.force_encoding("UTF-8")
             end
           end
 


### PR DESCRIPTION
Incompatible encodings will result in an error when the exception
is translated. The outputs may not be UTF-8 encoded so force
the encoding when providing the values in the exception.

Fixes #13515
