### PR TITLE
Fix overly strict dependency requirement of the logger gem to allow plugin installation

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "i18n", "~> 1.12"
   s.add_dependency "listen", "~> 3.7"
   s.add_dependency "log4r", "~> 1.1.9", "< 1.1.11"
-  s.add_dependency "logger", "~> 1.6.1"
+  s.add_dependency "logger", "~> 1.6.0"
   s.add_dependency "mime-types", "~> 3.3"
   s.add_dependency "net-ftp", "~> 0.2"
   s.add_dependency "net-ssh", "~> 7.0"

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_dependency "i18n", "~> 1.12"
   s.add_dependency "listen", "~> 3.7"
   s.add_dependency "log4r", "~> 1.1.9", "< 1.1.11"
-  s.add_dependency "logger", "~> 1.6.0"
+  s.add_dependency "logger", "~> 1.0"
   s.add_dependency "mime-types", "~> 3.3"
   s.add_dependency "net-ftp", "~> 0.2"
   s.add_dependency "net-ssh", "~> 7.0"


### PR DESCRIPTION
Vagrant version 2.4.2 introduced a patch(512bb74) that sets the logger gem dependency to "~>1.6.1", which is too strict and prevents many Vagrant plugins from being installed.

This patch tones down the dependency specification to mitigate this problem.

Fixes #13527.

Refer-to: Add logger and ostruct to the gemspec by hswong3i · Pull Request #13499 · hashicorp/vagrant <https://github.com/hashicorp/vagrant/pull/13499>

I'm not acquainted with Ruby, RubyGems, and the usage of the `logger` gem in Vagrant, please review.