### PR TITLE
Update runtime dependency activations

### DIFF
--- a/bin/vagrant
+++ b/bin/vagrant
@@ -10,16 +10,6 @@ if Thread.respond_to?(:report_on_exception=)
   Thread.report_on_exception = false
 end
 
-# Activate all the runtime dependencies before
-# moving on.
-begin
-  Gem::Specification.find_by_name("vagrant").runtime_dependencies.each do |dep|
-    gem(dep.name, dep.requirement.as_list)
-  end
-rescue Gem::MissingSpecError
-  $stderr.puts "WARN: Failed to locate vagrant specification for dependency loading"
-end
-
 # Split arguments by "--" if its there, we'll recombine them later
 argv = ARGV.dup
 argv_extra = []
@@ -117,7 +107,6 @@ end
 
 env = nil
 begin
-  require 'log4r'
   require 'vagrant'
   require 'vagrant/bundler'
   require 'vagrant/cli'

--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -1,14 +1,19 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
-require "log4r"
+
+# Load the shared helpers first to make the custom
+# require helper available.
+require "vagrant/shared_helpers"
+
+Vagrant.require "log4r"
 
 # Add patches to log4r to support trace level
-require "vagrant/patches/log4r"
-require "vagrant/patches/net-ssh"
-require "vagrant/patches/rubygems"
+Vagrant.require "vagrant/patches/log4r"
+Vagrant.require "vagrant/patches/net-ssh"
+Vagrant.require "vagrant/patches/rubygems"
 
 # Set our log levels and include trace
-require 'log4r/configurator'
+Vagrant.require 'log4r/configurator'
 Log4r::Configurator.custom_levels(*(["TRACE"] + Log4r::Log4rConfig::LogLevels))
 
 # Update the default formatter within the log4r library to ensure
@@ -20,7 +25,7 @@ class Log4r::BasicFormatter
   end
 end
 
-require "optparse"
+Vagrant.require "optparse"
 
 module Vagrant
   # This is a customized OptionParser for Vagrant plugins. It
@@ -45,10 +50,9 @@ module VagrantPlugins
 end
 
 # Load in our helpers and utilities
-require "vagrant/shared_helpers"
-require "rubygems"
-require "vagrant/util"
-require "vagrant/plugin/manager"
+Vagrant.require "rubygems"
+Vagrant.require "vagrant/util"
+Vagrant.require "vagrant/plugin/manager"
 
 # Enable logging if it is requested. We do this before
 # anything else so that we can setup the output before
@@ -105,19 +109,19 @@ if ENV["VAGRANT_LOG"] && ENV["VAGRANT_LOG"] != ""
   end
 end
 
-require 'json'
-require 'pathname'
-require 'stringio'
+Vagrant.require 'json'
+Vagrant.require 'pathname'
+Vagrant.require 'stringio'
 
-require 'childprocess'
-require 'i18n'
+Vagrant.require 'childprocess'
+Vagrant.require 'i18n'
 
 # OpenSSL must be loaded here since when it is loaded via `autoload`
 # there are issues with ciphers not being properly loaded.
-require 'openssl'
+Vagrant.require 'openssl'
 
 # Always make the version available
-require 'vagrant/version'
+Vagrant.require 'vagrant/version'
 global_logger = Log4r::Logger.new("vagrant::global")
 Vagrant.global_logger = global_logger
 global_logger.info("Vagrant version: #{Vagrant::VERSION}")
@@ -138,7 +142,7 @@ vagrant_ssl_locations = [
 if vagrant_ssl_locations.any? { |f| File.exist?(f) }
   global_logger.debug("vagrant ssl helper found for loading ssl providers")
   begin
-    require "vagrant/vagrant_ssl"
+    Vagrant.require "vagrant/vagrant_ssl"
     Vagrant.vagrant_ssl_load
     global_logger.debug("ssl providers successfully loaded")
   rescue LoadError => err
@@ -152,8 +156,8 @@ end
 
 # We need these components always so instead of an autoload we
 # just require them explicitly here.
-require "vagrant/plugin"
-require "vagrant/registry"
+Vagrant.require "vagrant/plugin"
+Vagrant.require "vagrant/registry"
 
 module Vagrant
   autoload :Action,         'vagrant/action'
@@ -230,7 +234,7 @@ module Vagrant
     end
 
     # Now check the plugin gem names
-    require "vagrant/plugin/manager"
+    Vagrant.require "vagrant/plugin/manager"
     Plugin::Manager.instance.plugin_installed?(name, version)
   end
 

--- a/lib/vagrant/action.rb
+++ b/lib/vagrant/action.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'vagrant/action/builder'
+Vagrant.require 'vagrant/action/builder'
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -1,16 +1,16 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "digest/sha1"
-require "log4r"
-require "pathname"
-require "uri"
+Vagrant.require "digest/sha1"
+Vagrant.require "log4r"
+Vagrant.require "pathname"
+Vagrant.require "uri"
 
-require "vagrant/box_metadata"
-require "vagrant/util/downloader"
-require "vagrant/util/file_checksum"
-require "vagrant/util/file_mutex"
-require "vagrant/util/platform"
+Vagrant.require "vagrant/box_metadata"
+Vagrant.require "vagrant/util/downloader"
+Vagrant.require "vagrant/util/file_checksum"
+Vagrant.require "vagrant/util/file_mutex"
+Vagrant.require "vagrant/util/platform"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/box_check_outdated.rb
+++ b/lib/vagrant/action/builtin/box_check_outdated.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/box_remove.rb
+++ b/lib/vagrant/action/builtin/box_remove.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/box_update.rb
+++ b/lib/vagrant/action/builtin/box_update.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/cleanup_disks.rb
+++ b/lib/vagrant/action/builtin/cleanup_disks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "json"
+Vagrant.require "json"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/cloud_init_setup.rb
+++ b/lib/vagrant/action/builtin/cloud_init_setup.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'vagrant/util/mime'
-require 'tmpdir'
+Vagrant.require 'vagrant/util/mime'
+Vagrant.require 'tmpdir'
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/cloud_init_wait.rb
+++ b/lib/vagrant/action/builtin/cloud_init_wait.rb
@@ -1,6 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
+Vagrant.require "log4r"
+
 module Vagrant
   module Action
     module Builtin

--- a/lib/vagrant/action/builtin/config_validate.rb
+++ b/lib/vagrant/action/builtin/config_validate.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/util/template_renderer"
+Vagrant.require "vagrant/util/template_renderer"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/disk.rb
+++ b/lib/vagrant/action/builtin/disk.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "json"
+Vagrant.require "json"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/graceful_halt.rb
+++ b/lib/vagrant/action/builtin/graceful_halt.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-require "timeout"
+Vagrant.require "log4r"
+Vagrant.require "timeout"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/handle_box.rb
+++ b/lib/vagrant/action/builtin/handle_box.rb
@@ -1,9 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "thread"
-
-require "log4r"
+Vagrant.require "thread"
+Vagrant.require "log4r"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
+++ b/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
@@ -1,13 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "set"
+Vagrant.require "set"
+Vagrant.require "log4r"
+Vagrant.require "socket"
 
-require "log4r"
-require "socket"
-
-require "vagrant/util/is_port_open"
-require "vagrant/util/ipv4_interfaces"
+Vagrant.require "vagrant/util/is_port_open"
+Vagrant.require "vagrant/util/ipv4_interfaces"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/lock.rb
+++ b/lib/vagrant/action/builtin/lock.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/mixin_synced_folders.rb
+++ b/lib/vagrant/action/builtin/mixin_synced_folders.rb
@@ -1,10 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "json"
-require "set"
-
-require 'vagrant/util/scoped_hash_override'
+Vagrant.require "json"
+Vagrant.require "set"
+Vagrant.require 'vagrant/util/scoped_hash_override'
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/prepare_clone.rb
+++ b/lib/vagrant/action/builtin/prepare_clone.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/provision.rb
+++ b/lib/vagrant/action/builtin/provision.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 require_relative "mixin_provisioners"
 

--- a/lib/vagrant/action/builtin/provisioner_cleanup.rb
+++ b/lib/vagrant/action/builtin/provisioner_cleanup.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 require_relative "mixin_provisioners"
 

--- a/lib/vagrant/action/builtin/set_hostname.rb
+++ b/lib/vagrant/action/builtin/set_hostname.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/ssh_exec.rb
+++ b/lib/vagrant/action/builtin/ssh_exec.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
+Vagrant.require "pathname"
 
-require "vagrant/util/ssh"
+Vagrant.require "vagrant/util/ssh"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/ssh_run.rb
+++ b/lib/vagrant/action/builtin/ssh_run.rb
@@ -1,11 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
-require "vagrant/util/platform"
-require "vagrant/util/ssh"
-require "vagrant/util/shell_quote"
+Vagrant.require "vagrant/util/platform"
+Vagrant.require "vagrant/util/ssh"
+Vagrant.require "vagrant/util/shell_quote"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/synced_folder_cleanup.rb
+++ b/lib/vagrant/action/builtin/synced_folder_cleanup.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 require_relative "mixin_synced_folders"
 

--- a/lib/vagrant/action/builtin/synced_folders.rb
+++ b/lib/vagrant/action/builtin/synced_folders.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
-require 'vagrant/util/platform'
+Vagrant.require 'vagrant/util/platform'
 
 require_relative "mixin_synced_folders"
 

--- a/lib/vagrant/action/general/package.rb
+++ b/lib/vagrant/action/general/package.rb
@@ -1,12 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'fileutils'
-require "pathname"
-
-require 'vagrant/util/safe_chdir'
-require 'vagrant/util/subprocess'
-require 'vagrant/util/presence'
+Vagrant.require 'fileutils'
+Vagrant.require "pathname"
+Vagrant.require 'vagrant/util/safe_chdir'
+Vagrant.require 'vagrant/util/subprocess'
+Vagrant.require 'vagrant/util/presence'
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/general/package_setup_folders.rb
+++ b/lib/vagrant/action/general/package_setup_folders.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "fileutils"
+Vagrant.require "fileutils"
 require_relative "package"
 
 module Vagrant

--- a/lib/vagrant/action/runner.rb
+++ b/lib/vagrant/action/runner.rb
@@ -1,11 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'log4r'
+Vagrant.require 'log4r'
 
-require 'vagrant/action/hook'
-require 'vagrant/util/busy'
-require 'vagrant/util/experimental'
+Vagrant.require 'vagrant/action/hook'
+Vagrant.require 'vagrant/util/busy'
+Vagrant.require 'vagrant/util/experimental'
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/warden.rb
+++ b/lib/vagrant/action/warden.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-require 'vagrant/util/experimental'
+Vagrant.require "log4r"
+Vagrant.require 'vagrant/util/experimental'
 
 module Vagrant
   module Action

--- a/lib/vagrant/alias.rb
+++ b/lib/vagrant/alias.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/registry"
+Vagrant.require "vagrant/registry"
 
 module Vagrant
   # This class imports and processes CLI aliases stored in ~/.vagrant.d/aliases

--- a/lib/vagrant/batch_action.rb
+++ b/lib/vagrant/batch_action.rb
@@ -1,9 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'thread'
-
-require "log4r"
+Vagrant.require 'thread'
+Vagrant.require "log4r"
 
 module Vagrant
   # This class executes multiple actions as a single batch, parallelizing

--- a/lib/vagrant/box.rb
+++ b/lib/vagrant/box.rb
@@ -1,17 +1,17 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'fileutils'
-require "tempfile"
+Vagrant.require 'fileutils'
+Vagrant.require "tempfile"
 
-require "json"
-require "log4r"
+Vagrant.require "json"
+Vagrant.require "log4r"
 
-require "vagrant/box_metadata"
-require "vagrant/util/downloader"
-require "vagrant/util/platform"
-require "vagrant/util/safe_chdir"
-require "vagrant/util/subprocess"
+Vagrant.require "vagrant/box_metadata"
+Vagrant.require "vagrant/util/downloader"
+Vagrant.require "vagrant/util/platform"
+Vagrant.require "vagrant/util/safe_chdir"
+Vagrant.require "vagrant/util/subprocess"
 
 module Vagrant
   # Represents a "box," which is a package Vagrant environment that is used

--- a/lib/vagrant/box_collection.rb
+++ b/lib/vagrant/box_collection.rb
@@ -1,15 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "digest/sha1"
-require "fileutils"
-require "monitor"
-require "tmpdir"
-
-require "log4r"
-
-require "vagrant/util/platform"
-require "vagrant/util/subprocess"
+Vagrant.require "digest/sha1"
+Vagrant.require "fileutils"
+Vagrant.require "monitor"
+Vagrant.require "tmpdir"
+Vagrant.require "log4r"
+Vagrant.require "vagrant/util/platform"
+Vagrant.require "vagrant/util/subprocess"
 
 module Vagrant
   # Represents a collection a boxes found on disk. This provides methods

--- a/lib/vagrant/box_metadata.rb
+++ b/lib/vagrant/box_metadata.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "json"
+Vagrant.require "json"
 
 module Vagrant
   # BoxMetadata represents metadata about a box, including the name

--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -1,16 +1,16 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "monitor"
-require "pathname"
-require "set"
-require "tempfile"
-require "fileutils"
-require "uri"
+Vagrant.require "monitor"
+Vagrant.require "pathname"
+Vagrant.require "set"
+Vagrant.require "tempfile"
+Vagrant.require "fileutils"
+Vagrant.require "uri"
 
-require "rubygems/package"
-require "rubygems/uninstaller"
-require "rubygems/name_tuple"
+Vagrant.require "rubygems/package"
+Vagrant.require "rubygems/uninstaller"
+Vagrant.require "rubygems/name_tuple"
 
 require_relative "shared_helpers"
 require_relative "version"

--- a/lib/vagrant/cli.rb
+++ b/lib/vagrant/cli.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'log4r'
-require 'optparse'
+Vagrant.require 'log4r'
+Vagrant.require 'optparse'
 
-require 'vagrant/util/experimental'
+Vagrant.require 'vagrant/util/experimental'
 
 module Vagrant
   # Manages the command line interface to Vagrant.

--- a/lib/vagrant/config.rb
+++ b/lib/vagrant/config.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/registry"
+Vagrant.require "vagrant/registry"
 
 module Vagrant
   module Config

--- a/lib/vagrant/config/v1/loader.rb
+++ b/lib/vagrant/config/v1/loader.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/config/v1/root"
+Vagrant.require "vagrant/config/v1/root"
 
 module Vagrant
   module Config

--- a/lib/vagrant/config/v1/root.rb
+++ b/lib/vagrant/config/v1/root.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "set"
+Vagrant.require "set"
 
 module Vagrant
   module Config

--- a/lib/vagrant/config/v2/loader.rb
+++ b/lib/vagrant/config/v2/loader.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/config/v2/root"
+Vagrant.require "vagrant/config/v2/root"
 
 module Vagrant
   module Config

--- a/lib/vagrant/config/v2/root.rb
+++ b/lib/vagrant/config/v2/root.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "set"
+Vagrant.require "set"
 
-require "vagrant/config/v2/util"
+Vagrant.require "vagrant/config/v2/util"
 
 module Vagrant
   module Config

--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -1,20 +1,20 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'fileutils'
-require 'json'
-require 'pathname'
-require 'set'
-require 'thread'
+Vagrant.require 'fileutils'
+Vagrant.require 'json'
+Vagrant.require 'pathname'
+Vagrant.require 'set'
+Vagrant.require 'thread'
 
-require 'log4r'
+Vagrant.require 'log4r'
 
-require 'vagrant/util/file_mode'
-require 'vagrant/util/platform'
-require 'vagrant/util/hash_with_indifferent_access'
-require "vagrant/util/silence_warnings"
-require "vagrant/vagrantfile"
-require "vagrant/version"
+Vagrant.require 'vagrant/util/file_mode'
+Vagrant.require 'vagrant/util/platform'
+Vagrant.require 'vagrant/util/hash_with_indifferent_access'
+Vagrant.require "vagrant/util/silence_warnings"
+Vagrant.require "vagrant/vagrantfile"
+Vagrant.require "vagrant/version"
 
 module Vagrant
   # A "Vagrant environment" represents a configuration of how Vagrant

--- a/lib/vagrant/environment/remote.rb
+++ b/lib/vagrant/environment/remote.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'vagrant/machine_index/remote'
+Vagrant.require 'vagrant/machine_index/remote'
 
 module Vagrant
   class Environment

--- a/lib/vagrant/guest.rb
+++ b/lib/vagrant/guest.rb
@@ -1,9 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-
-require "vagrant/capability_host"
+Vagrant.require "log4r"
+Vagrant.require "vagrant/capability_host"
 
 module Vagrant
   # This class handles guest-OS specific interactions with a machine.

--- a/lib/vagrant/host.rb
+++ b/lib/vagrant/host.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/capability_host"
+Vagrant.require "vagrant/capability_host"
 
 module Vagrant
   # This class handles host-OS specific interactions. It is responsible for

--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -4,10 +4,9 @@
 require_relative "./util/ssh"
 require_relative "./action/builtin/mixin_synced_folders"
 
-require "digest/md5"
-require "thread"
-
-require "log4r"
+Vagrant.require "digest/md5"
+Vagrant.require "thread"
+Vagrant.require "log4r"
 
 module Vagrant
   # This represents a machine that Vagrant manages. This provides a singular

--- a/lib/vagrant/machine/remote.rb
+++ b/lib/vagrant/machine/remote.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'ostruct'
-require "vagrant/util/scoped_hash_override"
+Vagrant.require 'ostruct'
+Vagrant.require "vagrant/util/scoped_hash_override"
 
 module Vagrant
   class Machine

--- a/lib/vagrant/machine_index.rb
+++ b/lib/vagrant/machine_index.rb
@@ -1,12 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "json"
-require "pathname"
-require "securerandom"
-require "thread"
+Vagrant.require "json"
+Vagrant.require "pathname"
+Vagrant.require "securerandom"
+Vagrant.require "thread"
 
-require "vagrant/util/silence_warnings"
+Vagrant.require "vagrant/util/silence_warnings"
 
 module Vagrant
   # MachineIndex is able to manage the index of created Vagrant environments

--- a/lib/vagrant/patches/fake_ftp.rb
+++ b/lib/vagrant/patches/fake_ftp.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "fake_ftp"
+Vagrant.require "fake_ftp"
 
 module FakeFtp
   class File

--- a/lib/vagrant/patches/log4r.rb
+++ b/lib/vagrant/patches/log4r.rb
@@ -6,7 +6,7 @@
 # information should be included in the output, we
 # make some modifications to allow the trace check to
 # still work while also supporting trace as a valid level
-require "log4r/loggerfactory"
+Vagrant.require "log4r/loggerfactory"
 
 if !Log4r::Logger::LoggerFactory.respond_to?(:fake_define_methods)
   class Log4r::Logger::LoggerFactory

--- a/lib/vagrant/patches/net-ssh.rb
+++ b/lib/vagrant/patches/net-ssh.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "net/ssh"
-require "net/ssh/buffer"
+Vagrant.require "net/ssh"
+Vagrant.require "net/ssh/buffer"
 
 # Set the version requirement for when net-ssh should be patched
 NET_SSH_PATCH_REQUIREMENT = Gem::Requirement.new(">= 7.0.0", "<= 7.3")

--- a/lib/vagrant/plugin/manager.rb
+++ b/lib/vagrant/plugin/manager.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
-require "set"
+Vagrant.require "pathname"
+Vagrant.require "set"
 
 require_relative "../bundler"
 require_relative "../shared_helpers"

--- a/lib/vagrant/plugin/remote.rb
+++ b/lib/vagrant/plugin/remote.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/remote/manager.rb
+++ b/lib/vagrant/plugin/remote/manager.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/state_file.rb
+++ b/lib/vagrant/plugin/state_file.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "json"
-require "fileutils"
-require "tempfile"
+Vagrant.require "json"
+Vagrant.require "fileutils"
+Vagrant.require "tempfile"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v1.rb
+++ b/lib/vagrant/plugin/v1.rb
@@ -1,9 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-
-require "vagrant/plugin/v1/errors"
+Vagrant.require "log4r"
+Vagrant.require "vagrant/plugin/v1/errors"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v1/command.rb
+++ b/lib/vagrant/plugin/v1/command.rb
@@ -1,9 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'log4r'
-
-require "vagrant/util/safe_puts"
+Vagrant.require 'log4r'
+Vagrant.require "vagrant/util/safe_puts"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v1/manager.rb
+++ b/lib/vagrant/plugin/v1/manager.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v1/plugin.rb
+++ b/lib/vagrant/plugin/v1/plugin.rb
@@ -1,9 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "set"
-
-require "log4r"
+Vagrant.require "set"
+Vagrant.require "log4r"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v2.rb
+++ b/lib/vagrant/plugin/v2.rb
@@ -1,12 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 # We don't autoload components because if we're loading anything in the
 # V2 namespace anyways, then we're going to need the Components class.
-require "vagrant/plugin/v2/components"
-require "vagrant/plugin/v2/errors"
+Vagrant.require "vagrant/plugin/v2/components"
+Vagrant.require "vagrant/plugin/v2/errors"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v2/command.rb
+++ b/lib/vagrant/plugin/v2/command.rb
@@ -1,9 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'log4r'
-
-require "vagrant/util/safe_puts"
+Vagrant.require 'log4r'
+Vagrant.require "vagrant/util/safe_puts"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v2/communicator.rb
+++ b/lib/vagrant/plugin/v2/communicator.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "timeout"
+Vagrant.require "timeout"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v2/config.rb
+++ b/lib/vagrant/plugin/v2/config.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "set"
+Vagrant.require "set"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v2/manager.rb
+++ b/lib/vagrant/plugin/v2/manager.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v2/plugin.rb
+++ b/lib/vagrant/plugin/v2/plugin.rb
@@ -1,11 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "set"
-
-require "log4r"
-
-require "vagrant/plugin/v2/components"
+Vagrant.require "set"
+Vagrant.require "log4r"
+Vagrant.require "vagrant/plugin/v2/components"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v2/provider.rb
+++ b/lib/vagrant/plugin/v2/provider.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/capability_host"
+Vagrant.require "vagrant/capability_host"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v2/trigger.rb
+++ b/lib/vagrant/plugin/v2/trigger.rb
@@ -1,14 +1,14 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'fileutils'
-require 'log4r'
-require 'shellwords'
+Vagrant.require 'fileutils'
+Vagrant.require 'log4r'
+Vagrant.require 'shellwords'
 
-require Vagrant.source_root.join("plugins/provisioners/shell/provisioner")
-require "vagrant/util/subprocess"
-require "vagrant/util/platform"
-require "vagrant/util/powershell"
+Vagrant.require Vagrant.source_root.join("plugins/provisioners/shell/provisioner")
+Vagrant.require "vagrant/util/subprocess"
+Vagrant.require "vagrant/util/platform"
+Vagrant.require "vagrant/util/powershell"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/shared_helpers.rb
+++ b/lib/vagrant/shared_helpers.rb
@@ -168,7 +168,7 @@ module Vagrant
     if ENV["VAGRANT_ENABLE_RESOLV_REPLACE"]
       if !ENV["VAGRANT_DISABLE_RESOLV_REPLACE"]
         begin
-          require "resolv-replace"
+          Vagrant.require "resolv-replace"
           true
         rescue
           false
@@ -192,7 +192,7 @@ module Vagrant
   # @return [Logger]
   def self.global_logger
     if @_global_logger.nil?
-      require "log4r"
+      Vagrant.require "log4r"
       @_global_logger = Log4r::Logger.new("vagrant::global")
     end
     @_global_logger
@@ -224,6 +224,68 @@ module Vagrant
   def self.default_cli_options
     @_default_cli_options = [] if !@_default_cli_options
     @_default_cli_options.dup
+  end
+
+  # Loads the provided path. If the base of the path
+  # is a Vagrant runtime dependency, the gem will be
+  # activated with the proper constraint first.
+  #
+  # NOTE: This is currently disabled by default and
+  # will transition to enabled by default as more
+  # non-installer based environments are tested.
+  #
+  # @return [nil]
+  def self.require(path)
+    catch(:activation_complete) do
+      # If activation is not enabled, don't attempt activation
+      throw :activation_complete if ENV["VAGRANT_ENABLE_GEM_ACTIVATION"].nil?
+
+      # If it's a vagrant path, don't do anything.
+      throw :activation_complete if path.to_s.start_with?("vagrant/")
+
+      # Attempt to fetch the vagrant specification
+      if @_vagrant_spec.nil?
+        @_vagrant_activated_dependencies = {}
+        begin
+          @_vagrant_spec = Gem::Specification.find_by_name("vagrant")
+        rescue Gem::MissingSpecError
+          # If it couldn't be found, print a warning to stderr and bail
+          if !@_spec_load_failure_warning
+            $stderr.puts "WARN: Failed to locate vagrant specification for dependency loading"
+            @_spec_load_failure_warning = true
+          end
+
+          throw :activation_complete
+        end
+      end
+
+      # Attempt to get the name of the gem by the given path
+      dep_name = Gem::Specification.find_by_path(path)&.name
+
+      # Bail if a dependency name cannot be determined
+      throw :activation_complete if dep_name.nil?
+
+      # Bail if already activated
+      throw :activation_complete if @_vagrant_activated_dependencies[dep_name]
+
+      # Extract the dependency from the runtime dependency list
+      dependency = @_vagrant_spec.runtime_dependencies.detect do |d|
+        d.name == dep_name
+      end
+
+      # If the dependency isn't found, bail
+      throw :activation_complete if dependency.nil?
+
+      # Activate the gem
+      gem(dependency.name, dependency.requirement.as_list)
+puts "Activated: #{dependency.name}"
+      @_vagrant_activated_dependencies[dependency.name] = true
+    end
+
+    # Finally, require the provided path.
+    ::Kernel.require(path)
+
+    nil
   end
 
   # Check if Vagrant is running in server mode

--- a/lib/vagrant/ui.rb
+++ b/lib/vagrant/ui.rb
@@ -1,14 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "delegate"
-require "io/console"
-require "thread"
-
-require "log4r"
-
-require "vagrant/util/platform"
-require "vagrant/util/safe_puts"
+Vagrant.require "delegate"
+Vagrant.require "io/console"
+Vagrant.require "thread"
+Vagrant.require "log4r"
+Vagrant.require "vagrant/util/platform"
+Vagrant.require "vagrant/util/safe_puts"
 
 module Vagrant
   module UI

--- a/lib/vagrant/util/caps.rb
+++ b/lib/vagrant/util/caps.rb
@@ -1,11 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
-require "fileutils"
-require "pathname"
-require "vagrant/util/directory"
-require "vagrant/util/subprocess"
+Vagrant.require "tempfile"
+Vagrant.require "fileutils"
+Vagrant.require "pathname"
+Vagrant.require "vagrant/util/directory"
+Vagrant.require "vagrant/util/subprocess"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/checkpoint_client.rb
+++ b/lib/vagrant/util/checkpoint_client.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-require "singleton"
+Vagrant.require "log4r"
+Vagrant.require "singleton"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/counter.rb
+++ b/lib/vagrant/util/counter.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'thread'
+Vagrant.require 'thread'
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/directory.rb
+++ b/lib/vagrant/util/directory.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'pathname'
+Vagrant.require 'pathname'
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -1,18 +1,18 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "cgi"
-require "uri"
+Vagrant.require "cgi"
+Vagrant.require "uri"
 
-require "log4r"
-require "digest"
-require "digest/md5"
-require "digest/sha1"
-require "vagrant/util/busy"
-require "vagrant/util/platform"
-require "vagrant/util/subprocess"
-require "vagrant/util/curl_helper"
-require "vagrant/util/file_checksum"
+Vagrant.require "log4r"
+Vagrant.require "digest"
+Vagrant.require "digest/md5"
+Vagrant.require "digest/sha1"
+Vagrant.require "vagrant/util/busy"
+Vagrant.require "vagrant/util/platform"
+Vagrant.require "vagrant/util/subprocess"
+Vagrant.require "vagrant/util/curl_helper"
+Vagrant.require "vagrant/util/file_checksum"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/file_checksum.rb
+++ b/lib/vagrant/util/file_checksum.rb
@@ -6,7 +6,7 @@
 # the moment, and this class isn't directly used. It is merely here for
 # documentation of structure of the class.
 
-require "vagrant/errors"
+Vagrant.require "vagrant/errors"
 
 class DigestClass
   def update(string); end

--- a/lib/vagrant/util/io.rb
+++ b/lib/vagrant/util/io.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/util/platform"
+Vagrant.require "vagrant/util/platform"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/is_port_open.rb
+++ b/lib/vagrant/util/is_port_open.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "socket"
+Vagrant.require "socket"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/keypair.rb
+++ b/lib/vagrant/util/keypair.rb
@@ -1,11 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "base64"
-require "ed25519"
-require "securerandom"
+Vagrant.require "base64"
+Vagrant.require "ed25519"
+Vagrant.require "securerandom"
 
-require "vagrant/util/retryable"
+Vagrant.require "vagrant/util/retryable"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/logging_formatter.rb
+++ b/lib/vagrant/util/logging_formatter.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/util/credential_scrubber"
-require "log4r/formatter/formatter"
+Vagrant.require "vagrant/util/credential_scrubber"
+Vagrant.require "log4r/formatter/formatter"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/mime.rb
+++ b/lib/vagrant/util/mime.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'mime/types'
-require 'securerandom'
+Vagrant.require 'mime/types'
+Vagrant.require 'securerandom'
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/network_ip.rb
+++ b/lib/vagrant/util/network_ip.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "ipaddr"
+Vagrant.require "ipaddr"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -1,15 +1,15 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "rbconfig"
-require "shellwords"
-require "tempfile"
-require "tmpdir"
-require "log4r"
+Vagrant.require "rbconfig"
+Vagrant.require "shellwords"
+Vagrant.require "tempfile"
+Vagrant.require "tmpdir"
+Vagrant.require "log4r"
 
-require "vagrant/util/subprocess"
-require "vagrant/util/powershell"
-require "vagrant/util/which"
+Vagrant.require "vagrant/util/subprocess"
+Vagrant.require "vagrant/util/powershell"
+Vagrant.require "vagrant/util/which"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/powershell.rb
+++ b/lib/vagrant/util/powershell.rb
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "base64"
-require "tmpdir"
+Vagrant.require "base64"
+Vagrant.require "tmpdir"
+
 require_relative "subprocess"
 require_relative "which"
 

--- a/lib/vagrant/util/retryable.rb
+++ b/lib/vagrant/util/retryable.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/safe_chdir.rb
+++ b/lib/vagrant/util/safe_chdir.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'thread'
+Vagrant.require 'thread'
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/ssh.rb
+++ b/lib/vagrant/util/ssh.rb
@@ -1,16 +1,16 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
-require 'childprocess'
+Vagrant.require 'childprocess'
 
-require "vagrant/util/file_mode"
-require "vagrant/util/platform"
-require "vagrant/util/safe_exec"
-require "vagrant/util/safe_puts"
-require "vagrant/util/subprocess"
-require "vagrant/util/which"
+Vagrant.require "vagrant/util/file_mode"
+Vagrant.require "vagrant/util/platform"
+Vagrant.require "vagrant/util/safe_exec"
+Vagrant.require "vagrant/util/safe_puts"
+Vagrant.require "vagrant/util/subprocess"
+Vagrant.require "vagrant/util/which"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/subprocess.rb
+++ b/lib/vagrant/util/subprocess.rb
@@ -1,15 +1,15 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'thread'
+Vagrant.require 'thread'
 
-require 'childprocess'
-require 'log4r'
+Vagrant.require 'childprocess'
+Vagrant.require 'log4r'
 
-require 'vagrant/util/io'
-require 'vagrant/util/platform'
-require 'vagrant/util/safe_chdir'
-require 'vagrant/util/which'
+Vagrant.require 'vagrant/util/io'
+Vagrant.require 'vagrant/util/platform'
+Vagrant.require 'vagrant/util/safe_chdir'
+Vagrant.require 'vagrant/util/which'
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/template_renderer.rb
+++ b/lib/vagrant/util/template_renderer.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'ostruct'
-require "pathname"
+Vagrant.require 'ostruct'
+Vagrant.require "pathname"
 
-require 'erubi'
+Vagrant.require 'erubi'
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/uploader.rb
+++ b/lib/vagrant/util/uploader.rb
@@ -1,13 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "uri"
+Vagrant.require "uri"
 
-require "log4r"
-require "vagrant/util/busy"
-require "vagrant/util/platform"
-require "vagrant/util/subprocess"
-require "vagrant/util/curl_helper"
+Vagrant.require "log4r"
+Vagrant.require "vagrant/util/busy"
+Vagrant.require "vagrant/util/platform"
+Vagrant.require "vagrant/util/subprocess"
+Vagrant.require "vagrant/util/curl_helper"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/which.rb
+++ b/lib/vagrant/util/which.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/util/platform"
+Vagrant.require "vagrant/util/platform"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/windows_path.rb
+++ b/lib/vagrant/util/windows_path.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "fiddle/import"
+Vagrant.require "fiddle/import"
 
 module Vagrant
   module Util

--- a/lib/vagrant/vagrantfile.rb
+++ b/lib/vagrant/vagrantfile.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/util/template_renderer"
-require "log4r"
+Vagrant.require "vagrant/util/template_renderer"
+Vagrant.require "log4r"
 
 module Vagrant
   # This class provides a way to load and access the contents

--- a/plugins/commands/autocomplete/command/install.rb
+++ b/plugins/commands/autocomplete/command/install.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 require 'vagrant/util/install_cli_autocomplete'
 

--- a/plugins/commands/autocomplete/command/root.rb
+++ b/plugins/commands/autocomplete/command/root.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "optparse"
+Vagrant.require "optparse"
 require 'vagrant/util/install_cli_autocomplete'
 
 module VagrantPlugins

--- a/plugins/commands/box/command/add.rb
+++ b/plugins/commands/box/command/add.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 require_relative 'download_mixins'
 

--- a/plugins/commands/box/command/list.rb
+++ b/plugins/commands/box/command/list.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandBox

--- a/plugins/commands/box/command/outdated.rb
+++ b/plugins/commands/box/command/outdated.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 require_relative 'download_mixins'
 

--- a/plugins/commands/box/command/prune.rb
+++ b/plugins/commands/box/command/prune.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandBox

--- a/plugins/commands/box/command/remove.rb
+++ b/plugins/commands/box/command/remove.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandBox

--- a/plugins/commands/box/command/repackage.rb
+++ b/plugins/commands/box/command/repackage.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "fileutils"
-require 'optparse'
-require "pathname"
+Vagrant.require "fileutils"
+Vagrant.require 'optparse'
+Vagrant.require "pathname"
 
 module VagrantPlugins
   module CommandBox

--- a/plugins/commands/box/command/root.rb
+++ b/plugins/commands/box/command/root.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandBox

--- a/plugins/commands/box/command/update.rb
+++ b/plugins/commands/box/command/update.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 require_relative 'download_mixins'
 

--- a/plugins/commands/cap/command.rb
+++ b/plugins/commands/cap/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandCap

--- a/plugins/commands/cloud/auth/login.rb
+++ b/plugins/commands/cloud/auth/login.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/auth/logout.rb
+++ b/plugins/commands/cloud/auth/logout.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/auth/middleware/add_authentication.rb
+++ b/plugins/commands/cloud/auth/middleware/add_authentication.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "cgi"
-require "uri"
-require "log4r"
+Vagrant.require "cgi"
+Vagrant.require "uri"
+Vagrant.require "log4r"
 
 require Vagrant.source_root.join("plugins/commands/cloud/client/client")
 

--- a/plugins/commands/cloud/auth/middleware/add_downloader_authentication.rb
+++ b/plugins/commands/cloud/auth/middleware/add_downloader_authentication.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "cgi"
-require "uri"
+Vagrant.require "cgi"
+Vagrant.require "uri"
+Vagrant.require "vagrant/util/credential_scrubber"
 
-require "vagrant/util/credential_scrubber"
 require_relative "./add_authentication"
 
 require Vagrant.source_root.join("plugins/commands/cloud/client/client")

--- a/plugins/commands/cloud/auth/whoami.rb
+++ b/plugins/commands/cloud/auth/whoami.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/box/create.rb
+++ b/plugins/commands/cloud/box/create.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/box/delete.rb
+++ b/plugins/commands/cloud/box/delete.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/box/show.rb
+++ b/plugins/commands/cloud/box/show.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/box/update.rb
+++ b/plugins/commands/cloud/box/update.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/client/client.rb
+++ b/plugins/commands/cloud/client/client.rb
@@ -1,9 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant_cloud"
-require "vagrant/util/downloader"
-require "vagrant/util/presence"
+Vagrant.require "vagrant_cloud"
+Vagrant.require "vagrant/util/downloader"
+Vagrant.require "vagrant/util/presence"
+
 require Vagrant.source_root.join("plugins/commands/cloud/errors")
 
 module VagrantPlugins

--- a/plugins/commands/cloud/list.rb
+++ b/plugins/commands/cloud/list.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/plugin.rb
+++ b/plugins/commands/cloud/plugin.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant"
-require 'vagrant_cloud'
+Vagrant.require 'vagrant_cloud'
+
 require Vagrant.source_root.join("plugins/commands/cloud/util")
 require Vagrant.source_root.join("plugins/commands/cloud/client/client")
 

--- a/plugins/commands/cloud/provider/create.rb
+++ b/plugins/commands/cloud/provider/create.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/provider/delete.rb
+++ b/plugins/commands/cloud/provider/delete.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/provider/update.rb
+++ b/plugins/commands/cloud/provider/update.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/provider/upload.rb
+++ b/plugins/commands/cloud/provider/upload.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
-require "vagrant/util/uploader"
+Vagrant.require 'optparse'
+Vagrant.require "vagrant/util/uploader"
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/publish.rb
+++ b/plugins/commands/cloud/publish.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
-require "vagrant/util/uploader"
+Vagrant.require 'optparse'
+Vagrant.require "vagrant/util/uploader"
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/search.rb
+++ b/plugins/commands/cloud/search.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/version/release.rb
+++ b/plugins/commands/cloud/version/release.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/version/revoke.rb
+++ b/plugins/commands/cloud/version/revoke.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/version/update.rb
+++ b/plugins/commands/cloud/version/update.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/global-status/command.rb
+++ b/plugins/commands/global-status/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandGlobalStatus

--- a/plugins/commands/halt/command.rb
+++ b/plugins/commands/halt/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandHalt

--- a/plugins/commands/help/command.rb
+++ b/plugins/commands/help/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandHelp

--- a/plugins/commands/init/command.rb
+++ b/plugins/commands/init/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 require 'vagrant/util/template_renderer'
 

--- a/plugins/commands/list-commands/command.rb
+++ b/plugins/commands/list-commands/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "optparse"
+Vagrant.require "optparse"
 
 module VagrantPlugins
   module CommandListCommands

--- a/plugins/commands/package/command.rb
+++ b/plugins/commands/package/command.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
-require 'securerandom'
+Vagrant.require 'optparse'
+Vagrant.require 'securerandom'
 
 module VagrantPlugins
   module CommandPackage

--- a/plugins/commands/plugin/action.rb
+++ b/plugins/commands/plugin/action.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
+Vagrant.require "pathname"
 
-require "vagrant/action/builder"
+Vagrant.require "vagrant/action/builder"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/action/expunge_plugins.rb
+++ b/plugins/commands/plugin/action/expunge_plugins.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/plugin/manager"
+Vagrant.require "vagrant/plugin/manager"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/action/install_gem.rb
+++ b/plugins/commands/plugin/action/install_gem.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-require "vagrant/plugin/manager"
-require "vagrant/util/platform"
+Vagrant.require "log4r"
+Vagrant.require "vagrant/plugin/manager"
+Vagrant.require "vagrant/util/platform"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/action/license_plugin.rb
+++ b/plugins/commands/plugin/action/license_plugin.rb
@@ -1,12 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "fileutils"
-require "pathname"
-require "rubygems"
-require "set"
+Vagrant.require "fileutils"
+Vagrant.require "pathname"
+Vagrant.require "rubygems"
+Vagrant.require "set"
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/action/list_plugins.rb
+++ b/plugins/commands/plugin/action/list_plugins.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/plugin/manager"
+Vagrant.require "vagrant/plugin/manager"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/action/plugin_exists_check.rb
+++ b/plugins/commands/plugin/action/plugin_exists_check.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/plugin/manager"
+Vagrant.require "vagrant/plugin/manager"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/action/repair_plugins.rb
+++ b/plugins/commands/plugin/action/repair_plugins.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/plugin/manager"
+Vagrant.require "vagrant/plugin/manager"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/action/update_gems.rb
+++ b/plugins/commands/plugin/action/update_gems.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/plugin/manager"
+Vagrant.require "vagrant/plugin/manager"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/command/base.rb
+++ b/plugins/commands/plugin/command/base.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/plugin/state_file"
+Vagrant.require "vagrant/plugin/state_file"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/command/expunge.rb
+++ b/plugins/commands/plugin/command/expunge.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 require_relative "base"
 

--- a/plugins/commands/plugin/command/install.rb
+++ b/plugins/commands/plugin/command/install.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 require_relative "base"
 require_relative "mixin_install_opts"

--- a/plugins/commands/plugin/command/license.rb
+++ b/plugins/commands/plugin/command/license.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 require_relative "base"
 

--- a/plugins/commands/plugin/command/list.rb
+++ b/plugins/commands/plugin/command/list.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 require_relative "base"
 

--- a/plugins/commands/plugin/command/repair.rb
+++ b/plugins/commands/plugin/command/repair.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 require_relative "base"
 

--- a/plugins/commands/plugin/command/root.rb
+++ b/plugins/commands/plugin/command/root.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/command/uninstall.rb
+++ b/plugins/commands/plugin/command/uninstall.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 require_relative "base"
 

--- a/plugins/commands/plugin/command/update.rb
+++ b/plugins/commands/plugin/command/update.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 require_relative "base"
 require_relative "mixin_install_opts"

--- a/plugins/commands/plugin/gem_helper.rb
+++ b/plugins/commands/plugin/gem_helper.rb
@@ -1,11 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "rubygems"
-require "rubygems/config_file"
-require "rubygems/gem_runner"
+Vagrant.require "rubygems"
+Vagrant.require "rubygems/config_file"
+Vagrant.require "rubygems/gem_runner"
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/port/command.rb
+++ b/plugins/commands/port/command.rb
@@ -3,7 +3,7 @@
 
 require "vagrant/util/presence"
 
-require "optparse"
+Vagrant.require "optparse"
 
 module VagrantPlugins
   module CommandPort

--- a/plugins/commands/powershell/command.rb
+++ b/plugins/commands/powershell/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "optparse"
+Vagrant.require "optparse"
 
 require "vagrant/util/powershell"
 require_relative "../../communicators/winrm/helper"

--- a/plugins/commands/provider/command.rb
+++ b/plugins/commands/provider/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandProvider

--- a/plugins/commands/provision/command.rb
+++ b/plugins/commands/provision/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandProvision

--- a/plugins/commands/push/command.rb
+++ b/plugins/commands/push/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandPush

--- a/plugins/commands/rdp/command.rb
+++ b/plugins/commands/rdp/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "optparse"
+Vagrant.require "optparse"
 
 module VagrantPlugins
   module CommandRDP

--- a/plugins/commands/reload/command.rb
+++ b/plugins/commands/reload/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 require "vagrant"
 

--- a/plugins/commands/resume/command.rb
+++ b/plugins/commands/resume/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 require Vagrant.source_root.join("plugins/commands/up/start_mixins")
 

--- a/plugins/commands/serve/broker.rb
+++ b/plugins/commands/serve/broker.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "singleton"
-require "thread"
+Vagrant.require "singleton"
+Vagrant.require "thread"
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/client/capability_platform.rb
+++ b/plugins/commands/serve/client/capability_platform.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "google/protobuf/well_known_types"
+Vagrant.require "google/protobuf/well_known_types"
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/client/guest.rb
+++ b/plugins/commands/serve/client/guest.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "google/protobuf/well_known_types"
+Vagrant.require "google/protobuf/well_known_types"
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/client/target.rb
+++ b/plugins/commands/serve/client/target.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "time"
+Vagrant.require "time"
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/client/vagrantfile.rb
+++ b/plugins/commands/serve/client/vagrantfile.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'ostruct'
+Vagrant.require 'ostruct'
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/command.rb
+++ b/plugins/commands/serve/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "optparse"
+Vagrant.require "optparse"
 
 module VagrantPlugins
   module CommandServe
@@ -25,9 +25,9 @@ module VagrantPlugins
       # the command is actually executed.
       def load_dependencies!
         return if @dependencies_loaded
-        require 'grpc'
-        require 'grpc/health/checker'
-        require 'grpc/health/v1/health_services_pb'
+        Vagrant.require 'grpc'
+        Vagrant.require 'grpc/health/checker'
+        Vagrant.require 'grpc/health/v1/health_services_pb'
 
         # Add conversion patches
         require Vagrant.source_root.join("plugins/commands/serve/util/direct_conversions.rb").to_s

--- a/plugins/commands/serve/mappers.rb
+++ b/plugins/commands/serve/mappers.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "digest/sha2"
-require "google/protobuf/wrappers_pb"
-require "google/protobuf/well_known_types"
+Vagrant.require "digest/sha2"
+Vagrant.require "google/protobuf/wrappers_pb"
+Vagrant.require "google/protobuf/well_known_types"
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/mappers/direct.rb
+++ b/plugins/commands/serve/mappers/direct.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pp"
-require "google/protobuf/well_known_types"
-require "google/protobuf/wrappers_pb"
+Vagrant.require "pp"
+Vagrant.require "google/protobuf/well_known_types"
+Vagrant.require "google/protobuf/wrappers_pb"
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/mappers/internal/graph.rb
+++ b/plugins/commands/serve/mappers/internal/graph.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "rgl/adjacency"
-require "rgl/traversal"
-require "rgl/dijkstra"
-require "rgl/topsort"
+Vagrant.require "rgl/adjacency"
+Vagrant.require "rgl/traversal"
+Vagrant.require "rgl/dijkstra"
+Vagrant.require "rgl/topsort"
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/mappers/known_types.rb
+++ b/plugins/commands/serve/mappers/known_types.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "google/protobuf/well_known_types"
+Vagrant.require "google/protobuf/well_known_types"
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/mappers/proc.rb
+++ b/plugins/commands/serve/mappers/proc.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "singleton"
+Vagrant.require "singleton"
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/mappers/wrappers.rb
+++ b/plugins/commands/serve/mappers/wrappers.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "google/protobuf/wrappers_pb"
+Vagrant.require "google/protobuf/wrappers_pb"
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/service.rb
+++ b/plugins/commands/serve/service.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "ostruct"
+Vagrant.require "ostruct"
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/service/capability_platform_service.rb
+++ b/plugins/commands/serve/service/capability_platform_service.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "google/protobuf/well_known_types"
+Vagrant.require "google/protobuf/well_known_types"
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/service/command_service.rb
+++ b/plugins/commands/serve/service/command_service.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'google/protobuf/well_known_types'
+Vagrant.require 'google/protobuf/well_known_types'
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/service/communicator_service.rb
+++ b/plugins/commands/serve/service/communicator_service.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "google/protobuf/well_known_types"
+Vagrant.require "google/protobuf/well_known_types"
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/service/guest_service.rb
+++ b/plugins/commands/serve/service/guest_service.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "google/protobuf/well_known_types"
+Vagrant.require "google/protobuf/well_known_types"
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/service/host_service.rb
+++ b/plugins/commands/serve/service/host_service.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "google/protobuf/well_known_types"
+Vagrant.require "google/protobuf/well_known_types"
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/service/internal_service.rb
+++ b/plugins/commands/serve/service/internal_service.rb
@@ -1,13 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/plugin/v2/plugin"
-require "vagrant/vagrantfile"
-require "vagrant/box_collection"
-require "vagrant/config"
-require "pathname"
+Vagrant.require "vagrant/plugin/v2/plugin"
+Vagrant.require "vagrant/vagrantfile"
+Vagrant.require "vagrant/box_collection"
+Vagrant.require "vagrant/config"
+Vagrant.require "pathname"
 
-require 'google/protobuf/well_known_types'
+Vagrant.require 'google/protobuf/well_known_types'
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/util/direct_conversions.rb
+++ b/plugins/commands/serve/util/direct_conversions.rb
@@ -2,10 +2,10 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 # Patch things to produce proto messages
-require "pathname"
-require "securerandom"
-require "google/protobuf/wrappers_pb"
-require "google/protobuf/well_known_types"
+Vagrant.require "pathname"
+Vagrant.require "securerandom"
+Vagrant.require "google/protobuf/wrappers_pb"
+Vagrant.require "google/protobuf/well_known_types"
 
 PROTO_LOGGER = Log4r::Logger.new("vagrant::protologger")
 

--- a/plugins/commands/serve/util/exception_transformer.rb
+++ b/plugins/commands/serve/util/exception_transformer.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'google/protobuf/well_known_types'
-require 'google/rpc/error_details_pb'
+Vagrant.require 'google/protobuf/well_known_types'
+Vagrant.require 'google/rpc/error_details_pb'
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/serve/util/usage_tracker.rb
+++ b/plugins/commands/serve/util/usage_tracker.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "mutex_m"
+Vagrant.require "mutex_m"
 
 module VagrantPlugins
   module CommandServe

--- a/plugins/commands/snapshot/command/delete.rb
+++ b/plugins/commands/snapshot/command/delete.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandSnapshot

--- a/plugins/commands/snapshot/command/list.rb
+++ b/plugins/commands/snapshot/command/list.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandSnapshot

--- a/plugins/commands/snapshot/command/pop.rb
+++ b/plugins/commands/snapshot/command/pop.rb
@@ -1,10 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'json'
-require 'optparse'
-
-require 'vagrant'
+Vagrant.require 'json'
+Vagrant.require 'optparse'
 
 require Vagrant.source_root.join("plugins/commands/up/start_mixins")
 

--- a/plugins/commands/snapshot/command/push.rb
+++ b/plugins/commands/snapshot/command/push.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'json'
-require 'optparse'
+Vagrant.require 'json'
+Vagrant.require 'optparse'
 
 require_relative "push_shared"
 

--- a/plugins/commands/snapshot/command/push_shared.rb
+++ b/plugins/commands/snapshot/command/push_shared.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'json'
+Vagrant.require 'json'
 
 module VagrantPlugins
   module CommandSnapshot

--- a/plugins/commands/snapshot/command/restore.rb
+++ b/plugins/commands/snapshot/command/restore.rb
@@ -1,9 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
-
-require 'vagrant'
+Vagrant.require 'optparse'
 
 require Vagrant.source_root.join("plugins/commands/up/start_mixins")
 

--- a/plugins/commands/snapshot/command/root.rb
+++ b/plugins/commands/snapshot/command/root.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandSnapshot

--- a/plugins/commands/snapshot/command/save.rb
+++ b/plugins/commands/snapshot/command/save.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandSnapshot

--- a/plugins/commands/ssh/command.rb
+++ b/plugins/commands/ssh/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandSSH

--- a/plugins/commands/ssh_config/command.rb
+++ b/plugins/commands/ssh_config/command.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
-require "vagrant/util/safe_puts"
-require "vagrant/util/platform"
+Vagrant.require "vagrant/util/safe_puts"
+Vagrant.require "vagrant/util/platform"
 
 module VagrantPlugins
   module CommandSSHConfig

--- a/plugins/commands/status/command.rb
+++ b/plugins/commands/status/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandStatus

--- a/plugins/commands/suspend/command.rb
+++ b/plugins/commands/suspend/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandSuspend

--- a/plugins/commands/up/command.rb
+++ b/plugins/commands/up/command.rb
@@ -1,10 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
-require 'set'
-
-require "vagrant"
+Vagrant.require 'optparse'
+Vagrant.require 'set'
 
 require File.expand_path("../start_mixins", __FILE__)
 

--- a/plugins/commands/up/start_mixins.rb
+++ b/plugins/commands/up/start_mixins.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "set"
+Vagrant.require "set"
 
 module VagrantPlugins
   module CommandUp

--- a/plugins/commands/upload/command.rb
+++ b/plugins/commands/upload/command.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
-require "rubygems/package"
+Vagrant.require 'optparse'
+Vagrant.require "rubygems/package"
 
 module VagrantPlugins
   module CommandUpload

--- a/plugins/commands/validate/command.rb
+++ b/plugins/commands/validate/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
 module VagrantPlugins
   module CommandValidate
@@ -59,7 +59,7 @@ module VagrantPlugins
       #
       # return [String] tmp_data_dir - Temporary dir used to store guest metadata during validation
       def mockup_providers!
-        require 'log4r'
+        Vagrant.require 'log4r'
         logger = Log4r::Logger.new("vagrant::validate")
         logger.debug("Overriding all registered provider classes for validate")
 

--- a/plugins/commands/version/command.rb
+++ b/plugins/commands/version/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "optparse"
+Vagrant.require "optparse"
 
 module VagrantPlugins
   module CommandVersion

--- a/plugins/commands/winrm/command.rb
+++ b/plugins/commands/winrm/command.rb
@@ -1,9 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
-
-require "vagrant/util/safe_puts"
+Vagrant.require 'optparse'
+Vagrant.require "vagrant/util/safe_puts"
 
 module VagrantPlugins
   module CommandWinRM

--- a/plugins/commands/winrm_config/command.rb
+++ b/plugins/commands/winrm_config/command.rb
@@ -1,7 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
+
 require "vagrant/util/safe_puts"
 require_relative "../../communicators/winrm/helper"
 

--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -1,23 +1,23 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'etc'
-require 'logger'
-require 'pathname'
-require 'stringio'
-require 'thread'
-require 'timeout'
+Vagrant.require 'etc'
+Vagrant.require 'logger'
+Vagrant.require 'pathname'
+Vagrant.require 'stringio'
+Vagrant.require 'thread'
+Vagrant.require 'timeout'
 
-require 'log4r'
-require 'net/ssh'
-require 'net/ssh/proxy/command'
-require 'net/scp'
+Vagrant.require 'log4r'
+Vagrant.require 'net/ssh'
+Vagrant.require 'net/ssh/proxy/command'
+Vagrant.require 'net/scp'
 
-require 'vagrant/util/ansi_escape_code_remover'
-require 'vagrant/util/file_mode'
-require 'vagrant/util/keypair'
-require 'vagrant/util/platform'
-require 'vagrant/util/retryable'
+Vagrant.require 'vagrant/util/ansi_escape_code_remover'
+Vagrant.require 'vagrant/util/file_mode'
+Vagrant.require 'vagrant/util/keypair'
+Vagrant.require 'vagrant/util/platform'
+Vagrant.require 'vagrant/util/retryable'
 
 module VagrantPlugins
   module CommunicatorSSH

--- a/plugins/communicators/winrm/command_filters/mkdir.rb
+++ b/plugins/communicators/winrm/command_filters/mkdir.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "shellwords"
+Vagrant.require "shellwords"
 
 module VagrantPlugins
   module CommunicatorWinRM

--- a/plugins/communicators/winrm/command_filters/rm.rb
+++ b/plugins/communicators/winrm/command_filters/rm.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "shellwords"
+Vagrant.require "shellwords"
 
 module VagrantPlugins
   module CommunicatorWinRM

--- a/plugins/communicators/winrm/command_filters/test.rb
+++ b/plugins/communicators/winrm/command_filters/test.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "shellwords"
+Vagrant.require "shellwords"
 
 module VagrantPlugins
   module CommunicatorWinRM

--- a/plugins/communicators/winrm/command_filters/which.rb
+++ b/plugins/communicators/winrm/command_filters/which.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "shellwords"
+Vagrant.require "shellwords"
 
 module VagrantPlugins
   module CommunicatorWinRM

--- a/plugins/communicators/winrm/communicator.rb
+++ b/plugins/communicators/winrm/communicator.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-require "tempfile"
-require "timeout"
+Vagrant.require "log4r"
+Vagrant.require "tempfile"
+Vagrant.require "timeout"
 
 require_relative "helper"
 require_relative "shell"

--- a/plugins/communicators/winrm/shell.rb
+++ b/plugins/communicators/winrm/shell.rb
@@ -1,19 +1,19 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "timeout"
+Vagrant.require "timeout"
 
-require "log4r"
+Vagrant.require "log4r"
 
-require "vagrant/util/retryable"
-require "vagrant/util/silence_warnings"
+Vagrant.require "vagrant/util/retryable"
+Vagrant.require "vagrant/util/silence_warnings"
 
 Vagrant::Util::SilenceWarnings.silence! do
-  require "winrm"
+  Vagrant.require "winrm"
 end
 
-require "winrm-elevated"
-require "winrm-fs"
+Vagrant.require "winrm-elevated"
+Vagrant.require "winrm-fs"
 
 module VagrantPlugins
   module CommunicatorWinRM

--- a/plugins/communicators/winssh/communicator.rb
+++ b/plugins/communicators/winssh/communicator.rb
@@ -3,7 +3,7 @@
 
 require File.expand_path("../../ssh/communicator", __FILE__)
 
-require 'net/sftp'
+Vagrant.require "net/sftp"
 
 module VagrantPlugins
   module CommunicatorWinSSH

--- a/plugins/guests/alpine/cap/configure_networks.rb
+++ b/plugins/guests/alpine/cap/configure_networks.rb
@@ -7,10 +7,10 @@
 #
 # FIXME: address disabled warnings
 #
-require 'set'
-require 'tempfile'
-require 'pathname'
-require 'vagrant/util/template_renderer'
+Vagrant.require 'set'
+Vagrant.require 'tempfile'
+Vagrant.require 'pathname'
+Vagrant.require 'vagrant/util/template_renderer'
 
 module VagrantPlugins
   module GuestAlpine

--- a/plugins/guests/alt/cap/configure_networks.rb
+++ b/plugins/guests/alt/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
+Vagrant.require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/arch/cap/configure_networks.rb
+++ b/plugins/guests/arch/cap/configure_networks.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "ipaddr"
-require "socket"
-require "tempfile"
+Vagrant.require "ipaddr"
+Vagrant.require "socket"
+Vagrant.require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/bsd/cap/nfs.rb
+++ b/plugins/guests/bsd/cap/nfs.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "shellwords"
-require "vagrant/util/retryable"
+Vagrant.require "shellwords"
+Vagrant.require "vagrant/util/retryable"
 
 module VagrantPlugins
   module GuestBSD

--- a/plugins/guests/bsd/cap/public_key.rb
+++ b/plugins/guests/bsd/cap/public_key.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
+Vagrant.require "tempfile"
 
-require "vagrant/util/shell_quote"
+Vagrant.require "vagrant/util/shell_quote"
 
 module VagrantPlugins
   module GuestBSD

--- a/plugins/guests/coreos/cap/change_host_name.rb
+++ b/plugins/guests/coreos/cap/change_host_name.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
-require "yaml"
+Vagrant.require "tempfile"
+Vagrant.require "yaml"
 
 module VagrantPlugins
   module GuestCoreOS

--- a/plugins/guests/darwin/cap/configure_networks.rb
+++ b/plugins/guests/darwin/cap/configure_networks.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
+Vagrant.require "tempfile"
 
-require "vagrant/util/template_renderer"
+Vagrant.require "vagrant/util/template_renderer"
 
 module VagrantPlugins
   module GuestDarwin

--- a/plugins/guests/darwin/cap/mount_smb_shared_folder.rb
+++ b/plugins/guests/darwin/cap/mount_smb_shared_folder.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/util/retryable"
-require "shellwords"
+Vagrant.require "vagrant/util/retryable"
+Vagrant.require "shellwords"
 
 module VagrantPlugins
   module GuestDarwin

--- a/plugins/guests/darwin/cap/mount_vmware_shared_folder.rb
+++ b/plugins/guests/darwin/cap/mount_vmware_shared_folder.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "securerandom"
+Vagrant.require "securerandom"
 
 module VagrantPlugins
   module GuestDarwin

--- a/plugins/guests/debian/cap/change_host_name.rb
+++ b/plugins/guests/debian/cap/change_host_name.rb
@@ -1,9 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-require 'vagrant/util/guest_hosts'
-require 'vagrant/util/guest_inspection'
+Vagrant.require "log4r"
+Vagrant.require 'vagrant/util/guest_hosts'
+Vagrant.require 'vagrant/util/guest_inspection'
+
 require_relative "../../linux/cap/network_interfaces"
 
 module VagrantPlugins

--- a/plugins/guests/debian/cap/configure_networks.rb
+++ b/plugins/guests/debian/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
+Vagrant.require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/esxi/cap/public_key.rb
+++ b/plugins/guests/esxi/cap/public_key.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
+Vagrant.require "tempfile"
 
-require "vagrant/util/shell_quote"
+Vagrant.require "vagrant/util/shell_quote"
 
 module VagrantPlugins
   module GuestEsxi

--- a/plugins/guests/freebsd/cap/configure_networks.rb
+++ b/plugins/guests/freebsd/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
+Vagrant.require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/funtoo/cap/configure_networks.rb
+++ b/plugins/guests/funtoo/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
+Vagrant.require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/gentoo/cap/configure_networks.rb
+++ b/plugins/guests/gentoo/cap/configure_networks.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
-require "ipaddr"
+Vagrant.require "tempfile"
+Vagrant.require "ipaddr"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/linux/cap/mount_smb_shared_folder.rb
+++ b/plugins/guests/linux/cap/mount_smb_shared_folder.rb
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "fileutils"
-require "shellwords"
+Vagrant.require "fileutils"
+Vagrant.require "shellwords"
+
 require_relative "../../../synced_folders/unix_mount_helpers"
 
 module VagrantPlugins

--- a/plugins/guests/linux/cap/public_key.rb
+++ b/plugins/guests/linux/cap/public_key.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
+Vagrant.require "tempfile"
 
-require "vagrant/util/shell_quote"
+Vagrant.require "vagrant/util/shell_quote"
 
 module VagrantPlugins
   module GuestLinux

--- a/plugins/guests/linux/cap/reboot.rb
+++ b/plugins/guests/linux/cap/reboot.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'vagrant/util/guest_inspection'
-require "log4r"
+Vagrant.require 'vagrant/util/guest_inspection'
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module GuestLinux

--- a/plugins/guests/netbsd/cap/configure_networks.rb
+++ b/plugins/guests/netbsd/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
+Vagrant.require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/nixos/cap/change_host_name.rb
+++ b/plugins/guests/nixos/cap/change_host_name.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
+Vagrant.require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/nixos/cap/configure_networks.rb
+++ b/plugins/guests/nixos/cap/configure_networks.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "ipaddr"
-require "tempfile"
+Vagrant.require "ipaddr"
+Vagrant.require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/openbsd/cap/configure_networks.rb
+++ b/plugins/guests/openbsd/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
+Vagrant.require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
+Vagrant.require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/slackware/cap/configure_networks.rb
+++ b/plugins/guests/slackware/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
+Vagrant.require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/suse/cap/configure_networks.rb
+++ b/plugins/guests/suse/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
+Vagrant.require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/tinycore/cap/configure_networks.rb
+++ b/plugins/guests/tinycore/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "ipaddr"
+Vagrant.require "ipaddr"
 
 module VagrantPlugins
   module GuestTinyCore

--- a/plugins/guests/windows/cap/change_host_name.rb
+++ b/plugins/guests/windows/cap/change_host_name.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module GuestWindows

--- a/plugins/guests/windows/cap/configure_networks.rb
+++ b/plugins/guests/windows/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 require_relative "../guest_network"
 

--- a/plugins/guests/windows/cap/mount_shared_folder.rb
+++ b/plugins/guests/windows/cap/mount_shared_folder.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/util/template_renderer"
-require "base64"
+Vagrant.require "vagrant/util/template_renderer"
+Vagrant.require "base64"
 
 module VagrantPlugins
   module GuestWindows

--- a/plugins/guests/windows/cap/public_key.rb
+++ b/plugins/guests/windows/cap/public_key.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
+Vagrant.require "tempfile"
 
 require_relative '../../../communicators/winssh/communicator'
 

--- a/plugins/guests/windows/cap/reboot.rb
+++ b/plugins/guests/windows/cap/reboot.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module GuestWindows

--- a/plugins/guests/windows/guest_network.rb
+++ b/plugins/guests/windows/guest_network.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module GuestWindows

--- a/plugins/hosts/bsd/cap/nfs.rb
+++ b/plugins/hosts/bsd/cap/nfs.rb
@@ -1,11 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
-require "vagrant/util"
-require "vagrant/util/shell_quote"
-require "vagrant/util/which"
+Vagrant.require "vagrant/util"
+Vagrant.require "vagrant/util/shell_quote"
+Vagrant.require "vagrant/util/which"
 
 module VagrantPlugins
   module HostBSD

--- a/plugins/hosts/darwin/cap/configured_ip_addresses.rb
+++ b/plugins/hosts/darwin/cap/configured_ip_addresses.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "socket"
+Vagrant.require "socket"
 
 module VagrantPlugins
   module HostDarwin

--- a/plugins/hosts/darwin/cap/fs_iso.rb
+++ b/plugins/hosts/darwin/cap/fs_iso.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
-require "vagrant/util/caps"
+Vagrant.require "pathname"
+Vagrant.require "vagrant/util/caps"
 
 module VagrantPlugins
   module HostDarwin

--- a/plugins/hosts/darwin/cap/provider_install_virtualbox.rb
+++ b/plugins/hosts/darwin/cap/provider_install_virtualbox.rb
@@ -1,12 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
-require "tempfile"
+Vagrant.require "pathname"
+Vagrant.require "tempfile"
 
-require "vagrant/util/downloader"
-require "vagrant/util/file_checksum"
-require "vagrant/util/subprocess"
+Vagrant.require "vagrant/util/downloader"
+Vagrant.require "vagrant/util/file_checksum"
+Vagrant.require "vagrant/util/subprocess"
 
 module VagrantPlugins
   module HostDarwin

--- a/plugins/hosts/darwin/cap/rdp.rb
+++ b/plugins/hosts/darwin/cap/rdp.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
-require "tmpdir"
+Vagrant.require "pathname"
+Vagrant.require "tmpdir"
 
-require "vagrant/util/subprocess"
+Vagrant.require "vagrant/util/subprocess"
 
 module VagrantPlugins
   module HostDarwin

--- a/plugins/hosts/linux/cap/fs_iso.rb
+++ b/plugins/hosts/linux/cap/fs_iso.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
-require "vagrant/util/caps"
+Vagrant.require "pathname"
+Vagrant.require "vagrant/util/caps"
 
 module VagrantPlugins
   module HostLinux

--- a/plugins/hosts/linux/cap/nfs.rb
+++ b/plugins/hosts/linux/cap/nfs.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "shellwords"
-require "vagrant/util"
-require "vagrant/util/shell_quote"
-require "vagrant/util/retryable"
+Vagrant.require "shellwords"
+Vagrant.require "vagrant/util"
+Vagrant.require "vagrant/util/shell_quote"
+Vagrant.require "vagrant/util/retryable"
 
 module VagrantPlugins
   module HostLinux

--- a/plugins/hosts/linux/cap/rdp.rb
+++ b/plugins/hosts/linux/cap/rdp.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "vagrant/util/which"
+Vagrant.require "vagrant/util/which"
 
 module VagrantPlugins
   module HostLinux

--- a/plugins/hosts/redhat/cap/nfs.rb
+++ b/plugins/hosts/redhat/cap/nfs.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
+Vagrant.require "pathname"
 
 module VagrantPlugins
   module HostRedHat

--- a/plugins/hosts/redhat/host.rb
+++ b/plugins/hosts/redhat/host.rb
@@ -1,9 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
-
-require "vagrant"
+Vagrant.require "pathname"
 
 module VagrantPlugins
   module HostRedHat

--- a/plugins/hosts/suse/host.rb
+++ b/plugins/hosts/suse/host.rb
@@ -1,9 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
-
-require "vagrant"
+Vagrant.require "pathname"
 
 module VagrantPlugins
   module HostSUSE

--- a/plugins/hosts/void/host.rb
+++ b/plugins/hosts/void/host.rb
@@ -1,9 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'pathname'
-
-require 'vagrant'
+Vagrant.require 'pathname'
 
 module VagrantPlugins
   module HostVoid

--- a/plugins/hosts/windows/cap/configured_ip_addresses.rb
+++ b/plugins/hosts/windows/cap/configured_ip_addresses.rb
@@ -1,13 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
-require "tempfile"
+Vagrant.require "pathname"
+Vagrant.require "tempfile"
 
-require "vagrant/util/downloader"
-require "vagrant/util/file_checksum"
-require "vagrant/util/powershell"
-require "vagrant/util/subprocess"
+Vagrant.require "vagrant/util/downloader"
+Vagrant.require "vagrant/util/file_checksum"
+Vagrant.require "vagrant/util/powershell"
+Vagrant.require "vagrant/util/subprocess"
 
 module VagrantPlugins
   module HostWindows

--- a/plugins/hosts/windows/cap/fs_iso.rb
+++ b/plugins/hosts/windows/cap/fs_iso.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
-require "vagrant/util/caps"
+Vagrant.require "pathname"
+Vagrant.require "vagrant/util/caps"
 
 module VagrantPlugins
   module HostWindows

--- a/plugins/hosts/windows/cap/provider_install_virtualbox.rb
+++ b/plugins/hosts/windows/cap/provider_install_virtualbox.rb
@@ -1,13 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
-require "tempfile"
+Vagrant.require "pathname"
+Vagrant.require "tempfile"
 
-require "vagrant/util/downloader"
-require "vagrant/util/file_checksum"
-require "vagrant/util/powershell"
-require "vagrant/util/subprocess"
+Vagrant.require "vagrant/util/downloader"
+Vagrant.require "vagrant/util/file_checksum"
+Vagrant.require "vagrant/util/powershell"
+Vagrant.require "vagrant/util/subprocess"
 
 module VagrantPlugins
   module HostWindows

--- a/plugins/hosts/windows/cap/ps.rb
+++ b/plugins/hosts/windows/cap/ps.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
-require "tmpdir"
+Vagrant.require "pathname"
+Vagrant.require "tmpdir"
 
-require "vagrant/util/safe_exec"
+Vagrant.require "vagrant/util/safe_exec"
 
 module VagrantPlugins
   module HostWindows

--- a/plugins/hosts/windows/cap/rdp.rb
+++ b/plugins/hosts/windows/cap/rdp.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
-require "tmpdir"
+Vagrant.require "pathname"
+Vagrant.require "tmpdir"
 
-require "vagrant/util/subprocess"
+Vagrant.require "vagrant/util/subprocess"
 
 module VagrantPlugins
   module HostWindows

--- a/plugins/kernel_v2/config/cloud_init.rb
+++ b/plugins/kernel_v2/config/cloud_init.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-require "securerandom"
+Vagrant.require "log4r"
+Vagrant.require "securerandom"
 
 module VagrantPlugins
   module Kernel_V2

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-require "securerandom"
+Vagrant.require "log4r"
+Vagrant.require "securerandom"
 
-require "vagrant/util/numeric"
+Vagrant.require "vagrant/util/numeric"
 
 module VagrantPlugins
   module Kernel_V2

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -1,17 +1,17 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
-require "securerandom"
-require "set"
+Vagrant.require "pathname"
+Vagrant.require "securerandom"
+Vagrant.require "set"
 
-require "vagrant"
-require "vagrant/action/builtin/mixin_synced_folders"
-require "vagrant/config/v2/util"
-require "vagrant/util/platform"
-require "vagrant/util/presence"
-require "vagrant/util/experimental"
-require "vagrant/util/map_command_options"
+Vagrant.require "vagrant"
+Vagrant.require "vagrant/action/builtin/mixin_synced_folders"
+Vagrant.require "vagrant/config/v2/util"
+Vagrant.require "vagrant/util/platform"
+Vagrant.require "vagrant/util/presence"
+Vagrant.require "vagrant/util/experimental"
+Vagrant.require "vagrant/util/map_command_options"
 
 require File.expand_path("../vm_provisioner", __FILE__)
 require File.expand_path("../vm_subvm", __FILE__)

--- a/plugins/kernel_v2/config/vm_provisioner.rb
+++ b/plugins/kernel_v2/config/vm_provisioner.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'log4r'
+Vagrant.require 'log4r'
 
 module VagrantPlugins
   module Kernel_V2

--- a/plugins/kernel_v2/config/vm_trigger.rb
+++ b/plugins/kernel_v2/config/vm_trigger.rb
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-require "securerandom"
+Vagrant.require "log4r"
+Vagrant.require "securerandom"
+
 require Vagrant.source_root.join("plugins/provisioners/shell/config")
 
 module VagrantPlugins

--- a/plugins/providers/docker/action/build.rb
+++ b/plugins/providers/docker/action/build.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
-require "vagrant/util/ansi_escape_code_remover"
+Vagrant.require "vagrant/util/ansi_escape_code_remover"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/connect_networks.rb
+++ b/plugins/providers/docker/action/connect_networks.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'ipaddr'
-require 'log4r'
+Vagrant.require 'ipaddr'
+Vagrant.require 'log4r'
 
-require 'vagrant/util/scoped_hash_override'
+Vagrant.require 'vagrant/util/scoped_hash_override'
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/destroy_build_image.rb
+++ b/plugins/providers/docker/action/destroy_build_image.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/destroy_network.rb
+++ b/plugins/providers/docker/action/destroy_network.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'log4r'
+Vagrant.require 'log4r'
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/host_machine.rb
+++ b/plugins/providers/docker/action/host_machine.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/host_machine_build_dir.rb
+++ b/plugins/providers/docker/action/host_machine_build_dir.rb
@@ -1,9 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "digest/md5"
-
-require "log4r"
+Vagrant.require "digest/md5"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/host_machine_sync_folders.rb
+++ b/plugins/providers/docker/action/host_machine_sync_folders.rb
@@ -1,12 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "digest/md5"
-require "securerandom"
+Vagrant.require "digest/md5"
+Vagrant.require "securerandom"
+Vagrant.require "log4r"
 
-require "log4r"
-
-require "vagrant/action/builtin/mixin_synced_folders"
+Vagrant.require "vagrant/action/builtin/mixin_synced_folders"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/host_machine_sync_folders_disable.rb
+++ b/plugins/providers/docker/action/host_machine_sync_folders_disable.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
-require "vagrant/action/builtin/mixin_synced_folders"
+Vagrant.require "vagrant/action/builtin/mixin_synced_folders"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/login.rb
+++ b/plugins/providers/docker/action/login.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/prepare_networks.rb
+++ b/plugins/providers/docker/action/prepare_networks.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'ipaddr'
-require 'log4r'
+Vagrant.require 'ipaddr'
+Vagrant.require 'log4r'
 
-require 'vagrant/util/scoped_hash_override'
+Vagrant.require 'vagrant/util/scoped_hash_override'
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/wait_for_running.rb
+++ b/plugins/providers/docker/action/wait_for_running.rb
@@ -1,9 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "thread"
-
-require "log4r"
+Vagrant.require "thread"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/communicator.rb
+++ b/plugins/providers/docker/communicator.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "digest/md5"
-require "tempfile"
+Vagrant.require "digest/md5"
+Vagrant.require "tempfile"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/config.rb
+++ b/plugins/providers/docker/config.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
+Vagrant.require "pathname"
 
 require_relative "../../../lib/vagrant/util/platform"
 

--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "json"
-require "log4r"
+Vagrant.require "json"
+Vagrant.require "log4r"
 
 require_relative "./driver/compose"
 

--- a/plugins/providers/docker/driver/compose.rb
+++ b/plugins/providers/docker/driver/compose.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "json"
-require "log4r"
+Vagrant.require "json"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/provider.rb
+++ b/plugins/providers/docker/provider.rb
@@ -1,13 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "digest/md5"
-require "fileutils"
-require "thread"
+Vagrant.require "digest/md5"
+Vagrant.require "fileutils"
+Vagrant.require "thread"
+Vagrant.require "log4r"
 
-require "log4r"
-
-require "vagrant/util/silence_warnings"
+Vagrant.require "vagrant/util/silence_warnings"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/hyperv/action/check_enabled.rb
+++ b/plugins/providers/hyperv/action/check_enabled.rb
@@ -1,9 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "fileutils"
-
-require "log4r"
+Vagrant.require "fileutils"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/action/configure.rb
+++ b/plugins/providers/hyperv/action/configure.rb
@@ -1,9 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "fileutils"
-
-require "log4r"
+Vagrant.require "fileutils"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/action/export.rb
+++ b/plugins/providers/hyperv/action/export.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "fileutils"
+Vagrant.require "fileutils"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "fileutils"
-require "log4r"
+Vagrant.require "fileutils"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/action/package_metadata_json.rb
+++ b/plugins/providers/hyperv/action/package_metadata_json.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "json"
+Vagrant.require "json"
 
 #require 'vagrant/util/template_renderer'
 

--- a/plugins/providers/hyperv/action/package_setup_folders.rb
+++ b/plugins/providers/hyperv/action/package_setup_folders.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "fileutils"
+Vagrant.require "fileutils"
 
 require_relative "../../../../lib/vagrant/action/general/package_setup_folders"
 

--- a/plugins/providers/hyperv/action/read_guest_ip.rb
+++ b/plugins/providers/hyperv/action/read_guest_ip.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-require "timeout"
+Vagrant.require "log4r"
+Vagrant.require "timeout"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/action/read_state.rb
+++ b/plugins/providers/hyperv/action/read_state.rb
@@ -1,8 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/action/set_name.rb
+++ b/plugins/providers/hyperv/action/set_name.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/action/wait_for_ip_address.rb
+++ b/plugins/providers/hyperv/action/wait_for_ip_address.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "ipaddr"
-require "timeout"
+Vagrant.require "ipaddr"
+Vagrant.require "timeout"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/cap/cleanup_disks.rb
+++ b/plugins/providers/hyperv/cap/cleanup_disks.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-require "vagrant/util/experimental"
+Vagrant.require "log4r"
+Vagrant.require "vagrant/util/experimental"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/cap/configure_disks.rb
+++ b/plugins/providers/hyperv/cap/configure_disks.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-require "fileutils"
-require "vagrant/util/numeric"
-require "vagrant/util/experimental"
+Vagrant.require "log4r"
+Vagrant.require "fileutils"
+Vagrant.require "vagrant/util/numeric"
+Vagrant.require "vagrant/util/experimental"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/cap/validate_disk_ext.rb
+++ b/plugins/providers/hyperv/cap/validate_disk_ext.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/driver.rb
+++ b/plugins/providers/hyperv/driver.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "json"
-require "log4r"
+Vagrant.require "json"
+Vagrant.require "log4r"
 
-require "vagrant/util/powershell"
+Vagrant.require "vagrant/util/powershell"
 
 require_relative "plugin"
 

--- a/plugins/providers/hyperv/provider.rb
+++ b/plugins/providers/hyperv/provider.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 require_relative "driver"
 require_relative "plugin"

--- a/plugins/providers/virtualbox/action/check_guest_additions.rb
+++ b/plugins/providers/virtualbox/action/check_guest_additions.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/clean_machine_folder.rb
+++ b/plugins/providers/virtualbox/action/clean_machine_folder.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "fileutils"
+Vagrant.require "fileutils"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/destroy_unused_network_interfaces.rb
+++ b/plugins/providers/virtualbox/action/destroy_unused_network_interfaces.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/export.rb
+++ b/plugins/providers/virtualbox/action/export.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "fileutils"
-require 'vagrant/util/platform'
+Vagrant.require "fileutils"
+Vagrant.require 'vagrant/util/platform'
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/import_master.rb
+++ b/plugins/providers/virtualbox/action/import_master.rb
@@ -1,9 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-
-require "digest/md5"
+Vagrant.require "log4r"
+Vagrant.require "digest/md5"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -1,14 +1,14 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "ipaddr"
-require "resolv"
-require "set"
+Vagrant.require "ipaddr"
+Vagrant.require "resolv"
+Vagrant.require "set"
 
-require "log4r"
+Vagrant.require "log4r"
 
-require "vagrant/util/network_ip"
-require "vagrant/util/scoped_hash_override"
+Vagrant.require "vagrant/util/network_ip"
+Vagrant.require "vagrant/util/scoped_hash_override"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/network_fix_ipv6.rb
+++ b/plugins/providers/virtualbox/action/network_fix_ipv6.rb
@@ -1,13 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "ipaddr"
-require "socket"
+Vagrant.require "ipaddr"
+Vagrant.require "socket"
 
-require "log4r"
+Vagrant.require "log4r"
 
-require "vagrant/util/presence"
-require "vagrant/util/scoped_hash_override"
+Vagrant.require "vagrant/util/presence"
+Vagrant.require "vagrant/util/scoped_hash_override"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/package_setup_folders.rb
+++ b/plugins/providers/virtualbox/action/package_setup_folders.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "fileutils"
+Vagrant.require "fileutils"
 
 require_relative "../../../../lib/vagrant/action/general/package_setup_folders"
 

--- a/plugins/providers/virtualbox/action/prepare_clone_snapshot.rb
+++ b/plugins/providers/virtualbox/action/prepare_clone_snapshot.rb
@@ -1,9 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-
-require "digest/md5"
+Vagrant.require "log4r"
+Vagrant.require "digest/md5"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/prepare_nfs_settings.rb
+++ b/plugins/providers/virtualbox/action/prepare_nfs_settings.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "ipaddr"
-require "vagrant/action/builtin/mixin_synced_folders"
+Vagrant.require "ipaddr"
+Vagrant.require "vagrant/action/builtin/mixin_synced_folders"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/sane_defaults.rb
+++ b/plugins/providers/virtualbox/action/sane_defaults.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/set_default_nic_type.rb
+++ b/plugins/providers/virtualbox/action/set_default_nic_type.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/set_name.rb
+++ b/plugins/providers/virtualbox/action/set_name.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/setup_package_files.rb
+++ b/plugins/providers/virtualbox/action/setup_package_files.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 require_relative "package_setup_files"
 

--- a/plugins/providers/virtualbox/cap/cleanup_disks.rb
+++ b/plugins/providers/virtualbox/cap/cleanup_disks.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-require "vagrant/util/experimental"
+Vagrant.require "log4r"
+Vagrant.require "vagrant/util/experimental"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/cap/configure_disks.rb
+++ b/plugins/providers/virtualbox/cap/configure_disks.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-require "fileutils"
-require "vagrant/util/numeric"
-require "vagrant/util/experimental"
+Vagrant.require "log4r"
+Vagrant.require "fileutils"
+Vagrant.require "vagrant/util/numeric"
+Vagrant.require "vagrant/util/experimental"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/cap/validate_disk_ext.rb
+++ b/plugins/providers/virtualbox/cap/validate_disk_ext.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/driver/base.rb
+++ b/plugins/providers/virtualbox/driver/base.rb
@@ -1,13 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'log4r'
+Vagrant.require 'log4r'
 
-require 'vagrant/util/busy'
-require 'vagrant/util/platform'
-require 'vagrant/util/retryable'
-require 'vagrant/util/subprocess'
-require 'vagrant/util/which'
+Vagrant.require 'vagrant/util/busy'
+Vagrant.require 'vagrant/util/platform'
+Vagrant.require 'vagrant/util/retryable'
+Vagrant.require 'vagrant/util/subprocess'
+Vagrant.require 'vagrant/util/which'
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/driver/version_4_1.rb
+++ b/plugins/providers/virtualbox/driver/version_4_1.rb
@@ -1,9 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'log4r'
-
-require "vagrant/util/platform"
+Vagrant.require 'log4r'
+Vagrant.require "vagrant/util/platform"
 
 require File.expand_path("../base", __FILE__)
 

--- a/plugins/providers/virtualbox/driver/version_7_0.rb
+++ b/plugins/providers/virtualbox/driver/version_7_0.rb
@@ -1,7 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "rexml"
+Vagrant.require "rexml"
+
 require File.expand_path("../version_6_1", __FILE__)
 
 module VagrantPlugins

--- a/plugins/providers/virtualbox/provider.rb
+++ b/plugins/providers/virtualbox/provider.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/synced_folder.rb
+++ b/plugins/providers/virtualbox/synced_folder.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "fileutils"
-require "vagrant/util/platform"
+Vagrant.require "fileutils"
+Vagrant.require "vagrant/util/platform"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/provisioners/ansible/provisioner/guest.rb
+++ b/plugins/provisioners/ansible/provisioner/guest.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
+Vagrant.require "tempfile"
 
 require_relative "base"
 

--- a/plugins/provisioners/ansible/provisioner/host.rb
+++ b/plugins/provisioners/ansible/provisioner/host.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "thread"
+Vagrant.require "thread"
 
 require_relative "base"
 

--- a/plugins/provisioners/cfengine/cap/linux/cfengine_needs_bootstrap.rb
+++ b/plugins/provisioners/cfengine/cap/linux/cfengine_needs_bootstrap.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module CFEngine

--- a/plugins/provisioners/cfengine/cap/redhat/cfengine_install.rb
+++ b/plugins/provisioners/cfengine/cap/redhat/cfengine_install.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module CFEngine

--- a/plugins/provisioners/cfengine/config.rb
+++ b/plugins/provisioners/cfengine/config.rb
@@ -1,9 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
-
-require "vagrant"
+Vagrant.require "pathname"
 
 module VagrantPlugins
   module CFEngine

--- a/plugins/provisioners/cfengine/provisioner.rb
+++ b/plugins/provisioners/cfengine/provisioner.rb
@@ -1,8 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-require "vagrant"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module CFEngine

--- a/plugins/provisioners/chef/plugin.rb
+++ b/plugins/provisioners/chef/plugin.rb
@@ -1,9 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
-
-require "vagrant"
+Vagrant.require "pathname"
 
 require_relative "command_builder"
 

--- a/plugins/provisioners/chef/provisioner/base.rb
+++ b/plugins/provisioners/chef/provisioner/base.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "tempfile"
+Vagrant.require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/presence"
 require_relative "../../../../lib/vagrant/util/template_renderer"

--- a/plugins/provisioners/chef/provisioner/chef_apply.rb
+++ b/plugins/provisioners/chef/provisioner/chef_apply.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "digest/md5"
-require "tempfile"
+Vagrant.require "digest/md5"
+Vagrant.require "tempfile"
 
 require_relative "base"
 

--- a/plugins/provisioners/chef/provisioner/chef_client.rb
+++ b/plugins/provisioners/chef/provisioner/chef_client.rb
@@ -1,11 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'pathname'
+Vagrant.require 'pathname'
 
-require 'vagrant'
-require 'vagrant/util/presence'
-require 'vagrant/util/subprocess'
+Vagrant.require 'vagrant'
+Vagrant.require 'vagrant/util/presence'
+Vagrant.require 'vagrant/util/subprocess'
 
 require_relative "base"
 

--- a/plugins/provisioners/chef/provisioner/chef_zero.rb
+++ b/plugins/provisioners/chef/provisioner/chef_zero.rb
@@ -1,13 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "digest/md5"
-require "securerandom"
-require "set"
+Vagrant.require "digest/md5"
+Vagrant.require "securerandom"
+Vagrant.require "set"
 
-require "log4r"
+Vagrant.require "log4r"
 
-require "vagrant/util/counter"
+Vagrant.require "vagrant/util/counter"
 
 require_relative "chef_solo"
 

--- a/plugins/provisioners/container/client.rb
+++ b/plugins/provisioners/container/client.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'digest/sha1'
+Vagrant.require 'digest/sha1'
 
 module VagrantPlugins
   module ContainerProvisioner

--- a/plugins/provisioners/container/config.rb
+++ b/plugins/provisioners/container/config.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'set'
+Vagrant.require 'set'
 
 module VagrantPlugins
   module ContainerProvisioner

--- a/plugins/provisioners/file/config.rb
+++ b/plugins/provisioners/file/config.rb
@@ -1,9 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
-
-require "vagrant"
+Vagrant.require "pathname"
 
 module VagrantPlugins
   module FileUpload

--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -1,9 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "digest/md5"
-
-require "log4r"
+Vagrant.require "digest/md5"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module Puppet

--- a/plugins/provisioners/salt/bootstrap_downloader.rb
+++ b/plugins/provisioners/salt/bootstrap_downloader.rb
@@ -1,8 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'open-uri'
-require 'digest'
+Vagrant.require 'open-uri'
+Vagrant.require 'digest'
+
 require_relative "./errors"
 
 module VagrantPlugins

--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -1,7 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'json'
+Vagrant.require 'json'
+
 require_relative "bootstrap_downloader"
 
 module VagrantPlugins

--- a/plugins/provisioners/shell/config.rb
+++ b/plugins/provisioners/shell/config.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'uri'
+Vagrant.require 'uri'
 
 module VagrantPlugins
   module Shell

--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -1,12 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
-require "tempfile"
+Vagrant.require "pathname"
+Vagrant.require "tempfile"
 
-require "vagrant/util/downloader"
-require "vagrant/util/line_buffer"
-require "vagrant/util/retryable"
+Vagrant.require "vagrant/util/downloader"
+Vagrant.require "vagrant/util/line_buffer"
+Vagrant.require "vagrant/util/retryable"
 
 module VagrantPlugins
   module Shell

--- a/plugins/pushes/ftp/adapter.rb
+++ b/plugins/pushes/ftp/adapter.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "pathname"
+Vagrant.require "pathname"
 
 module VagrantPlugins
   module FTPPush
@@ -50,7 +50,7 @@ module VagrantPlugins
     #
     class FTPAdapter < Adapter
       def initialize(*)
-        require "net/ftp"
+        Vagrant.require "net/ftp"
         super
       end
 
@@ -107,7 +107,7 @@ module VagrantPlugins
     #
     class SFTPAdapter < Adapter
       def initialize(*)
-        require "net/sftp"
+        Vagrant.require "net/sftp"
         super
         @dirs = {}
       end

--- a/plugins/pushes/ftp/push.rb
+++ b/plugins/pushes/ftp/push.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "net/ftp"
-require "pathname"
+Vagrant.require "net/ftp"
+Vagrant.require "pathname"
 
 require_relative "adapter"
 require_relative "errors"

--- a/plugins/pushes/local-exec/push.rb
+++ b/plugins/pushes/local-exec/push.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "fileutils"
-require "tempfile"
-require "vagrant/util/safe_exec"
+Vagrant.require "fileutils"
+Vagrant.require "tempfile"
+Vagrant.require "vagrant/util/safe_exec"
 
 require_relative "errors"
 

--- a/plugins/synced_folders/nfs/action_cleanup.rb
+++ b/plugins/synced_folders/nfs/action_cleanup.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
 module VagrantPlugins
   module SyncedFolderNFS

--- a/plugins/synced_folders/nfs/synced_folder.rb
+++ b/plugins/synced_folders/nfs/synced_folder.rb
@@ -1,13 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'fileutils'
-require 'thread'
-require 'zlib'
+Vagrant.require 'fileutils'
+Vagrant.require 'thread'
+Vagrant.require 'zlib'
 
-require "log4r"
+Vagrant.require "log4r"
 
-require "vagrant/util/platform"
+Vagrant.require "vagrant/util/platform"
 
 module VagrantPlugins
   module SyncedFolderNFS

--- a/plugins/synced_folders/rsync/command/rsync.rb
+++ b/plugins/synced_folders/rsync/command/rsync.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require 'optparse'
+Vagrant.require 'optparse'
 
-require "vagrant/action/builtin/mixin_synced_folders"
+Vagrant.require "vagrant/action/builtin/mixin_synced_folders"
 
 require_relative "../helper"
 

--- a/plugins/synced_folders/rsync/command/rsync_auto.rb
+++ b/plugins/synced_folders/rsync/command/rsync_auto.rb
@@ -1,17 +1,17 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
-require 'optparse'
-require "thread"
+Vagrant.require "log4r"
+Vagrant.require 'optparse'
+Vagrant.require "thread"
 
-require "vagrant/action/builtin/mixin_synced_folders"
-require "vagrant/util/busy"
-require "vagrant/util/platform"
+Vagrant.require "vagrant/action/builtin/mixin_synced_folders"
+Vagrant.require "vagrant/util/busy"
+Vagrant.require "vagrant/util/platform"
 
 require_relative "../helper"
 
-require "listen"
+Vagrant.require "listen"
 
 module VagrantPlugins
   module SyncedFolderRSync

--- a/plugins/synced_folders/rsync/default_unix_cap.rb
+++ b/plugins/synced_folders/rsync/default_unix_cap.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "shellwords"
+Vagrant.require "shellwords"
 
 module VagrantPlugins
   module SyncedFolderRSync

--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "fileutils"
-require "ipaddr"
-require "shellwords"
-require "tmpdir"
+Vagrant.require "fileutils"
+Vagrant.require "ipaddr"
+Vagrant.require "shellwords"
+Vagrant.require "tmpdir"
 
 require "vagrant/util/platform"
 require "vagrant/util/subprocess"

--- a/plugins/synced_folders/rsync/synced_folder.rb
+++ b/plugins/synced_folders/rsync/synced_folder.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "log4r"
+Vagrant.require "log4r"
 
-require "vagrant/util/subprocess"
-require "vagrant/util/which"
+Vagrant.require "vagrant/util/subprocess"
+Vagrant.require "vagrant/util/which"
 
 require_relative "helper"
 

--- a/plugins/synced_folders/smb/synced_folder.rb
+++ b/plugins/synced_folders/smb/synced_folder.rb
@@ -1,13 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "digest/md5"
-require "json"
+Vagrant.require "digest/md5"
+Vagrant.require "json"
 
-require "log4r"
+Vagrant.require "log4r"
 
-require "vagrant/util/platform"
-require "vagrant/util/powershell"
+Vagrant.require "vagrant/util/platform"
+Vagrant.require "vagrant/util/powershell"
 
 require_relative "errors"
 

--- a/plugins/synced_folders/unix_mount_helpers.rb
+++ b/plugins/synced_folders/unix_mount_helpers.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-require "shellwords"
-require "vagrant/util/retryable"
+Vagrant.require "shellwords"
+Vagrant.require "vagrant/util/retryable"
 
 module VagrantPlugins
   module SyncedFolder

--- a/test/unit/plugins/guests/linux/cap/mount_smb_shared_folder_test.rb
+++ b/test/unit/plugins/guests/linux/cap/mount_smb_shared_folder_test.rb
@@ -59,6 +59,7 @@ describe "VagrantPlugins::GuestLinux::Cap::MountSMBSharedFolder" do
       allow(comm).to receive(:execute).with(any_args)
       allow(machine).to receive(:guest).and_return(guest)
       allow(guest).to receive(:capability).with(:shell_expand_guest_path, mount_guest_path).and_return(mount_guest_path)
+      allow(ENV).to receive(:[]).and_call_original
       allow(ENV).to receive(:[]).with("VAGRANT_DISABLE_SMBMFSYMLINKS").and_return(false)
       allow(ENV).to receive(:[]).with("GEM_SKIP").and_return(false)
       allow(cap).to receive(:display_mfsymlinks_warning)


### PR DESCRIPTION
This removes the activation of runtime dependencies at startup. A new loading helper is added to lazily activate runtime dependencies as needed when requested for loading. Activation is disabled by default, and will be enabled after further non-installer based testing.