### PR TITLE
Update authentication handling

### DIFF
--- a/lib/vagrant/util/curl_helper.rb
+++ b/lib/vagrant/util/curl_helper.rb
@@ -9,7 +9,8 @@ module Vagrant
       SILENCED_HOSTS = [
         "vagrantcloud-files-production.s3-accelerate.amazonaws.com".freeze,
         "vagrantcloud.com".freeze,
-        "vagrantup.com".freeze
+        "vagrantup.com".freeze,
+        "cloud.hashicorp.com".freeze,
       ].freeze
 
       def self.capture_output_proc(logger, ui, source=nil)

--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -26,12 +26,6 @@ module Vagrant
       #     Vagrant/1.7.4 (+https://www.vagrantup.com; ruby2.1.0)
       USER_AGENT = "Vagrant/#{VERSION} (+https://www.vagrantup.com; #{RUBY_ENGINE}#{RUBY_VERSION}) #{ENV['VAGRANT_USER_AGENT_PROVISIONAL_STRING']}".strip.freeze
 
-      # Hosts that do not require notification on redirect
-      SILENCED_HOSTS = [
-        "vagrantcloud.com".freeze,
-        "vagrantup.com".freeze
-      ].freeze
-
       attr_accessor :source
       attr_reader :destination
       attr_accessor :headers

--- a/plugins/commands/cloud/auth/middleware/add_downloader_authentication.rb
+++ b/plugins/commands/cloud/auth/middleware/add_downloader_authentication.rb
@@ -5,9 +5,8 @@ Vagrant.require "cgi"
 Vagrant.require "uri"
 Vagrant.require "vagrant/util/credential_scrubber"
 
-require_relative "./add_authentication"
-
 require Vagrant.source_root.join("plugins/commands/cloud/client/client")
+require_relative "./add_authentication"
 
 # Similar to AddAuthentication this middleware will add authentication for interacting
 # with Vagrant cloud. It does this by adding Authentication headers to a
@@ -54,6 +53,8 @@ module VagrantPlugins
               else
                 env[:downloader].headers << "Authorization: Bearer #{token}"
               end
+            else
+              @logger.debug("Not adding authentication header, host mismatch #{target_url.host} != #{server_uri.host}")
             end
 
             env[:downloader]

--- a/plugins/commands/cloud/client/client.rb
+++ b/plugins/commands/cloud/client/client.rb
@@ -37,10 +37,13 @@ module VagrantPlugins
       def initialize(env)
         @logger = Log4r::Logger.new("vagrant::cloud::client")
         @env    = env
-        @client = VagrantCloud::Client.new(
-          access_token: token,
-          url_base: api_server_url
-        )
+        if !defined?(@@client)
+          @@client = VagrantCloud::Client.new(
+            access_token: token,
+            url_base: api_server_url
+          )
+        end
+        @client = @@client
       end
 
       # Removes the token, effectively logging the user out.
@@ -54,7 +57,8 @@ module VagrantPlugins
       #
       # @return [Boolean]
       def logged_in?
-        return false if !client.access_token
+        return false if !client&.access_token
+
         Vagrant::Util::CredentialScrubber.sensitive(client.access_token)
 
         with_error_handling do
@@ -128,6 +132,10 @@ module VagrantPlugins
       #
       # @return [String]
       def token
+        # If the client is defined, use the client for the access token
+        # to allow proper token generation if required
+        return client.access_token if client && !client.access_token.nil?
+
         if present?(ENV["VAGRANT_CLOUD_TOKEN"]) && token_path.exist?
           # Only show warning if it has not been previously shown
           if !defined?(@@double_token_warning)

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -56,7 +56,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec", "~> 3.11"
   s.add_development_dependency "rspec-its", "~> 1.3.0"
   s.add_development_dependency "fake_ftp", "~> 0.3.0"
-  s.add_development_dependency "webrick", "~> 1.7.0"
+  s.add_development_dependency "webrick", "~> 1.7"
 
   # The following block of code determines the files that should be included
   # in the gem. It does this by reading all the files in the directory where

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rexml", "~> 3.2"
   s.add_dependency "rgl", "~> 0.5.10"
   s.add_dependency "rubyzip", "~> 2.3.2"
-  s.add_dependency "vagrant_cloud", "~> 3.1.1"
+  s.add_dependency "vagrant_cloud", "~> 3.1.2"
   s.add_dependency "wdm", "~> 0.1.1"
   s.add_dependency "winrm", ">= 2.3.9", "< 3.0"
   s.add_dependency "winrm-elevated", ">= 1.2.3", "< 2.0"


### PR DESCRIPTION
Updates the minimum constraint for the `vagrant_cloud` gem dependency. Cleans up some of the client wrapper within the cloud plugin. Updated `vagrant_cloud` gem provided authentication now handles HCP based authentication. 
