### PR TITLE
Use ISO 9660 format in create_iso under darwin

### DIFF
--- a/plugins/hosts/darwin/cap/fs_iso.rb
+++ b/plugins/hosts/darwin/cap/fs_iso.rb
@@ -36,7 +36,7 @@ module VagrantPlugins
           source_directory = Pathname.new(source_directory)
           file_destination = self.ensure_output_iso(extra_opts[:file_destination])
 
-          iso_command = [BUILD_ISO_CMD, "makehybrid", "-hfs", "-iso", "-joliet", "-ov"]
+          iso_command = [BUILD_ISO_CMD, "makehybrid", "-iso", "-joliet", "-ov"]
           iso_command.concat(["-default-volume-name", extra_opts[:volume_id]]) if extra_opts[:volume_id]
           iso_command << "-o"
           iso_command << file_destination.to_s


### PR DESCRIPTION
Currently `create_iso` in darwin produces CD image with hybrid format HFS+ISO 9660 This is less interoperable than ISO 9660 alone. In particular, CD label is not readable by the `udev` and breaks some automated configuration system.
Here are the command output on Ubuntu guest:

|   | HFS+ISO 9660 | ISO 9660 |
|---|---|---|
| `sudo blkid -o udev -p /dev/sr0` | ID_PART_TABLE_TYPE=mac | ID_FS_FSBLOCKSIZE=2048<br>ID_FS_BLOCK_SIZE=2048<br>ID_FS_FSSIZE=55296<br>ID_FS_SYSTEM_ID=APPLE\x20INC.\x2c\x20TYPE:\x200002<br>ID_FS_VOLUME_SET_ID=<br>ID_FS_PUBLISHER_ID=<br>ID_FS_DATA_PREPARER_ID=<br>ID_FS_APPLICATION_ID=<br>ID_FS_UUID=2024-12-29-15-35-20-00<br>ID_FS_UUID_ENC=2024-12-29-15-35-20-00<br>ID_FS_VERSION=Joliet\x20Extension<br>ID_FS_LABEL=cidata<br>ID_FS_LABEL_ENC=cidata<br>ID_FS_TYPE=iso9660<br>ID_FS_USAGE=filesystem |
| `ls /dev/disk/by-label` | BOOT  UEFI  cidata  cloudimg-rootfs | BOOT  UEFI  cloudimg-rootfs **_cidata_** |

Environment:
Host: `VMware Fusion 13.6.2 on MacOS`
Guest: `Linux ubuntu 6.8.0-49-generic #49-Ubuntu SMP PREEMPT_DYNAMIC Sun Nov  3 21:21:58 UTC 2024 aarch64 aarch64 aarch64 GNU/Linux`