### PR TITLE
docker provider: handle variation in error text during image removal

### DIFF
--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -225,8 +225,9 @@ module VagrantPlugins
         execute('docker', 'rmi', id)
         return true
       rescue => e
-        return false if e.to_s.include?("is using it")
-        return false if e.to_s.include?("is being used")
+        return false if e.to_s.include?("is using it") or
+                        e.to_s.include?("is being used") or
+                        e.to_s.include?("is in use")
         raise if !e.to_s.include?("No such image")
       end
 

--- a/test/unit/plugins/providers/docker/driver_test.rb
+++ b/test/unit/plugins/providers/docker/driver_test.rb
@@ -579,6 +579,15 @@ describe VagrantPlugins::DockerProvider::Driver do
         subject.rmi(id)
       end
     end
+
+    context 'image is in use by a container' do
+      before { allow(subject).to receive(:execute).and_raise("image is in use by a container") }
+
+      it 'does not remove the image' do
+        expect(subject.rmi(id)).to eq(false)
+        subject.rmi(id)
+      end
+    end
   end
 
   describe '#inspect_container' do


### PR DESCRIPTION

Handles the slightly different error text when podman backend is used:

```
Stderr: Error response from daemon: image xxx is in use: image used by yyy: image is in use by a container: consider listing external containers and force-removing image
```

Fixes #13563

