### PR TITLE
Remove references to support email address

### DIFF
--- a/website/content/intro/support.mdx
+++ b/website/content/intro/support.mdx
@@ -3,7 +3,8 @@ layout: intro
 page_title: Vagrant Support
 description: "Find Vagrant & HCP Vagrant Support"
 ---
-# Contacting Support
+
+# Contact Support
 
 To submit a support ticket:
 1.  Navigate to the HashiCorp [Support Page](https://support.hashicorp.com/hc/en-us). You may find the answers you need by searching our support knowledge base, but if not select `Open a new ticket`.

--- a/website/content/intro/support.mdx
+++ b/website/content/intro/support.mdx
@@ -12,5 +12,4 @@ To submit a support ticket:
 
 ### Free Support
 
-We do not currently publish support SLAs for free accounts, but endeavor to
-respond as quickly as possible.
+We do not currently publish support SLAs for free accounts but aim to respond as quickly as possible.

--- a/website/content/intro/support.mdx
+++ b/website/content/intro/support.mdx
@@ -1,0 +1,19 @@
+---
+layout: intro
+page_title: Vagrant Support
+description: "Find Vagrant & HCP Vagrant Support"
+---
+# Contacting Support
+
+~> **Note**: You will need a Hashicorp Zendesk account to submit a support ticket. You may create an account [here](https://hashicorp.zendesk.com/auth/v2/login/registration)
+or when prompted by selecting the `New to Hashicorp? Sign up` link just below the sign-in
+
+To submit a support ticket:
+1.  Navigate to the HashiCorp [Support Page](https://support.hashicorp.com/hc/en-us). You may find the answers you need by searching our support knowledge base, but if not select `Open a new ticket`.
+2. To submit a new support request select `Other / No Contract`. Read the SLA disclaimer and then click `I still want to submit a ticket`.
+3. You will then be prompted to log-in to a HashiCorp specific Zendesk. If you do not have an account you can create one by clicking the `Sign up` link below the sign-in.
+
+### Free Support
+
+We do not currently publish support SLAs for free accounts, but endeavor to
+respond as quickly as possible.

--- a/website/content/intro/support.mdx
+++ b/website/content/intro/support.mdx
@@ -8,7 +8,7 @@ description: "Find Vagrant & HCP Vagrant Support"
 
 To submit a support ticket:
 1.  Visit the HashiCorp [Support Page](https://support.hashicorp.com/hc/en-us) to explore our support knowledge base for answers to your questions. If you do not find what you need, click `Open a new ticket` to get in touch with us directly.
-2. To submit a new support ticket select `Cloud Customer` and choose `HCP Vagrant` from the dropdown menu.
+2. Submit a new support ticket by selecting `Cloud Customer` and choose `HCP Vagrant` from the dropdown menu.
 
 ### Free Support
 

--- a/website/content/intro/support.mdx
+++ b/website/content/intro/support.mdx
@@ -5,13 +5,9 @@ description: "Find Vagrant & HCP Vagrant Support"
 ---
 # Contacting Support
 
-~> **Note**: You will need a Hashicorp Zendesk account to submit a support ticket. You may create an account [here](https://hashicorp.zendesk.com/auth/v2/login/registration)
-or when prompted by selecting the `New to Hashicorp? Sign up` link just below the sign-in
-
 To submit a support ticket:
 1.  Navigate to the HashiCorp [Support Page](https://support.hashicorp.com/hc/en-us). You may find the answers you need by searching our support knowledge base, but if not select `Open a new ticket`.
-2. To submit a new support request select `Other / No Contract`. Read the SLA disclaimer and then click `I still want to submit a ticket`.
-3. You will then be prompted to log-in to a HashiCorp specific Zendesk. If you do not have an account you can create one by clicking the `Sign up` link below the sign-in.
+2. To submit a new support ticket select `Cloud Customer` and choose `HCP Vagrant` from the dropdown menu.
 
 ### Free Support
 

--- a/website/content/intro/support.mdx
+++ b/website/content/intro/support.mdx
@@ -7,7 +7,7 @@ description: "Find Vagrant & HCP Vagrant Support"
 # Contact Support
 
 To submit a support ticket:
-1.  Navigate to the HashiCorp [Support Page](https://support.hashicorp.com/hc/en-us). You may find the answers you need by searching our support knowledge base, but if not select `Open a new ticket`.
+1.  Visit the HashiCorp [Support Page](https://support.hashicorp.com/hc/en-us) to explore our support knowledge base for answers to your questions. If you do not find what you need, click `Open a new ticket` to get in touch with us directly.
 2. To submit a new support ticket select `Cloud Customer` and choose `HCP Vagrant` from the dropdown menu.
 
 ### Free Support

--- a/website/content/vagrant-cloud/api/v1.mdx
+++ b/website/content/vagrant-cloud/api/v1.mdx
@@ -75,7 +75,7 @@ The resource you are trying to access does not exist. This may also be returned 
 
 ##### **429** Too Many Requests
 
-You are currently being rate-limited. Please decrease your frequency of usage, or [contact support](/vagrant/intro/support) with a description of your use case so that we can consider creating an exception.
+You are currently being rate-limited. Please decrease your frequency of usage or [contact support](/vagrant/intro/support) with a description of your use case so that we can consider creating an exception.
 
 #### Server Errors
 

--- a/website/content/vagrant-cloud/api/v1.mdx
+++ b/website/content/vagrant-cloud/api/v1.mdx
@@ -75,14 +75,14 @@ The resource you are trying to access does not exist. This may also be returned 
 
 ##### **429** Too Many Requests
 
-You are currently being rate-limited. Please decrease your frequency of usage, or contact us at [support+vagrantcloud@hashicorp.com](mailto:support+vagrantcloud@hashicorp.com) with a description of your use case so that we can consider creating an exception.
+You are currently being rate-limited. Please decrease your frequency of usage, or [contact support](/vagrant/intro/support) with a description of your use case so that we can consider creating an exception.
 
 #### Server Errors
 
 ##### **500** Internal Server Error
 
 The server failed to respond to the request for an unknown reason.
-Please contact [support+vagrantcloud@hashicorp.com](mailto:support+vagrantcloud@hashicorp.com) with a description of the problem so that we can investigate.
+Please [contact support](/vagrant/intro/support) with a description of the problem so that we can investigate.
 
 ##### **503** Service Unavailable
 

--- a/website/content/vagrant-cloud/api/v2.mdx
+++ b/website/content/vagrant-cloud/api/v2.mdx
@@ -75,7 +75,7 @@ The resource you are trying to access does not exist. This may also be returned 
 
 ##### **429** Too Many Requests
 
-You are currently being rate-limited. Please decrease your frequency of usage, or [contact support](/vagrant/intro/support) with a description of your use case so that we can consider creating an exception.
+You are currently being rate-limited. Please decrease your frequency of usage or [contact support](/vagrant/intro/support) with a description of your use case so that we can consider creating an exception.
 
 #### Server Errors
 

--- a/website/content/vagrant-cloud/api/v2.mdx
+++ b/website/content/vagrant-cloud/api/v2.mdx
@@ -75,14 +75,14 @@ The resource you are trying to access does not exist. This may also be returned 
 
 ##### **429** Too Many Requests
 
-You are currently being rate-limited. Please decrease your frequency of usage, or contact us at [support+vagrantcloud@hashicorp.com](mailto:support+vagrantcloud@hashicorp.com) with a description of your use case so that we can consider creating an exception.
+You are currently being rate-limited. Please decrease your frequency of usage, or [contact support](/vagrant/intro/support) with a description of your use case so that we can consider creating an exception.
 
 #### Server Errors
 
 ##### **500** Internal Server Error
 
 The server failed to respond to the request for an unknown reason.
-Please contact [support+vagrantcloud@hashicorp.com](mailto:support+vagrantcloud@hashicorp.com) with a description of the problem so that we can investigate.
+Please [contact support](/vagrant/intro/support) with a description of the problem so that we can investigate.
 
 ##### **503** Service Unavailable
 

--- a/website/content/vagrant-cloud/boxes/catalog.mdx
+++ b/website/content/vagrant-cloud/boxes/catalog.mdx
@@ -39,7 +39,7 @@ are some things to note when you're choosing a box:
   are likely vetted more often by other members of the community. HashiCorp
   responds to reports of malicious software distributed via Vagrant Cloud
   by disabling and/or removing boxes. If you find a box which includes
-  malicious software, please report it to: [support+vagrantcloud@hashicorp.com](mailto:support+vagrantcloud@hashicorp.com).
+  malicious software, please [contact support](/vagrant/intro/support) to make a report.
 - **The latest release date**. Boxes which are updated periodically or which
   have recent release dates will generally contain more up-to-date software.
 - **Availability of the box download**. Vagrant Cloud periodically checks if a box

--- a/website/content/vagrant-cloud/hcp-vagrant/migration-guide.mdx
+++ b/website/content/vagrant-cloud/hcp-vagrant/migration-guide.mdx
@@ -83,4 +83,4 @@ It is important to note that while a migrated organization will no longer be ava
 
 ## Conclusion
 
-If for some reason you are unable to access your new HCP Registry or your migration does not complete successfully, review the [Migration Troubleshooting](/vagrant/vagrant-cloud/hcp-vagrant/troubleshooting) guide or contact us at [support+vagrantcloud@hashicorp.com](mailto:support@hashicorp.com) with the subject `HCP Vagrant Migration`. Our team will be happy to help you complete your migration or reset your organization state.
+If for some reason you are unable to access your new HCP Registry or your migration does not complete successfully, review the [Migration Troubleshooting](/vagrant/vagrant-cloud/hcp-vagrant/troubleshooting) guide or [contact support](/vagrant/intro/support) . Our team will be happy to help you complete your migration or reset your organization state.

--- a/website/content/vagrant-cloud/hcp-vagrant/troubleshooting.mdx
+++ b/website/content/vagrant-cloud/hcp-vagrant/troubleshooting.mdx
@@ -17,4 +17,4 @@ In the rare case that an inoperable box was successfully uploaded (e.g legacy bo
 ### Retrying Migrations
 
 If a migration fails, a `retry` icon will appear beside the name of that organization on the [migration status](https://app.vagrantup.com/migration/status) page. Failed migrations can be retried once.
-In the event of a second failure, contact us at [support+vagrantcloud@hashicorp.com](mailto:support@hashicorp.com) with the subject `Vagrant Migration`. Our team will be happy to help you complete your migration or reset your organization state.
+In the event of a second failure, please [contact support](/vagrant/intro/support) with a description of your issue. Our team will be happy to help you complete your migration or reset your organization state.

--- a/website/content/vagrant-cloud/index.mdx
+++ b/website/content/vagrant-cloud/index.mdx
@@ -8,10 +8,10 @@ description: "Vagrant Cloud serves a public, searchable index of Vagrant boxes"
 
 ## Support
 
-For Vagrant Cloud questions, feedback, or feature requests, please email
-HashiCorp Support at [support+vagrantcloud@hashicorp.com](mailto:support+vagrantcloud@hashicorp.com).
+For Vagrant Cloud questions, feedback, or feature requests, please submit a ticket to
+HashiCorp Support.
 
-[Click here](/vagrant/vagrant-cloud/support) for more support information.
+[Click here](/vagrant/vagrant-cloud/support) for instructions on submitting a support ticket.
 
 ## Features
 

--- a/website/content/vagrant-cloud/request-limits.mdx
+++ b/website/content/vagrant-cloud/request-limits.mdx
@@ -27,5 +27,4 @@ If you have received a 429 HTTP status code in the response to your request, you
 - **X-RateLimit-Reset**: The Unix timestamp for when the window resets.
 
 ## My use case requires more requests. What do I do?
-
-Please contact [support+vagrantcloud@hashicorp.com](mailto:support+vagrantcloud@hashicorp.com).
+Please [contact support](/vagrant/intro/support) with a description of your use case so that we can consider creating an exception..

--- a/website/content/vagrant-cloud/support.mdx
+++ b/website/content/vagrant-cloud/support.mdx
@@ -1,13 +1,11 @@
 ---
 layout: vagrant-cloud
 page_title: Vagrant Cloud Support
-description: "Find support for Vagrant Cloud through our email or community channels."
+description: "Find support for Vagrant Cloud"
 ---
-
 # Contacting Support
-
-All users of Vagrant Cloud are urged to email feedback, questions, and requests
-to HashiCorp Support at [support+vagrantcloud@hashicorp.com](mailto:support+vagrantcloud@hashicorp.com).
+For Vagrant Cloud questions, feedback, or feature requests, please submit a ticket to
+[HashiCorp Support](/vagrant/intro/support).
 
 ### Free Support
 
@@ -37,5 +35,4 @@ please submit a pull-request to the
 [Vagrant project on GitHub](https://github.com/hashicorp/vagrant/tree/main/website/content/vagrant-cloud/).
 The Vagrant Cloud documentation can be found in the `/website/pages/vagrant-cloud/` directory.
 
-Otherwise, to make a suggestion or report an error in documentation, please
-email feedback to [support+vagrantcloud@hashicorp.com](mailto:support+vagrantcloud@hashicorp.com).
+Otherwise, to make a suggestion or report an error in documentation, please [contact support](/vagrant/intro/support).

--- a/website/content/vagrant-cloud/users/recovery.mdx
+++ b/website/content/vagrant-cloud/users/recovery.mdx
@@ -9,5 +9,5 @@ description: "Reset your Vagrant Cloud password with the reset link in the UI."
 If you have lost access to your Vagrant Cloud account, use the reset
 password form on the login page to send yourself a link to reset your password.
 
-If an email is unknown, [contact us](mailto:support+vagrantcloud@hashicorp.com)
+If an email is unknown, [contact support](/vagrant/intro/support)
 for further help.

--- a/website/data/intro-nav-data.json
+++ b/website/data/intro-nav-data.json
@@ -31,5 +31,9 @@
   {
     "title": "Contributing",
     "path": "contributing-guide"
+  },
+  {
+    "title": "Support",
+    "path": "support"
   }
 ]


### PR DESCRIPTION
Adds a Support page to the `Intro` section of the vagrant docs. Then replaces all references to the support email with a link to contact support that takes users to the blurb on how to file a support ticket.

This PR replaces #13567, because a vercel outage led to that PR getting a bit cluttered.  