### PR TITLE
Update template link

### DIFF
--- a/templates/commands/init/Vagrantfile.erb
+++ b/templates/commands/init/Vagrantfile.erb
@@ -11,7 +11,7 @@ Vagrant.configure("2") do |config|
   # https://docs.vagrantup.com.
 
   # Every Vagrant development environment requires a box. You can search for
-  # boxes at https://vagrantcloud.com/search.
+  # boxes at https://portal.cloud.hashicorp.com/vagrant/discover.
   config.vm.box = "<%= box_name %>"
   <% if box_version -%>
   config.vm.box_version = "<%= box_version %>"


### PR DESCRIPTION
This PR update the template link.

The old link currently redirect to "https://portal.cloud.hashicorp.com/vagrant/discover/search" which is a 404 not found page, I correct the link url to "https://portal.cloud.hashicorp.com/vagrant/discover".