### PR TITLE
Update from app.vagrantup.com to vagrantcloud.com

### DIFF
--- a/internal/core/box_test.go
+++ b/internal/core/box_test.go
@@ -27,7 +27,7 @@ func hashicorpBionicBoxData() *vagrant_server.Box {
 		Version:     "0.0.282",
 		Directory:   "/tmp/boxes",
 		Metadata:    testMetadata,
-		MetadataUrl: "https://app.vagrantup.com/hashicorp/boxes/bionic64.json",
+		MetadataUrl: "https://vagrantcloud.com/hashicorp/boxes/bionic64.json",
 		Name:        "hashicorp/bionic64",
 		LastUpdate:  timestamppb.Now(),
 	}

--- a/test/vagrant-spec/Vagrantfile.spec
+++ b/test/vagrant-spec/Vagrantfile.spec
@@ -56,7 +56,7 @@ enabled_providers.each do |provider_name|
     box_path = File.join(File.dirname(__FILE__), "./boxes/#{guest_box.sub('/', '_')}.#{provider_name}.#{box_version}.box")
     if !File.exist?(box_path)
       $stderr.puts "Downloading guest box #{guest_box}"
-      cmd = "curl -Lf -o #{box_path} https://app.vagrantup.com/#{box_owner}/boxes/#{box_name}/versions/#{box_version}/providers/#{provider_name}.box"
+      cmd = "curl -Lf -o #{box_path} https://vagrantcloud.com/#{box_owner}/boxes/#{box_name}/versions/#{box_version}/providers/#{provider_name}.box"
       if vagrantcloud_token
         cmd += "?access_token=#{vagrantcloud_token}"
       end

--- a/website/content/docs/boxes/format.mdx
+++ b/website/content/docs/boxes/format.mdx
@@ -33,7 +33,7 @@ There are four different components that make up a box:
 So, if you extract a box and look at it's contents it will look like:
 ```
 # contents of the hashicorp/bionic64 box
-# ref: https://app.vagrantup.com/hashicorp/boxes/bionic64
+# ref: https://vagrantcloud.com/hashicorp/boxes/bionic64
 $ ls hashicorp_bionic_box  
 Vagrantfile                     metadata.json
 box.ovf                         ubuntu-18.04-amd64-disk001.vmdk

--- a/website/content/vagrant-cloud/api/v1.mdx
+++ b/website/content/vagrant-cloud/api/v1.mdx
@@ -91,7 +91,7 @@ Please check the [HashiCorp Status Site](http://status.hashicorp.com) for more i
 
 ## Creating a usable box from scratch
 
--> This assumes that you have a valid Vagrant Cloud authentication token. You can [create one via the API](#create-a-token), or [create one on the Vagrant Cloud website](https://app.vagrantup.com/settings/security).
+-> This assumes that you have a valid Vagrant Cloud authentication token. You can [create one via the API](#create-a-token), or [create one on the Vagrant Cloud website](https://vagrantcloud.com/settings/security).
 
 In order to create a usable box on Vagrant Cloud, perform the following steps:
 
@@ -112,7 +112,7 @@ curl \
   --request POST \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/boxes \
+  https://vagrantcloud.com/api/v1/boxes \
   --data '{ "box": { "username": "myuser", "name": "test" } }'
 
 # Create a new version
@@ -121,7 +121,7 @@ curl \
   --request POST \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/box/myuser/test/versions \
+  https://vagrantcloud.com/api/v1/box/myuser/test/versions \
   --data '{ "version": { "version": "1.2.3" } }'
 
 # Create a new provider
@@ -130,7 +130,7 @@ curl \
   --request POST \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/providers \
+  https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/providers \
   --data '{ "provider": { "name": "virtualbox" } }'
 
 # Prepare the provider for upload/get an upload URL
@@ -138,7 +138,7 @@ curl \
 response=$(curl \
     --request GET \
     --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-    https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/provider/virtualbox/upload)
+    https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/provider/virtualbox/upload)
 
 # Extract the upload URL from the response (requires the jq command)
 
@@ -153,7 +153,7 @@ curl --request PUT "${upload_path}" --upload-file virtualbox-1.2.3.box
 curl \
   --request PUT \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/release
+  https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/release
 
 ```
 
@@ -164,7 +164,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Content-Type" => "application/json",
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
@@ -232,7 +232,7 @@ Creates a new token for the given user.
 curl \
   --request POST \
   --header "Content-Type: application/json" \
-  https://app.vagrantup.com/api/v1/authenticate \
+  https://vagrantcloud.com/api/v1/authenticate \
   --data '
     {
       "token": {
@@ -253,7 +253,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
 "Content-Type" => "application/json"
 )
 
@@ -298,7 +298,7 @@ Responds [`200 OK`](#200-ok) if the authentication request was successful, other
 curl \
   --request GET \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/authenticate
+  https://vagrantcloud.com/api/v1/authenticate
 ```
 
 </Tab>
@@ -308,7 +308,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -339,7 +339,7 @@ Responds [`204 OK`](#204-no-content) if the deletion request was successful, oth
 curl \
   --request DELETE \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/authenticate
+  https://vagrantcloud.com/api/v1/authenticate
 ```
 
 </Tab>
@@ -349,7 +349,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -388,7 +388,7 @@ Sends a 2FA code to the requested delivery method.
 curl \
   --request POST \
   --header "Content-Type: application/json" \
-  https://app.vagrantup.com/api/v1/two-factor/request-code \
+  https://vagrantcloud.com/api/v1/two-factor/request-code \
   --data '
     {
       "two_factor": {
@@ -409,7 +409,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Content-Type" => "application/json"
 )
 
@@ -453,7 +453,7 @@ end
 curl \
   --request GET \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/user/myuser
+  https://vagrantcloud.com/api/v1/user/myuser
 ```
 
 </Tab>
@@ -463,7 +463,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -517,7 +517,7 @@ end
 curl \
   --request GET \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  "https://app.vagrantup.com/api/v1/search?q=test&provider=virtualbox"
+  "https://vagrantcloud.com/api/v1/search?q=test&provider=virtualbox"
 ```
 
 </Tab>
@@ -527,7 +527,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -572,8 +572,8 @@ end
         "created_at": "2017-10-20T15:23:17.184Z",
         "updated_at": "2017-10-20T15:23:53.355Z",
         "number": "1.2.3",
-        "release_url": "https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/release",
-        "revoke_url": "https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/revoke",
+        "release_url": "https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/release",
+        "revoke_url": "https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/revoke",
         "providers": [
           {
             "name": "virtualbox",
@@ -606,7 +606,7 @@ end
 curl \
   --request GET \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/box/myuser/test
+  https://vagrantcloud.com/api/v1/box/myuser/test
 ```
 
 </Tab>
@@ -616,7 +616,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -654,8 +654,8 @@ end
     "created_at": "2017-10-20T15:23:17.184Z",
     "updated_at": "2017-10-20T15:23:53.355Z",
     "number": "1.2.3",
-    "release_url": "https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/release",
-    "revoke_url": "https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/revoke",
+    "release_url": "https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/release",
+    "revoke_url": "https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/revoke",
     "providers": [
       {
         "name": "virtualbox",
@@ -677,8 +677,8 @@ end
       "created_at": "2017-10-20T15:23:17.184Z",
       "updated_at": "2017-10-20T15:23:53.355Z",
       "number": "1.2.3",
-      "release_url": "https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/release",
-      "revoke_url": "https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/revoke",
+      "release_url": "https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/release",
+      "revoke_url": "https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/revoke",
       "providers": [
         {
           "name": "virtualbox",
@@ -718,7 +718,7 @@ curl \
   --request POST \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/boxes \
+  https://vagrantcloud.com/api/v1/boxes \
   --data '
     {
       "box": {
@@ -739,7 +739,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Content-Type" => "application/json",
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
@@ -792,7 +792,7 @@ curl \
   --request PUT \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/box/myuser/test \
+  https://vagrantcloud.com/api/v1/box/myuser/test \
   --data '
     {
       "box": {
@@ -812,7 +812,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Content-Type" => "application/json",
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
@@ -851,7 +851,7 @@ end
 curl \
   --request DELETE \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/box/myuser/test
+  https://vagrantcloud.com/api/v1/box/myuser/test
 ```
 
 </Tab>
@@ -861,7 +861,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -898,7 +898,7 @@ Response body is identical to [Reading a box](#read-a-box).
 curl \
   --request GET \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3
+  https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3
 ```
 
 </Tab>
@@ -908,7 +908,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -937,8 +937,8 @@ end
   "created_at": "2017-10-20T15:23:17.184Z",
   "updated_at": "2017-10-20T15:23:53.355Z",
   "number": "1.2.3",
-  "release_url": "https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/release",
-  "revoke_url": "https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/revoke",
+  "release_url": "https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/release",
+  "revoke_url": "https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/revoke",
   "providers": [
     {
       "name": "virtualbox",
@@ -975,7 +975,7 @@ curl \
   --request POST \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/box/myuser/test/versions \
+  https://vagrantcloud.com/api/v1/box/myuser/test/versions \
   --data '
     {
       "version": {
@@ -993,7 +993,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Content-Type" => "application/json",
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
@@ -1041,7 +1041,7 @@ curl \
   --request PUT \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3 \
+  https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3 \
   --data '
     {
       "version": {
@@ -1059,7 +1059,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Content-Type" => "application/json",
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
@@ -1100,7 +1100,7 @@ Response body is identical to [Reading a version](#read-a-version).
 curl \
   --request DELETE \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3
+  https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3
 ```
 
 </Tab>
@@ -1110,7 +1110,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -1145,7 +1145,7 @@ Response body is identical to [Reading a version](#read-a-version).
 curl \
   --request PUT \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/release
+  https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/release
 ```
 
 </Tab>
@@ -1155,7 +1155,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -1190,7 +1190,7 @@ Response body is identical to [Reading a version](#read-a-version).
 curl \
   --request PUT \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/revoke
+  https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/revoke
 ```
 
 </Tab>
@@ -1200,7 +1200,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -1237,7 +1237,7 @@ Response body is identical to [Reading a version](#read-a-version).
 curl \
   --request GET \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/provider/virtualbox
+  https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/provider/virtualbox
 ```
 
 </Tab>
@@ -1247,7 +1247,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -1303,7 +1303,7 @@ curl \
   --request POST \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/providers \
+  https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/providers \
   --data '
     {
       "provider": {
@@ -1323,7 +1323,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Content-Type" => "application/json",
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
@@ -1371,7 +1371,7 @@ curl \
   --request PUT \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/provider/virtualbox \
+  https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/provider/virtualbox \
   --data '
     {
       "provider": {
@@ -1391,7 +1391,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Content-Type" => "application/json",
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
@@ -1432,7 +1432,7 @@ Response body is identical to [Reading a provider](#read-a-provider).
 curl \
   --request DELETE \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/provider/virtualbox
+  https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/provider/virtualbox
 ```
 
 </Tab>
@@ -1442,7 +1442,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -1481,7 +1481,7 @@ Prepares the provider for upload, and returns a JSON blob containing an `upload_
 response=$(curl \
   --request GET \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/provider/virtualbox/upload)
+  https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/provider/virtualbox/upload)
 
 # Requires the jq command
 upload_path=$(echo "$response" | jq .upload_path)
@@ -1499,7 +1499,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -1553,7 +1553,7 @@ provided in the `callback` field (complete with authentication header) finalizes
 response=$(curl \
   --request GET \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/provider/virtualbox/upload/direct)
+  https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/provider/virtualbox/upload/direct)
 
 # Requires the jq command
 upload_path=$(echo "$response" | jq .upload_path)
@@ -1578,7 +1578,7 @@ curl
 require "http"
 require "uri"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -1606,7 +1606,7 @@ end
 ```json
 {
   "upload_path": "https://remote-storage.example.com/bucket/630e42d9-2364-2412-4121-18266770468e?auth=9023wqfda",
-  "callback": "https://app.vagrantup.com/api/v1/box/myuser/test/version/1.2.3/provider/virtualbox/upload/direct/630e42d9-2364-2412-4121-18266770468e"
+  "callback": "https://vagrantcloud.com/api/v1/box/myuser/test/version/1.2.3/provider/virtualbox/upload/direct/630e42d9-2364-2412-4121-18266770468e"
 }
 ```
 

--- a/website/content/vagrant-cloud/api/v2.mdx
+++ b/website/content/vagrant-cloud/api/v2.mdx
@@ -91,7 +91,7 @@ Please check the [HashiCorp Status Site](http://status.hashicorp.com) for more i
 
 ## Creating a usable box from scratch
 
--> This assumes that you have a valid Vagrant Cloud authentication token. You can [create one via the API](#create-a-token), or [create one on the Vagrant Cloud website](https://app.vagrantup.com/settings/security).
+-> This assumes that you have a valid Vagrant Cloud authentication token. You can [create one via the API](#create-a-token), or [create one on the Vagrant Cloud website](https://vagrantcloud.com/settings/security).
 
 In order to create a usable box on Vagrant Cloud, perform the following steps:
 
@@ -112,7 +112,7 @@ curl \
   --request POST \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/boxes \
+  https://vagrantcloud.com/api/v2/boxes \
   --data '{ "box": { "username": "myuser", "name": "test" } }'
 
 # Create a new version
@@ -121,7 +121,7 @@ curl \
   --request POST \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/box/myuser/test/versions \
+  https://vagrantcloud.com/api/v2/box/myuser/test/versions \
   --data '{ "version": { "version": "1.2.3" } }'
 
 # Create a new provider
@@ -130,7 +130,7 @@ curl \
   --request POST \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/providers \
+  https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/providers \
   --data '{ "provider": { "name": "virtualbox" } }'
 
 # Prepare the provider for upload/get an upload URL
@@ -138,7 +138,7 @@ curl \
 response=$(curl \
     --request GET \
     --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-    https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/provider/virtualbox/upload)
+    https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/provider/virtualbox/upload)
 
 # Extract the upload URL from the response (requires the jq command)
 
@@ -153,7 +153,7 @@ curl --request PUT "${upload_path}" --upload-file virtualbox-1.2.3.box
 curl \
   --request PUT \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/release
+  https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/release
 
 ```
 
@@ -164,7 +164,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Content-Type" => "application/json",
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
@@ -221,7 +221,7 @@ Responds [`200 OK`](#200-ok) if the authentication request was successful, other
 curl \
   --request GET \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/authenticate
+  https://vagrantcloud.com/api/v2/authenticate
 ```
 
 </Tab>
@@ -231,7 +231,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -262,7 +262,7 @@ end
 curl \
   --request GET \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/user/myuser
+  https://vagrantcloud.com/api/v2/user/myuser
 ```
 
 </Tab>
@@ -272,7 +272,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -327,7 +327,7 @@ end
 curl \
   --request GET \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  "https://app.vagrantup.com/api/v2/search?q=test&provider=virtualbox"
+  "https://vagrantcloud.com/api/v2/search?q=test&provider=virtualbox"
 ```
 
 </Tab>
@@ -337,7 +337,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -382,8 +382,8 @@ end
         "created_at": "2017-10-20T15:23:17.184Z",
         "updated_at": "2017-10-20T15:23:53.355Z",
         "number": "1.2.3",
-        "release_url": "https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/release",
-        "revoke_url": "https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/revoke",
+        "release_url": "https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/release",
+        "revoke_url": "https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/revoke",
         "providers": [
           {
             "name": "virtualbox",
@@ -416,7 +416,7 @@ end
 curl \
   --request GET \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/box/myuser/test
+  https://vagrantcloud.com/api/v2/box/myuser/test
 ```
 
 </Tab>
@@ -426,7 +426,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -464,8 +464,8 @@ end
     "created_at": "2017-10-20T15:23:17.184Z",
     "updated_at": "2017-10-20T15:23:53.355Z",
     "number": "1.2.3",
-    "release_url": "https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/release",
-    "revoke_url": "https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/revoke",
+    "release_url": "https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/release",
+    "revoke_url": "https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/revoke",
     "providers": [
       {
         "name": "virtualbox",
@@ -487,8 +487,8 @@ end
       "created_at": "2017-10-20T15:23:17.184Z",
       "updated_at": "2017-10-20T15:23:53.355Z",
       "number": "1.2.3",
-      "release_url": "https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/release",
-      "revoke_url": "https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/revoke",
+      "release_url": "https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/release",
+      "revoke_url": "https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/revoke",
       "providers": [
         {
           "name": "virtualbox",
@@ -528,7 +528,7 @@ curl \
   --request POST \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/boxes \
+  https://vagrantcloud.com/api/v2/boxes \
   --data '
     {
       "box": {
@@ -549,7 +549,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Content-Type" => "application/json",
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
@@ -602,7 +602,7 @@ curl \
   --request PUT \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/box/myuser/test \
+  https://vagrantcloud.com/api/v2/box/myuser/test \
   --data '
     {
       "box": {
@@ -622,7 +622,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Content-Type" => "application/json",
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
@@ -661,7 +661,7 @@ end
 curl \
   --request DELETE \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/box/myuser/test
+  https://vagrantcloud.com/api/v2/box/myuser/test
 ```
 
 </Tab>
@@ -671,7 +671,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -708,7 +708,7 @@ Response body is identical to [Reading a box](#read-a-box).
 curl \
   --request GET \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3
+  https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3
 ```
 
 </Tab>
@@ -718,7 +718,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -747,8 +747,8 @@ end
   "created_at": "2017-10-20T15:23:17.184Z",
   "updated_at": "2017-10-20T15:23:53.355Z",
   "number": "1.2.3",
-  "release_url": "https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/release",
-  "revoke_url": "https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/revoke",
+  "release_url": "https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/release",
+  "revoke_url": "https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/revoke",
   "providers": [
     {
       "name": "virtualbox",
@@ -787,7 +787,7 @@ curl \
   --request POST \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/box/myuser/test/versions \
+  https://vagrantcloud.com/api/v2/box/myuser/test/versions \
   --data '
     {
       "version": {
@@ -805,7 +805,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Content-Type" => "application/json",
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
@@ -853,7 +853,7 @@ curl \
   --request PUT \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3 \
+  https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3 \
   --data '
     {
       "version": {
@@ -871,7 +871,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Content-Type" => "application/json",
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
@@ -912,7 +912,7 @@ Response body is identical to [Reading a version](#read-a-version).
 curl \
   --request DELETE \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3
+  https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3
 ```
 
 </Tab>
@@ -922,7 +922,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -957,7 +957,7 @@ Response body is identical to [Reading a version](#read-a-version).
 curl \
   --request PUT \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/release
+  https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/release
 ```
 
 </Tab>
@@ -967,7 +967,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -1002,7 +1002,7 @@ Response body is identical to [Reading a version](#read-a-version).
 curl \
   --request PUT \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/revoke
+  https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/revoke
 ```
 
 </Tab>
@@ -1012,7 +1012,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -1049,7 +1049,7 @@ Response body is identical to [Reading a version](#read-a-version).
 curl \
   --request GET \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/provider/virtualbox/amd64
+  https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/provider/virtualbox/amd64
 ```
 
 </Tab>
@@ -1059,7 +1059,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -1119,7 +1119,7 @@ curl \
   --request POST \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/providers \
+  https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/providers \
   --data '
     {
       "provider": {
@@ -1141,7 +1141,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Content-Type" => "application/json",
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
@@ -1195,7 +1195,7 @@ curl \
   --request PUT \
   --header "Content-Type: application/json" \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/provider/virtualbox/amd64 \
+  https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/provider/virtualbox/amd64 \
   --data '
     {
       "provider": {
@@ -1215,7 +1215,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Content-Type" => "application/json",
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
@@ -1256,7 +1256,7 @@ Response body is identical to [Reading a provider](#read-a-provider).
 curl \
   --request DELETE \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/provider/virtualbox/amd64
+  https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/provider/virtualbox/amd64
 ```
 
 </Tab>
@@ -1266,7 +1266,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -1305,7 +1305,7 @@ Prepares the provider for upload, and returns a JSON blob containing an `upload_
 response=$(curl \
   --request GET \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/provider/virtualbox/amd64/upload)
+  https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/provider/virtualbox/amd64/upload)
 
 # Requires the jq command
 upload_path=$(echo "$response" | jq .upload_path)
@@ -1323,7 +1323,7 @@ curl \
 # gem install http, or add `gem "http"` to your Gemfile
 require "http"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -1377,7 +1377,7 @@ provided in the `callback` field (complete with authentication header) finalizes
 response=$(curl \
   --request GET \
   --header "Authorization: Bearer $VAGRANT_CLOUD_TOKEN" \
-  https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/provider/virtualbox/amd64/upload/direct)
+  https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/provider/virtualbox/amd64/upload/direct)
 
 # Requires the jq command
 upload_path=$(echo "$response" | jq .upload_path)
@@ -1402,7 +1402,7 @@ curl
 require "http"
 require "uri"
 
-api = HTTP.persistent("https://app.vagrantup.com").headers(
+api = HTTP.persistent("https://vagrantcloud.com").headers(
   "Authorization" => "Bearer #{ENV['VAGRANT_CLOUD_TOKEN']}"
 )
 
@@ -1430,7 +1430,7 @@ end
 ```json
 {
   "upload_path": "https://remote-storage.example.com/bucket/630e42d9-2364-2412-4121-18266770468e?auth=9023wqfda",
-  "callback": "https://app.vagrantup.com/api/v2/box/myuser/test/version/1.2.3/provider/virtualbox/amd64/upload/direct/630e42d9-2364-2412-4121-18266770468e"
+  "callback": "https://vagrantcloud.com/api/v2/box/myuser/test/version/1.2.3/provider/virtualbox/amd64/upload/direct/630e42d9-2364-2412-4121-18266770468e"
 }
 ```
 

--- a/website/content/vagrant-cloud/boxes/using.mdx
+++ b/website/content/vagrant-cloud/boxes/using.mdx
@@ -10,7 +10,7 @@ A primary use case of Vagrant Cloud by HashiCorp is to be able to easily find
 boxes you can use with Vagrant that contain the technologies you need
 for a Vagrant environment. We've made it extremely easy to do that:
 
-1. Go to the [Discover page](https://app.vagrantup.com/boxes/search), and search for
+1. Go to the [Discover page](https://vagrantcloud.com/boxes/search), and search for
    any box you want.
 
 1. Once you find a box, click its name to learn more about it.

--- a/website/content/vagrant-cloud/hcp-vagrant/migration-guide.mdx
+++ b/website/content/vagrant-cloud/hcp-vagrant/migration-guide.mdx
@@ -53,7 +53,7 @@ Your HCP account must use the email address associated with your Vagrant Cloud a
 
 #### 1. Sign in to both accounts and open the migration tool
 
-Once you have signed into both your HCP and Vagrant Cloud accounts, you can access the [migration tool](https://app.vagrantup.com/migration).
+Once you have signed into both your HCP and Vagrant Cloud accounts, you can access the [migration tool](https://vagrantcloud.com/migration).
 
 #### 2. Select a Vagrant Cloud organization to migrate
 
@@ -79,7 +79,7 @@ Once your migration is complete you can view your new Registry in HCP.
 
 To view your registries , click on [Vagrant Registry](https://portal.cloud.hashicorp.com/services/vagrant/registries) in the side panel or by visiting [https://portal.cloud.hashicorp.com/services/vagrant/registries](https://portal.cloud.hashicorp.com/services/vagrant/registries).
 
-It is important to note that while a migrated organization will no longer be available in Vagrant Cloud the status of the migration will be visible from the `Status` tab on the [Migration](https://app.vagrantup.com/migration) page.
+It is important to note that while a migrated organization will no longer be available in Vagrant Cloud the status of the migration will be visible from the `Status` tab on the [Migration](https://vagrantcloud.com/migration) page.
 
 ## Conclusion
 

--- a/website/content/vagrant-cloud/hcp-vagrant/troubleshooting.mdx
+++ b/website/content/vagrant-cloud/hcp-vagrant/troubleshooting.mdx
@@ -16,5 +16,5 @@ In the rare case that an inoperable box was successfully uploaded (e.g legacy bo
 
 ### Retrying Migrations
 
-If a migration fails, a `retry` icon will appear beside the name of that organization on the [migration status](https://app.vagrantup.com/migration/status) page. Failed migrations can be retried once.
+If a migration fails, a `retry` icon will appear beside the name of that organization on the [migration status](https://vagrantcloud.com/migration/status) page. Failed migrations can be retried once.
 In the event of a second failure, please [contact support](/vagrant/intro/support) with a description of your issue. Our team will be happy to help you complete your migration or reset your organization state.

--- a/website/content/vagrant-cloud/organizations/migrate.mdx
+++ b/website/content/vagrant-cloud/organizations/migrate.mdx
@@ -14,7 +14,7 @@ To migrate an existing user account to an organization:
 
 2. Sign in as the account you wish to migrate.
 
-3. Go to [the account migration page](https://app.vagrantup.com/account/migrate).
+3. Go to [the account migration page](https://vagrantcloud.com/account/migrate).
 
 4. Put the username of the personal account you wish to make an owner of the
    organization into the username text field and press "Migrate".


### PR DESCRIPTION
As <https://github.com/hashicorp/vagrant/issues/13571#issuecomment-2589249126> mentioned:

> After further debug, this looks like a change introduced in HCP
> Vagrant Registry after 2025-01-09, that broke Vagrant versions before
> 2.4.0. I could confirm that everything works fine with Vagrant 2.4.0
> (and later), but fails to work with Vagrant 2.3.7 (and earlier). The
> root cause is that Vagrant 2.3.7 uses the equivalent of curl
> --location --verbose -H "Accept: application/json"
> <https://vagrantcloud.com/debian/bookworm64> to fetch the box
> metadata, but this no longer returns a JSON document. Vagrant 2.4.0
> uses <https://vagrantcloud.com/api/v2/vagrant/debian/bookworm64>
> instead.

This PR replace most <https://developer.hashicorp.com/vagrant/vagrant-cloud/api/v2> URL from existing <https://app.vagrantup.com> to <https://vagrantcloud.com>.

Fixes <https://github.com/hashicorp/vagrant/issues/13571> 
Fixes <https://github.com/hashicorp/vagrant/issues/13574> 
Fixes <https://github.com/hashicorp/vagrant/issues/13575>