### PR TITLE
Add VirtioSCSI to the list of supported storage controllers for VirtualBox

### DIFF
--- a/plugins/providers/virtualbox/model/storage_controller.rb
+++ b/plugins/providers/virtualbox/model/storage_controller.rb
@@ -9,7 +9,7 @@ module VagrantPlugins
       class StorageController
         IDE_CONTROLLER_TYPES = ["PIIX4", "PIIX3", "ICH6"].map(&:freeze).freeze
         SATA_CONTROLLER_TYPES = ["IntelAhci"].map(&:freeze).freeze
-        SCSI_CONTROLLER_TYPES = [ "LsiLogic", "BusLogic"].map(&:freeze).freeze
+        SCSI_CONTROLLER_TYPES = ["LsiLogic", "BusLogic", "VirtioSCSI"].map(&:freeze).freeze
 
         IDE_DEVICES_PER_PORT = 2.freeze
         SATA_DEVICES_PER_PORT = 1.freeze

--- a/plugins/providers/virtualbox/model/storage_controller_array.rb
+++ b/plugins/providers/virtualbox/model/storage_controller_array.rb
@@ -35,7 +35,7 @@ module VagrantPlugins
 
           if !controller
             raise Vagrant::Errors::VirtualBoxDisksNoSupportedControllers,
-              supported_types: supported_types.join(" ,")
+              supported_types: supported_types.join(", ")
           end
 
           controller
@@ -67,7 +67,7 @@ module VagrantPlugins
           controller = ordered.first
           if !controller
             raise Vagrant::Errors::VirtualBoxDisksNoSupportedControllers,
-              supported_types: supported_types.join(" ,")
+              supported_types: supported_types.join(", ")
           end
 
           controller


### PR DESCRIPTION
This minor change, adds virtio-scsi storage controller to the list of supported. closes #13586

Also it changes formatting of exception

From
> Vagrant was unable to detect a disk controller with any of the
> following supported types:
> 
> **IntelAhci ,PIIX4 ,PIIX3 ,ICH6 ,LsiLogic ,BusLogic**
> 
> Please add one of the supported controller types in order to use the
> disk configuration feature.

To

> ...
> IntelAhci, PIIX4, PIIX3, ICH6, LsiLogic, BusLogic
> ...


