### PR TITLE
Update architecture constraints in box outdated/update commands

### DIFF
--- a/lib/vagrant/box_metadata.rb
+++ b/lib/vagrant/box_metadata.rb
@@ -149,10 +149,11 @@ module Vagrant
         # on architecture and return match if found. If
         # no match is found and architecture wasn't automatically
         # detected, return nil as an explicit match is
-        # being requested
+        # being requested. If the box architecture is unknown, return that as well.
         if arch_name
           match = @provider_map[name].detect do |p|
-            p.architecture == arch_name
+            p.architecture == arch_name || 
+              p.architecture == "unknown"
           end
 
           return match if match || architecture != :auto

--- a/plugins/commands/box/command/outdated.rb
+++ b/plugins/commands/box/command/outdated.rb
@@ -57,7 +57,6 @@ module VagrantPlugins
         end
 
         def outdated_global(download_options)
-          boxes = {}
           @env.boxes.all.reverse.each do |name, version, provider|
             box = @env.boxes.find(name, provider, version)
             if !box.metadata_url
@@ -81,7 +80,7 @@ module VagrantPlugins
             end
 
             current = Gem::Version.new(box.version)
-            box_versions = md.versions(provider: box.provider)
+            box_versions = md.versions(provider: box.provider, architecture: box.architecture)
 
             if box_versions.empty?
               latest_box_version = box_versions.last.to_i

--- a/test/unit/plugins/commands/box/command/outdated_test.rb
+++ b/test/unit/plugins/commands/box/command/outdated_test.rb
@@ -138,6 +138,107 @@ describe VagrantPlugins::CommandBox::Command::Outdated do
           subject.outdated_global({})
         end
       end
+
+      context "with architectures" do
+        let(:md) {
+          md = Vagrant::BoxMetadata.new(StringIO.new(<<-RAW))
+        {
+          "name": "foo",
+          "versions": [
+            {
+              "version": "1.0"
+            },
+            {
+              "version": "1.1",
+              "providers": [
+                {
+                  "name": "vmware",
+                  "architecture": "amd64",
+                  "url": "bar"
+                },
+                {
+                  "name": "virtualbox",
+                  "architecture": "unknown",
+                  "url": "foo"
+                }
+              ]
+            },
+            {
+              "version": "1.2",
+              "providers": [
+                {
+                  "name": "vmware",
+                  "architecture": "arm64",
+                  "url": "baz"
+                },
+                {
+                  "name": "virtualbox",
+                  "architecture": "unknown",
+                  "url": "bat"
+                }
+              ]
+            }
+          ]
+        }
+          RAW
+        }
+
+
+      context "when latest version is available for provider with unknown architecture" do
+        let(:box) do
+          box_dir = test_iso_env.box3("foo", "1.0", :virtualbox, architecture: "arm64")
+          box = Vagrant::Box.new(
+            "foo", :virtualbox, "1.0", box_dir, metadata_url: "foo", architecture: "arm64")
+          allow(box).to receive(:load_metadata).and_return(md)
+          box
+        end
+
+        it "displays the latest version" do
+          allow(iso_env).to receive(:boxes).and_return(collection)
+
+          expect(I18n).to receive(:t).with(/box_outdated$/, hash_including(latest: "1.2"))
+
+          subject.outdated_global({})
+        end
+      end
+
+
+      context "when latest version isn't available for provider with explicit architecture" do
+        let(:box) do
+          box_dir = test_iso_env.box3("foo", "1.0", :vmware, architecture: "amd64")
+          box = Vagrant::Box.new(
+            "foo", :vmware, "1.0", box_dir, metadata_url: "foo", architecture: "amd64")
+          allow(box).to receive(:load_metadata).and_return(md)
+          box
+        end
+
+        it "displays the latest version" do
+          allow(iso_env).to receive(:boxes).and_return(collection)
+
+          expect(I18n).to receive(:t).with(/box_outdated$/, hash_including(latest: "1.1"))
+
+          subject.outdated_global({})
+        end
+      end
+
+      context "when no versions are available provider with explicit architecture" do
+        let(:box) do
+          box_dir = test_iso_env.box3("foo", "1.1", :vmware)
+          box = Vagrant::Box.new(
+            "foo", :vmware, "1.1", box_dir, metadata_url: "foo", architecture: "amd64")
+          allow(box).to receive(:load_metadata).and_return(md)
+          box
+        end
+
+        it "displays up to date message" do
+          allow(iso_env).to receive(:boxes).and_return(collection)
+
+          expect(I18n).to receive(:t).with(/box_up_to_date$/, hash_including(version: "1.1"))
+
+          subject.outdated_global({})
+        end
+      end
+    end
     end
   end
 end

--- a/test/unit/vagrant/box_metadata_test.rb
+++ b/test/unit/vagrant/box_metadata_test.rb
@@ -292,6 +292,58 @@ describe Vagrant::BoxMetadata do
           expect(result).to be_nil
         end
       end
+
+      context "with unknown architecture" do 
+        let(:raw) do
+          {
+            name: "foo",
+            description: "bar",
+            versions: [
+              {
+                version: "1.0.0",
+                providers: [
+                  {
+                    name: "virtualbox",
+                    default_architecture: true,
+                    architecture: "amd64"
+                  },
+                  {
+                    name: "virtualbox",
+                    default_architecture: false,
+                    architecture: "arm64"
+                  },
+                  {
+                    name: "vmware",
+                    default_architecture: true,
+                    architecture: "arm64"
+                  },
+                  {
+                    name: "vmware",
+                    default_architecture: false,
+                    architecture: "amd64"
+                  }
+                ],
+              },
+              {
+                version: "2.0.0",
+                providers: [
+                  {
+                    name: "vmware",
+                    architecture: "unknown",
+                    default_architecture: true,
+                  }
+                ]
+              }
+            ]
+          }.to_json
+        end
+
+        it "matches the version despite host architecture" do 
+          result = subject.version("> 0", architecture: "arm64")
+          expect(result).to be_kind_of(Vagrant::BoxMetadata::Version)
+          expect(result.version).to eq("2.0.0")
+        end
+      end
     end
 
     describe "#versions" do

--- a/test/unit/vagrant/box_test.rb
+++ b/test/unit/vagrant/box_test.rb
@@ -276,6 +276,40 @@ describe Vagrant::Box, :skip_windows do
         expect(result[2].url).to eq("bar")
       end
 
+      it "returns updated box if architecture is unknown" do
+        metadata = Vagrant::BoxMetadata.new(
+          {
+            name: "foo",
+            versions: [
+              {version: "1.0"},
+              {
+                version: "1.1",
+                providers: [
+                  {
+                    name: "virtualbox",
+                    url: "bar",
+                    architecture: "unknown",
+                  }
+                ]
+              }
+            ]
+          }.to_json
+        )
+
+        allow(subject).to receive(:load_metadata).and_return(metadata)
+
+        result = subject.has_update?
+        expect(result).to_not be_nil
+
+        expect(result[0]).to be_kind_of(Vagrant::BoxMetadata)
+        expect(result[1]).to be_kind_of(Vagrant::BoxMetadata::Version)
+        expect(result[2]).to be_kind_of(Vagrant::BoxMetadata::Provider)
+
+        expect(result[0].name).to eq("foo")
+        expect(result[1].version).to eq("1.1")
+        expect(result[2].url).to eq("bar")
+      end
+
       it "returns nil if update does not support architecture" do
         metadata = Vagrant::BoxMetadata.new(
           {


### PR DESCRIPTION
This PR addresses two issues that surfaced with the `box outdated` command, both having to do with architectures.

When `box outdated` was run for a single box, the architecture was being used as a constraint strictly, not accounting for boxes that had uploaded with `unknown` architectures while the host architecture was known. This bug causes any box that hadn't added architecture information to not show any outdated boxes, though there might be some, and would prevent updating using the command. An update has been made to account for these types of explicitly `unknown` architectures, and to return them even when the host architecture is explicit.

When `box outdated --global` was run, the check would omit architecture information, resulting in different results depending on how the command was run. The logic has been updated to include the architecture information, which will handle the `unknown` boxes as well.


