### PR TITLE
update to macOS documentation

### DIFF
--- a/contrib/sudoers/osx
+++ b/contrib/sudoers/osx
@@ -1,5 +1,5 @@
 Cmnd_Alias VAGRANT_EXPORTS_ADD = /usr/bin/tee -a /etc/exports
-Cmnd_Alias VAGRANT_NFSD = /sbin/nfsd restart
+Cmnd_Alias VAGRANT_NFSD = /sbin/nfsd ^(restart|status|update)$
 Cmnd_Alias VAGRANT_EXPORTS_REMOVE = /usr/bin/sed -E -e /*/ d -ibak /etc/exports
 Cmnd_Alias VAGRANT_SMB_ADD = /usr/sbin/sharing -a * -S * -s * -g * -n *
 Cmnd_Alias VAGRANT_SMB_REMOVE = /usr/sbin/sharing -r *

--- a/website/content/docs/synced-folders/nfs.mdx
+++ b/website/content/docs/synced-folders/nfs.mdx
@@ -156,7 +156,7 @@ For macOS, sudoers should have this entry:
 
 ```
 Cmnd_Alias VAGRANT_EXPORTS_ADD = /usr/bin/tee -a /etc/exports
-Cmnd_Alias VAGRANT_NFSD = /sbin/nfsd restart
+Cmnd_Alias VAGRANT_NFSD = /sbin/nfsd ^(restart|status|update)$
 Cmnd_Alias VAGRANT_EXPORTS_REMOVE = /usr/bin/sed -E -e /*/ d -ibak /etc/exports
 %admin ALL=(root) NOPASSWD: VAGRANT_EXPORTS_ADD, VAGRANT_NFSD, VAGRANT_EXPORTS_REMOVE
 ```


### PR DESCRIPTION
current vagrant (2.4.3) on macOS invokes nfs with at least two other arguments (status & update) rather than just restart

Fix #13582 @allisonlarson 