### PR TITLE
Fix architecture constraint in `box outdated` commands

### DIFF
--- a/lib/vagrant/box.rb
+++ b/lib/vagrant/box.rb
@@ -203,7 +203,8 @@ module Vagrant
       version += "> #{@version}"
       md      = self.load_metadata(download_options)
       newer   = md.version(version, provider: @provider, architecture: @architecture)
-      return nil if !newer
+      
+      return nil if newer == nil || !md.compatible_version_update?(@version, newer.version, provider: @provider, architecture: @architecture)
 
       [md, newer, newer.provider(@provider, @architecture)]
     end

--- a/lib/vagrant/box_collection.rb
+++ b/lib/vagrant/box_collection.rb
@@ -388,7 +388,7 @@ module Vagrant
 
                 return Box.new(
                   name, provider, version_dir_map[v.to_s], providerdir,
-                  architecture: architecture, metadata_url: metadata_url, hook: @hook
+                  architecture: box_architecture, metadata_url: metadata_url, hook: @hook
                 )
               end
             end
@@ -410,7 +410,7 @@ module Vagrant
 
             return Box.new(
               name, provider, version_dir_map[v.to_s], providerdir,
-              architecture: architecture, metadata_url: metadata_url, hook: @hook
+              architecture: box_architecture, metadata_url: metadata_url, hook: @hook
             )
           end
         end

--- a/plugins/commands/box/command/outdated.rb
+++ b/plugins/commands/box/command/outdated.rb
@@ -79,7 +79,6 @@ module VagrantPlugins
               next
             end
 
-            current = Gem::Version.new(box.version)
             box_versions = md.versions(provider: box.provider, architecture: box.architecture)
 
             if box_versions.empty?
@@ -88,8 +87,7 @@ module VagrantPlugins
               latest_box_version = box_versions.last
             end
 
-            latest  = Gem::Version.new(latest_box_version)
-            if latest <= current
+            if !md.compatible_version_update?(box.version, latest_box_version, provider: box.provider, architecture: box.architecture)
               @env.ui.success(I18n.t(
                 "vagrant.box_up_to_date",
                 name: box.name,
@@ -101,7 +99,7 @@ module VagrantPlugins
                 name: box.name,
                 provider: box.provider,
                 current: box.version,
-                latest: latest.to_s,))
+                latest: latest_box_version.to_s,))
             end
           end
         end

--- a/plugins/commands/box/command/outdated.rb
+++ b/plugins/commands/box/command/outdated.rb
@@ -57,7 +57,6 @@ module VagrantPlugins
         end
 
         def outdated_global(download_options)
-          boxes = {}
           @env.boxes.all.reverse.each do |name, version, provider|
             box = @env.boxes.find(name, provider, version)
             if !box.metadata_url
@@ -81,7 +80,7 @@ module VagrantPlugins
             end
 
             current = Gem::Version.new(box.version)
-            box_versions = md.versions(provider: box.provider)
+            box_versions = md.versions(provider: box.provider, architecture: box.architecture)
 
             if box_versions.empty?
               latest_box_version = box_versions.last.to_i

--- a/plugins/commands/box/command/outdated.rb
+++ b/plugins/commands/box/command/outdated.rb
@@ -59,11 +59,11 @@ module VagrantPlugins
         def outdated_global(download_options)
           @env.boxes.all.reverse.each do |name, version, provider|
             box = @env.boxes.find(name, provider, version)
-            if !box.metadata_url
+            if !box&.metadata_url
               @env.ui.output(I18n.t(
                 "vagrant.box_outdated_no_metadata",
-                name: box.name,
-                provider: box.provider))
+                name: name,
+                provider: provider))
               next
             end
 

--- a/test/unit/plugins/commands/box/command/outdated_test.rb
+++ b/test/unit/plugins/commands/box/command/outdated_test.rb
@@ -138,6 +138,107 @@ describe VagrantPlugins::CommandBox::Command::Outdated do
           subject.outdated_global({})
         end
       end
+
+      context "with architectures" do
+        let(:md) {
+          md = Vagrant::BoxMetadata.new(StringIO.new(<<-RAW))
+        {
+          "name": "foo",
+          "versions": [
+            {
+              "version": "1.0"
+            },
+            {
+              "version": "1.1",
+              "providers": [
+                {
+                  "name": "vmware",
+                  "architecture": "amd64",
+                  "url": "bar"
+                },
+                {
+                  "name": "virtualbox",
+                  "architecture": "unknown",
+                  "url": "foo"
+                }
+              ]
+            },
+            {
+              "version": "1.2",
+              "providers": [
+                {
+                  "name": "vmware",
+                  "architecture": "arm64",
+                  "url": "baz"
+                },
+                {
+                  "name": "virtualbox",
+                  "architecture": "unknown",
+                  "url": "bat"
+                }
+              ]
+            }
+          ]
+        }
+          RAW
+        }
+
+
+      context "when latest version is available for provider with unknown architecture" do
+        let(:box) do
+          box_dir = test_iso_env.box3("foo", "1.0", :virtualbox, architecture: "arm64")
+          box = Vagrant::Box.new(
+            "foo", :virtualbox, "1.0", box_dir, metadata_url: "foo", architecture: "arm64")
+          allow(box).to receive(:load_metadata).and_return(md)
+          box
+        end
+
+        it "displays the latest version" do
+          allow(iso_env).to receive(:boxes).and_return(collection)
+
+          expect(I18n).to receive(:t).with(/box_outdated$/, hash_including(latest: "1.2"))
+
+          subject.outdated_global({})
+        end
+      end
+
+
+      context "when latest version isn't available for provider with explicit architecture" do
+        let(:box) do
+          box_dir = test_iso_env.box3("foo", "1.0", :vmware, architecture: "amd64")
+          box = Vagrant::Box.new(
+            "foo", :vmware, "1.0", box_dir, metadata_url: "foo", architecture: "amd64")
+          allow(box).to receive(:load_metadata).and_return(md)
+          box
+        end
+
+        it "displays the latest version" do
+          allow(iso_env).to receive(:boxes).and_return(collection)
+
+          expect(I18n).to receive(:t).with(/box_outdated$/, hash_including(latest: "1.1"))
+
+          subject.outdated_global({})
+        end
+      end
+
+      context "when no versions are available provider with explicit architecture" do
+        let(:box) do
+          box_dir = test_iso_env.box3("foo", "1.1", :vmware)
+          box = Vagrant::Box.new(
+            "foo", :vmware, "1.1", box_dir, metadata_url: "foo", architecture: "amd64")
+          allow(box).to receive(:load_metadata).and_return(md)
+          box
+        end
+
+        it "displays up to date message" do
+          allow(iso_env).to receive(:boxes).and_return(collection)
+
+          expect(I18n).to receive(:t).with(/box_up_to_date$/, hash_including(version: "1.1"))
+
+          subject.outdated_global({})
+        end
+      end
+    end
     end
   end
 end


### PR DESCRIPTION
When a requesting to check an outdated box or update a box, add an explicit architecture compatibility check in addition to ensuring the version is newer than before.

The architecture compatibility checks allow boxes that were marked as an "unknown" architecture to see new "unknown" architectures as viable update options, if an architecture specific provider is not available. In the scenario that the existing version/provider has an explicit architecture defined, a new version/provider with an "unknown" architecture is not considered compatible.

This architecture check can be bypassed by explicitly setting `config.vm.box_architecture = nil` in the Vagrantfile.

This also fixes an issue where if architecture wasn't defined in the metadata at all, it also wouldn't detect newer versions. 

Fixes https://github.com/hashicorp/vagrant/issues/13345 https://github.com/hashicorp/vagrant/issues/13376 https://github.com/hashicorp/vagrant/issues/13285