### PR TITLE
Fix network template for Alpine Linux

### DIFF
--- a/templates/guests/alpine/network_dhcp.erb
+++ b/templates/guests/alpine/network_dhcp.erb
@@ -7,7 +7,6 @@ iface eth<%= options[:interface] %> inet dhcp
 <% else %>
     # We need to disable eth0, see GH-2648
     post-up route del default dev eth0
-    post-up dhclient $IFACE
     pre-down route add default dev eth0
 <% end %>
 #VAGRANT-END


### PR DESCRIPTION
Alpine Linux does not use dhclient by default, but udhcpc.  Simply deleting the line works as expected, and prevents an error on startup when `use_dhcp_assigned_default_route = true` is used on a public network.