### PR TITLE
Catch IO::Timeout when waiting for communicator

### DIFF
--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -11,6 +11,7 @@ Vagrant.require "log4r"
 Vagrant.require "vagrant/patches/log4r"
 Vagrant.require "vagrant/patches/net-ssh"
 Vagrant.require "vagrant/patches/rubygems"
+Vagrant.require "vagrant/patches/timeout_error"
 
 # Set our log levels and include trace
 Vagrant.require 'log4r/configurator'

--- a/lib/vagrant/patches/timeout_error.rb
+++ b/lib/vagrant/patches/timeout_error.rb
@@ -1,0 +1,5 @@
+# Adds an IO::TimeoutError for versions of ruby where it isn't defined (< 3.2). 
+if !defined?(IO::TimeoutError)
+  class IO::TimeoutError < StandardError
+  end
+end

--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -539,7 +539,7 @@ module VagrantPlugins
         rescue Errno::EACCES
           # This happens on connect() for unknown reasons yet...
           raise Vagrant::Errors::SSHConnectEACCES
-        rescue Errno::ETIMEDOUT, Timeout::Error
+        rescue Errno::ETIMEDOUT, Timeout::Error, IO::TimeoutError
           # This happens if we continued to timeout when attempting to connect.
           raise Vagrant::Errors::SSHConnectionTimeout
         rescue Net::SSH::AuthenticationFailed

--- a/plugins/communicators/winrm/shell.rb
+++ b/plugins/communicators/winrm/shell.rb
@@ -181,6 +181,8 @@ module VagrantPlugins
           raise Errors::SSLError, message: exception.message
         when HTTPClient::TimeoutError
           raise Errors::ConnectionTimeout, message: exception.message
+        when IO::TimeoutError
+          raise Errors::ConnectionTimeout
         when Errno::ETIMEDOUT
           raise Errors::ConnectionTimeout
           # This is raised if the connection timed out

--- a/test/unit/plugins/communicators/winrm/shell_test.rb
+++ b/test/unit/plugins/communicators/winrm/shell_test.rb
@@ -173,6 +173,12 @@ describe VagrantPlugins::CommunicatorWinRM::WinRMShell do
         expect(subject.cmd("dir").exitcode).to eq(0)
       end
     end
+
+    it "should catch timeout errors" do
+      expect(connection).to receive(:shell).with(:cmd, { })
+      expect(shell).to receive(:run).with("hostname").and_raise(IO::TimeoutError)
+      expect { subject.cmd("hostname") }.to raise_error(VagrantPlugins::CommunicatorWinRM::Errors::ConnectionTimeout)
+    end
   end
 
   describe ".wql" do


### PR DESCRIPTION
Ruby 3.2 introduced a new error, `IO:TimeoutError`, for blocking operations. Formerly, this case would return `Errno::ETIMEDOUT`. Catch the new error while waiting for the communicator so that the retries can be correctly attempted.

https://bugs.ruby-lang.org/issues/18630

Fixes https://github.com/hashicorp/vagrant/issues/13559