### PR TITLE
Bump wdm, childprocess gem constraints

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "base64", "~> 0.2.0"
   s.add_dependency "bcrypt_pbkdf", "~> 1.1"
-  s.add_dependency "childprocess", "~> 4.1.0"
+  s.add_dependency "childprocess", "~> 5.0.0"
   s.add_dependency "ed25519", "~> 1.3.0"
   s.add_dependency "erubi"
   s.add_dependency 'googleapis-common-protos-types', '~> 1.3'
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency "rgl", "~> 0.5.10"
   s.add_dependency "rubyzip", "~> 2.3.2"
   s.add_dependency "vagrant_cloud", "~> 3.1.2"
-  s.add_dependency "wdm", "~> 0.1.1"
+  s.add_dependency "wdm", "~> 0.2.0"
   s.add_dependency "winrm", ">= 2.3.9", "< 3.0"
   s.add_dependency "winrm-elevated", ">= 1.2.3", "< 2.0"
   s.add_dependency "winrm-fs", ">= 1.3.5", "< 2.0"


### PR DESCRIPTION
Bumps the versions of `wdm` and `childprocess` gems, which support ruby 3.x