### PR TITLE
Remove binary generation from build script

### DIFF
--- a/.ci/build
+++ b/.ci/build
@@ -36,22 +36,4 @@ fi
 wrap mv "${gem}" "${dest}" \
      "Failed to relocate Vagrant RubyGem"
 
-info "Installing submodules for vagrant-go build..."
-wrap git submodule update --init --recursive \
-     "Failed to install git submodules"
-
-info "Building vagrant-go linux binaries..."
-# Build vagrant-go binaries
-wrap make bin/linux \
-     "Failed to build the Vagrant go linux binaries"
-
-info "Building vagrant-go darwin binaries..."
-# Build darwin binary
-wrap make bin/darwin \
-     "Failed to build the Vagrant go darwin amd64 binary"
-
-info "Relocating vagrant-go binaries..."
-wrap mv bin/vagrant-go* "${dest}" \
-     "Failed to relocate vagrant binaries to destination directory"
-
 printf "build-artifacts-path=%s\n" "${dest}"


### PR DESCRIPTION
This removes the binary build steps from the build script as the binaries are not longer included when generating the packages.
