### PR TITLE
Update RHEL guest networking

### DIFF
--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 Vagrant.require "tempfile"
+Vagrant.require "securerandom"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 
@@ -13,6 +14,111 @@ module VagrantPlugins
         extend Vagrant::Util::GuestInspection::Linux
 
         def self.configure_networks(machine, networks)
+          @logger = Log4r::Logger.new("vagrant::guest::redhat::configurenetworks")
+
+          # Start with the scripts directory to determine how to configure
+          network_scripts_dir = machine.guest.capability(:network_scripts_dir)
+          @logger.debug("guest network scripts directory: #{network_scripts_dir}")
+
+          # The legacy configuration will handle rhel/centos pre-10
+          # versions. The newer versions have a different path for
+          # network configuration files.
+
+          return configure_networks_legacy(machine, networks) if network_scripts_dir.end_with?("network-scripts")
+
+          comm = machine.communicate
+
+          interfaces = machine.guest.capability(:network_interfaces)
+          net_configs = machine.config.vm.networks.find_all { |type, _| type.to_s.end_with?("_network") }.map(&:last)
+
+          # Get IDs of currently configured devices
+          current_devs = Hash.new.tap do |cd|
+            comm.execute("nmcli -t c show") do |type, data|
+              if type == :stdout
+                _, id, _, dev = data.strip.split(":")
+                cd[dev] = id
+              end
+            end
+          end
+
+          networks.each.with_index do |network, i|
+            net_opts = (net_configs[i] || {}).merge(network)
+            net_opts[:type] = net_opts[:type].to_s
+            net_opts[:device] = interfaces[network[:interface]]
+
+            if !net_opts[:mac_address]
+              comm.execute("cat /sys/class/net/#{net_opts[:device]}/address") do |type, data|
+                net_opts[:mac_address] = data if type == :stdout
+              end
+            end
+
+            tmpl_opts = {
+              interface_name: net_opts[:device],
+              type: net_opts[:type],
+              mac_address: net_opts[:mac_address],
+              uuid: SecureRandom.uuid
+            }
+
+            if net_opts[:type] != "dhcp"
+              begin
+                addr = IPAddr.new("#{net_opts[:ip]}")
+                if addr.ipv4?
+                  tmpl_opts[:ipv4] = addr.to_string
+                  masked = addr.mask(net_opts[:netmask])
+
+                  tmpl_opts[:ipv4_mask] = masked.prefix
+                  tmpl_opts[:ipv4_gateway] = masked.succ.to_string
+                else
+                  tmpl_opts[:ipv6] = addr.to_string
+                  masked = addr.mask(net_opts[:netmask])
+
+                  tmpl_opts[:ipv6_mask] = masked.prefix
+                  tmpl_opts[:ipv6_gateway] = masked.succ.to_string
+                end
+              rescue IPAddr::Error => err
+                raise NetworkAddressInvalid,
+                  address: net_opts[:ip],
+                  mask: net_opts[:netmask],
+                  error: err.to_s
+              end
+            end
+
+            entry = TemplateRenderer.render("guests/redhat/network_manager_device", options: tmpl_opts)
+            remote_path = "/tmp/vagrant-network-entry-#{net_opts[:device]}-#{Time.now.to_i}-#{i}"
+            final_path = "#{network_scripts_dir}/#{net_opts[:device]}.nmconnection"
+
+            Tempfile.open("vagrant-redhat-configure-networks") do |f|
+              f.binmode
+              f.write(entry)
+              f.fsync
+              f.close
+              comm.upload(f.path, remote_path)
+            end
+
+            # Remove the device if it already exists
+            if device_id = current_devs[net_opts[:device]]
+              [
+                "nmcli d disconnect '#{net_opts[:device]}'",
+                "nmcli c delete '#{device_id}'",
+              ].each do |cmd|
+                comm.sudo(cmd, error_check: false)
+              end
+            end
+
+            # Apply the config
+            [
+              "chown root:root '#{remote_path}'",
+              "chmod 0600 '#{remote_path}'",
+              "mv '#{remote_path}' '#{final_path}'",
+              "nmcli c load '#{final_path}'",
+              "nmcli d connect '#{net_opts[:device]}'"
+            ].each do |cmd|
+              comm.sudo(cmd)
+            end
+          end
+        end
+
+        def self.configure_networks_legacy(machine, networks)
           comm = machine.communicate
 
           network_scripts_dir = machine.guest.capability(:network_scripts_dir)

--- a/plugins/guests/redhat/cap/network_scripts_dir.rb
+++ b/plugins/guests/redhat/cap/network_scripts_dir.rb
@@ -6,7 +6,11 @@ module VagrantPlugins
     module Cap
       class NetworkScriptsDir
         def self.network_scripts_dir(machine)
-          "/etc/sysconfig/network-scripts"
+          if machine.communicate.test("test -d /etc/sysconfig/network-scripts")
+            "/etc/sysconfig/network-scripts"
+          else
+            "/etc/NetworkManager/system-connections"
+          end
         end
       end
     end

--- a/templates/guests/redhat/network_manager_device.erb
+++ b/templates/guests/redhat/network_manager_device.erb
@@ -1,0 +1,41 @@
+[connection]
+id=<%= options[:interface_name] %>
+uuid=<%= options[:uuid] %>
+type=ethernet
+autoconnect-priority=-100
+autoconnect-retries=1
+interface-name=<%= options[:interface_name] %>
+
+[ethernet]
+<% if options[:mac_address] -%>
+mac-address=<%= options[:mac_address] %>
+<% end -%>
+
+<% if options[:ipv4] -%>
+[ipv4]
+<% if options[:type] == "dhcp" -%>
+dhcp-timeout=90
+method=auto
+required-timeout=20000
+<% elsif options[:ipv4] -%>
+method=manual
+addresses=<%= options[:ipv4] %>/<%= options[:ipv4_mask] %>
+gateway=<%= options[:ipv4_gateway] %>
+<% end -%>
+<% end -%>
+
+<% if options[:ipv6] -%>
+[ipv6]
+<% if options[:type] == "dhcp" -%>
+addr-gen-mode=eui64
+dhcp-timeout=90
+method=auto
+<% elsif options[:ipv6] -%>
+method=manual
+addresses=<%= options[:ipv6] %>/<%= options[:ipv6_mask] %>
+gateway=<%= options[:ipv6_gateway] %>
+<% end -%>
+<% end -%>
+
+[user]
+org.freedesktop.NetworkManager.origin=vagrant

--- a/test/unit/plugins/guests/redhat/cap/configure_networks_test.rb
+++ b/test/unit/plugins/guests/redhat/cap/configure_networks_test.rb
@@ -25,21 +25,21 @@ describe "VagrantPlugins::GuestRedHat::Cap::ConfigureNetworks" do
     comm.verify_expectations!
   end
 
-  describe ".configure_networks" do
+  context "with systems-connections network configuration path" do
     let(:cap) { caps.get(:configure_networks) }
 
     before do
       allow(guest).to receive(:capability)
-        .with(:flavor)
-        .and_return(:rhel)
+                        .with(:flavor)
+                        .and_return(:rhel)
 
       allow(guest).to receive(:capability)
-        .with(:network_scripts_dir)
-        .and_return("/scripts")
+                        .with(:network_scripts_dir)
+                        .and_return("/system-connections")
 
       allow(guest).to receive(:capability)
-        .with(:network_interfaces)
-        .and_return(["eth1", "eth2"])
+                        .with(:network_interfaces)
+                        .and_return(["eth1", "eth2", "eth3"])
     end
 
     let(:network_1) do
@@ -69,8 +69,65 @@ describe "VagrantPlugins::GuestRedHat::Cap::ConfigureNetworks" do
       }
     end
 
+    it "should fetch mac address for devices" do
+      cap.configure_networks(machine, [network_1, network_2, network_3])
+
+      expect(comm.received_commands).to include(%r{/net/eth1/address})
+      expect(comm.received_commands).to include(%r{/net/eth2/address})
+      expect(comm.received_commands).to include(%r{/net/eth3/address})
+    end
+
+    it "should change ownership of files" do
+      cap.configure_networks(machine, [network_1, network_2, network_3])
+
+      expect(comm.received_commands).to include(%r{chown root:root '/tmp/vagrant.*eth1.*'})
+      expect(comm.received_commands).to include(%r{chown root:root '/tmp/vagrant.*eth2.*'})
+      expect(comm.received_commands).to include(%r{chown root:root '/tmp/vagrant.*eth3.*'})
+    end
+
+    it "should change mode of files" do
+      cap.configure_networks(machine, [network_1, network_2, network_3])
+
+      expect(comm.received_commands).to include(%r{chmod 0600 '/tmp/vagrant.*eth1.*'})
+      expect(comm.received_commands).to include(%r{chmod 0600 '/tmp/vagrant.*eth2.*'})
+      expect(comm.received_commands).to include(%r{chmod 0600 '/tmp/vagrant.*eth3.*'})
+    end
+
+    it "should move configuration files" do
+      cap.configure_networks(machine, [network_1, network_2, network_3])
+
+      expect(comm.received_commands).to include(%r{mv '/tmp/vagrant.*eth1.*' '/system-connections/eth1.nmconnection'})
+      expect(comm.received_commands).to include(%r{mv '/tmp/vagrant.*eth2.*' '/system-connections/eth2.nmconnection'})
+      expect(comm.received_commands).to include(%r{mv '/tmp/vagrant.*eth3.*' '/system-connections/eth3.nmconnection'})
+    end
+
+    it "should move configuration files" do
+      cap.configure_networks(machine, [network_1, network_2, network_3])
+
+      expect(comm.received_commands).to include(%r{mv '/tmp/vagrant.*eth1.*' '/system-connections/eth1.nmconnection'})
+      expect(comm.received_commands).to include(%r{mv '/tmp/vagrant.*eth2.*' '/system-connections/eth2.nmconnection'})
+      expect(comm.received_commands).to include(%r{mv '/tmp/vagrant.*eth3.*' '/system-connections/eth3.nmconnection'})
+    end
+
+    it "should move load new configuration files" do
+      cap.configure_networks(machine, [network_1, network_2, network_3])
+
+      expect(comm.received_commands).to include("nmcli c load '/system-connections/eth1.nmconnection'")
+      expect(comm.received_commands).to include("nmcli c load '/system-connections/eth2.nmconnection'")
+      expect(comm.received_commands).to include("nmcli c load '/system-connections/eth3.nmconnection'")
+    end
+
+    it "should connect new devices" do
+      cap.configure_networks(machine, [network_1, network_2, network_3])
+
+      expect(comm.received_commands).to include("nmcli d connect 'eth1'")
+      expect(comm.received_commands).to include("nmcli d connect 'eth2'")
+      expect(comm.received_commands).to include("nmcli d connect 'eth3'")
+    end
+
     context "network configuration file" do
       let(:networks){ [[:public_network, network_1], [:private_network, network_2], [:private_network, network_3]] }
+
       let(:tempfile) { double("tempfile") }
 
       before do
@@ -103,152 +160,235 @@ describe "VagrantPlugins::GuestRedHat::Cap::ConfigureNetworks" do
       end
     end
 
-    context "with NetworkManager installed" do
-      let(:net1_nm_controlled) { true }
-      let(:net2_nm_controlled) { true }
 
-      let(:networks){ [
-        [:public_network, network_1.merge(nm_controlled: net1_nm_controlled)],
-        [:private_network, network_2.merge(nm_controlled: net2_nm_controlled)]
-      ] }
+  end
+
+  describe ".configure_networks" do
+    context "when version is less than 10" do
+      let(:cap) { caps.get(:configure_networks) }
 
       before do
-        allow(cap).to receive(:nmcli?).and_return true
+        allow(guest).to receive(:capability)
+                          .with(:flavor)
+                          .and_return(:rhel)
+
+        allow(guest).to receive(:capability)
+                          .with(:network_scripts_dir)
+                          .and_return("/network-scripts")
+
+        allow(guest).to receive(:capability)
+                          .with(:network_interfaces)
+                          .and_return(["eth1", "eth2"])
       end
 
-      context "with devices managed by NetworkManager" do
+      let(:network_1) do
+        {
+          interface: 0,
+          type: "dhcp",
+        }
+      end
+
+      let(:network_2) do
+        {
+          interface: 1,
+          type: "static",
+          ip: "33.33.33.10",
+          netmask: "255.255.0.0",
+          gateway: "33.33.0.1",
+        }
+      end
+
+      let(:network_3) do
+        {
+          interface: 2,
+          type: "static",
+          ip: "33.33.33.11",
+          netmask: "255.255.0.0",
+          gateway: "33.33.0.1",
+        }
+      end
+
+      context "network configuration file" do
+        let(:networks){ [[:public_network, network_1], [:private_network, network_2], [:private_network, network_3]] }
+        let(:tempfile) { double("tempfile") }
+
         before do
-          allow(cap).to receive(:nm_controlled?).and_return true
+          allow(tempfile).to receive(:binmode)
+          allow(tempfile).to receive(:write)
+          allow(tempfile).to receive(:fsync)
+          allow(tempfile).to receive(:close)
+          allow(tempfile).to receive(:path)
+          allow(Tempfile).to receive(:open).and_yield(tempfile)
+        end
+
+        it "should generate two configuration files" do
+          expect(Tempfile).to receive(:open).twice
+          cap.configure_networks(machine, [network_1, network_2])
+        end
+
+        it "should generate three configuration files" do
+          expect(Tempfile).to receive(:open).thrice
+          cap.configure_networks(machine, [network_1, network_2, network_3])
+        end
+
+        it "should generate configuration with network_2 IP address" do
+          expect(tempfile).to receive(:write).with(/#{network_2[:ip]}/)
+          cap.configure_networks(machine, [network_1, network_2, network_3])
+        end
+
+        it "should generate configuration with network_3 IP address" do
+          expect(tempfile).to receive(:write).with(/#{network_3[:ip]}/)
+          cap.configure_networks(machine, [network_1, network_2, network_3])
+        end
+      end
+
+      context "with NetworkManager installed" do
+        let(:net1_nm_controlled) { true }
+        let(:net2_nm_controlled) { true }
+
+        let(:networks){ [
+          [:public_network, network_1.merge(nm_controlled: net1_nm_controlled)],
+          [:private_network, network_2.merge(nm_controlled: net2_nm_controlled)]
+        ] }
+
+        before do
+          allow(cap).to receive(:nmcli?).and_return true
+        end
+
+        context "with devices managed by NetworkManager" do
+          before do
+            allow(cap).to receive(:nm_controlled?).and_return true
+          end
+
+          context "with nm_controlled option omitted" do
+            let(:networks){ [
+              [:public_network, network_1],
+              [:private_network, network_2]
+            ] }
+
+            it "creates and starts the networks via nmcli" do
+              cap.configure_networks(machine, [network_1, network_2])
+              expect(comm.received_commands[0]).to match(/nmcli/)
+              expect(comm.received_commands[0]).to_not match(/(ifdown|ifup)/)
+            end
+          end
+
+          context "with nm_controlled option set to true" do
+            it "creates and starts the networks via nmcli" do
+              cap.configure_networks(machine, [network_1, network_2])
+              expect(comm.received_commands[0]).to match(/nmcli/)
+              expect(comm.received_commands[0]).to_not match(/(ifdown|ifup)/)
+            end
+          end
+
+          context "with nm_controlled option set to false" do
+            let(:net1_nm_controlled) { false }
+            let(:net2_nm_controlled) { false }
+
+            it "creates and starts the networks via ifup and disables devices in NetworkManager" do
+              cap.configure_networks(machine, [network_1, network_2])
+              expect(comm.received_commands[0]).to match(/nmcli.*disconnect/)
+              expect(comm.received_commands[0]).to match(/ifup/)
+              expect(comm.received_commands[0]).to_not match(/ifdown/)
+            end
+          end
+
+          context "with nm_controlled option set to false on first device" do
+            let(:net1_nm_controlled) { false }
+            let(:net2_nm_controlled) { true }
+
+            it "creates and starts the networks with one managed manually and one NetworkManager controlled" do
+              cap.configure_networks(machine, [network_1, network_2])
+              expect(comm.received_commands[0]).to match(/nmcli.*disconnect.*eth1/)
+              expect(comm.received_commands[0]).to match(/ifup.*eth1/)
+              expect(comm.received_commands[0]).to_not match(/ifdown/)
+            end
+          end
+        end
+
+        context "with devices not managed by NetworkManager" do
+          before do
+            allow(cap).to receive(:nm_controlled?).and_return false
+          end
+
+          context "with nm_controlled option omitted" do
+            let(:networks){ [
+              [:public_network, network_1],
+              [:private_network, network_2]
+            ] }
+
+            it "creates and starts the networks manually" do
+              cap.configure_networks(machine, [network_1, network_2])
+              expect(comm.received_commands[0]).to match(/ifdown/)
+              expect(comm.received_commands[0]).to match(/ifup/)
+              expect(comm.received_commands[0]).to_not match(/nmcli c up/)
+              expect(comm.received_commands[0]).to_not match(/nmcli d disconnect/)
+            end
+          end
+
+          context "with nm_controlled option set to true" do
+            let(:net1_nm_controlled) { true }
+            let(:net2_nm_controlled) { true }
+
+            it "creates and starts the networks via nmcli" do
+              cap.configure_networks(machine, [network_1, network_2])
+              expect(comm.received_commands[0]).to match(/NetworkManager/)
+              expect(comm.received_commands[0]).to match(/ifdown/)
+              expect(comm.received_commands[0]).to_not match(/ifup/)
+            end
+          end
+
+          context "with nm_controlled option set to false" do
+            let(:net1_nm_controlled) { false }
+            let(:net2_nm_controlled) { false }
+
+            it "creates and starts the networks via ifup " do
+              cap.configure_networks(machine, [network_1, network_2])
+              expect(comm.received_commands[0]).to match(/ifup/)
+              expect(comm.received_commands[0]).to match(/ifdown/)
+              expect(comm.received_commands[0]).to_not match(/nmcli c up/)
+              expect(comm.received_commands[0]).to_not match(/nmcli d disconnect/)
+            end
+          end
+
+          context "with nm_controlled option set to false on first device" do
+            let(:net1_nm_controlled) { false }
+            let(:net2_nm_controlled) { true }
+
+            it "creates and starts the networks with one managed manually and one NetworkManager controlled" do
+              cap.configure_networks(machine, [network_1, network_2])
+              expect(comm.received_commands[0]).to_not match(/nmcli.*disconnect/)
+              expect(comm.received_commands[0]).to match(/ifdown/)
+              expect(comm.received_commands[0]).to match(/ifup.*eth1/)
+            end
+          end
+        end
+      end
+
+      context "without NetworkManager installed" do
+        before do
+          allow(cap).to receive(:nmcli?).and_return false
         end
 
         context "with nm_controlled option omitted" do
-          let(:networks){ [
-            [:public_network, network_1],
-            [:private_network, network_2]
-          ] }
-
-          it "creates and starts the networks via nmcli" do
-            cap.configure_networks(machine, [network_1, network_2])
-            expect(comm.received_commands[0]).to match(/nmcli/)
-            expect(comm.received_commands[0]).to_not match(/(ifdown|ifup)/)
-          end
-        end
-
-        context "with nm_controlled option set to true" do
-          it "creates and starts the networks via nmcli" do
-            cap.configure_networks(machine, [network_1, network_2])
-            expect(comm.received_commands[0]).to match(/nmcli/)
-            expect(comm.received_commands[0]).to_not match(/(ifdown|ifup)/)
-          end
-        end
-
-        context "with nm_controlled option set to false" do
-          let(:net1_nm_controlled) { false }
-          let(:net2_nm_controlled) { false }
-
-          it "creates and starts the networks via ifup and disables devices in NetworkManager" do
-            cap.configure_networks(machine, [network_1, network_2])
-            expect(comm.received_commands[0]).to match(/nmcli.*disconnect/)
-            expect(comm.received_commands[0]).to match(/ifup/)
-            expect(comm.received_commands[0]).to_not match(/ifdown/)
-          end
-        end
-
-        context "with nm_controlled option set to false on first device" do
-          let(:net1_nm_controlled) { false }
-          let(:net2_nm_controlled) { true }
-
-          it "creates and starts the networks with one managed manually and one NetworkManager controlled" do
-            cap.configure_networks(machine, [network_1, network_2])
-            expect(comm.received_commands[0]).to match(/nmcli.*disconnect.*eth1/)
-            expect(comm.received_commands[0]).to match(/ifup.*eth1/)
-            expect(comm.received_commands[0]).to_not match(/ifdown/)
-          end
-        end
-      end
-
-      context "with devices not managed by NetworkManager" do
-        before do
-          allow(cap).to receive(:nm_controlled?).and_return false
-        end
-
-        context "with nm_controlled option omitted" do
-          let(:networks){ [
-            [:public_network, network_1],
-            [:private_network, network_2]
-          ] }
 
           it "creates and starts the networks manually" do
             cap.configure_networks(machine, [network_1, network_2])
             expect(comm.received_commands[0]).to match(/ifdown/)
             expect(comm.received_commands[0]).to match(/ifup/)
-            expect(comm.received_commands[0]).to_not match(/nmcli c up/)
-            expect(comm.received_commands[0]).to_not match(/nmcli d disconnect/)
+            expect(comm.received_commands[0]).to_not match(/nmcli/)
           end
         end
 
-        context "with nm_controlled option set to true" do
-          let(:net1_nm_controlled) { true }
-          let(:net2_nm_controlled) { true }
+        context "with nm_controlled option set" do
+          let(:networks){ [
+            [:public_network, network_1.merge(nm_controlled: true)],
+            [:private_network, network_2.merge(nm_controlled: true)]
+          ] }
 
-          it "creates and starts the networks via nmcli" do
-            cap.configure_networks(machine, [network_1, network_2])
-            expect(comm.received_commands[0]).to match(/NetworkManager/)
-            expect(comm.received_commands[0]).to match(/ifdown/)
-            expect(comm.received_commands[0]).to_not match(/ifup/)
+          it "raises an error" do
+            expect{ cap.configure_networks(machine, [network_1, network_2]) }.to raise_error(Vagrant::Errors::NetworkManagerNotInstalled)
           end
-        end
-
-        context "with nm_controlled option set to false" do
-          let(:net1_nm_controlled) { false }
-          let(:net2_nm_controlled) { false }
-
-          it "creates and starts the networks via ifup " do
-            cap.configure_networks(machine, [network_1, network_2])
-            expect(comm.received_commands[0]).to match(/ifup/)
-            expect(comm.received_commands[0]).to match(/ifdown/)
-            expect(comm.received_commands[0]).to_not match(/nmcli c up/)
-            expect(comm.received_commands[0]).to_not match(/nmcli d disconnect/)
-          end
-        end
-
-        context "with nm_controlled option set to false on first device" do
-          let(:net1_nm_controlled) { false }
-          let(:net2_nm_controlled) { true }
-
-          it "creates and starts the networks with one managed manually and one NetworkManager controlled" do
-            cap.configure_networks(machine, [network_1, network_2])
-            expect(comm.received_commands[0]).to_not match(/nmcli.*disconnect/)
-            expect(comm.received_commands[0]).to match(/ifdown/)
-            expect(comm.received_commands[0]).to match(/ifup.*eth1/)
-          end
-        end
-      end
-    end
-
-    context "without NetworkManager installed" do
-      before do
-        allow(cap).to receive(:nmcli?).and_return false
-      end
-
-      context "with nm_controlled option omitted" do
-
-        it "creates and starts the networks manually" do
-          cap.configure_networks(machine, [network_1, network_2])
-          expect(comm.received_commands[0]).to match(/ifdown/)
-          expect(comm.received_commands[0]).to match(/ifup/)
-          expect(comm.received_commands[0]).to_not match(/nmcli/)
-        end
-      end
-
-      context "with nm_controlled option set" do
-        let(:networks){ [
-          [:public_network, network_1.merge(nm_controlled: true)],
-          [:private_network, network_2.merge(nm_controlled: true)]
-        ] }
-
-        it "raises an error" do
-          expect{ cap.configure_networks(machine, [network_1, network_2]) }.to raise_error(Vagrant::Errors::NetworkManagerNotInstalled)
         end
       end
     end

--- a/test/unit/plugins/guests/redhat/cap/network_scripts_dir_test.rb
+++ b/test/unit/plugins/guests/redhat/cap/network_scripts_dir_test.rb
@@ -10,15 +10,29 @@ describe "VagrantPlugins::GuestRedHat::Cap::NetworkScriptsDir" do
       .guest_capabilities[:redhat]
   end
 
-  let(:machine) { double("machine") }
+  let(:is_legacy) { false }
+  let(:communicator) { double("communicator") }
+  let(:machine) { double("machine", communicate: communicator) }
+
+  before do
+    allow(communicator).to receive(:test).with("test -d /etc/sysconfig/network-scripts").and_return(is_legacy)
+  end
 
   describe ".network_scripts_dir" do
     let(:cap) { caps.get(:network_scripts_dir) }
 
     let(:name) { "banana-rama.example.com" }
 
-    it "is /etc/sysconfig/network-scripts" do
-      expect(cap.network_scripts_dir(machine)).to eq("/etc/sysconfig/network-scripts")
+    it "is /etc/NetworkManager/system-connections" do
+      expect(cap.network_scripts_dir(machine)).to eq("/etc/NetworkManager/system-connections")
+    end
+
+    context 'when version is legacy' do
+      let(:is_legacy) { true }
+
+      it "is /etc/sysconfig/network-scripts" do
+        expect(cap.network_scripts_dir(machine)).to eq("/etc/sysconfig/network-scripts")
+      end
     end
   end
 end


### PR DESCRIPTION
Recent versions of RHEL based guests have updated network configuration.
Detect the correct location of the network configuration files, and
configure the guest based on the detected location.

Fixes #13616
