### PR TITLE
Update amazonlinux guest network configuration

### DIFF
--- a/plugins/guests/amazon/cap/configure_networks.rb
+++ b/plugins/guests/amazon/cap/configure_networks.rb
@@ -1,0 +1,26 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+require_relative "../../debian/cap/configure_networks"
+require_relative "../../redhat/cap/configure_networks"
+
+module VagrantPlugins
+  module GuestAmazon
+    module Cap
+      class ConfigureNetworks
+        extend Vagrant::Util::GuestInspection::Linux
+
+        def self.configure_networks(machine, networks)
+          # If the guest is using networkd, call the debian capability
+          # as it will handle networkd. Otherwise, fallback to using
+          # the RHEL capability.
+          if systemd_networkd?(machine.communicate)
+            VagrantPlugins::GuestDebian::Cap::ConfigureNetworks.configure_networks(machine, networks)
+          else
+            VagrantPlugins::GuestRedHat::Cap::ConfigureNetworks.configure_networks(machine, networks)
+          end
+        end
+      end
+    end
+  end
+end

--- a/plugins/guests/amazon/plugin.rb
+++ b/plugins/guests/amazon/plugin.rb
@@ -18,6 +18,11 @@ module VagrantPlugins
         require_relative "cap/flavor"
         Cap::Flavor
       end
+
+      guest_capability(:amazon, :configure_networks) do
+        require_relative "cap/configure_networks"
+        Cap::ConfigureNetworks
+      end
     end
   end
 end

--- a/plugins/guests/debian/cap/configure_networks.rb
+++ b/plugins/guests/debian/cap/configure_networks.rb
@@ -68,7 +68,7 @@ module VagrantPlugins
             renderer = "networkd"
             ethernets.keys.each do |k|
               if nm_controlled?(comm, k)
-                render = "NetworkManager"
+                renderer = "NetworkManager"
                 if !nmcli?(comm)
                   raise Vagrant::Errors::NetworkManagerNotInstalled, device: k
                 end
@@ -94,7 +94,6 @@ module VagrantPlugins
 
         # Configure guest networking using networkd
         def self.configure_networkd(machine, interfaces, comm, networks)
-          root_device = interfaces.first
           networks.each do |network|
             dev_name = interfaces[network[:interface]]
             net_conf = []

--- a/test/unit/plugins/guests/amazon/cap/configure_networks_test.rb
+++ b/test/unit/plugins/guests/amazon/cap/configure_networks_test.rb
@@ -1,0 +1,46 @@
+# Copyright (c) HashiCorp, Inc.
+# SPDX-License-Identifier: BUSL-1.1
+
+require_relative "../../../../base"
+
+describe "VagrantPlugins::GuestAmazon::Cap::ConfigureNetworks" do
+  let(:caps) do
+    VagrantPlugins::GuestAmazon::Plugin
+      .components
+      .guest_capabilities[:amazon]
+  end
+
+  let(:machine) { double("machine", communicate: communicator) }
+  let(:communicator) { double("communicator") }
+  let(:networks) { double("networks") }
+
+  describe ".configure_networks" do
+    let(:cap) { caps.get(:configure_networks) }
+    before do
+      allow(cap).to receive(:systemd_networkd?).
+        with(communicator).and_return(is_networkd)
+    end
+
+    context "when guest is using networkd" do
+      let(:is_networkd) { true  }
+
+      it "should call the debian capability" do
+        expect(VagrantPlugins::GuestDebian::Cap::ConfigureNetworks).
+          to receive(:configure_networks).with(machine, networks)
+
+        cap.configure_networks(machine, networks)
+      end
+    end
+
+    context "when guest is not using networkd" do
+      let(:is_networkd) { false }
+
+      it "should call the redhat capability" do
+        expect(VagrantPlugins::GuestRedHat::Cap::ConfigureNetworks).
+          to receive(:configure_networks).with(machine, networks)
+
+        cap.configure_networks(machine, networks)
+      end
+    end
+  end
+end

--- a/test/unit/plugins/hosts/darwin/cap/fs_iso_test.rb
+++ b/test/unit/plugins/hosts/darwin/cap/fs_iso_test.rb
@@ -27,7 +27,7 @@ describe VagrantPlugins::HostDarwin::Cap::FsISO do
 
     it "builds an iso" do
       expect(Vagrant::Util::Subprocess).to receive(:execute).with(
-        "hdiutil", "makehybrid", "-hfs", "-iso", "-joliet", "-ov", "-o", /.iso/, /\/foo\/src/
+        "hdiutil", "makehybrid", "-iso", "-joliet", "-ov", "-o", /.iso/, /\/foo\/src/
       ).and_return(double(exit_code: 0))
       expect(FileUtils).to receive(:mkdir_p).with(Pathname.new(file_destination).dirname)
 
@@ -37,7 +37,7 @@ describe VagrantPlugins::HostDarwin::Cap::FsISO do
 
     it "builds an iso with volume_id" do
       expect(Vagrant::Util::Subprocess).to receive(:execute).with(
-        "hdiutil", "makehybrid", "-hfs", "-iso", "-joliet", "-ov", "-default-volume-name", "cidata", "-o", /.iso/, /\/foo\/src/
+        "hdiutil", "makehybrid", "-iso", "-joliet", "-ov", "-default-volume-name", "cidata", "-o", /.iso/, /\/foo\/src/
       ).and_return(double(exit_code: 0))
       expect(FileUtils).to receive(:mkdir_p).with(Pathname.new(file_destination).dirname)
 
@@ -47,7 +47,7 @@ describe VagrantPlugins::HostDarwin::Cap::FsISO do
 
     it "builds an iso given a file destination without an extension" do
       expect(Vagrant::Util::Subprocess).to receive(:execute).with(
-        "hdiutil", "makehybrid", "-hfs", "-iso", "-joliet", "-ov", "-o", /.iso/, /\/foo\/src/
+        "hdiutil", "makehybrid", "-iso", "-joliet", "-ov", "-o", /.iso/, /\/foo\/src/
       ).and_return(double(exit_code: 0))
       expect(FileUtils).to receive(:mkdir_p).with(Pathname.new("/woo/out_dir"))
 
@@ -61,7 +61,7 @@ describe VagrantPlugins::HostDarwin::Cap::FsISO do
       allow(file_destination).to receive(:path).and_return(file_destination)
       allow(file_destination).to receive(:delete)
       expect(Vagrant::Util::Subprocess).to receive(:execute).with(
-        "hdiutil", "makehybrid", "-hfs", "-iso", "-joliet", "-ov", "-o", /.iso/, /\/foo\/src/
+        "hdiutil", "makehybrid", "-iso", "-joliet", "-ov", "-o", /.iso/, /\/foo\/src/
       ).and_return(double(exit_code: 0))
       # Should create a directory wherever Tempfile creates files by default
       expect(FileUtils).to receive(:mkdir_p).with(Pathname.new(file_destination).dirname)


### PR DESCRIPTION
Adds suppport for configuring networking on amazonlinux when
network devices are handled by networkd. When not handled by
networkd, falls back to using the redhat capability.

Fixes #13358 