### PR TITLE
Update Vagrant behavior outside of installers

### DIFF
--- a/bin/vagrant
+++ b/bin/vagrant
@@ -187,12 +187,6 @@ begin
     argv += argv_extra
   end
 
-  sub_cmd = Class.new(Vagrant.plugin("2", :command)) {
-    def sub_command
-      split_main_and_subcommand(@argv)[1]
-    end
-  }.new(argv.dup, nil).sub_command
-
   # Create the environment, which is the cwd of wherever the
   # `vagrant` command was invoked from
   logger.debug("Creating Vagrant environment")
@@ -209,9 +203,17 @@ begin
     end
   end
 
-  if !Vagrant.in_installer? && !Vagrant.very_quiet?
-    # If we're not in the installer, warn.
-    env.ui.warn(I18n.t("vagrant.general.not_in_installer") + "\n", prefix: false)
+  # If not being run from the installer, check if expected tools
+  # are available.
+  if !Vagrant.in_installer?
+    missing_tools = Vagrant.detect_missing_tools
+
+    if !missing_tools.empty?
+      env.ui.warn(
+        I18n.t("vagrant.general.not_in_installer", tools: missing_tools.sort.join(", ")) + "\n",
+        prefix: false
+      )
+    end
   end
 
   # Acceptable experimental flag values include:

--- a/lib/vagrant.rb
+++ b/lib/vagrant.rb
@@ -5,16 +5,16 @@
 # require helper available.
 require "vagrant/shared_helpers"
 
-Vagrant.require "log4r"
+require "log4r"
 
 # Add patches to log4r to support trace level
-Vagrant.require "vagrant/patches/log4r"
-Vagrant.require "vagrant/patches/net-ssh"
-Vagrant.require "vagrant/patches/rubygems"
-Vagrant.require "vagrant/patches/timeout_error"
+require "vagrant/patches/log4r"
+require "vagrant/patches/net-ssh"
+require "vagrant/patches/rubygems"
+require "vagrant/patches/timeout_error"
 
 # Set our log levels and include trace
-Vagrant.require 'log4r/configurator'
+require 'log4r/configurator'
 Log4r::Configurator.custom_levels(*(["TRACE"] + Log4r::Log4rConfig::LogLevels))
 
 # Update the default formatter within the log4r library to ensure
@@ -26,7 +26,7 @@ class Log4r::BasicFormatter
   end
 end
 
-Vagrant.require "optparse"
+require "optparse"
 
 module Vagrant
   # This is a customized OptionParser for Vagrant plugins. It
@@ -51,9 +51,9 @@ module VagrantPlugins
 end
 
 # Load in our helpers and utilities
-Vagrant.require "rubygems"
-Vagrant.require "vagrant/util"
-Vagrant.require "vagrant/plugin/manager"
+require "rubygems"
+require "vagrant/util"
+require "vagrant/plugin/manager"
 
 # Enable logging if it is requested. We do this before
 # anything else so that we can setup the output before
@@ -110,19 +110,19 @@ if ENV["VAGRANT_LOG"] && ENV["VAGRANT_LOG"] != ""
   end
 end
 
-Vagrant.require 'json'
-Vagrant.require 'pathname'
-Vagrant.require 'stringio'
+require 'json'
+require 'pathname'
+require 'stringio'
 
-Vagrant.require 'childprocess'
-Vagrant.require 'i18n'
+require 'childprocess'
+require 'i18n'
 
 # OpenSSL must be loaded here since when it is loaded via `autoload`
 # there are issues with ciphers not being properly loaded.
-Vagrant.require 'openssl'
+require 'openssl'
 
 # Always make the version available
-Vagrant.require 'vagrant/version'
+require 'vagrant/version'
 global_logger = Log4r::Logger.new("vagrant::global")
 Vagrant.global_logger = global_logger
 global_logger.info("Vagrant version: #{Vagrant::VERSION}")
@@ -143,7 +143,7 @@ vagrant_ssl_locations = [
 if vagrant_ssl_locations.any? { |f| File.exist?(f) }
   global_logger.debug("vagrant ssl helper found for loading ssl providers")
   begin
-    Vagrant.require "vagrant/vagrant_ssl"
+    require "vagrant/vagrant_ssl"
     Vagrant.vagrant_ssl_load
     global_logger.debug("ssl providers successfully loaded")
   rescue LoadError => err
@@ -157,8 +157,8 @@ end
 
 # We need these components always so instead of an autoload we
 # just require them explicitly here.
-Vagrant.require "vagrant/plugin"
-Vagrant.require "vagrant/registry"
+require "vagrant/plugin"
+require "vagrant/registry"
 
 module Vagrant
   autoload :Action,         'vagrant/action'
@@ -235,7 +235,7 @@ module Vagrant
     end
 
     # Now check the plugin gem names
-    Vagrant.require "vagrant/plugin/manager"
+    require "vagrant/plugin/manager"
     Plugin::Manager.instance.plugin_installed?(name, version)
   end
 
@@ -273,7 +273,7 @@ module Vagrant
 
   # @deprecated
   def self.require_plugin(name)
-    puts "Vagrant.require_plugin is deprecated and has no effect any longer."
+    puts "require_plugin is deprecated and has no effect any longer."
     puts "Use `vagrant plugin` commands to manage plugins. This warning will"
     puts "be removed in the next version of Vagrant."
   end
@@ -297,9 +297,9 @@ module Vagrant
   #
   # Examples are shown below:
   #
-  #   Vagrant.require_version(">= 1.3.5")
-  #   Vagrant.require_version(">= 1.3.5", "< 1.4.0")
-  #   Vagrant.require_version("~> 1.3.5")
+  #   require_version(">= 1.3.5")
+  #   require_version(">= 1.3.5", "< 1.4.0")
+  #   require_version("~> 1.3.5")
   #
   def self.require_version(*requirements)
     logger = Log4r::Logger.new("vagrant::root")

--- a/lib/vagrant/action.rb
+++ b/lib/vagrant/action.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'vagrant/action/builder'
+require 'vagrant/action/builder'
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -1,16 +1,16 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "digest/sha1"
-Vagrant.require "log4r"
-Vagrant.require "pathname"
-Vagrant.require "uri"
+require "digest/sha1"
+require "log4r"
+require "pathname"
+require "uri"
 
-Vagrant.require "vagrant/box_metadata"
-Vagrant.require "vagrant/util/downloader"
-Vagrant.require "vagrant/util/file_checksum"
-Vagrant.require "vagrant/util/file_mutex"
-Vagrant.require "vagrant/util/platform"
+require "vagrant/box_metadata"
+require "vagrant/util/downloader"
+require "vagrant/util/file_checksum"
+require "vagrant/util/file_mutex"
+require "vagrant/util/platform"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/box_check_outdated.rb
+++ b/lib/vagrant/action/builtin/box_check_outdated.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/box_remove.rb
+++ b/lib/vagrant/action/builtin/box_remove.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/box_update.rb
+++ b/lib/vagrant/action/builtin/box_update.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/cleanup_disks.rb
+++ b/lib/vagrant/action/builtin/cleanup_disks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "json"
+require "json"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/cloud_init_setup.rb
+++ b/lib/vagrant/action/builtin/cloud_init_setup.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'vagrant/util/mime'
-Vagrant.require 'tmpdir'
+require 'vagrant/util/mime'
+require 'tmpdir'
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/cloud_init_wait.rb
+++ b/lib/vagrant/action/builtin/cloud_init_wait.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/config_validate.rb
+++ b/lib/vagrant/action/builtin/config_validate.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/util/template_renderer"
+require "vagrant/util/template_renderer"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/disk.rb
+++ b/lib/vagrant/action/builtin/disk.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "json"
+require "json"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/graceful_halt.rb
+++ b/lib/vagrant/action/builtin/graceful_halt.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require "timeout"
+require "log4r"
+require "timeout"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/handle_box.rb
+++ b/lib/vagrant/action/builtin/handle_box.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "thread"
-Vagrant.require "log4r"
+require "thread"
+require "log4r"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
+++ b/lib/vagrant/action/builtin/handle_forwarded_port_collisions.rb
@@ -1,12 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "set"
-Vagrant.require "log4r"
-Vagrant.require "socket"
+require "set"
+require "log4r"
+require "socket"
 
-Vagrant.require "vagrant/util/is_port_open"
-Vagrant.require "vagrant/util/ipv4_interfaces"
+require "vagrant/util/is_port_open"
+require "vagrant/util/ipv4_interfaces"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/lock.rb
+++ b/lib/vagrant/action/builtin/lock.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/mixin_synced_folders.rb
+++ b/lib/vagrant/action/builtin/mixin_synced_folders.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "json"
-Vagrant.require "set"
-Vagrant.require 'vagrant/util/scoped_hash_override'
+require "json"
+require "set"
+require 'vagrant/util/scoped_hash_override'
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/prepare_clone.rb
+++ b/lib/vagrant/action/builtin/prepare_clone.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/provision.rb
+++ b/lib/vagrant/action/builtin/provision.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 require_relative "mixin_provisioners"
 

--- a/lib/vagrant/action/builtin/provisioner_cleanup.rb
+++ b/lib/vagrant/action/builtin/provisioner_cleanup.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 require_relative "mixin_provisioners"
 

--- a/lib/vagrant/action/builtin/set_hostname.rb
+++ b/lib/vagrant/action/builtin/set_hostname.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/ssh_exec.rb
+++ b/lib/vagrant/action/builtin/ssh_exec.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
+require "pathname"
 
-Vagrant.require "vagrant/util/ssh"
+require "vagrant/util/ssh"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/ssh_run.rb
+++ b/lib/vagrant/action/builtin/ssh_run.rb
@@ -1,11 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
-Vagrant.require "vagrant/util/platform"
-Vagrant.require "vagrant/util/ssh"
-Vagrant.require "vagrant/util/shell_quote"
+require "vagrant/util/platform"
+require "vagrant/util/ssh"
+require "vagrant/util/shell_quote"
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/builtin/synced_folder_cleanup.rb
+++ b/lib/vagrant/action/builtin/synced_folder_cleanup.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 require_relative "mixin_synced_folders"
 

--- a/lib/vagrant/action/builtin/synced_folders.rb
+++ b/lib/vagrant/action/builtin/synced_folders.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
-Vagrant.require 'vagrant/util/platform'
+require 'vagrant/util/platform'
 
 require_relative "mixin_synced_folders"
 

--- a/lib/vagrant/action/general/package.rb
+++ b/lib/vagrant/action/general/package.rb
@@ -1,11 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'fileutils'
-Vagrant.require "pathname"
-Vagrant.require 'vagrant/util/safe_chdir'
-Vagrant.require 'vagrant/util/subprocess'
-Vagrant.require 'vagrant/util/presence'
+require 'fileutils'
+require "pathname"
+require 'vagrant/util/safe_chdir'
+require 'vagrant/util/subprocess'
+require 'vagrant/util/presence'
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/general/package_setup_folders.rb
+++ b/lib/vagrant/action/general/package_setup_folders.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "fileutils"
+require "fileutils"
 require_relative "package"
 
 module Vagrant

--- a/lib/vagrant/action/runner.rb
+++ b/lib/vagrant/action/runner.rb
@@ -1,11 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'log4r'
+require 'log4r'
 
-Vagrant.require 'vagrant/action/hook'
-Vagrant.require 'vagrant/util/busy'
-Vagrant.require 'vagrant/util/experimental'
+require 'vagrant/action/hook'
+require 'vagrant/util/busy'
+require 'vagrant/util/experimental'
 
 module Vagrant
   module Action

--- a/lib/vagrant/action/warden.rb
+++ b/lib/vagrant/action/warden.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require 'vagrant/util/experimental'
+require "log4r"
+require 'vagrant/util/experimental'
 
 module Vagrant
   module Action

--- a/lib/vagrant/alias.rb
+++ b/lib/vagrant/alias.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/registry"
+require "vagrant/registry"
 
 module Vagrant
   # This class imports and processes CLI aliases stored in ~/.vagrant.d/aliases

--- a/lib/vagrant/batch_action.rb
+++ b/lib/vagrant/batch_action.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'thread'
-Vagrant.require "log4r"
+require 'thread'
+require "log4r"
 
 module Vagrant
   # This class executes multiple actions as a single batch, parallelizing

--- a/lib/vagrant/box.rb
+++ b/lib/vagrant/box.rb
@@ -1,17 +1,17 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'fileutils'
-Vagrant.require "tempfile"
+require 'fileutils'
+require "tempfile"
 
-Vagrant.require "json"
-Vagrant.require "log4r"
+require "json"
+require "log4r"
 
-Vagrant.require "vagrant/box_metadata"
-Vagrant.require "vagrant/util/downloader"
-Vagrant.require "vagrant/util/platform"
-Vagrant.require "vagrant/util/safe_chdir"
-Vagrant.require "vagrant/util/subprocess"
+require "vagrant/box_metadata"
+require "vagrant/util/downloader"
+require "vagrant/util/platform"
+require "vagrant/util/safe_chdir"
+require "vagrant/util/subprocess"
 
 module Vagrant
   # Represents a "box," which is a package Vagrant environment that is used

--- a/lib/vagrant/box_collection.rb
+++ b/lib/vagrant/box_collection.rb
@@ -1,13 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "digest/sha1"
-Vagrant.require "fileutils"
-Vagrant.require "monitor"
-Vagrant.require "tmpdir"
-Vagrant.require "log4r"
-Vagrant.require "vagrant/util/platform"
-Vagrant.require "vagrant/util/subprocess"
+require "digest/sha1"
+require "fileutils"
+require "monitor"
+require "tmpdir"
+require "log4r"
+require "vagrant/util/platform"
+require "vagrant/util/subprocess"
 
 module Vagrant
   # Represents a collection a boxes found on disk. This provides methods

--- a/lib/vagrant/box_metadata.rb
+++ b/lib/vagrant/box_metadata.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "json"
+require "json"
 
 module Vagrant
   # BoxMetadata represents metadata about a box, including the name

--- a/lib/vagrant/bundler.rb
+++ b/lib/vagrant/bundler.rb
@@ -1,16 +1,16 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "monitor"
-Vagrant.require "pathname"
-Vagrant.require "set"
-Vagrant.require "tempfile"
-Vagrant.require "fileutils"
-Vagrant.require "uri"
+require "monitor"
+require "pathname"
+require "set"
+require "tempfile"
+require "fileutils"
+require "uri"
 
-Vagrant.require "rubygems/package"
-Vagrant.require "rubygems/uninstaller"
-Vagrant.require "rubygems/name_tuple"
+require "rubygems/package"
+require "rubygems/uninstaller"
+require "rubygems/name_tuple"
 
 require_relative "shared_helpers"
 require_relative "version"

--- a/lib/vagrant/cli.rb
+++ b/lib/vagrant/cli.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'log4r'
-Vagrant.require 'optparse'
+require 'log4r'
+require 'optparse'
 
-Vagrant.require 'vagrant/util/experimental'
+require 'vagrant/util/experimental'
 
 module Vagrant
   # Manages the command line interface to Vagrant.

--- a/lib/vagrant/config.rb
+++ b/lib/vagrant/config.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/registry"
+require "vagrant/registry"
 
 module Vagrant
   module Config

--- a/lib/vagrant/config/v1/loader.rb
+++ b/lib/vagrant/config/v1/loader.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/config/v1/root"
+require "vagrant/config/v1/root"
 
 module Vagrant
   module Config

--- a/lib/vagrant/config/v1/root.rb
+++ b/lib/vagrant/config/v1/root.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "set"
+require "set"
 
 module Vagrant
   module Config

--- a/lib/vagrant/config/v2/loader.rb
+++ b/lib/vagrant/config/v2/loader.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/config/v2/root"
+require "vagrant/config/v2/root"
 
 module Vagrant
   module Config

--- a/lib/vagrant/config/v2/root.rb
+++ b/lib/vagrant/config/v2/root.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "set"
+require "set"
 
-Vagrant.require "vagrant/config/v2/util"
+require "vagrant/config/v2/util"
 
 module Vagrant
   module Config

--- a/lib/vagrant/environment.rb
+++ b/lib/vagrant/environment.rb
@@ -1,20 +1,20 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'fileutils'
-Vagrant.require 'json'
-Vagrant.require 'pathname'
-Vagrant.require 'set'
-Vagrant.require 'thread'
+require 'fileutils'
+require 'json'
+require 'pathname'
+require 'set'
+require 'thread'
 
-Vagrant.require 'log4r'
+require 'log4r'
 
-Vagrant.require 'vagrant/util/file_mode'
-Vagrant.require 'vagrant/util/platform'
-Vagrant.require 'vagrant/util/hash_with_indifferent_access'
-Vagrant.require "vagrant/util/silence_warnings"
-Vagrant.require "vagrant/vagrantfile"
-Vagrant.require "vagrant/version"
+require 'vagrant/util/file_mode'
+require 'vagrant/util/platform'
+require 'vagrant/util/hash_with_indifferent_access'
+require "vagrant/util/silence_warnings"
+require "vagrant/vagrantfile"
+require "vagrant/version"
 
 module Vagrant
   # A "Vagrant environment" represents a configuration of how Vagrant

--- a/lib/vagrant/guest.rb
+++ b/lib/vagrant/guest.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require "vagrant/capability_host"
+require "log4r"
+require "vagrant/capability_host"
 
 module Vagrant
   # This class handles guest-OS specific interactions with a machine.

--- a/lib/vagrant/host.rb
+++ b/lib/vagrant/host.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/capability_host"
+require "vagrant/capability_host"
 
 module Vagrant
   # This class handles host-OS specific interactions. It is responsible for

--- a/lib/vagrant/machine.rb
+++ b/lib/vagrant/machine.rb
@@ -4,9 +4,9 @@
 require_relative "./util/ssh"
 require_relative "./action/builtin/mixin_synced_folders"
 
-Vagrant.require "digest/md5"
-Vagrant.require "thread"
-Vagrant.require "log4r"
+require "digest/md5"
+require "thread"
+require "log4r"
 
 module Vagrant
   # This represents a machine that Vagrant manages. This provides a singular

--- a/lib/vagrant/machine_index.rb
+++ b/lib/vagrant/machine_index.rb
@@ -1,12 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "json"
-Vagrant.require "pathname"
-Vagrant.require "securerandom"
-Vagrant.require "thread"
+require "json"
+require "pathname"
+require "securerandom"
+require "thread"
 
-Vagrant.require "vagrant/util/silence_warnings"
+require "vagrant/util/silence_warnings"
 
 module Vagrant
   # MachineIndex is able to manage the index of created Vagrant environments

--- a/lib/vagrant/patches/fake_ftp.rb
+++ b/lib/vagrant/patches/fake_ftp.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "fake_ftp"
+require "fake_ftp"
 
 module FakeFtp
   class File

--- a/lib/vagrant/patches/log4r.rb
+++ b/lib/vagrant/patches/log4r.rb
@@ -6,7 +6,7 @@
 # information should be included in the output, we
 # make some modifications to allow the trace check to
 # still work while also supporting trace as a valid level
-Vagrant.require "log4r/loggerfactory"
+require "log4r/loggerfactory"
 
 if !Log4r::Logger::LoggerFactory.respond_to?(:fake_define_methods)
   class Log4r::Logger::LoggerFactory

--- a/lib/vagrant/patches/net-ssh.rb
+++ b/lib/vagrant/patches/net-ssh.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "net/ssh"
-Vagrant.require "net/ssh/buffer"
+require "net/ssh"
+require "net/ssh/buffer"
 
 # Set the version requirement for when net-ssh should be patched
 NET_SSH_PATCH_REQUIREMENT = Gem::Requirement.new(">= 7.0.0", "<= 7.3")

--- a/lib/vagrant/plugin/manager.rb
+++ b/lib/vagrant/plugin/manager.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
-Vagrant.require "set"
+require "pathname"
+require "set"
 
 require_relative "../bundler"
 require_relative "../shared_helpers"

--- a/lib/vagrant/plugin/state_file.rb
+++ b/lib/vagrant/plugin/state_file.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "json"
-Vagrant.require "fileutils"
-Vagrant.require "tempfile"
+require "json"
+require "fileutils"
+require "tempfile"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v1.rb
+++ b/lib/vagrant/plugin/v1.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require "vagrant/plugin/v1/errors"
+require "log4r"
+require "vagrant/plugin/v1/errors"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v1/command.rb
+++ b/lib/vagrant/plugin/v1/command.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'log4r'
-Vagrant.require "vagrant/util/safe_puts"
+require 'log4r'
+require "vagrant/util/safe_puts"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v1/manager.rb
+++ b/lib/vagrant/plugin/v1/manager.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v1/plugin.rb
+++ b/lib/vagrant/plugin/v1/plugin.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "set"
-Vagrant.require "log4r"
+require "set"
+require "log4r"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v2.rb
+++ b/lib/vagrant/plugin/v2.rb
@@ -1,12 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 # We don't autoload components because if we're loading anything in the
 # V2 namespace anyways, then we're going to need the Components class.
-Vagrant.require "vagrant/plugin/v2/components"
-Vagrant.require "vagrant/plugin/v2/errors"
+require "vagrant/plugin/v2/components"
+require "vagrant/plugin/v2/errors"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v2/command.rb
+++ b/lib/vagrant/plugin/v2/command.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'log4r'
-Vagrant.require "vagrant/util/safe_puts"
+require 'log4r'
+require "vagrant/util/safe_puts"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v2/communicator.rb
+++ b/lib/vagrant/plugin/v2/communicator.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "timeout"
+require "timeout"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v2/config.rb
+++ b/lib/vagrant/plugin/v2/config.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "set"
+require "set"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v2/manager.rb
+++ b/lib/vagrant/plugin/v2/manager.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v2/plugin.rb
+++ b/lib/vagrant/plugin/v2/plugin.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "set"
-Vagrant.require "log4r"
-Vagrant.require "vagrant/plugin/v2/components"
+require "set"
+require "log4r"
+require "vagrant/plugin/v2/components"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v2/provider.rb
+++ b/lib/vagrant/plugin/v2/provider.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/capability_host"
+require "vagrant/capability_host"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/plugin/v2/trigger.rb
+++ b/lib/vagrant/plugin/v2/trigger.rb
@@ -1,14 +1,14 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'fileutils'
-Vagrant.require 'log4r'
-Vagrant.require 'shellwords'
+require 'fileutils'
+require 'log4r'
+require 'shellwords'
 
-Vagrant.require Vagrant.source_root.join("plugins/provisioners/shell/provisioner")
-Vagrant.require "vagrant/util/subprocess"
-Vagrant.require "vagrant/util/platform"
-Vagrant.require "vagrant/util/powershell"
+require Vagrant.source_root.join("plugins/provisioners/shell/provisioner")
+require "vagrant/util/subprocess"
+require "vagrant/util/platform"
+require "vagrant/util/powershell"
 
 module Vagrant
   module Plugin

--- a/lib/vagrant/shared_helpers.rb
+++ b/lib/vagrant/shared_helpers.rb
@@ -21,6 +21,10 @@ module Vagrant
   # @note This is not the maximum time for a thread to complete.
   THREAD_MAX_JOIN_TIMEOUT = 60
 
+  # List of required external tools that are expected to be
+  # present when running outside of the installers
+  REQUIRED_EXTERNAL_TOOLS = ["bsdtar", "curl", "ssh"].map(&:freeze).freeze
+
   # This holds a global lock for the duration of the block. This should
   # be invoked around anything that is modifying process state (such as
   # environmental variables).
@@ -168,7 +172,7 @@ module Vagrant
     if ENV["VAGRANT_ENABLE_RESOLV_REPLACE"]
       if !ENV["VAGRANT_DISABLE_RESOLV_REPLACE"]
         begin
-          Vagrant.require "resolv-replace"
+          require "resolv-replace"
           true
         rescue
           false
@@ -192,7 +196,7 @@ module Vagrant
   # @return [Logger]
   def self.global_logger
     if @_global_logger.nil?
-      Vagrant.require "log4r"
+      require "log4r"
       @_global_logger = Log4r::Logger.new("vagrant::global")
     end
     @_global_logger
@@ -226,65 +230,9 @@ module Vagrant
     @_default_cli_options.dup
   end
 
-  # Loads the provided path. If the base of the path
-  # is a Vagrant runtime dependency, the gem will be
-  # activated with the proper constraint first.
-  #
-  # NOTE: This is currently disabled by default and
-  # will transition to enabled by default as more
-  # non-installer based environments are tested.
-  #
-  # @return [nil]
-  def self.require(path)
-    catch(:activation_complete) do
-      # If activation is not enabled, don't attempt activation
-      throw :activation_complete if ENV["VAGRANT_ENABLE_GEM_ACTIVATION"].nil?
-
-      # If it's a vagrant path, don't do anything.
-      throw :activation_complete if path.to_s.start_with?("vagrant/")
-
-      # Attempt to fetch the vagrant specification
-      if @_vagrant_spec.nil?
-        @_vagrant_activated_dependencies = {}
-        begin
-          @_vagrant_spec = Gem::Specification.find_by_name("vagrant")
-        rescue Gem::MissingSpecError
-          # If it couldn't be found, print a warning to stderr and bail
-          if !@_spec_load_failure_warning
-            $stderr.puts "WARN: Failed to locate vagrant specification for dependency loading"
-            @_spec_load_failure_warning = true
-          end
-
-          throw :activation_complete
-        end
-      end
-
-      # Attempt to get the name of the gem by the given path
-      dep_name = Gem::Specification.find_by_path(path)&.name
-
-      # Bail if a dependency name cannot be determined
-      throw :activation_complete if dep_name.nil?
-
-      # Bail if already activated
-      throw :activation_complete if @_vagrant_activated_dependencies[dep_name]
-
-      # Extract the dependency from the runtime dependency list
-      dependency = @_vagrant_spec.runtime_dependencies.detect do |d|
-        d.name == dep_name
-      end
-
-      # If the dependency isn't found, bail
-      throw :activation_complete if dependency.nil?
-
-      # Activate the gem
-      gem(dependency.name, dependency.requirement.as_list)
-
-      @_vagrant_activated_dependencies[dependency.name] = true
+  def self.detect_missing_tools
+    REQUIRED_EXTERNAL_TOOLS.find_all do |tool|
+      !Vagrant::Util::Which.which(tool)
     end
-
-    # Finally, require the provided path.
-    ::Kernel.require(path)
-
-    nil
   end
 end

--- a/lib/vagrant/ui.rb
+++ b/lib/vagrant/ui.rb
@@ -1,12 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "delegate"
-Vagrant.require "io/console"
-Vagrant.require "thread"
-Vagrant.require "log4r"
-Vagrant.require "vagrant/util/platform"
-Vagrant.require "vagrant/util/safe_puts"
+require "delegate"
+require "io/console"
+require "thread"
+require "log4r"
+require "vagrant/util/platform"
+require "vagrant/util/safe_puts"
 
 module Vagrant
   module UI

--- a/lib/vagrant/util/caps.rb
+++ b/lib/vagrant/util/caps.rb
@@ -1,11 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
-Vagrant.require "fileutils"
-Vagrant.require "pathname"
-Vagrant.require "vagrant/util/directory"
-Vagrant.require "vagrant/util/subprocess"
+require "tempfile"
+require "fileutils"
+require "pathname"
+require "vagrant/util/directory"
+require "vagrant/util/subprocess"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/checkpoint_client.rb
+++ b/lib/vagrant/util/checkpoint_client.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require "singleton"
+require "log4r"
+require "singleton"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/counter.rb
+++ b/lib/vagrant/util/counter.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'thread'
+require 'thread'
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/directory.rb
+++ b/lib/vagrant/util/directory.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'pathname'
+require 'pathname'
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/downloader.rb
+++ b/lib/vagrant/util/downloader.rb
@@ -1,18 +1,18 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "cgi"
-Vagrant.require "uri"
+require "cgi"
+require "uri"
 
-Vagrant.require "log4r"
-Vagrant.require "digest"
-Vagrant.require "digest/md5"
-Vagrant.require "digest/sha1"
-Vagrant.require "vagrant/util/busy"
-Vagrant.require "vagrant/util/platform"
-Vagrant.require "vagrant/util/subprocess"
-Vagrant.require "vagrant/util/curl_helper"
-Vagrant.require "vagrant/util/file_checksum"
+require "log4r"
+require "digest"
+require "digest/md5"
+require "digest/sha1"
+require "vagrant/util/busy"
+require "vagrant/util/platform"
+require "vagrant/util/subprocess"
+require "vagrant/util/curl_helper"
+require "vagrant/util/file_checksum"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/file_checksum.rb
+++ b/lib/vagrant/util/file_checksum.rb
@@ -6,7 +6,7 @@
 # the moment, and this class isn't directly used. It is merely here for
 # documentation of structure of the class.
 
-Vagrant.require "vagrant/errors"
+require "vagrant/errors"
 
 class DigestClass
   def update(string); end

--- a/lib/vagrant/util/io.rb
+++ b/lib/vagrant/util/io.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/util/platform"
+require "vagrant/util/platform"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/is_port_open.rb
+++ b/lib/vagrant/util/is_port_open.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "socket"
+require "socket"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/keypair.rb
+++ b/lib/vagrant/util/keypair.rb
@@ -1,11 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "base64"
-Vagrant.require "ed25519"
-Vagrant.require "securerandom"
+require "base64"
+require "ed25519"
+require "securerandom"
 
-Vagrant.require "vagrant/util/retryable"
+require "vagrant/util/retryable"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/logging_formatter.rb
+++ b/lib/vagrant/util/logging_formatter.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/util/credential_scrubber"
-Vagrant.require "log4r/formatter/formatter"
+require "vagrant/util/credential_scrubber"
+require "log4r/formatter/formatter"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/mime.rb
+++ b/lib/vagrant/util/mime.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'mime/types'
-Vagrant.require 'securerandom'
+require 'mime/types'
+require 'securerandom'
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/network_ip.rb
+++ b/lib/vagrant/util/network_ip.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "ipaddr"
+require "ipaddr"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/platform.rb
+++ b/lib/vagrant/util/platform.rb
@@ -1,15 +1,15 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "rbconfig"
-Vagrant.require "shellwords"
-Vagrant.require "tempfile"
-Vagrant.require "tmpdir"
-Vagrant.require "log4r"
+require "rbconfig"
+require "shellwords"
+require "tempfile"
+require "tmpdir"
+require "log4r"
 
-Vagrant.require "vagrant/util/subprocess"
-Vagrant.require "vagrant/util/powershell"
-Vagrant.require "vagrant/util/which"
+require "vagrant/util/subprocess"
+require "vagrant/util/powershell"
+require "vagrant/util/which"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/powershell.rb
+++ b/lib/vagrant/util/powershell.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "base64"
-Vagrant.require "tmpdir"
+require "base64"
+require "tmpdir"
 
 require_relative "subprocess"
 require_relative "which"

--- a/lib/vagrant/util/retryable.rb
+++ b/lib/vagrant/util/retryable.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/safe_chdir.rb
+++ b/lib/vagrant/util/safe_chdir.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'thread'
+require 'thread'
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/ssh.rb
+++ b/lib/vagrant/util/ssh.rb
@@ -1,16 +1,16 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
-Vagrant.require 'childprocess'
+require 'childprocess'
 
-Vagrant.require "vagrant/util/file_mode"
-Vagrant.require "vagrant/util/platform"
-Vagrant.require "vagrant/util/safe_exec"
-Vagrant.require "vagrant/util/safe_puts"
-Vagrant.require "vagrant/util/subprocess"
-Vagrant.require "vagrant/util/which"
+require "vagrant/util/file_mode"
+require "vagrant/util/platform"
+require "vagrant/util/safe_exec"
+require "vagrant/util/safe_puts"
+require "vagrant/util/subprocess"
+require "vagrant/util/which"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/subprocess.rb
+++ b/lib/vagrant/util/subprocess.rb
@@ -1,15 +1,15 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'thread'
+require 'thread'
 
-Vagrant.require 'childprocess'
-Vagrant.require 'log4r'
+require 'childprocess'
+require 'log4r'
 
-Vagrant.require 'vagrant/util/io'
-Vagrant.require 'vagrant/util/platform'
-Vagrant.require 'vagrant/util/safe_chdir'
-Vagrant.require 'vagrant/util/which'
+require 'vagrant/util/io'
+require 'vagrant/util/platform'
+require 'vagrant/util/safe_chdir'
+require 'vagrant/util/which'
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/template_renderer.rb
+++ b/lib/vagrant/util/template_renderer.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'ostruct'
-Vagrant.require "pathname"
+require 'ostruct'
+require "pathname"
 
-Vagrant.require 'erubi'
+require 'erubi'
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/uploader.rb
+++ b/lib/vagrant/util/uploader.rb
@@ -1,13 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "uri"
+require "uri"
 
-Vagrant.require "log4r"
-Vagrant.require "vagrant/util/busy"
-Vagrant.require "vagrant/util/platform"
-Vagrant.require "vagrant/util/subprocess"
-Vagrant.require "vagrant/util/curl_helper"
+require "log4r"
+require "vagrant/util/busy"
+require "vagrant/util/platform"
+require "vagrant/util/subprocess"
+require "vagrant/util/curl_helper"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/which.rb
+++ b/lib/vagrant/util/which.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/util/platform"
+require "vagrant/util/platform"
 
 module Vagrant
   module Util

--- a/lib/vagrant/util/windows_path.rb
+++ b/lib/vagrant/util/windows_path.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "fiddle/import"
+require "fiddle/import"
 
 module Vagrant
   module Util

--- a/lib/vagrant/vagrantfile.rb
+++ b/lib/vagrant/vagrantfile.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/util/template_renderer"
-Vagrant.require "log4r"
+require "vagrant/util/template_renderer"
+require "log4r"
 
 module Vagrant
   # This class provides a way to load and access the contents

--- a/plugins/commands/autocomplete/command/install.rb
+++ b/plugins/commands/autocomplete/command/install.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 require 'vagrant/util/install_cli_autocomplete'
 

--- a/plugins/commands/autocomplete/command/root.rb
+++ b/plugins/commands/autocomplete/command/root.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "optparse"
+require "optparse"
 require 'vagrant/util/install_cli_autocomplete'
 
 module VagrantPlugins

--- a/plugins/commands/box/command/add.rb
+++ b/plugins/commands/box/command/add.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 require_relative 'download_mixins'
 

--- a/plugins/commands/box/command/list.rb
+++ b/plugins/commands/box/command/list.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandBox

--- a/plugins/commands/box/command/outdated.rb
+++ b/plugins/commands/box/command/outdated.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 require_relative 'download_mixins'
 

--- a/plugins/commands/box/command/prune.rb
+++ b/plugins/commands/box/command/prune.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandBox

--- a/plugins/commands/box/command/remove.rb
+++ b/plugins/commands/box/command/remove.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandBox

--- a/plugins/commands/box/command/repackage.rb
+++ b/plugins/commands/box/command/repackage.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "fileutils"
-Vagrant.require 'optparse'
-Vagrant.require "pathname"
+require "fileutils"
+require 'optparse'
+require "pathname"
 
 module VagrantPlugins
   module CommandBox

--- a/plugins/commands/box/command/root.rb
+++ b/plugins/commands/box/command/root.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandBox

--- a/plugins/commands/box/command/update.rb
+++ b/plugins/commands/box/command/update.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 require_relative 'download_mixins'
 

--- a/plugins/commands/cap/command.rb
+++ b/plugins/commands/cap/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandCap

--- a/plugins/commands/cloud/auth/login.rb
+++ b/plugins/commands/cloud/auth/login.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/auth/logout.rb
+++ b/plugins/commands/cloud/auth/logout.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/auth/middleware/add_authentication.rb
+++ b/plugins/commands/cloud/auth/middleware/add_authentication.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "cgi"
-Vagrant.require "uri"
-Vagrant.require "log4r"
+require "cgi"
+require "uri"
+require "log4r"
 
 require Vagrant.source_root.join("plugins/commands/cloud/client/client")
 

--- a/plugins/commands/cloud/auth/middleware/add_downloader_authentication.rb
+++ b/plugins/commands/cloud/auth/middleware/add_downloader_authentication.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "cgi"
-Vagrant.require "uri"
-Vagrant.require "vagrant/util/credential_scrubber"
+require "cgi"
+require "uri"
+require "vagrant/util/credential_scrubber"
 
 require Vagrant.source_root.join("plugins/commands/cloud/client/client")
 require_relative "./add_authentication"

--- a/plugins/commands/cloud/auth/whoami.rb
+++ b/plugins/commands/cloud/auth/whoami.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/box/create.rb
+++ b/plugins/commands/cloud/box/create.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/box/delete.rb
+++ b/plugins/commands/cloud/box/delete.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/box/show.rb
+++ b/plugins/commands/cloud/box/show.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/box/update.rb
+++ b/plugins/commands/cloud/box/update.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/client/client.rb
+++ b/plugins/commands/cloud/client/client.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant_cloud"
-Vagrant.require "vagrant/util/downloader"
-Vagrant.require "vagrant/util/presence"
+require "vagrant_cloud"
+require "vagrant/util/downloader"
+require "vagrant/util/presence"
 
 require Vagrant.source_root.join("plugins/commands/cloud/errors")
 

--- a/plugins/commands/cloud/list.rb
+++ b/plugins/commands/cloud/list.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/plugin.rb
+++ b/plugins/commands/cloud/plugin.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'vagrant_cloud'
+require 'vagrant_cloud'
 
 require Vagrant.source_root.join("plugins/commands/cloud/util")
 require Vagrant.source_root.join("plugins/commands/cloud/client/client")

--- a/plugins/commands/cloud/provider/create.rb
+++ b/plugins/commands/cloud/provider/create.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/provider/delete.rb
+++ b/plugins/commands/cloud/provider/delete.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/provider/update.rb
+++ b/plugins/commands/cloud/provider/update.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/provider/upload.rb
+++ b/plugins/commands/cloud/provider/upload.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
-Vagrant.require "vagrant/util/uploader"
+require 'optparse'
+require "vagrant/util/uploader"
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/publish.rb
+++ b/plugins/commands/cloud/publish.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
-Vagrant.require "vagrant/util/uploader"
+require 'optparse'
+require "vagrant/util/uploader"
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/search.rb
+++ b/plugins/commands/cloud/search.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/version/release.rb
+++ b/plugins/commands/cloud/version/release.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/version/revoke.rb
+++ b/plugins/commands/cloud/version/revoke.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/cloud/version/update.rb
+++ b/plugins/commands/cloud/version/update.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CloudCommand

--- a/plugins/commands/global-status/command.rb
+++ b/plugins/commands/global-status/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandGlobalStatus

--- a/plugins/commands/halt/command.rb
+++ b/plugins/commands/halt/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandHalt

--- a/plugins/commands/help/command.rb
+++ b/plugins/commands/help/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandHelp

--- a/plugins/commands/init/command.rb
+++ b/plugins/commands/init/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 require 'vagrant/util/template_renderer'
 

--- a/plugins/commands/list-commands/command.rb
+++ b/plugins/commands/list-commands/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "optparse"
+require "optparse"
 
 module VagrantPlugins
   module CommandListCommands

--- a/plugins/commands/package/command.rb
+++ b/plugins/commands/package/command.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
-Vagrant.require 'securerandom'
+require 'optparse'
+require 'securerandom'
 
 module VagrantPlugins
   module CommandPackage

--- a/plugins/commands/plugin/action.rb
+++ b/plugins/commands/plugin/action.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
+require "pathname"
 
-Vagrant.require "vagrant/action/builder"
+require "vagrant/action/builder"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/action/expunge_plugins.rb
+++ b/plugins/commands/plugin/action/expunge_plugins.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/plugin/manager"
+require "vagrant/plugin/manager"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/action/install_gem.rb
+++ b/plugins/commands/plugin/action/install_gem.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require "vagrant/plugin/manager"
-Vagrant.require "vagrant/util/platform"
+require "log4r"
+require "vagrant/plugin/manager"
+require "vagrant/util/platform"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/action/license_plugin.rb
+++ b/plugins/commands/plugin/action/license_plugin.rb
@@ -1,12 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "fileutils"
-Vagrant.require "pathname"
-Vagrant.require "rubygems"
-Vagrant.require "set"
+require "fileutils"
+require "pathname"
+require "rubygems"
+require "set"
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/action/list_plugins.rb
+++ b/plugins/commands/plugin/action/list_plugins.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/plugin/manager"
+require "vagrant/plugin/manager"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/action/plugin_exists_check.rb
+++ b/plugins/commands/plugin/action/plugin_exists_check.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/plugin/manager"
+require "vagrant/plugin/manager"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/action/repair_plugins.rb
+++ b/plugins/commands/plugin/action/repair_plugins.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/plugin/manager"
+require "vagrant/plugin/manager"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/action/update_gems.rb
+++ b/plugins/commands/plugin/action/update_gems.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/plugin/manager"
+require "vagrant/plugin/manager"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/command/base.rb
+++ b/plugins/commands/plugin/command/base.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/plugin/state_file"
+require "vagrant/plugin/state_file"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/command/expunge.rb
+++ b/plugins/commands/plugin/command/expunge.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 require_relative "base"
 

--- a/plugins/commands/plugin/command/install.rb
+++ b/plugins/commands/plugin/command/install.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 require_relative "base"
 require_relative "mixin_install_opts"

--- a/plugins/commands/plugin/command/license.rb
+++ b/plugins/commands/plugin/command/license.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 require_relative "base"
 

--- a/plugins/commands/plugin/command/list.rb
+++ b/plugins/commands/plugin/command/list.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 require_relative "base"
 

--- a/plugins/commands/plugin/command/repair.rb
+++ b/plugins/commands/plugin/command/repair.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 require_relative "base"
 

--- a/plugins/commands/plugin/command/root.rb
+++ b/plugins/commands/plugin/command/root.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/plugin/command/uninstall.rb
+++ b/plugins/commands/plugin/command/uninstall.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 require_relative "base"
 

--- a/plugins/commands/plugin/command/update.rb
+++ b/plugins/commands/plugin/command/update.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 require_relative "base"
 require_relative "mixin_install_opts"

--- a/plugins/commands/plugin/gem_helper.rb
+++ b/plugins/commands/plugin/gem_helper.rb
@@ -1,11 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "rubygems"
-Vagrant.require "rubygems/config_file"
-Vagrant.require "rubygems/gem_runner"
+require "rubygems"
+require "rubygems/config_file"
+require "rubygems/gem_runner"
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module CommandPlugin

--- a/plugins/commands/port/command.rb
+++ b/plugins/commands/port/command.rb
@@ -3,7 +3,7 @@
 
 require "vagrant/util/presence"
 
-Vagrant.require "optparse"
+require "optparse"
 
 module VagrantPlugins
   module CommandPort

--- a/plugins/commands/powershell/command.rb
+++ b/plugins/commands/powershell/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "optparse"
+require "optparse"
 
 require "vagrant/util/powershell"
 require_relative "../../communicators/winrm/helper"

--- a/plugins/commands/provider/command.rb
+++ b/plugins/commands/provider/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandProvider

--- a/plugins/commands/provision/command.rb
+++ b/plugins/commands/provision/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandProvision

--- a/plugins/commands/push/command.rb
+++ b/plugins/commands/push/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandPush

--- a/plugins/commands/rdp/command.rb
+++ b/plugins/commands/rdp/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "optparse"
+require "optparse"
 
 module VagrantPlugins
   module CommandRDP

--- a/plugins/commands/reload/command.rb
+++ b/plugins/commands/reload/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 require "vagrant"
 

--- a/plugins/commands/resume/command.rb
+++ b/plugins/commands/resume/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 require Vagrant.source_root.join("plugins/commands/up/start_mixins")
 

--- a/plugins/commands/snapshot/command/delete.rb
+++ b/plugins/commands/snapshot/command/delete.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandSnapshot

--- a/plugins/commands/snapshot/command/list.rb
+++ b/plugins/commands/snapshot/command/list.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandSnapshot

--- a/plugins/commands/snapshot/command/pop.rb
+++ b/plugins/commands/snapshot/command/pop.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'json'
-Vagrant.require 'optparse'
+require 'json'
+require 'optparse'
 
 require Vagrant.source_root.join("plugins/commands/up/start_mixins")
 

--- a/plugins/commands/snapshot/command/push.rb
+++ b/plugins/commands/snapshot/command/push.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'json'
-Vagrant.require 'optparse'
+require 'json'
+require 'optparse'
 
 require_relative "push_shared"
 

--- a/plugins/commands/snapshot/command/push_shared.rb
+++ b/plugins/commands/snapshot/command/push_shared.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'json'
+require 'json'
 
 module VagrantPlugins
   module CommandSnapshot

--- a/plugins/commands/snapshot/command/restore.rb
+++ b/plugins/commands/snapshot/command/restore.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 require Vagrant.source_root.join("plugins/commands/up/start_mixins")
 

--- a/plugins/commands/snapshot/command/root.rb
+++ b/plugins/commands/snapshot/command/root.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandSnapshot

--- a/plugins/commands/snapshot/command/save.rb
+++ b/plugins/commands/snapshot/command/save.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandSnapshot

--- a/plugins/commands/ssh/command.rb
+++ b/plugins/commands/ssh/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandSSH

--- a/plugins/commands/ssh_config/command.rb
+++ b/plugins/commands/ssh_config/command.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
-Vagrant.require "vagrant/util/safe_puts"
-Vagrant.require "vagrant/util/platform"
+require "vagrant/util/safe_puts"
+require "vagrant/util/platform"
 
 module VagrantPlugins
   module CommandSSHConfig

--- a/plugins/commands/status/command.rb
+++ b/plugins/commands/status/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandStatus

--- a/plugins/commands/suspend/command.rb
+++ b/plugins/commands/suspend/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandSuspend

--- a/plugins/commands/up/command.rb
+++ b/plugins/commands/up/command.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
-Vagrant.require 'set'
+require 'optparse'
+require 'set'
 
 require File.expand_path("../start_mixins", __FILE__)
 

--- a/plugins/commands/up/start_mixins.rb
+++ b/plugins/commands/up/start_mixins.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "set"
+require "set"
 
 module VagrantPlugins
   module CommandUp

--- a/plugins/commands/upload/command.rb
+++ b/plugins/commands/upload/command.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
-Vagrant.require "rubygems/package"
+require 'optparse'
+require "rubygems/package"
 
 module VagrantPlugins
   module CommandUpload

--- a/plugins/commands/validate/command.rb
+++ b/plugins/commands/validate/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 module VagrantPlugins
   module CommandValidate
@@ -59,7 +59,7 @@ module VagrantPlugins
       #
       # return [String] tmp_data_dir - Temporary dir used to store guest metadata during validation
       def mockup_providers!
-        Vagrant.require 'log4r'
+        require 'log4r'
         logger = Log4r::Logger.new("vagrant::validate")
         logger.debug("Overriding all registered provider classes for validate")
 

--- a/plugins/commands/version/command.rb
+++ b/plugins/commands/version/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "optparse"
+require "optparse"
 
 module VagrantPlugins
   module CommandVersion

--- a/plugins/commands/winrm/command.rb
+++ b/plugins/commands/winrm/command.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
-Vagrant.require "vagrant/util/safe_puts"
+require 'optparse'
+require "vagrant/util/safe_puts"
 
 module VagrantPlugins
   module CommandWinRM

--- a/plugins/commands/winrm_config/command.rb
+++ b/plugins/commands/winrm_config/command.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
 require "vagrant/util/safe_puts"
 require_relative "../../communicators/winrm/helper"

--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -1,23 +1,23 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'etc'
-Vagrant.require 'logger'
-Vagrant.require 'pathname'
-Vagrant.require 'stringio'
-Vagrant.require 'thread'
-Vagrant.require 'timeout'
+require 'etc'
+require 'logger'
+require 'pathname'
+require 'stringio'
+require 'thread'
+require 'timeout'
 
-Vagrant.require 'log4r'
-Vagrant.require 'net/ssh'
-Vagrant.require 'net/ssh/proxy/command'
-Vagrant.require 'net/scp'
+require 'log4r'
+require 'net/ssh'
+require 'net/ssh/proxy/command'
+require 'net/scp'
 
-Vagrant.require 'vagrant/util/ansi_escape_code_remover'
-Vagrant.require 'vagrant/util/file_mode'
-Vagrant.require 'vagrant/util/keypair'
-Vagrant.require 'vagrant/util/platform'
-Vagrant.require 'vagrant/util/retryable'
+require 'vagrant/util/ansi_escape_code_remover'
+require 'vagrant/util/file_mode'
+require 'vagrant/util/keypair'
+require 'vagrant/util/platform'
+require 'vagrant/util/retryable'
 
 module VagrantPlugins
   module CommunicatorSSH

--- a/plugins/communicators/winrm/command_filters/mkdir.rb
+++ b/plugins/communicators/winrm/command_filters/mkdir.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "shellwords"
+require "shellwords"
 
 module VagrantPlugins
   module CommunicatorWinRM

--- a/plugins/communicators/winrm/command_filters/rm.rb
+++ b/plugins/communicators/winrm/command_filters/rm.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "shellwords"
+require "shellwords"
 
 module VagrantPlugins
   module CommunicatorWinRM

--- a/plugins/communicators/winrm/command_filters/test.rb
+++ b/plugins/communicators/winrm/command_filters/test.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "shellwords"
+require "shellwords"
 
 module VagrantPlugins
   module CommunicatorWinRM

--- a/plugins/communicators/winrm/command_filters/which.rb
+++ b/plugins/communicators/winrm/command_filters/which.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "shellwords"
+require "shellwords"
 
 module VagrantPlugins
   module CommunicatorWinRM

--- a/plugins/communicators/winrm/communicator.rb
+++ b/plugins/communicators/winrm/communicator.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require "tempfile"
-Vagrant.require "timeout"
+require "log4r"
+require "tempfile"
+require "timeout"
 
 require_relative "helper"
 require_relative "shell"

--- a/plugins/communicators/winrm/shell.rb
+++ b/plugins/communicators/winrm/shell.rb
@@ -1,19 +1,19 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "timeout"
+require "timeout"
 
-Vagrant.require "log4r"
+require "log4r"
 
-Vagrant.require "vagrant/util/retryable"
-Vagrant.require "vagrant/util/silence_warnings"
+require "vagrant/util/retryable"
+require "vagrant/util/silence_warnings"
 
 Vagrant::Util::SilenceWarnings.silence! do
-  Vagrant.require "winrm"
+  require "winrm"
 end
 
-Vagrant.require "winrm-elevated"
-Vagrant.require "winrm-fs"
+require "winrm-elevated"
+require "winrm-fs"
 
 module VagrantPlugins
   module CommunicatorWinRM

--- a/plugins/communicators/winssh/communicator.rb
+++ b/plugins/communicators/winssh/communicator.rb
@@ -3,7 +3,7 @@
 
 require File.expand_path("../../ssh/communicator", __FILE__)
 
-Vagrant.require "net/sftp"
+require "net/sftp"
 
 module VagrantPlugins
   module CommunicatorWinSSH

--- a/plugins/guests/alpine/cap/configure_networks.rb
+++ b/plugins/guests/alpine/cap/configure_networks.rb
@@ -7,10 +7,10 @@
 #
 # FIXME: address disabled warnings
 #
-Vagrant.require 'set'
-Vagrant.require 'tempfile'
-Vagrant.require 'pathname'
-Vagrant.require 'vagrant/util/template_renderer'
+require 'set'
+require 'tempfile'
+require 'pathname'
+require 'vagrant/util/template_renderer'
 
 module VagrantPlugins
   module GuestAlpine

--- a/plugins/guests/alt/cap/configure_networks.rb
+++ b/plugins/guests/alt/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
+require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/arch/cap/configure_networks.rb
+++ b/plugins/guests/arch/cap/configure_networks.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "ipaddr"
-Vagrant.require "socket"
-Vagrant.require "tempfile"
+require "ipaddr"
+require "socket"
+require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/bsd/cap/nfs.rb
+++ b/plugins/guests/bsd/cap/nfs.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "shellwords"
-Vagrant.require "vagrant/util/retryable"
+require "shellwords"
+require "vagrant/util/retryable"
 
 module VagrantPlugins
   module GuestBSD

--- a/plugins/guests/bsd/cap/public_key.rb
+++ b/plugins/guests/bsd/cap/public_key.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
+require "tempfile"
 
-Vagrant.require "vagrant/util/shell_quote"
+require "vagrant/util/shell_quote"
 
 module VagrantPlugins
   module GuestBSD

--- a/plugins/guests/coreos/cap/change_host_name.rb
+++ b/plugins/guests/coreos/cap/change_host_name.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
-Vagrant.require "yaml"
+require "tempfile"
+require "yaml"
 
 module VagrantPlugins
   module GuestCoreOS

--- a/plugins/guests/darwin/cap/configure_networks.rb
+++ b/plugins/guests/darwin/cap/configure_networks.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
+require "tempfile"
 
-Vagrant.require "vagrant/util/template_renderer"
+require "vagrant/util/template_renderer"
 
 module VagrantPlugins
   module GuestDarwin

--- a/plugins/guests/darwin/cap/mount_smb_shared_folder.rb
+++ b/plugins/guests/darwin/cap/mount_smb_shared_folder.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/util/retryable"
-Vagrant.require "shellwords"
+require "vagrant/util/retryable"
+require "shellwords"
 
 module VagrantPlugins
   module GuestDarwin

--- a/plugins/guests/darwin/cap/mount_vmware_shared_folder.rb
+++ b/plugins/guests/darwin/cap/mount_vmware_shared_folder.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "securerandom"
+require "securerandom"
 
 module VagrantPlugins
   module GuestDarwin

--- a/plugins/guests/debian/cap/change_host_name.rb
+++ b/plugins/guests/debian/cap/change_host_name.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require 'vagrant/util/guest_hosts'
-Vagrant.require 'vagrant/util/guest_inspection'
+require "log4r"
+require 'vagrant/util/guest_hosts'
+require 'vagrant/util/guest_inspection'
 
 require_relative "../../linux/cap/network_interfaces"
 

--- a/plugins/guests/debian/cap/configure_networks.rb
+++ b/plugins/guests/debian/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
+require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/esxi/cap/public_key.rb
+++ b/plugins/guests/esxi/cap/public_key.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
+require "tempfile"
 
-Vagrant.require "vagrant/util/shell_quote"
+require "vagrant/util/shell_quote"
 
 module VagrantPlugins
   module GuestEsxi

--- a/plugins/guests/freebsd/cap/configure_networks.rb
+++ b/plugins/guests/freebsd/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
+require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/funtoo/cap/configure_networks.rb
+++ b/plugins/guests/funtoo/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
+require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/gentoo/cap/configure_networks.rb
+++ b/plugins/guests/gentoo/cap/configure_networks.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
-Vagrant.require "ipaddr"
+require "tempfile"
+require "ipaddr"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/linux/cap/mount_smb_shared_folder.rb
+++ b/plugins/guests/linux/cap/mount_smb_shared_folder.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "fileutils"
-Vagrant.require "shellwords"
+require "fileutils"
+require "shellwords"
 
 require_relative "../../../synced_folders/unix_mount_helpers"
 

--- a/plugins/guests/linux/cap/public_key.rb
+++ b/plugins/guests/linux/cap/public_key.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
+require "tempfile"
 
-Vagrant.require "vagrant/util/shell_quote"
+require "vagrant/util/shell_quote"
 
 module VagrantPlugins
   module GuestLinux

--- a/plugins/guests/linux/cap/reboot.rb
+++ b/plugins/guests/linux/cap/reboot.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'vagrant/util/guest_inspection'
-Vagrant.require "log4r"
+require 'vagrant/util/guest_inspection'
+require "log4r"
 
 module VagrantPlugins
   module GuestLinux

--- a/plugins/guests/netbsd/cap/configure_networks.rb
+++ b/plugins/guests/netbsd/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
+require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/nixos/cap/change_host_name.rb
+++ b/plugins/guests/nixos/cap/change_host_name.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
+require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/nixos/cap/configure_networks.rb
+++ b/plugins/guests/nixos/cap/configure_networks.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "ipaddr"
-Vagrant.require "tempfile"
+require "ipaddr"
+require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/openbsd/cap/configure_networks.rb
+++ b/plugins/guests/openbsd/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
+require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/redhat/cap/configure_networks.rb
+++ b/plugins/guests/redhat/cap/configure_networks.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
-Vagrant.require "securerandom"
+require "tempfile"
+require "securerandom"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/slackware/cap/configure_networks.rb
+++ b/plugins/guests/slackware/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
+require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/suse/cap/configure_networks.rb
+++ b/plugins/guests/suse/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
+require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 

--- a/plugins/guests/tinycore/cap/configure_networks.rb
+++ b/plugins/guests/tinycore/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "ipaddr"
+require "ipaddr"
 
 module VagrantPlugins
   module GuestTinyCore

--- a/plugins/guests/windows/cap/change_host_name.rb
+++ b/plugins/guests/windows/cap/change_host_name.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module GuestWindows

--- a/plugins/guests/windows/cap/configure_networks.rb
+++ b/plugins/guests/windows/cap/configure_networks.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 require_relative "../guest_network"
 

--- a/plugins/guests/windows/cap/mount_shared_folder.rb
+++ b/plugins/guests/windows/cap/mount_shared_folder.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/util/template_renderer"
-Vagrant.require "base64"
+require "vagrant/util/template_renderer"
+require "base64"
 
 module VagrantPlugins
   module GuestWindows

--- a/plugins/guests/windows/cap/public_key.rb
+++ b/plugins/guests/windows/cap/public_key.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
+require "tempfile"
 
 require_relative '../../../communicators/winssh/communicator'
 

--- a/plugins/guests/windows/cap/reboot.rb
+++ b/plugins/guests/windows/cap/reboot.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module GuestWindows

--- a/plugins/guests/windows/guest_network.rb
+++ b/plugins/guests/windows/guest_network.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module GuestWindows

--- a/plugins/hosts/bsd/cap/nfs.rb
+++ b/plugins/hosts/bsd/cap/nfs.rb
@@ -1,11 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
-Vagrant.require "vagrant/util"
-Vagrant.require "vagrant/util/shell_quote"
-Vagrant.require "vagrant/util/which"
+require "vagrant/util"
+require "vagrant/util/shell_quote"
+require "vagrant/util/which"
 
 module VagrantPlugins
   module HostBSD

--- a/plugins/hosts/darwin/cap/configured_ip_addresses.rb
+++ b/plugins/hosts/darwin/cap/configured_ip_addresses.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "socket"
+require "socket"
 
 module VagrantPlugins
   module HostDarwin

--- a/plugins/hosts/darwin/cap/fs_iso.rb
+++ b/plugins/hosts/darwin/cap/fs_iso.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
-Vagrant.require "vagrant/util/caps"
+require "pathname"
+require "vagrant/util/caps"
 
 module VagrantPlugins
   module HostDarwin

--- a/plugins/hosts/darwin/cap/provider_install_virtualbox.rb
+++ b/plugins/hosts/darwin/cap/provider_install_virtualbox.rb
@@ -1,12 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
-Vagrant.require "tempfile"
+require "pathname"
+require "tempfile"
 
-Vagrant.require "vagrant/util/downloader"
-Vagrant.require "vagrant/util/file_checksum"
-Vagrant.require "vagrant/util/subprocess"
+require "vagrant/util/downloader"
+require "vagrant/util/file_checksum"
+require "vagrant/util/subprocess"
 
 module VagrantPlugins
   module HostDarwin

--- a/plugins/hosts/darwin/cap/rdp.rb
+++ b/plugins/hosts/darwin/cap/rdp.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
-Vagrant.require "tmpdir"
+require "pathname"
+require "tmpdir"
 
-Vagrant.require "vagrant/util/subprocess"
+require "vagrant/util/subprocess"
 
 module VagrantPlugins
   module HostDarwin

--- a/plugins/hosts/linux/cap/fs_iso.rb
+++ b/plugins/hosts/linux/cap/fs_iso.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
-Vagrant.require "vagrant/util/caps"
+require "pathname"
+require "vagrant/util/caps"
 
 module VagrantPlugins
   module HostLinux

--- a/plugins/hosts/linux/cap/nfs.rb
+++ b/plugins/hosts/linux/cap/nfs.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "shellwords"
-Vagrant.require "vagrant/util"
-Vagrant.require "vagrant/util/shell_quote"
-Vagrant.require "vagrant/util/retryable"
+require "shellwords"
+require "vagrant/util"
+require "vagrant/util/shell_quote"
+require "vagrant/util/retryable"
 
 module VagrantPlugins
   module HostLinux

--- a/plugins/hosts/linux/cap/rdp.rb
+++ b/plugins/hosts/linux/cap/rdp.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "vagrant/util/which"
+require "vagrant/util/which"
 
 module VagrantPlugins
   module HostLinux

--- a/plugins/hosts/redhat/cap/nfs.rb
+++ b/plugins/hosts/redhat/cap/nfs.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
+require "pathname"
 
 module VagrantPlugins
   module HostRedHat

--- a/plugins/hosts/redhat/host.rb
+++ b/plugins/hosts/redhat/host.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
+require "pathname"
 
 module VagrantPlugins
   module HostRedHat

--- a/plugins/hosts/suse/host.rb
+++ b/plugins/hosts/suse/host.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
+require "pathname"
 
 module VagrantPlugins
   module HostSUSE

--- a/plugins/hosts/void/host.rb
+++ b/plugins/hosts/void/host.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'pathname'
+require 'pathname'
 
 module VagrantPlugins
   module HostVoid

--- a/plugins/hosts/windows/cap/configured_ip_addresses.rb
+++ b/plugins/hosts/windows/cap/configured_ip_addresses.rb
@@ -1,13 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
-Vagrant.require "tempfile"
+require "pathname"
+require "tempfile"
 
-Vagrant.require "vagrant/util/downloader"
-Vagrant.require "vagrant/util/file_checksum"
-Vagrant.require "vagrant/util/powershell"
-Vagrant.require "vagrant/util/subprocess"
+require "vagrant/util/downloader"
+require "vagrant/util/file_checksum"
+require "vagrant/util/powershell"
+require "vagrant/util/subprocess"
 
 module VagrantPlugins
   module HostWindows

--- a/plugins/hosts/windows/cap/fs_iso.rb
+++ b/plugins/hosts/windows/cap/fs_iso.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
-Vagrant.require "vagrant/util/caps"
+require "pathname"
+require "vagrant/util/caps"
 
 module VagrantPlugins
   module HostWindows

--- a/plugins/hosts/windows/cap/provider_install_virtualbox.rb
+++ b/plugins/hosts/windows/cap/provider_install_virtualbox.rb
@@ -1,13 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
-Vagrant.require "tempfile"
+require "pathname"
+require "tempfile"
 
-Vagrant.require "vagrant/util/downloader"
-Vagrant.require "vagrant/util/file_checksum"
-Vagrant.require "vagrant/util/powershell"
-Vagrant.require "vagrant/util/subprocess"
+require "vagrant/util/downloader"
+require "vagrant/util/file_checksum"
+require "vagrant/util/powershell"
+require "vagrant/util/subprocess"
 
 module VagrantPlugins
   module HostWindows

--- a/plugins/hosts/windows/cap/ps.rb
+++ b/plugins/hosts/windows/cap/ps.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
-Vagrant.require "tmpdir"
+require "pathname"
+require "tmpdir"
 
-Vagrant.require "vagrant/util/safe_exec"
+require "vagrant/util/safe_exec"
 
 module VagrantPlugins
   module HostWindows

--- a/plugins/hosts/windows/cap/rdp.rb
+++ b/plugins/hosts/windows/cap/rdp.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
-Vagrant.require "tmpdir"
+require "pathname"
+require "tmpdir"
 
-Vagrant.require "vagrant/util/subprocess"
+require "vagrant/util/subprocess"
 
 module VagrantPlugins
   module HostWindows

--- a/plugins/kernel_v2/config/cloud_init.rb
+++ b/plugins/kernel_v2/config/cloud_init.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require "securerandom"
+require "log4r"
+require "securerandom"
 
 module VagrantPlugins
   module Kernel_V2

--- a/plugins/kernel_v2/config/disk.rb
+++ b/plugins/kernel_v2/config/disk.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require "securerandom"
+require "log4r"
+require "securerandom"
 
-Vagrant.require "vagrant/util/numeric"
+require "vagrant/util/numeric"
 
 module VagrantPlugins
   module Kernel_V2

--- a/plugins/kernel_v2/config/vm.rb
+++ b/plugins/kernel_v2/config/vm.rb
@@ -1,17 +1,17 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
-Vagrant.require "securerandom"
-Vagrant.require "set"
+require "pathname"
+require "securerandom"
+require "set"
 
-Vagrant.require "vagrant"
-Vagrant.require "vagrant/action/builtin/mixin_synced_folders"
-Vagrant.require "vagrant/config/v2/util"
-Vagrant.require "vagrant/util/platform"
-Vagrant.require "vagrant/util/presence"
-Vagrant.require "vagrant/util/experimental"
-Vagrant.require "vagrant/util/map_command_options"
+require "vagrant"
+require "vagrant/action/builtin/mixin_synced_folders"
+require "vagrant/config/v2/util"
+require "vagrant/util/platform"
+require "vagrant/util/presence"
+require "vagrant/util/experimental"
+require "vagrant/util/map_command_options"
 
 require File.expand_path("../vm_provisioner", __FILE__)
 require File.expand_path("../vm_subvm", __FILE__)

--- a/plugins/kernel_v2/config/vm_provisioner.rb
+++ b/plugins/kernel_v2/config/vm_provisioner.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'log4r'
+require 'log4r'
 
 module VagrantPlugins
   module Kernel_V2

--- a/plugins/kernel_v2/config/vm_trigger.rb
+++ b/plugins/kernel_v2/config/vm_trigger.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require "securerandom"
+require "log4r"
+require "securerandom"
 
 require Vagrant.source_root.join("plugins/provisioners/shell/config")
 

--- a/plugins/providers/docker/action/build.rb
+++ b/plugins/providers/docker/action/build.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
-Vagrant.require "vagrant/util/ansi_escape_code_remover"
+require "vagrant/util/ansi_escape_code_remover"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/connect_networks.rb
+++ b/plugins/providers/docker/action/connect_networks.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'ipaddr'
-Vagrant.require 'log4r'
+require 'ipaddr'
+require 'log4r'
 
-Vagrant.require 'vagrant/util/scoped_hash_override'
+require 'vagrant/util/scoped_hash_override'
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/destroy_build_image.rb
+++ b/plugins/providers/docker/action/destroy_build_image.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/destroy_network.rb
+++ b/plugins/providers/docker/action/destroy_network.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'log4r'
+require 'log4r'
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/host_machine.rb
+++ b/plugins/providers/docker/action/host_machine.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/host_machine_build_dir.rb
+++ b/plugins/providers/docker/action/host_machine_build_dir.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "digest/md5"
-Vagrant.require "log4r"
+require "digest/md5"
+require "log4r"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/host_machine_sync_folders.rb
+++ b/plugins/providers/docker/action/host_machine_sync_folders.rb
@@ -1,11 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "digest/md5"
-Vagrant.require "securerandom"
-Vagrant.require "log4r"
+require "digest/md5"
+require "securerandom"
+require "log4r"
 
-Vagrant.require "vagrant/action/builtin/mixin_synced_folders"
+require "vagrant/action/builtin/mixin_synced_folders"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/host_machine_sync_folders_disable.rb
+++ b/plugins/providers/docker/action/host_machine_sync_folders_disable.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
-Vagrant.require "vagrant/action/builtin/mixin_synced_folders"
+require "vagrant/action/builtin/mixin_synced_folders"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/login.rb
+++ b/plugins/providers/docker/action/login.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/prepare_networks.rb
+++ b/plugins/providers/docker/action/prepare_networks.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'ipaddr'
-Vagrant.require 'log4r'
+require 'ipaddr'
+require 'log4r'
 
-Vagrant.require 'vagrant/util/scoped_hash_override'
+require 'vagrant/util/scoped_hash_override'
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/action/wait_for_running.rb
+++ b/plugins/providers/docker/action/wait_for_running.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "thread"
-Vagrant.require "log4r"
+require "thread"
+require "log4r"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/communicator.rb
+++ b/plugins/providers/docker/communicator.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "digest/md5"
-Vagrant.require "tempfile"
+require "digest/md5"
+require "tempfile"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/config.rb
+++ b/plugins/providers/docker/config.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
+require "pathname"
 
 require_relative "../../../lib/vagrant/util/platform"
 

--- a/plugins/providers/docker/driver.rb
+++ b/plugins/providers/docker/driver.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "json"
-Vagrant.require "log4r"
+require "json"
+require "log4r"
 
 require_relative "./driver/compose"
 

--- a/plugins/providers/docker/driver/compose.rb
+++ b/plugins/providers/docker/driver/compose.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "json"
-Vagrant.require "log4r"
+require "json"
+require "log4r"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/docker/provider.rb
+++ b/plugins/providers/docker/provider.rb
@@ -1,12 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "digest/md5"
-Vagrant.require "fileutils"
-Vagrant.require "thread"
-Vagrant.require "log4r"
+require "digest/md5"
+require "fileutils"
+require "thread"
+require "log4r"
 
-Vagrant.require "vagrant/util/silence_warnings"
+require "vagrant/util/silence_warnings"
 
 module VagrantPlugins
   module DockerProvider

--- a/plugins/providers/hyperv/action/check_enabled.rb
+++ b/plugins/providers/hyperv/action/check_enabled.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "fileutils"
-Vagrant.require "log4r"
+require "fileutils"
+require "log4r"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/action/configure.rb
+++ b/plugins/providers/hyperv/action/configure.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "fileutils"
-Vagrant.require "log4r"
+require "fileutils"
+require "log4r"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/action/export.rb
+++ b/plugins/providers/hyperv/action/export.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "fileutils"
+require "fileutils"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "fileutils"
-Vagrant.require "log4r"
+require "fileutils"
+require "log4r"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/action/package_metadata_json.rb
+++ b/plugins/providers/hyperv/action/package_metadata_json.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "json"
+require "json"
 
 #require 'vagrant/util/template_renderer'
 

--- a/plugins/providers/hyperv/action/package_setup_folders.rb
+++ b/plugins/providers/hyperv/action/package_setup_folders.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "fileutils"
+require "fileutils"
 
 require_relative "../../../../lib/vagrant/action/general/package_setup_folders"
 

--- a/plugins/providers/hyperv/action/read_guest_ip.rb
+++ b/plugins/providers/hyperv/action/read_guest_ip.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require "timeout"
+require "log4r"
+require "timeout"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/action/read_state.rb
+++ b/plugins/providers/hyperv/action/read_state.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/action/set_name.rb
+++ b/plugins/providers/hyperv/action/set_name.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/action/wait_for_ip_address.rb
+++ b/plugins/providers/hyperv/action/wait_for_ip_address.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "ipaddr"
-Vagrant.require "timeout"
+require "ipaddr"
+require "timeout"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/cap/cleanup_disks.rb
+++ b/plugins/providers/hyperv/cap/cleanup_disks.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require "vagrant/util/experimental"
+require "log4r"
+require "vagrant/util/experimental"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/cap/configure_disks.rb
+++ b/plugins/providers/hyperv/cap/configure_disks.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require "fileutils"
-Vagrant.require "vagrant/util/numeric"
-Vagrant.require "vagrant/util/experimental"
+require "log4r"
+require "fileutils"
+require "vagrant/util/numeric"
+require "vagrant/util/experimental"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/cap/validate_disk_ext.rb
+++ b/plugins/providers/hyperv/cap/validate_disk_ext.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module HyperV

--- a/plugins/providers/hyperv/driver.rb
+++ b/plugins/providers/hyperv/driver.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "json"
-Vagrant.require "log4r"
+require "json"
+require "log4r"
 
-Vagrant.require "vagrant/util/powershell"
+require "vagrant/util/powershell"
 
 require_relative "plugin"
 

--- a/plugins/providers/hyperv/provider.rb
+++ b/plugins/providers/hyperv/provider.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 require_relative "driver"
 require_relative "plugin"

--- a/plugins/providers/virtualbox/action/check_guest_additions.rb
+++ b/plugins/providers/virtualbox/action/check_guest_additions.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/clean_machine_folder.rb
+++ b/plugins/providers/virtualbox/action/clean_machine_folder.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "fileutils"
+require "fileutils"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/destroy_unused_network_interfaces.rb
+++ b/plugins/providers/virtualbox/action/destroy_unused_network_interfaces.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/export.rb
+++ b/plugins/providers/virtualbox/action/export.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "fileutils"
-Vagrant.require 'vagrant/util/platform'
+require "fileutils"
+require 'vagrant/util/platform'
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/import_master.rb
+++ b/plugins/providers/virtualbox/action/import_master.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require "digest/md5"
+require "log4r"
+require "digest/md5"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -1,14 +1,14 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "ipaddr"
-Vagrant.require "resolv"
-Vagrant.require "set"
+require "ipaddr"
+require "resolv"
+require "set"
 
-Vagrant.require "log4r"
+require "log4r"
 
-Vagrant.require "vagrant/util/network_ip"
-Vagrant.require "vagrant/util/scoped_hash_override"
+require "vagrant/util/network_ip"
+require "vagrant/util/scoped_hash_override"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/network_fix_ipv6.rb
+++ b/plugins/providers/virtualbox/action/network_fix_ipv6.rb
@@ -1,13 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "ipaddr"
-Vagrant.require "socket"
+require "ipaddr"
+require "socket"
 
-Vagrant.require "log4r"
+require "log4r"
 
-Vagrant.require "vagrant/util/presence"
-Vagrant.require "vagrant/util/scoped_hash_override"
+require "vagrant/util/presence"
+require "vagrant/util/scoped_hash_override"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/package_setup_folders.rb
+++ b/plugins/providers/virtualbox/action/package_setup_folders.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "fileutils"
+require "fileutils"
 
 require_relative "../../../../lib/vagrant/action/general/package_setup_folders"
 

--- a/plugins/providers/virtualbox/action/prepare_clone_snapshot.rb
+++ b/plugins/providers/virtualbox/action/prepare_clone_snapshot.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require "digest/md5"
+require "log4r"
+require "digest/md5"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/prepare_nfs_settings.rb
+++ b/plugins/providers/virtualbox/action/prepare_nfs_settings.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "ipaddr"
-Vagrant.require "vagrant/action/builtin/mixin_synced_folders"
+require "ipaddr"
+require "vagrant/action/builtin/mixin_synced_folders"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/sane_defaults.rb
+++ b/plugins/providers/virtualbox/action/sane_defaults.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/set_default_nic_type.rb
+++ b/plugins/providers/virtualbox/action/set_default_nic_type.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/set_name.rb
+++ b/plugins/providers/virtualbox/action/set_name.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/action/setup_package_files.rb
+++ b/plugins/providers/virtualbox/action/setup_package_files.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 require_relative "package_setup_files"
 

--- a/plugins/providers/virtualbox/cap/cleanup_disks.rb
+++ b/plugins/providers/virtualbox/cap/cleanup_disks.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require "vagrant/util/experimental"
+require "log4r"
+require "vagrant/util/experimental"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/cap/configure_disks.rb
+++ b/plugins/providers/virtualbox/cap/configure_disks.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require "fileutils"
-Vagrant.require "vagrant/util/numeric"
-Vagrant.require "vagrant/util/experimental"
+require "log4r"
+require "fileutils"
+require "vagrant/util/numeric"
+require "vagrant/util/experimental"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/cap/validate_disk_ext.rb
+++ b/plugins/providers/virtualbox/cap/validate_disk_ext.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/driver/base.rb
+++ b/plugins/providers/virtualbox/driver/base.rb
@@ -1,13 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'log4r'
+require 'log4r'
 
-Vagrant.require 'vagrant/util/busy'
-Vagrant.require 'vagrant/util/platform'
-Vagrant.require 'vagrant/util/retryable'
-Vagrant.require 'vagrant/util/subprocess'
-Vagrant.require 'vagrant/util/which'
+require 'vagrant/util/busy'
+require 'vagrant/util/platform'
+require 'vagrant/util/retryable'
+require 'vagrant/util/subprocess'
+require 'vagrant/util/which'
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/driver/version_4_1.rb
+++ b/plugins/providers/virtualbox/driver/version_4_1.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'log4r'
-Vagrant.require "vagrant/util/platform"
+require 'log4r'
+require "vagrant/util/platform"
 
 require File.expand_path("../base", __FILE__)
 

--- a/plugins/providers/virtualbox/driver/version_7_0.rb
+++ b/plugins/providers/virtualbox/driver/version_7_0.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "rexml"
+require "rexml"
 
 require File.expand_path("../version_6_1", __FILE__)
 

--- a/plugins/providers/virtualbox/provider.rb
+++ b/plugins/providers/virtualbox/provider.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/providers/virtualbox/synced_folder.rb
+++ b/plugins/providers/virtualbox/synced_folder.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "fileutils"
-Vagrant.require "vagrant/util/platform"
+require "fileutils"
+require "vagrant/util/platform"
 
 module VagrantPlugins
   module ProviderVirtualBox

--- a/plugins/provisioners/ansible/provisioner/guest.rb
+++ b/plugins/provisioners/ansible/provisioner/guest.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
+require "tempfile"
 
 require_relative "base"
 

--- a/plugins/provisioners/ansible/provisioner/host.rb
+++ b/plugins/provisioners/ansible/provisioner/host.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "thread"
+require "thread"
 
 require_relative "base"
 

--- a/plugins/provisioners/cfengine/cap/linux/cfengine_needs_bootstrap.rb
+++ b/plugins/provisioners/cfengine/cap/linux/cfengine_needs_bootstrap.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module CFEngine

--- a/plugins/provisioners/cfengine/cap/redhat/cfengine_install.rb
+++ b/plugins/provisioners/cfengine/cap/redhat/cfengine_install.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module CFEngine

--- a/plugins/provisioners/cfengine/config.rb
+++ b/plugins/provisioners/cfengine/config.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
+require "pathname"
 
 module VagrantPlugins
   module CFEngine

--- a/plugins/provisioners/cfengine/provisioner.rb
+++ b/plugins/provisioners/cfengine/provisioner.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module CFEngine

--- a/plugins/provisioners/chef/plugin.rb
+++ b/plugins/provisioners/chef/plugin.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
+require "pathname"
 
 require_relative "command_builder"
 

--- a/plugins/provisioners/chef/provisioner/base.rb
+++ b/plugins/provisioners/chef/provisioner/base.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "tempfile"
+require "tempfile"
 
 require_relative "../../../../lib/vagrant/util/presence"
 require_relative "../../../../lib/vagrant/util/template_renderer"

--- a/plugins/provisioners/chef/provisioner/chef_apply.rb
+++ b/plugins/provisioners/chef/provisioner/chef_apply.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "digest/md5"
-Vagrant.require "tempfile"
+require "digest/md5"
+require "tempfile"
 
 require_relative "base"
 

--- a/plugins/provisioners/chef/provisioner/chef_client.rb
+++ b/plugins/provisioners/chef/provisioner/chef_client.rb
@@ -1,11 +1,11 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'pathname'
+require 'pathname'
 
-Vagrant.require 'vagrant'
-Vagrant.require 'vagrant/util/presence'
-Vagrant.require 'vagrant/util/subprocess'
+require 'vagrant'
+require 'vagrant/util/presence'
+require 'vagrant/util/subprocess'
 
 require_relative "base"
 

--- a/plugins/provisioners/chef/provisioner/chef_zero.rb
+++ b/plugins/provisioners/chef/provisioner/chef_zero.rb
@@ -1,13 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "digest/md5"
-Vagrant.require "securerandom"
-Vagrant.require "set"
+require "digest/md5"
+require "securerandom"
+require "set"
 
-Vagrant.require "log4r"
+require "log4r"
 
-Vagrant.require "vagrant/util/counter"
+require "vagrant/util/counter"
 
 require_relative "chef_solo"
 

--- a/plugins/provisioners/container/client.rb
+++ b/plugins/provisioners/container/client.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'digest/sha1'
+require 'digest/sha1'
 
 module VagrantPlugins
   module ContainerProvisioner

--- a/plugins/provisioners/container/config.rb
+++ b/plugins/provisioners/container/config.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'set'
+require 'set'
 
 module VagrantPlugins
   module ContainerProvisioner

--- a/plugins/provisioners/file/config.rb
+++ b/plugins/provisioners/file/config.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
+require "pathname"
 
 module VagrantPlugins
   module FileUpload

--- a/plugins/provisioners/puppet/provisioner/puppet.rb
+++ b/plugins/provisioners/puppet/provisioner/puppet.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "digest/md5"
-Vagrant.require "log4r"
+require "digest/md5"
+require "log4r"
 
 module VagrantPlugins
   module Puppet

--- a/plugins/provisioners/salt/bootstrap_downloader.rb
+++ b/plugins/provisioners/salt/bootstrap_downloader.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'open-uri'
-Vagrant.require 'digest'
+require 'open-uri'
+require 'digest'
 
 require_relative "./errors"
 

--- a/plugins/provisioners/salt/provisioner.rb
+++ b/plugins/provisioners/salt/provisioner.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'json'
+require 'json'
 
 require_relative "bootstrap_downloader"
 

--- a/plugins/provisioners/shell/config.rb
+++ b/plugins/provisioners/shell/config.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'uri'
+require 'uri'
 
 module VagrantPlugins
   module Shell

--- a/plugins/provisioners/shell/provisioner.rb
+++ b/plugins/provisioners/shell/provisioner.rb
@@ -1,12 +1,12 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
-Vagrant.require "tempfile"
+require "pathname"
+require "tempfile"
 
-Vagrant.require "vagrant/util/downloader"
-Vagrant.require "vagrant/util/line_buffer"
-Vagrant.require "vagrant/util/retryable"
+require "vagrant/util/downloader"
+require "vagrant/util/line_buffer"
+require "vagrant/util/retryable"
 
 module VagrantPlugins
   module Shell

--- a/plugins/pushes/ftp/adapter.rb
+++ b/plugins/pushes/ftp/adapter.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "pathname"
+require "pathname"
 
 module VagrantPlugins
   module FTPPush
@@ -50,7 +50,7 @@ module VagrantPlugins
     #
     class FTPAdapter < Adapter
       def initialize(*)
-        Vagrant.require "net/ftp"
+        require "net/ftp"
         super
       end
 
@@ -107,7 +107,7 @@ module VagrantPlugins
     #
     class SFTPAdapter < Adapter
       def initialize(*)
-        Vagrant.require "net/sftp"
+        require "net/sftp"
         super
         @dirs = {}
       end

--- a/plugins/pushes/ftp/push.rb
+++ b/plugins/pushes/ftp/push.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "net/ftp"
-Vagrant.require "pathname"
+require "net/ftp"
+require "pathname"
 
 require_relative "adapter"
 require_relative "errors"

--- a/plugins/pushes/local-exec/push.rb
+++ b/plugins/pushes/local-exec/push.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "fileutils"
-Vagrant.require "tempfile"
-Vagrant.require "vagrant/util/safe_exec"
+require "fileutils"
+require "tempfile"
+require "vagrant/util/safe_exec"
 
 require_relative "errors"
 

--- a/plugins/synced_folders/nfs/action_cleanup.rb
+++ b/plugins/synced_folders/nfs/action_cleanup.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
 module VagrantPlugins
   module SyncedFolderNFS

--- a/plugins/synced_folders/nfs/synced_folder.rb
+++ b/plugins/synced_folders/nfs/synced_folder.rb
@@ -1,13 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'fileutils'
-Vagrant.require 'thread'
-Vagrant.require 'zlib'
+require 'fileutils'
+require 'thread'
+require 'zlib'
 
-Vagrant.require "log4r"
+require "log4r"
 
-Vagrant.require "vagrant/util/platform"
+require "vagrant/util/platform"
 
 module VagrantPlugins
   module SyncedFolderNFS

--- a/plugins/synced_folders/rsync/command/rsync.rb
+++ b/plugins/synced_folders/rsync/command/rsync.rb
@@ -1,9 +1,9 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require 'optparse'
+require 'optparse'
 
-Vagrant.require "vagrant/action/builtin/mixin_synced_folders"
+require "vagrant/action/builtin/mixin_synced_folders"
 
 require_relative "../helper"
 

--- a/plugins/synced_folders/rsync/command/rsync_auto.rb
+++ b/plugins/synced_folders/rsync/command/rsync_auto.rb
@@ -1,17 +1,17 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
-Vagrant.require 'optparse'
-Vagrant.require "thread"
+require "log4r"
+require 'optparse'
+require "thread"
 
-Vagrant.require "vagrant/action/builtin/mixin_synced_folders"
-Vagrant.require "vagrant/util/busy"
-Vagrant.require "vagrant/util/platform"
+require "vagrant/action/builtin/mixin_synced_folders"
+require "vagrant/util/busy"
+require "vagrant/util/platform"
 
 require_relative "../helper"
 
-Vagrant.require "listen"
+require "listen"
 
 module VagrantPlugins
   module SyncedFolderRSync

--- a/plugins/synced_folders/rsync/default_unix_cap.rb
+++ b/plugins/synced_folders/rsync/default_unix_cap.rb
@@ -1,7 +1,7 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "shellwords"
+require "shellwords"
 
 module VagrantPlugins
   module SyncedFolderRSync

--- a/plugins/synced_folders/rsync/helper.rb
+++ b/plugins/synced_folders/rsync/helper.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "fileutils"
-Vagrant.require "ipaddr"
-Vagrant.require "shellwords"
-Vagrant.require "tmpdir"
+require "fileutils"
+require "ipaddr"
+require "shellwords"
+require "tmpdir"
 
 require "vagrant/util/platform"
 require "vagrant/util/subprocess"

--- a/plugins/synced_folders/rsync/synced_folder.rb
+++ b/plugins/synced_folders/rsync/synced_folder.rb
@@ -1,10 +1,10 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "log4r"
+require "log4r"
 
-Vagrant.require "vagrant/util/subprocess"
-Vagrant.require "vagrant/util/which"
+require "vagrant/util/subprocess"
+require "vagrant/util/which"
 
 require_relative "helper"
 

--- a/plugins/synced_folders/smb/synced_folder.rb
+++ b/plugins/synced_folders/smb/synced_folder.rb
@@ -1,13 +1,13 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "digest/md5"
-Vagrant.require "json"
+require "digest/md5"
+require "json"
 
-Vagrant.require "log4r"
+require "log4r"
 
-Vagrant.require "vagrant/util/platform"
-Vagrant.require "vagrant/util/powershell"
+require "vagrant/util/platform"
+require "vagrant/util/powershell"
 
 require_relative "errors"
 

--- a/plugins/synced_folders/unix_mount_helpers.rb
+++ b/plugins/synced_folders/unix_mount_helpers.rb
@@ -1,8 +1,8 @@
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: BUSL-1.1
 
-Vagrant.require "shellwords"
-Vagrant.require "vagrant/util/retryable"
+require "shellwords"
+require "vagrant/util/retryable"
 
 module VagrantPlugins
   module SyncedFolder

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -437,10 +437,10 @@ en:
       not_in_installer: |-
         You appear to be running Vagrant outside of the official installers.
         Note that the installers are what ensure that Vagrant has all required
-        dependencies, and Vagrant assumes that these dependencies exist. By
-        running outside of the installer environment, Vagrant may not function
-        properly. To remove this warning, install Vagrant using one of the
-        official packages from vagrantup.com.
+        dependencies. Vagrant has detected that the following  executables are
+        currently unavailable:
+
+          %{tools}
       upgraded_v1_dotfile: |-
         A Vagrant 1.0.x state file was found for this environment. Vagrant has
         gone ahead and auto-upgraded this to the latest format. Everything

--- a/test/unit/bin/vagrant_test.rb
+++ b/test/unit/bin/vagrant_test.rb
@@ -132,19 +132,19 @@ describe "vagrant bin" do
 
     before do
       expect(Vagrant).to receive(:in_installer?).and_return(false)
-      allow(I18n).to receive(:t).with(/not_in_installer/).and_return(warning)
+      allow(I18n).to receive(:t).with(/not_in_installer/, any_args).and_return(warning)
     end
 
-    context "when vagrant is not very quiet" do
-      before { expect(Vagrant).to receive(:very_quiet?).and_return(false) }
+    context "when tool is missing" do
+      before { expect(Vagrant).to receive(:detect_missing_tools).and_return(["tool"]) }
 
       it "should output a warning" do
         expect(env.ui).to receive(:warn).with(/#{warning}/, any_args)
       end
     end
 
-    context "when vagrant is very quiet" do
-      before { expect(Vagrant).to receive(:very_quiet?).and_return(true) }
+    context "when tool is not missing" do
+      before { expect(Vagrant).to receive(:detect_missing_tools).and_return([]) }
 
       it "should not output a warning" do
         expect(env.ui).not_to receive(:warn).with(/#{warning}/, any_args)


### PR DESCRIPTION
Remove customized require behaviors and modify the bin executable
to check for missing tools that Vagrant expects to exist when
running outside of an installer.
