### PR TITLE
Use interface name for hostonly network configuration

### DIFF
--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -356,6 +356,16 @@ module VagrantPlugins
             dhcp_options[:dhcp_upper] = options[:dhcp_upper] || (ip_range.last(2).first).to_s
           end
 
+          # Find the hostonly interface name if display name was
+          # provided
+          if options[:name]
+            hostif = @env[:machine].provider.driver.read_host_only_networks.detect { |interface|
+              interface[:name] == options[:name] ||
+                interface[:vboxnetworkname] == options[:name]
+            }
+            options[:name] = hostif[:name] if hostif
+          end
+
           return {
             adapter_ip:  options[:adapter_ip],
             auto_config: options[:auto_config],

--- a/test/unit/plugins/providers/virtualbox/action/network_test.rb
+++ b/test/unit/plugins/providers/virtualbox/action/network_test.rb
@@ -84,6 +84,52 @@ describe VagrantPlugins::ProviderVirtualBox::Action::Network do
         end
       end
     end
+
+    context "when name is provided as interface name" do
+      let(:options) {
+        {
+          type: type,
+          ip: address,
+          name: name
+        }
+      }
+      let(:name) { "hostonly_ifname" }
+      let(:display_name) { "HostInterfaceNetworking-hostonly_ifname" }
+      let(:hostonly_networks) do
+        [
+          {
+            name: name,
+            vboxnetworkname: display_name
+          }
+        ]
+      end
+
+      before { allow(driver).to receive(:read_host_only_networks).and_return(hostonly_networks) }
+
+      it "should lookup host only networks" do
+        expect(driver).to receive(:read_host_only_networks).and_return(hostonly_networks)
+
+        subject.hostonly_config(options)
+      end
+
+      it "should not change the name" do
+        expect(subject.hostonly_config(options)[:name]) == name
+      end
+
+      context "when display name is provided in options" do
+        let(:options) {
+          {
+            type: type,
+            ip: address,
+            name: display_name
+          }
+        }
+
+        it "should change the name to the interface name" do
+          expect(subject.hostonly_config(options)[:name]) == name
+        end
+      end
+    end
   end
 
   describe "#validate_hostonly_ip!" do


### PR DESCRIPTION
When provided a name for the hostonly network in the VirtualBox
provider, always use the interface name in the final configuration.

Fixes #13620
