### PR TITLE
Fix box add action to include architecture

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -292,7 +292,7 @@ module Vagrant
             # If we have only one provider in the metadata, just use that
             # provider.
             metadata_provider = metadata_version.provider(
-              metadata_version.providers.first, architecture)
+              metadata_version.providers(architecture).first, architecture)
           else
             providers = metadata_version.providers(architecture).sort
 


### PR DESCRIPTION
If only one provider is available for the architecture, it is
selected, but when actually selecting it the architecture
constraint was not included. Depending on the order of the provider
list, the wrong value would be chosen.

Fixes #13646
