### PR TITLE
Prefer pwsh executable over powershell excutable

### DIFF
--- a/website/content/docs/other/environmental-variables.mdx
+++ b/website/content/docs/other/environmental-variables.mdx
@@ -268,6 +268,14 @@ detection.
 When setting this environment variable, its value will be in seconds. By default,
 it will use 30 seconds as a timeout.
 
+## `VAGRANT_PREFERRED_POWERSHELL`
+
+When executing PowerShell commands, Vagrant will prefer to use `pwsh.exe`
+over `powershell.exe` by default. This environment variable can be used to
+modify this preference and make Vagrant prefer `powershell.exe`. The value
+set in this environment variable are any supported PowerShell executables
+which currently are: `powershell` and `pwsh`.
+
 ## `VAGRANT_PREFERRED_PROVIDERS`
 
 This configures providers that Vagrant should prefer.


### PR DESCRIPTION
Prefer to use the pwsh executable over the powershell executable
as the pwsh exectuable will be faster loading than the powershell
executable. If the pwsh executable is not found, the powershell
executable will be used instead. The preference can be overridden
using the VAGRANT_PREFERRED_POWERSHELL environment variable.
