### PR TITLE
Remove library dependencies

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -21,8 +21,6 @@ Gem::Specification.new do |s|
   s.add_dependency "csv", "~> 3.3"
   s.add_dependency "ed25519", "~> 1.3.0"
   s.add_dependency "erubi"
-  s.add_dependency 'googleapis-common-protos-types', '~> 1.3'
-  s.add_dependency "grpc", "~> 1.62"
   s.add_dependency "hashicorp-checkpoint", "~> 0.1.5"
   s.add_dependency "i18n", "~> 1.12"
   s.add_dependency "listen", "~> 3.7"
@@ -36,7 +34,6 @@ Gem::Specification.new do |s|
   s.add_dependency "ostruct", "~> 0.6.0"
   s.add_dependency "rb-kqueue", "~> 0.2.0"
   s.add_dependency "rexml", "~> 3.2"
-  s.add_dependency "rgl", "~> 0.5.10"
   s.add_dependency "rubyzip", "~> 2.3.2"
   s.add_dependency "vagrant_cloud", "~> 3.1.2"
   s.add_dependency "wdm", "~> 0.2.0"


### PR DESCRIPTION
Remove dependencies from the gemspec for libraries that
are no longer in use.
