### PR TITLE
Fix VirtualBox private network setup

### DIFF
--- a/plugins/providers/virtualbox/action/network.rb
+++ b/plugins/providers/virtualbox/action/network.rb
@@ -359,9 +359,9 @@ module VagrantPlugins
           # Find the hostonly interface name if display name was
           # provided
           if options[:name]
-            hostif = @env[:machine].provider.driver.read_host_only_networks.detect { |interface|
+            hostif = @env[:machine].provider.driver.read_host_only_interfaces.detect { |interface|
               interface[:name] == options[:name] ||
-                interface[:vboxnetworkname] == options[:name]
+                interface[:display_name] == options[:name]
             }
             options[:name] = hostif[:name] if hostif
           end

--- a/plugins/providers/virtualbox/driver/base.rb
+++ b/plugins/providers/virtualbox/driver/base.rb
@@ -256,10 +256,11 @@ module VagrantPlugins
         # Each interface is represented as a Hash with the following details:
         #
         # {
-        #  :name    => String, # interface name, e.g. "vboxnet0"
-        #  :ip      => String, # IP address of the interface, e.g. "172.28.128.1"
-        #  :netmask => String, # netmask associated with the interface, e.g. "255.255.255.0"
-        #  :status  => String, # status of the interface, e.g. "Up", "Down"
+        #  :name         => String, # interface name, e.g. "vboxnet0"
+        #  :ip           => String, # IP address of the interface, e.g. "172.28.128.1"
+        #  :netmask      => String, # netmask associated with the interface, e.g. "255.255.255.0"
+        #  :status       => String, # status of the interface, e.g. "Up", "Down"
+        #  :display_name => String, # user friendly display name if available
         # }
         #
         # @return [Array<Hash>] See comment above for details

--- a/plugins/providers/virtualbox/driver/meta.rb
+++ b/plugins/providers/virtualbox/driver/meta.rb
@@ -134,6 +134,7 @@ module VagrantPlugins
           :read_guest_ip,
           :read_guest_property,
           :read_host_only_interfaces,
+          :read_host_only_networks,
           :read_mac_address,
           :read_mac_addresses,
           :read_machine_folder,

--- a/plugins/providers/virtualbox/driver/version_4_0.rb
+++ b/plugins/providers/virtualbox/driver/version_4_0.rb
@@ -345,6 +345,8 @@ module VagrantPlugins
                 info[:ipv6_prefix] = $1.to_s.strip
               elsif status = line[/^Status:\s+(.+?)$/, 1]
                 info[:status] = status
+              elsif line =~ /^VBoxNetworkName:\s+(.+?)$/
+                info[:display_name] = $1.to_s
               end
             end
 

--- a/plugins/providers/virtualbox/driver/version_4_1.rb
+++ b/plugins/providers/virtualbox/driver/version_4_1.rb
@@ -447,6 +447,8 @@ module VagrantPlugins
                 info[:ipv6_prefix] = $1.to_s.strip
               elsif status = line[/^Status:\s+(.+?)$/, 1]
                 info[:status] = status
+              elsif line =~ /^VBoxNetworkName:\s+(.+?)$/
+                info[:display_name] = $1.to_s
               end
             end
 

--- a/plugins/providers/virtualbox/driver/version_4_2.rb
+++ b/plugins/providers/virtualbox/driver/version_4_2.rb
@@ -381,6 +381,8 @@ module VagrantPlugins
                 info[:ipv6_prefix] = $1.to_s.strip
               elsif line =~ /^Status:\s+(.+?)$/
                 info[:status] = $1.to_s
+              elsif line =~ /^VBoxNetworkName:\s+(.+?)$/
+                info[:display_name] = $1.to_s
               end
             end
 

--- a/plugins/providers/virtualbox/driver/version_4_3.rb
+++ b/plugins/providers/virtualbox/driver/version_4_3.rb
@@ -492,6 +492,8 @@ module VagrantPlugins
                 info[:ipv6_prefix] = $1.to_s.strip
               elsif line =~ /^Status:\s+(.+?)$/
                 info[:status] = $1.to_s
+              elsif line =~ /^VBoxNetworkName:\s+(.+?)$/
+                info[:display_name] = $1.to_s
               end
             end
 

--- a/plugins/providers/virtualbox/driver/version_5_0.rb
+++ b/plugins/providers/virtualbox/driver/version_5_0.rb
@@ -635,6 +635,8 @@ module VagrantPlugins
                 info[:ipv6_prefix] = $1.to_s.strip
               elsif line =~ /^Status:\s+(.+?)$/
                 info[:status] = $1.to_s
+              elsif line =~ /^VBoxNetworkName:\s+(.+?)$/
+                info[:display_name] = $1.to_s
               end
             end
 

--- a/plugins/providers/virtualbox/driver/version_7_0.rb
+++ b/plugins/providers/virtualbox/driver/version_7_0.rb
@@ -215,26 +215,6 @@ module VagrantPlugins
           end
         end
 
-        # Generate list of host only networks
-        def read_host_only_networks
-          networks = []
-          current = nil
-          execute("list", "hostonlynets", retryable: true).split("\n").each do |line|
-            line.chomp!
-            next if line.empty?
-            key, value = line.split(":", 2).map(&:strip)
-            key = key.downcase
-            if key == "name"
-              networks.push(current) if !current.nil?
-              current = Vagrant::Util::HashWithIndifferentAccess.new
-            end
-            current[key] = value
-          end
-          networks.push(current) if !current.nil?
-
-          networks
-        end
-
         # The initial VirtualBox 7.0 release has an issue with displaying port
         # forward information. When a single port forward is defined, the forwarding
         # information can be found in the `showvminfo` output. Once more than a
@@ -280,6 +260,29 @@ module VagrantPlugins
           end
 
           results
+        end
+
+        protected
+
+        # Generate list of host only networks
+        # NOTE: This is darwin specific
+        def read_host_only_networks
+          networks = []
+          current = nil
+          execute("list", "hostonlynets", retryable: true).split("\n").each do |line|
+            line.chomp!
+            next if line.empty?
+            key, value = line.split(":", 2).map(&:strip)
+            key = key.downcase
+            if key == "name"
+              networks.push(current) if !current.nil?
+              current = Vagrant::Util::HashWithIndifferentAccess.new
+            end
+            current[key] = value
+          end
+          networks.push(current) if !current.nil?
+
+          networks
         end
 
         private

--- a/test/unit/plugins/providers/virtualbox/action/network_test.rb
+++ b/test/unit/plugins/providers/virtualbox/action/network_test.rb
@@ -99,15 +99,15 @@ describe VagrantPlugins::ProviderVirtualBox::Action::Network do
         [
           {
             name: name,
-            vboxnetworkname: display_name
+            display_name: display_name
           }
         ]
       end
 
-      before { allow(driver).to receive(:read_host_only_networks).and_return(hostonly_networks) }
+      before { allow(driver).to receive(:read_host_only_interfaces).and_return(hostonly_networks) }
 
       it "should lookup host only networks" do
-        expect(driver).to receive(:read_host_only_networks).and_return(hostonly_networks)
+        expect(driver).to receive(:read_host_only_interfaces).and_return(hostonly_networks)
 
         subject.hostonly_config(options)
       end

--- a/test/unit/plugins/providers/virtualbox/driver/version_5_0_test.rb
+++ b/test/unit/plugins/providers/virtualbox/driver/version_5_0_test.rb
@@ -189,31 +189,6 @@ OUTPUT
       expect(storage_controllers.first.attachments).to eq(attachments_result)
     end
   end
-
-  describe "#read_machine_folder" do
-    let(:system_properties) { VBOX_SYSTEM_PROPERTIES }
-    let(:machine_folder) { "/home/username/VirtualBox VMs"}
-
-    before do
-      allow(subject).to receive(:execute).
-                          with("list", "systemproperties", any_args).
-                          and_return(system_properties)
-    end
-
-    it "should read the default folder" do
-      expect(subject.read_machine_folder).to eq(machine_folder)
-    end
-
-    context "when default folder value is missing" do
-      let(:system_properties) { VBOX_SYSTEM_PROPERTIES.sub(/^Default machine folder:.+$/, "")}
-
-      it "should raise a custom error" do
-        expect {
-          subject.read_machine_folder
-        }.to raise_error(Vagrant::Errors::VirtualBoxMachineFolderNotFound)
-      end
-    end
-  end
 end
 
 VBOX_SYSTEM_PROPERTIES=%(

--- a/test/unit/plugins/providers/virtualbox/support/shared/virtualbox_driver_version_4_x_examples.rb
+++ b/test/unit/plugins/providers/virtualbox/support/shared/virtualbox_driver_version_4_x_examples.rb
@@ -164,6 +164,7 @@ shared_examples "a version 4.x virtualbox driver" do |options|
           netmask: '255.255.255.0',
           ipv6_prefix: '0',
           status:  'Up',
+          display_name: 'HostInterfaceNetworking-vboxnet0',
         }])
       end
     end
@@ -200,8 +201,8 @@ shared_examples "a version 4.x virtualbox driver" do |options|
 
       it "returns a list with one entry for each interface" do
         expect(subject.read_host_only_interfaces).to eq([
-          {name: 'vboxnet0', ip: '172.28.128.1', netmask: '255.255.255.0', ipv6_prefix: "0", status: 'Up'},
-          {name: 'vboxnet1', ip: '10.0.0.1', netmask: '255.255.255.0', ipv6_prefix: "0", status: 'Up'},
+          {name: 'vboxnet0', ip: '172.28.128.1', netmask: '255.255.255.0', ipv6_prefix: "0", status: 'Up', display_name: 'HostInterfaceNetworking-vboxnet0'},
+          {name: 'vboxnet1', ip: '10.0.0.1', netmask: '255.255.255.0', ipv6_prefix: "0", status: 'Up', display_name: 'HostInterfaceNetworking-vboxnet1'},
         ])
       end
     end
@@ -231,6 +232,7 @@ shared_examples "a version 4.x virtualbox driver" do |options|
           ipv6: 'fde4:8dba:82e1::',
           ipv6_prefix: '64',
           status:  'Up',
+          display_name: 'HostInterfaceNetworking-vboxnet1'
         }])
       end
     end

--- a/test/unit/plugins/providers/virtualbox/support/shared/virtualbox_driver_version_7_x_examples.rb
+++ b/test/unit/plugins/providers/virtualbox/support/shared/virtualbox_driver_version_7_x_examples.rb
@@ -524,11 +524,11 @@ shared_examples "a version 7.x virtualbox driver" do |opts|
     end
 
     it "should return defined networks" do
-      expect(subject.read_host_only_networks.size).to eq(2)
+      expect(subject.send(:read_host_only_networks).size).to eq(2)
     end
 
     it "should return expected network information" do
-      result = subject.read_host_only_networks
+      result = subject.send(:read_host_only_networks)
       expect(result.first[:name]).to eq("vagrantnet-vbox1")
       expect(result.first[:lowerip]).to eq("192.168.61.0")
       expect(result.first[:networkmask]).to eq("255.255.255.0")


### PR DESCRIPTION
Include network display name within the output of the
`#read_host_only_interfaces` driver method. When matching
the private network name, use the `#read_host_only_interfaces`
method and not the `#read_host_only_networks` method which
is darwin specific. Backport the `display_name` inclusion
to old driver versions for consistent behavior.

Fixes #13655
