### PR TITLE
Make box add failure messages more helpful

### DIFF
--- a/lib/vagrant/box_metadata.rb
+++ b/lib/vagrant/box_metadata.rb
@@ -49,6 +49,9 @@ module Vagrant
     #
     # @param [String] version The version to return, this can also
     #   be a constraint.
+    # @option [Symbol, Array<Symbol>] :provider Provider filter
+    # @option [Symbol] :architecture Architecture filter
+    #
     # @return [Version] The matching version or nil if a matching
     #   version was not found.
     def version(version, **opts)
@@ -90,10 +93,13 @@ module Vagrant
     # latest version. Optionally filter versions by a matching
     # provider.
     #
+    # @option [Symbol, Array<Symbol>] :provider Provider filter
+    # @option [Symbol] :architecture Architecture filter
+    #
     # @return[Array<String>]
     def versions(**opts)
       architecture = opts[:architecture]
-      provider = opts[:provider].to_sym if opts[:provider]
+      provider = Array(opts[:provider]).map(&:to_sym) if opts[:provider]
 
       # Return full version list if no filters provided
       if provider.nil? && architecture.nil?
@@ -109,7 +115,7 @@ module Vagrant
       end
 
       @version_map.select { |_, version|
-        version.provider(provider, architecture)
+        provider.any? { |pv| version.provider(pv, architecture) }
       }.keys.sort.map(&:to_s)
     end
 

--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -139,6 +139,18 @@ module Vagrant
       error_key(:box_add_no_matching_provider)
     end
 
+    class BoxAddNoArchitectureSupport < VagrantError
+      error_key(:box_add_no_architecture_support)
+    end
+
+    class BoxAddNoMatchingArchitecture < VagrantError
+      error_key(:box_add_no_matching_architecture)
+    end
+
+    class BoxAddNoMatchingProviderVersion < VagrantError
+      error_key(:box_add_no_matching_provider_version)
+    end
+
     class BoxAddNoMatchingVersion < VagrantError
       error_key(:box_add_no_matching_version)
     end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -510,6 +510,41 @@ en:
         Name: %{name}
         Address: %{url}
         Requested provider: %{requested}
+      box_add_no_architecture_support: |-
+        The box you're attempting to add doesn't support the requested
+        architecture. Please find an alternate box that support the
+        requested architecture.
+
+        Box: %{name}
+        Address: %{url}
+        Architecture: %{architecture}
+      box_add_no_matching_architecture: |-
+        The box you're attempting to add doesn't support the requested
+        architecture with the current provider. The following providers
+        support the requested architecture for this box:
+
+          %{supported_providers}
+
+        If the above providers cannot be used, please find and alternate
+        box that supports the requested architecture.
+
+        Box: %{name}
+        Address: %{url}
+        Architecture: %{architecture}
+        Provider: %{provider}
+      box_add_no_matching_provider_version: |-
+        The box you're attempting to add has no available version that
+        matches the constraints you requested with support for the
+        required provider and architecture. Versions of the box that
+        support the required provider and architecture are listed
+        below.
+
+        Box: %{name}
+        Address: %{url}
+        Constraints: %{constraints}
+        Architecture: %{architecture}
+        Provider: %{provider}
+        Supported versions: %{versions}
       box_add_no_matching_version: |-
         The box you're attempting to add has no available version that
         matches the constraints you requested. Please double-check your

--- a/test/unit/vagrant/box_metadata_test.rb
+++ b/test/unit/vagrant/box_metadata_test.rb
@@ -30,7 +30,7 @@ describe Vagrant::BoxMetadata do
           version: "1.1.0",
           providers: [
             { name: "virtualbox" },
-            { name: "vmware" }
+            { name: "vmware", architecture: "test-arch" }
           ]
         }
       ]
@@ -117,6 +117,19 @@ describe Vagrant::BoxMetadata do
     it "filters versions by matching provider" do
       expect(subject.versions(provider: :vmware)).to eq(
         ["1.0.0", "1.1.0"])
+    end
+
+    it "filters versions by architecture" do
+      expect(subject.versions(architecture: "test-arch")).to eq(["1.1.0"])
+    end
+
+    it "filters versions by provider and architecture" do
+      expect(subject.versions(architecture: "test-arch", provider: "virtualbox")).to eq([])
+      expect(subject.versions(architecture: "test-arch", provider: "vmware")).to eq(["1.1.0"])
+    end
+
+    it "filters versions by multiple providers" do
+      expect(subject.versions(provider: ["vmware", "my-virt"])).to eq(["1.0.0", "1.1.0"])
     end
   end
   


### PR DESCRIPTION
This adjusts the failure detection and errors raised when a box
cannot be added. New errors are added for when a requested provider
on a box does not support an architecture, and for when the no
providers on a box support an architecture. When box supports
an architecture but not with the requested provider, a list of
supported providers will be returned in the error message. If
a version constraint is requested and cannot be satisfied due
to provider and architecture filtering, the list of valid versions
will be provided.

Small change to the version list in the error output: the list
has been reversed so the most recent versions are listed first.

Fixes #13552
