### PR TITLE
Add basic oscdimg detection on Windows

### DIFF
--- a/lib/vagrant/errors.rb
+++ b/lib/vagrant/errors.rb
@@ -619,6 +619,10 @@ module Vagrant
       error_key(:no_env)
     end
 
+    class OscdimgCommandMissingError < VagrantError
+      error_key(:oscdimg_command_missing)
+    end
+
     class PackageIncludeMissing < VagrantError
       error_key(:include_file_missing, "vagrant.actions.general.package")
     end

--- a/plugins/hosts/windows/cap/fs_iso.rb
+++ b/plugins/hosts/windows/cap/fs_iso.rb
@@ -12,14 +12,22 @@ module VagrantPlugins
 
         @@logger = Log4r::Logger.new("vagrant::host::windows::fs_iso")
 
-        BUILD_ISO_CMD = "oscdimg".freeze
+        BUILD_ISO_CMD = "oscdimg.exe".freeze
+        DEPLOYMENT_KIT_PATHS = [
+          "C:/Program Files (x86)/Windows Kits/10/Assessment and Deployment Kit/Deployment Tools".freeze,
+        ].freeze
 
         # Check that the host has the ability to generate ISOs
         #
         # @param [Vagrant::Environment] env
         # @return [Boolean]
         def self.isofs_available(env)
-          !!Vagrant::Util::Which.which(BUILD_ISO_CMD)
+          begin
+            oscdimg_path
+            true
+          rescue Vagrant::Errors::OscdimgCommandMissingError
+            false
+          end
         end
 
         # Generate an ISO file of the given source directory
@@ -36,7 +44,7 @@ module VagrantPlugins
           source_directory = Pathname.new(source_directory)
           file_destination = self.ensure_output_iso(extra_opts[:file_destination])
 
-          iso_command = [BUILD_ISO_CMD, "-j1", "-o", "-m"]
+          iso_command = [oscdimg_path, "-j1", "-o", "-m"]
           iso_command << "-l#{extra_opts[:volume_id]}" if extra_opts[:volume_id]
           iso_command << source_directory.to_s
           iso_command << file_destination.to_s
@@ -44,6 +52,20 @@ module VagrantPlugins
 
           @@logger.info("ISO available at #{file_destination}")
           file_destination
+        end
+
+        # @return [String] oscdimg executable
+        def self.oscdimg_path
+          return BUILD_ISO_CMD if Vagrant::Util::Which.which(BUILD_ISO_CMD)
+          @@logger.debug("#{BUILD_ISO_CMD} not found on PATH")
+          DEPLOYMENT_KIT_PATHS.each do |base|
+            path = File.join(base, Vagrant::Util::Platform.architecture,
+              "Oscdimg", BUILD_ISO_CMD)
+            @@logger.debug("#{BUILD_ISO_CMD} check at #{path}")
+            return path if File.executable?(path)
+          end
+
+          raise Vagrant::Errors::OscdimgCommandMissingError
         end
       end
     end

--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -1250,6 +1250,14 @@ en:
         get an ID of a target machine from `vagrant global-status` to run
         this command on. A final option is to change to a directory with a
         Vagrantfile and to try again.
+      oscdimg_command_missing: |-
+        Vagrant failed to locate the oscdimg.exe executable which is required
+        for creating ISO files. Please ensure the oscdimg.exe executable is
+        available on the configured PATH. If the oscdimg.exe executable is
+        not found on the local system, it can be installed with the Windows
+        Assessment and Deployment Kit:
+
+          https://go.microsoft.com/fwlink/?linkid=2196127
       plugin_gem_not_found: |-
         The plugin '%{name}' could not be installed because it could not
         be found. Please double check the name and try again.


### PR DESCRIPTION
Check for the oscdimg executable on both the PATH and known installation
location. When not found, provider a user friendly error message about
the missing executable and a helper link on where it can be found.
