### PR TITLE
Extract hyperv guest ID from result if needed

### DIFF
--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -72,12 +72,23 @@ module VagrantPlugins
             "VMName" => env[:machine].provider_config.vmname,
           }
 
-
           env[:ui].detail("Creating and registering the VM...")
           server = env[:machine].provider.driver.import(options)
 
+          @logger.debug("import result value: #{server.inspect}")
+
+          sid = case server["id"]
+                when String
+                  server["id"]
+                when Array
+                  server["id"].first
+                else
+                  raise TypeError,
+                    "Expected String or Array value, received: #{server["id"].class}"
+                end
+
           env[:ui].detail("Successfully imported VM")
-          env[:machine].id = server["id"]
+          env[:machine].id = sid
           @app.call(env)
         end
       end

--- a/test/unit/plugins/providers/hyperv/action/import_test.rb
+++ b/test/unit/plugins/providers/hyperv/action/import_test.rb
@@ -98,6 +98,17 @@ describe VagrantPlugins::HyperV::Action::Import do
       subject.call(env)
     end
 
+    context "VM ID result is Array" do
+      before do
+        expect(driver).to receive(:import).and_return("id" => "VMID")
+      end
+
+      it "should properly set the machine ID" do
+        expect(machine).to receive(:id=).with("VMID")
+        subject.call(env)
+      end
+    end
+
     context "with no vmcx support" do
       before do
         expect(driver).to receive(:has_vmcx_support?).and_return(false)


### PR DESCRIPTION
Result from import may be received in an array. Detect if the result
is an array and extract the first result. Otherwise, if the result
is not a string, force an error.
