### PR TITLE
Fix hyperv import failure due to lack of resources

### DIFF
--- a/plugins/providers/hyperv/action/import.rb
+++ b/plugins/providers/hyperv/action/import.rb
@@ -70,8 +70,10 @@ module VagrantPlugins
             "LinkedClone" => !!env[:machine].provider_config.linked_clone,
             "SourcePath" => Vagrant::Util::Platform.wsl_to_windows_path(image_path).gsub("/", "\\"),
             "VMName" => env[:machine].provider_config.vmname,
+            "Memory" => env[:machine].provider_config.memory,
+            "MaxMemory" => env[:machine].provider_config.maxmemory,
+            "Processors" => env[:machine].provider_config.cpus,
           }
-
 
           env[:ui].detail("Creating and registering the VM...")
           server = env[:machine].provider.driver.import(options)

--- a/plugins/providers/hyperv/scripts/import_vm.ps1
+++ b/plugins/providers/hyperv/scripts/import_vm.ps1
@@ -15,6 +15,12 @@ param(
     [parameter (Mandatory=$false)]
     [switch] $LinkedClone,
     [parameter (Mandatory=$false)]
+    [int] $Memory = $null,
+    [parameter (Mandatory=$false)]
+    [int] $MaxMemory = $null,
+    [parameter (Mandatory=$false)]
+    [int] $Processors = $null,
+    [parameter (Mandatory=$false)]
     [string] $VMName=$null
 )
 
@@ -28,7 +34,8 @@ try {
     }
 
     $VM = New-VagrantVM -VMConfigFile $VMConfigFile -DestinationPath $DestinationPath `
-      -DataPath $DataPath -SourcePath $SourcePath -LinkedClone $linked -VMName $VMName
+      -DataPath $DataPath -SourcePath $SourcePath -LinkedClone $linked -Memory $Memory `
+      -MaxMemory $MaxMemory -CPUCount $Processors -VMName $VMName
 
     $Result = @{
         id = $VM.Id.Guid;

--- a/plugins/providers/hyperv/scripts/utils/VagrantVM/VagrantVM.psm1
+++ b/plugins/providers/hyperv/scripts/utils/VagrantVM/VagrantVM.psm1
@@ -33,6 +33,12 @@ function New-VagrantVM {
         [string] $SourcePath,
         [parameter (Mandatory=$false)]
         [bool] $LinkedClone = $false,
+        [parameter (Mandatory=$false)]
+        [int] $Memory = $null,
+        [parameter (Mandatory=$false)]
+        [int] $MaxMemory = $null,
+        [parameter (Mandatory=$false)]
+        [int] $CPUCount = $null,
         [parameter(Mandatory=$false)]
         [string] $VMName
     )
@@ -93,6 +99,12 @@ function New-VagrantVMVMCX {
         [string] $SourcePath,
         [parameter (Mandatory=$false)]
         [bool] $LinkedClone = $false,
+        [parameter (Mandatory=$false)]
+        [int] $Memory = $null,
+        [parameter (Mandatory=$false)]
+        [int] $MaxMemory = $null,
+        [parameter (Mandatory=$false)]
+        [int] $CPUCount = $null,
         [parameter(Mandatory=$false)]
         [string] $VMName
     )
@@ -126,6 +138,16 @@ function New-VagrantVMVMCX {
 
     # Disconnect adapters from switches
     Hyper-V\Get-VMNetworkAdapter -VM $VM | Hyper-V\Disconnect-VMNetworkAdapter
+
+    # If we have a memory value provided, set it here
+    if($Memory -ne $null) {
+        Set-VagrantVMMemory -VM $VM -Memory $Memory -MaxMemory $MaxMemory
+    }
+
+    # If we have a CPU count provided, set it here
+    if($CPUCount -ne $null) {
+        Set-VagrantVMCPUS -VM $VM -CPUCount $CPUCount
+    }
 
     # Verify new VM
     $Report = Hyper-V\Compare-VM -CompatibilityReport $VMConfig

--- a/test/unit/plugins/providers/hyperv/action/import_test.rb
+++ b/test/unit/plugins/providers/hyperv/action/import_test.rb
@@ -15,7 +15,10 @@ describe VagrantPlugins::HyperV::Action::Import do
   let(:provider_config){
     double("provider_config",
       linked_clone: false,
-      vmname: "VMNAME"
+      vmname: "VMNAME",
+      cpus: nil,
+      memory: nil,
+      maxmemory: nil,
     )
   }
   let(:box){ double("box", directory: box_directory) }


### PR DESCRIPTION
When importing a box that was built with more resources than is
available on the current system, import would fail. If the memory
and/or cpu values are set in the Vagrantfile configuration, provide
them when importing the guest. This allows the values to be modified
prior to registering the new guest preventing a resource unavailability
error.

Fixes #12180
