### PR TITLE
updates "login" command and registry name

### DIFF
--- a/templates/locales/en.yml
+++ b/templates/locales/en.yml
@@ -556,11 +556,10 @@ en:
         Constraints: %{constraints}
         Available versions: %{versions}
       box_add_short_not_found: |-
-        The box '%{name}' could not be found or
-        could not be accessed in the remote catalog. If this is a private
-        box on HashiCorp's Vagrant Cloud, please verify you're logged in via
-        `vagrant login`. Also, please double-check the name. The expanded
-        URL and error message are shown below:
+        The box '%{name}' could not be found or could not be accessed in the remote catalog. 
+        If this is a private box on the HashiCorp Vagrant Public Registry, please verify 
+        you're logged in via `vagrant cloud auth login`. Also, please double-check the name. 
+        The expanded URL and error message are shown below:
 
         URL: %{url}
         Error: %{error}


### PR DESCRIPTION
Hello maintainers 👋🏼 

This PR updates the `en` language file with the updated login call.

For context, when running `vagrant login`, the following is shown:

> WARNING: This command has been deprecated and aliased to `vagrant cloud auth login`

I've also updated "HashiCorp's Vagrant Cloud" to "the HashiCorp Vagrant Public Registry" to mimic the name shown on https://portal.cloud.hashicorp.com/vagrant/discover.