### PR TITLE
Fix HyperV XML: System.Xml.XmlElement & The minimum amount

### DIFF
--- a/plugins/providers/hyperv/scripts/utils/VagrantVM/VagrantVM.psm1
+++ b/plugins/providers/hyperv/scripts/utils/VagrantVM/VagrantVM.psm1
@@ -333,7 +333,7 @@ function New-VagrantVMXML {
 
     # Apply original VM configuration to new VM instance
 
-    if($CPUCount -ne $null) {
+    if($CPUCount -ne $null -and $CPUCount -gt 0) {
         $processors = $CPUCount
     } else {
         $processors = $VMConfig.configuration.settings.processors.count."#text"
@@ -348,7 +348,7 @@ function New-VagrantVMXML {
     }
 
 
-    if($Memory -ne $null) {
+    if($Memory -ne $null -and $Memory -gt 0) {
         $MemoryMaximumBytes = $Memory * 1MB
         $MemoryStartupBytes = $Memory * 1MB
         $MemoryMinimumBytes = $Memory * 1MB
@@ -358,7 +358,7 @@ function New-VagrantVMXML {
         $MemoryMinimumBytes = ($memoryNode.reservation."#text" -as [int]) * 1MB
     }
 
-    if($MaxMemory -ne $null) {
+    if($MaxMemory -ne $null -and $MaxMemory -gt 0) {
         $dynamicmemory = $true
         $MemoryMaximumBytes = $MaxMemory * 1MB
     }


### PR DESCRIPTION
ERROR:
> New-VagrantVMXML : Cannot convert the "System.Xml.XmlElement" value of type "System.Xml.XmlElement"
to type "System.Int32

Valid XML config, which was causing the crash:
```xml
  <memory>
    <bank>
      <dynamic_memory_enabled type="bool">[...]</dynamic_memory_enabled>
      <limit type="integer">[...]</limit>
      <reservation type="integer">[...]</reservation>
      <size type="integer">[...]</size>
    </bank>
  </memory>
```

Invalid XML config, what was passing (but would then fail later as `dynamic_memory_enabled` is missing):

```xml
  <memory>
    <Bank>2048</Bank>
  </memory>
```

- - -

`$memory` -> `$memoryNode`
There is another variable `$Memory`, so renamed to make it clear.

- - -

`<Bank>` -> `<bank>` (lowercase b)
REF: https://github.com/mwrock/packer-templates/blob/a96114e3b0918f19cbb6907b797cdd26749cfd11/hyper-v-output/Virtual%20Machines/vm.XML#L397