### PR TITLE
Update box add action to pass arch correctly

### DIFF
--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -181,8 +181,8 @@ module Vagrant
           end
 
           provider = env[:box_provider]
+          
           provider = Array(provider) if provider
-
           box_add(
             urls,
             name,
@@ -192,7 +192,7 @@ module Vagrant
             env,
             checksum: env[:box_checksum],
             checksum_type: env[:box_checksum_type],
-            architecture: env[:architecture]
+            architecture: env[:box_architecture]
           )
         end
 

--- a/lib/vagrant/action/builtin/box_add.rb
+++ b/lib/vagrant/action/builtin/box_add.rb
@@ -181,8 +181,8 @@ module Vagrant
           end
 
           provider = env[:box_provider]
-          
           provider = Array(provider) if provider
+
           box_add(
             urls,
             name,

--- a/test/unit/vagrant/action/builtin/box_add_test.rb
+++ b/test/unit/vagrant/action/builtin/box_add_test.rb
@@ -114,11 +114,13 @@ describe Vagrant::Action::Builtin::BoxAdd, :skip_windows, :bsdtar do
 
       env[:box_name] = "foo"
       env[:box_url] = box_path.to_s
+      env[:box_architecture] = "x86_64"
 
       expect(box_collection).to receive(:add).with(any_args) { |path, name, version, opts|
         expect(checksum(path)).to eq(checksum(box_path))
         expect(name).to eq("foo")
         expect(version).to eq("0")
+        expect(opts[:architecture]).to eq("x86_64")
         expect(opts[:metadata_url]).to be_nil
         true
       }.and_return(box)


### PR DESCRIPTION
Currently, during the box add action `env[:architecture]` gets passed down to `add_direct`, however, there is no `architecture` in env, the correct arch which is set in `Vagrantfile` is `box_architecture`, this PR changes the action to pass down the correct parameter

Closes: #13698, #13697