### PR TITLE
Fix `Vagrant::Util::Keypair::Rsa.create` Use of a broken or weak cryptographic algorithm

### DIFF
--- a/lib/vagrant/util/keypair.rb
+++ b/lib/vagrant/util/keypair.rb
@@ -144,7 +144,7 @@ module Vagrant
           private_key = rsa_key.to_pem
 
           if password
-            cipher      = OpenSSL::Cipher.new('des3')
+            cipher      = OpenSSL::Cipher.new('aes-256-cbc')
             private_key = rsa_key.to_pem(cipher, password)
           end
 


### PR DESCRIPTION
fix the problem, replace the use of the weak `des3` cipher with a strong, modern cipher such as `aes-256-cbc` when encrypting the private key. This involves changing the argument to `OpenSSL::Cipher.new` from `'des3'` to `'aes-256-cbc'` on line 147. No other changes are required, as OpenSSL supports this cipher natively and the rest of the code does not depend on the specific cipher used. This change is limited to the `lib/vagrant/util/keypair.rb` file, specifically within the `Vagrant::Util::Keypair::Rsa.create` method.

#### References
NIST, FIPS 140 Annex a: [Approved Security Functions](http://csrc.nist.gov/publications/fips/fips140-2/fips1402annexa.pdf)
NIST, SP 800-131A: [Transitions: Recommendation for Transitioning the Use of Cryptographic Algorithms and Key Lengths](http://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-131Ar1.pdf)
OWASP: [Rule - Use strong approved cryptographic algorithms](https://cheatsheetseries.owasp.org/cheatsheets/Cryptographic_Storage_Cheat_Sheet.html#rule---use-strong-approved-authenticated-encryption)
