### PR TITLE
Update old docs.vagrantup.com Reference

### DIFF
--- a/website/content/vagrant-cloud/boxes/create.mdx
+++ b/website/content/vagrant-cloud/boxes/create.mdx
@@ -29,7 +29,7 @@ the way.
 ## Creating Boxes via the Vagrant Cloud Web Interface
 
 You'll first need to create a box file. This can be done via
-the [vagrant `package` command](http://docs.vagrantup.com/v2/boxes/base)
+the [vagrant `package` command](/vagrant/docs/boxes/base)
 or with Packer locally.
 
 After you've created the `.box` file, this guide can be followed.


### PR DESCRIPTION
Currently, it points to http://docs.vagrantup.com/v2/boxes/base, but that URL shows:  

> Fastly error: unknown domain: docs.vagrantup.com. Please check that this domain has been added to a service.

I think it should instead point to: 
https://developer.hashicorp.com/vagrant/docs/boxes/base
