### PR TITLE
Fix outdated supported provider information in the Disks overview page

### DIFF
--- a/website/content/docs/disks/index.mdx
+++ b/website/content/docs/disks/index.mdx
@@ -17,4 +17,8 @@ For more information about what options are available for configuring disks, see
 
 ## Supported Providers
 
-Currently, only VirtualBox is supported. Please refer to the [VirtualBox documentation](/vagrant/docs/disks/virtualbox) for more information on using disks with the VirtualBox provider!
+Currently, only VirtualBox, Hyper-V, and VMware are supported.  Refer to the following documentation for more information:
+
+* [VirtualBox](/vagrant/docs/disks/virtualbox)
+* [Hyper-V](/vagrant/docs/disks/hyperv)
+* [VMware](/vagrant/docs/disks/vmware)


### PR DESCRIPTION
Noticed it while reading the documetation.