### PR TITLE
Document `smb_id` for synced folders

### DIFF
--- a/website/content/docs/synced-folders/smb.mdx
+++ b/website/content/docs/synced-folders/smb.mdx
@@ -84,6 +84,9 @@ The SMB synced folder type has a variety of options it accepts:
   Windows username. If you sign into a domain, specify it as `user@domain`.
   If this option is not specified, Vagrant will prompt you for it.
 
+- `smb_id` (string) - The name for the mount point of this synced folder in the
+  guest machine. This shows up when you run `mount` in the guest machine.
+
 ## Example
 
 The following is an example of using SMB to sync a folder:


### PR DESCRIPTION
When using the `id` option documented [here](https://developer.hashicorp.com/vagrant/docs/synced-folders/basic_usage#options) like this
```
config.vm.synced_folder "C:/projects", "/projects", type: "smb", id: "projects", smb_username: ENV['SMB_USERNAME'], smb_password: ENV['SMB_PASSWORD'], mount_options: ["vers=3.0"]
```
I got this in my VM:
```
$ mount
//172.22.32.1/vgt-69a3aff238e79c45ffd1cd0472ccc0ad-35a2864c314e4367eb1684bfe126a967 on /projects type cifs (rw,relatime,vers=3.0,...
: 
```
Changing `id` to `smb_id` like this
```
config.vm.synced_folder "C:/projects", "/projects", type: "smb", smb_id: "projects", smb_username: ENV['SMB_USERNAME'], smb_password: ENV['SMB_PASSWORD'], mount_options: ["vers=3.0"]
```
yields the desired result:
```
$ mount
//172.22.32.1/projects on /projects type cifs (rw,relatime,vers=3.0,...
: 
```