### PR TITLE
ansible.mdx: fix broken links to ansible docs

### DIFF
--- a/website/content/docs/provisioning/ansible.mdx
+++ b/website/content/docs/provisioning/ansible.mdx
@@ -19,7 +19,7 @@ If you are not familiar with Ansible and Vagrant already, we recommend starting 
 
 - **[Install Ansible](https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html) on your Vagrant host**.
 
-- Your Vagrant host should ideally provide a recent version of OpenSSH that [supports ControlPersist](https://docs.ansible.com/faq.html#how-do-i-get-ansible-to-reuse-connections-enable-kerberized-ssh-or-have-ansible-pay-attention-to-my-local-ssh-config-file).
+- Your Vagrant host should ideally provide a recent version of OpenSSH that [supports ControlPersist](https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-get-ansible-to-reuse-connections-enable-kerberized-ssh-or-have-ansible-pay-attention-to-my-local-ssh-config-file).
 
 If installing Ansible directly on the Vagrant host is not an option in your development environment, you might be looking for the [Ansible Local provisioner](/vagrant/docs/provisioning/ansible_local) alternative.
 


### PR DESCRIPTION
Hello!
This PR fixes a broken URL to the Ansible documentation. The Ansible developers changed the structure of their documentation, so the link became broken.