### PR TITLE
Windows: Authenticate against a domain controller in a domain context

### DIFF
--- a/plugins/hosts/windows/scripts/check_credentials.ps1
+++ b/plugins/hosts/windows/scripts/check_credentials.ps1
@@ -20,7 +20,7 @@ if ( $DSContext.ValidateCredentials( $username, $password ) ) {
 
 $DSContext = New-Object System.DirectoryServices.AccountManagement.PrincipalContext(
     [System.DirectoryServices.AccountManagement.ContextType]::Domain,
-    $env:COMPUTERNAME
+    $env:USERDOMAIN
 )
 if ( $DSContext.ValidateCredentials( $username, $password ) ) {
     exit 0
@@ -35,3 +35,4 @@ if ( $DSContext.ValidateCredentials( $username, $password ) ) {
 } 
 
 exit 1
+


### PR DESCRIPTION
Attempting to authenticate against the local machine when in a domain context fails. Authenticate against a domain controller instead.
This addresses issue https://github.com/hashicorp/vagrant/issues/11945 with the suggested fix by onpubcom.

Seems the line endings were messed up, I can split up the commit into normalizing line endings and the actual change if preferred.