### PR TITLE
fix(commands/login): Load correct locales for the login command

### DIFF
--- a/plugins/commands/login/plugin.rb
+++ b/plugins/commands/login/plugin.rb
@@ -13,7 +13,15 @@ module VagrantPlugins
 
       command(:login) do
         require File.expand_path("../../cloud/auth/login", __FILE__)
+        init!
         VagrantPlugins::CloudCommand::AuthCommand::Command::Login
+      end
+
+      def self.init!
+        return if defined?(@_init)
+        I18n.load_path << File.expand_path("../../cloud/locales/en.yml", __FILE__)
+        I18n.reload!
+        @_init = true
       end
     end
   end


### PR DESCRIPTION
Add `init` method to correctly load the correct translations when running the login command.

Before:
```
➜ vagrant login
WARNING: This command has been deprecated and aliased to `vagrant cloud auth login`
Translation missing: en.cloud_command.command_header
```

After:
```
➜ vagrant login
WARNING: This command has been deprecated and aliased to `vagrant cloud auth login`
In a moment we will ask for your username and password to HashiCorp's
Vagrant Cloud. After authenticating, we will store an access token locally on
disk. Your login details will be transmitted over a secure connection, and
are never stored on disk locally.
```