### PR TITLE
Retain 'primary' attribute when resizing the Hyper-V primary disk

### DIFF
--- a/plugins/providers/hyperv/cap/configure_disks.rb
+++ b/plugins/providers/hyperv/cap/configure_disks.rb
@@ -239,6 +239,9 @@ module VagrantPlugins
 
           # Store updated metadata
           disk_metadata = {UUID: disk_info["DiskIdentifier"], Name: disk_config.name, Path: disk_info["Path"]}
+          if disk_config.primary
+            disk_metadata[:primary] = true
+          end
 
           disk_metadata
         end


### PR DESCRIPTION
Fix https://github.com/hashicorp/vagrant/issues/13720

The `primary` attribute is set when not resizing the current disk (`else` branch), but it is not set when resizing the current disk:
https://github.com/hashicorp/vagrant/blob/162b7c0d700a0fb244d1549ae8523006f4892eb0/plugins/providers/hyperv/cap/configure_disks.rb#L96-L102

Due to the missing `primary` attribute, a resized primary disk is deleted here upon the next `vagrant up`:
https://github.com/hashicorp/vagrant/blob/162b7c0d700a0fb244d1549ae8523006f4892eb0/plugins/providers/hyperv/cap/cleanup_disks.rb#L37-L48