### PR TITLE
Fix getting SSH IP address for Docker container

### DIFF
--- a/plugins/providers/docker/provider.rb
+++ b/plugins/providers/docker/provider.rb
@@ -154,7 +154,10 @@ module VagrantPlugins
         if network["Ports"][port_name].respond_to?(:first)
           port_info = network["Ports"][port_name].first
         else
-          ip = network["IPAddress"]
+          # As IPAddress was removed in Docker 29.0.0 we fallback
+          # to Networks/bridge/IPAddress here.
+          ip = network["IPAddress"] ||
+               network.dig("Networks", "bridge", "IPAddress")
           port = @machine.config.ssh.guest_port
           if !ip.to_s.empty?
             port_info = {


### PR DESCRIPTION
As [DefaultNetworkSettings.IPAddress was removed](https://github.com/moby/moby/pull/50846) in [Docker release 29.0.0](https://docs.docker.com/engine/release-notes/29/), add a fallback to get SSH IP address from default bridge network if configured.