### PR TITLE
Fix issue with odd number of arguments for Hash

### DIFF
--- a/plugins/communicators/ssh/communicator.rb
+++ b/plugins/communicators/ssh/communicator.rb
@@ -871,7 +871,7 @@ module VagrantPlugins
         end
 
         # Convert the options into a Hash for easy access
-        opts = Hash[*list.split("\n").map{|line| line.split(" ", 2)}.flatten]
+        opts = Hash[*list.split("\n").filter_map{|line| line.split(" ", 2) if line.include? " "}.flatten]
 
         # Define the option names to check for in preferred order
         # NOTE: pubkeyacceptedkeytypes has been renamed to pubkeyacceptedalgorithms


### PR DESCRIPTION
In case `sshd -T | grep key` returns some lines without spaces Hash creation in communicator.rb failed with ArgumentError "odd number of arguments for Hash".

As only "pubkeyacceptedalgorithms", "pubkeyacceptedkeytypes", "hostkeyalgorithms" are needed, change to ignore lines that have no space.

This fixes error:

```
/home/vyos/tasks/VD-2244-thread-starvation/vagrant/plugins/communicators/ssh/communicator.rb:879:in `[]': odd number of arguments for Has
h (ArgumentError)

        opts = Hash[*list.split("\n").map{|line| line.split(" ", 2)}.flatten]
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        from /home/vyos/tasks/VD-2244-thread-starvation/vagrant/plugins/communicators/ssh/communicator.rb:879:in `supported_key_types'
        from /home/vyos/tasks/VD-2244-thread-starvation/vagrant/plugins/communicators/ssh/communicator.rb:215:in `ready?'
        from /home/vyos/tasks/VD-2244-thread-starvation/vagrant/plugins/communicators/ssh/communicator.rb:91:in `block in wait_for_ready'
        from /home/vyos/.local/share/gem/ruby/3.3.0/gems/timeout-0.5.0/lib/timeout.rb:222:in `block in timeout'
        from /home/vyos/.local/share/gem/ruby/3.3.0/gems/timeout-0.5.0/lib/timeout.rb:38:in `handle_timeout'
        from /home/vyos/.local/share/gem/ruby/3.3.0/gems/timeout-0.5.0/lib/timeout.rb:231:in `timeout'
        from /home/vyos/tasks/VD-2244-thread-starvation/vagrant/plugins/communicators/ssh/communicator.rb:66:in `wait_for_ready'
        from /home/vyos/tasks/VD-2244-thread-starvation/vagrant/lib/vagrant/action/builtin/wait_for_communicator.rb:19:in `block in call'
```

I got it while trying to launch NixOS under Vagrant with https://github.com/nix-community/nixbox.git.

`list` in line 872 of communicator.rb ends with

```
"rekeylimit 0 0\npubkeyauthoptions none\n\e]0;\a"
```

I don't know yet where `\e]0;\a` came from, but anyway I think ignoring lines without spaces here is good idea.
