### PR TITLE
Support Ruby 4.0

### DIFF
--- a/.github/workflows/testing-skipped.yml
+++ b/.github/workflows/testing-skipped.yml
@@ -19,7 +19,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        ruby: [ '3.1', '3.2', '3.3', '3.4' ]
+        ruby: [ '3.1', '3.2', '3.3', '3.4', '3.5', '4.0' ]
     name: Vagrant unit tests on Ruby ${{ matrix.ruby }}
     steps:
       - name: Stubbed for skip

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -32,7 +32,7 @@ jobs:
     continue-on-error: true
     strategy:
       matrix:
-        ruby: [ '3.1', '3.2', '3.3', '3.4' ]
+        ruby: [ '3.1', '3.2', '3.3', '3.4', '3.5', '4.0' ]
     name: Vagrant unit tests on Ruby ${{ matrix.ruby }}
     steps:
       - name: Code Checkout

--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.summary       = "Build and distribute virtualized development environments."
   s.description   = "Vagrant is a tool for building and distributing virtualized development environments."
 
-  s.required_ruby_version     = ">= 3.0", "< 3.5"
+  s.required_ruby_version     = ">= 3.0"
   s.required_rubygems_version = ">= 1.3.6"
 
   s.add_dependency "base64", "~> 0.2.0"


### PR DESCRIPTION
The pull request proposes removing the < 4 upper bound on required_ruby_version in the gemspec. 
With Ruby 4.0 scheduled for release on Christmas Day and a preview already available.

Ruby 4.0.0 preview3 Released
https://www.ruby-lang.org/en/news/2025/12/18/ruby-4-0-0-preview3-released/


the current constraint prevents gem install hoe from working on Ruby 4.0. Dropping the upper bound ensures the gem will install cleanly on Ruby 4.0 and future Ruby versions. 


