### PR TITLE
chore: Bump rexml version from 3.2 to 3.4

### DIFF
--- a/vagrant.gemspec
+++ b/vagrant.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency "net-scp", "~> 4.0"
   s.add_dependency "ostruct", "~> 0.6.0"
   s.add_dependency "rb-kqueue", "~> 0.2.0"
-  s.add_dependency "rexml", "~> 3.2"
+  s.add_dependency "rexml", "~> 3.4"
   s.add_dependency "rubyzip", "~> 2.3.2"
   s.add_dependency "vagrant_cloud", "~> 3.1.2"
   s.add_dependency "wdm", "~> 0.2.0"


### PR DESCRIPTION
Update `rexml` and `vagrant_cloud` gem versions in response to flagged CVE(s)

Note: Yet to update `vagrant_cloud` gem dependency

Fixes: #13780