### PR TITLE
Reload systemd daemon after changing fstab

### DIFF
--- a/plugins/guests/linux/cap/persist_mount_shared_folder.rb
+++ b/plugins/guests/linux/cap/persist_mount_shared_folder.rb
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 require "vagrant/util"
+require "vagrant/util/guest_inspection"
 
 require_relative "../../../synced_folders/unix_mount_helpers"
 
@@ -10,6 +11,7 @@ module VagrantPlugins
     module Cap
       class PersistMountSharedFolder
         extend SyncedFolder::UnixMountHelpers
+        extend Vagrant::Util::GuestInspection::Linux
 
         @@logger = Log4r::Logger.new("vagrant::guest::linux::persist_mount_shared_folders")
 
@@ -22,7 +24,8 @@ module VagrantPlugins
         def self.persist_mount_shared_folder(machine, folders)
           if folders.nil?
             @@logger.info("clearing /etc/fstab")
-            self.remove_vagrant_managed_fstab(machine)
+            changed = remove_vagrant_managed_fstab(machine)
+            systemd_daemon_reload(machine) if changed
             return
           end
 
@@ -56,9 +59,16 @@ module VagrantPlugins
           fstab_entry = Vagrant::Util::TemplateRenderer.render('guests/linux/etc_fstab', folders: export_folders)
           self.remove_vagrant_managed_fstab(machine)
           machine.communicate.sudo("echo '#{fstab_entry}' >> /etc/fstab")
+          systemd_daemon_reload(machine)
         end
 
         private
+
+        def self.systemd_daemon_reload(machine)
+          if systemd?(machine.communicate)
+            machine.communicate.sudo("systemctl daemon-reload")
+          end
+        end
 
         def self.fstab_exists?(machine)
           machine.communicate.test("test -f /etc/fstab")
@@ -69,15 +79,20 @@ module VagrantPlugins
         end
 
         def self.remove_vagrant_managed_fstab(machine)
+          fstab_is_modified = false
+
           if fstab_exists?(machine)
             if contains_vagrant_data?(machine)
                 machine.communicate.sudo("sed -i '/\#VAGRANT-BEGIN/,/\#VAGRANT-END/d' /etc/fstab")
+                fstab_is_modified = true
             else
                 @@logger.info("no vagrant data in fstab file, carrying on")
             end
           else
             @@logger.info("no fstab file found, carrying on")
           end
+
+          fstab_is_modified
         end
       end
     end

--- a/test/unit/plugins/guests/linux/cap/persist_mount_shared_folder_test.rb
+++ b/test/unit/plugins/guests/linux/cap/persist_mount_shared_folder_test.rb
@@ -104,6 +104,53 @@ describe "VagrantPlugins::GuestLinux::Cap::PersistMountSharedFolder" do
       end
     end
 
+    context "fstab modified with systemd" do
+      before do
+        allow(cap).to receive(:systemd?).and_return(true)
+      end
+
+      it "reloads systemd daemon" do
+        expect(comm).to receive(:sudo).with("systemctl daemon-reload")
+        cap.persist_mount_shared_folder(machine, folders)
+      end
+    end
+
+    context "fstab modified without systemd" do
+      before do
+        allow(cap).to receive(:systemd?).and_return(false)
+        allow(cap).to receive(:contains_vagrant_data?).and_return(false)
+      end
+
+      it "does not reload systemd daemon" do
+        expect(comm).not_to receive(:sudo).with("systemctl daemon-reload")
+        cap.persist_mount_shared_folder(machine, folders)
+      end
+    end
+
+    context "fstab not modified with systemd" do
+      before do
+        allow(cap).to receive(:systemd?).and_return(true)
+        allow(cap).to receive(:contains_vagrant_data?).and_return(false)
+      end
+
+      it "does not reload systemd daemon" do
+        expect(comm).not_to receive(:sudo).with("systemctl daemon-reload")
+        cap.persist_mount_shared_folder(machine, nil)
+      end
+    end
+
+    context "fstab not modified without systemd" do
+      before do
+        allow(cap).to receive(:systemd?).and_return(false)
+        allow(cap).to receive(:contains_vagrant_data?).and_return(false)
+      end
+
+      it "does not reload systemd daemon" do
+        expect(comm).not_to receive(:sudo).with("systemctl daemon-reload")
+        cap.persist_mount_shared_folder(machine, nil)
+      end
+    end
+
     context "smb folder" do
       let (:fstab_folders) {
         Vagrant::Plugin::V2::SyncedFolder::Collection[


### PR DESCRIPTION
Calling `mount` may fail after modifying fstab unless systemd daemon is reloaded.

Relevant error message:
```
mount: (hint) your fstab has been modified, but systemd still uses
       the old version; use 'systemctl daemon-reload' to reload.
```

Refs:
- https://github.com/util-linux/util-linux/commit/1db0715169954a8f3898f7ca9d3902cd6c27084d