### PR TITLE
Fix Ubuntu 24.04 shutdown hang with synced folders

### DIFF
--- a/plugins/guests/linux/cap/mount_virtualbox_shared_folder.rb
+++ b/plugins/guests/linux/cap/mount_virtualbox_shared_folder.rb
@@ -21,6 +21,11 @@ module VagrantPlugins
 
           @@logger.debug("Mounting #{name} (#{options[:hostpath]} to #{guestpath})")
 
+          if mounted?(machine, guest_path)
+            @@logger.info("Skipping mount: #{guest_path} is already mounted")
+            return
+          end
+
           builtin_mount_type = "-cit #{mount_type}"
           addon_mount_type = "-t #{mount_type}"
 
@@ -71,6 +76,10 @@ module VagrantPlugins
           if result == 0
             machine.communicate.sudo("rmdir #{guest_path}", error_check: false)
           end
+        end
+
+        def self.mounted?(machine, guest_path)
+          machine.communicate.test("mountpoint -q #{guest_path}")
         end
       end
     end

--- a/test/unit/plugins/guests/linux/cap/mount_virtual_box_shared_folder_test.rb
+++ b/test/unit/plugins/guests/linux/cap/mount_virtual_box_shared_folder_test.rb
@@ -94,6 +94,16 @@ EOF
         cap.mount_virtualbox_shared_folder(machine, mount_name, mount_guest_path, folder_options)
       end
     end
+
+    context "already mounted" do
+      it "skips mounting if already mounted" do
+        expect(folder_plugin).to receive(:capability).with(:mount_type).and_return("vboxsf")
+        expect(comm).to receive(:test).with("mountpoint -q #{mount_guest_path}").and_return(true)
+        expect(comm).not_to receive(:sudo).with(/mount/)
+
+        cap.mount_virtualbox_shared_folder(machine, mount_name, mount_guest_path, folder_options)
+      end
+    end
   end
 
   describe ".unmount_virtualbox_shared_folder" do


### PR DESCRIPTION
Fix Ubuntu 24.04 shutdown hang by preventing vagrant from mounting already mounted synced folders. Fixes #13795.

Before:
```
vagrant ssh
mount | grep vagrant
vagrant on /vagrant type vboxsf (rw,nodev,relatime,iocharset=utf8,uid=1000,gid=1000)
vagrant on /vagrant type vboxsf (rw,nodev,relatime,iocharset=utf8,uid=1000,gid=1000,_netdev)
exit

time vagrant halt
==> default: Attempting graceful shutdown of VM...
==> default: Forcing shutdown of VM...

real	1m5.500s
user	0m3.900s
sys		0m4.279s
```

After:
```
vagrant ssh
mount | grep vagrant
vagrant on /vagrant type vboxsf (rw,nodev,relatime,iocharset=utf8,uid=1000,gid=1000,_netdev)
exit

time vagrant halt
==> default: Attempting graceful shutdown of VM...

real	0m5.210s
user	0m1.657s
sys		0m0.966s
```