### PR TITLE
fix(hyperv): correct dynamic memory allocation based on vagrant spec

### DIFF
--- a/plugins/providers/hyperv/scripts/utils/VagrantVM/VagrantVM.psm1
+++ b/plugins/providers/hyperv/scripts/utils/VagrantVM/VagrantVM.psm1
@@ -509,13 +509,14 @@ function Set-VagrantVMMemory {
         $MemoryMaximumBytes = ($ConfigMemory.Maximum)
     } else {
         $MemoryStartupBytes = $Memory * 1MB
-        $MemoryMinimumBytes = $Memory * 1MB
-        $MemoryMaximumBytes = $Memory * 1MB
+        $MemoryMinimumBytes = $MemoryStartupBytes
+        $MemoryMaximumBytes = $MemoryStartupBytes
     }
 
     if($MaxMemory) {
         $DynamicMemory = $true
-        $MemoryMaximumBytes = $MaxMemory * 1MB
+        $MemoryStartupBytes = $MaxMemory * 1MB
+        $MemoryMaximumBytes = $MemoryStartupBytes
     }
 
     if($DynamicMemory) {


### PR DESCRIPTION
Align the plugin with Vagrant documentation:
"memory (integer) - Number of megabytes allocated to VM at startup. If maxmemory is set, this will be amount of memory allocated at startup."

- Fix dynamic memory logic to respect the documentation where `memory` represents the allocated memory at startup.
- Override `MemoryMaximumBytes` with `$MaxMemory` when specified.