### PR TITLE
Fix SUSE guest networking

### DIFF
--- a/plugins/guests/suse/cap/configure_networks.rb
+++ b/plugins/guests/suse/cap/configure_networks.rb
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BUSL-1.1
 
 require "tempfile"
+require "securerandom"
 
 require_relative "../../../../lib/vagrant/util/template_renderer"
 
@@ -10,9 +11,24 @@ module VagrantPlugins
     module Cap
       class ConfigureNetworks
         extend Vagrant::Util::Retryable
+        extend Vagrant::Util::GuestNetworks::Linux
         include Vagrant::Util
 
         def self.configure_networks(machine, networks)
+          network_scripts_dir = machine.guest.capability(:network_scripts_dir)
+
+          # The legacy configuration will handle guests using wicked
+          # (SLES/Leap 15.x and earlier, Tumbleweed). Guests without
+          # wicked (SLES/Leap 16 and later, MicroOS) are configured
+          # via NetworkManager.
+          if network_scripts_dir.end_with?("sysconfig/network")
+            configure_networks_legacy(machine, networks)
+          else
+            configure_network_manager(machine, networks)
+          end
+        end
+
+        def self.configure_networks_legacy(machine, networks)
           comm = machine.communicate
 
           network_scripts_dir = machine.guest.capability(:network_scripts_dir)

--- a/plugins/guests/suse/cap/network_scripts_dir.rb
+++ b/plugins/guests/suse/cap/network_scripts_dir.rb
@@ -6,7 +6,11 @@ module VagrantPlugins
     module Cap
       class NetworkScriptsDir
         def self.network_scripts_dir(machine)
-          "/etc/sysconfig/network"
+          if machine.communicate.test("test -d /etc/sysconfig/network")
+            "/etc/sysconfig/network"
+          else
+            "/etc/NetworkManager/system-connections"
+          end
         end
       end
     end

--- a/test/unit/plugins/guests/suse/cap/configure_networks_test.rb
+++ b/test/unit/plugins/guests/suse/cap/configure_networks_test.rb
@@ -25,13 +25,6 @@ describe "VagrantPlugins::GuestSUSE::Cap::ConfigureNetworks" do
   describe ".configure_networks" do
     let(:cap) { caps.get(:configure_networks) }
 
-    before do
-      allow(guest).to receive(:capability).with(:network_scripts_dir)
-        .and_return("/scripts")
-      allow(guest).to receive(:capability).with(:network_interfaces)
-        .and_return(["eth1", "eth2"])
-    end
-
     let(:network_1) do
       {
         interface: 0,
@@ -49,12 +42,33 @@ describe "VagrantPlugins::GuestSUSE::Cap::ConfigureNetworks" do
       }
     end
 
-    it "creates and starts the networks" do
-      cap.configure_networks(machine, [network_1, network_2])
-      expect(comm.received_commands[0]).to match(/\/sbin\/ifdown 'eth1'/)
-      expect(comm.received_commands[0]).to match(/\/sbin\/ifup 'eth1'/)
-      expect(comm.received_commands[0]).to match(/\/sbin\/ifdown 'eth2'/)
-      expect(comm.received_commands[0]).to match(/\/sbin\/ifup 'eth2'/)
+    context "with wicked network configuration path" do
+      before do
+        allow(guest).to receive(:capability).with(:network_scripts_dir)
+          .and_return("/etc/sysconfig/network")
+        allow(guest).to receive(:capability).with(:network_interfaces)
+          .and_return(["eth1", "eth2"])
+      end
+
+      it "creates and starts the networks" do
+        cap.configure_networks(machine, [network_1, network_2])
+        expect(comm.received_commands[0]).to match(/\/sbin\/ifdown 'eth1'/)
+        expect(comm.received_commands[0]).to match(/\/sbin\/ifup 'eth1'/)
+        expect(comm.received_commands[0]).to match(/\/sbin\/ifdown 'eth2'/)
+        expect(comm.received_commands[0]).to match(/\/sbin\/ifup 'eth2'/)
+      end
+    end
+
+    context "with system-connections network configuration path" do
+      before do
+        allow(guest).to receive(:capability).with(:network_scripts_dir)
+          .and_return("/etc/NetworkManager/system-connections")
+      end
+
+      it "should configure with network manager" do
+        expect(cap).to receive(:configure_network_manager).with(machine, [network_1, network_2])
+        cap.configure_networks(machine, [network_1, network_2])
+      end
     end
   end
 end

--- a/test/unit/plugins/guests/suse/cap/network_scripts_dir_test.rb
+++ b/test/unit/plugins/guests/suse/cap/network_scripts_dir_test.rb
@@ -10,13 +10,32 @@ describe "VagrantPlugins::GuestSUSE::Cap::NetworkScriptsDir" do
       .guest_capabilities[:suse]
   end
 
-  let(:machine) { double("machine") }
+  let(:comm) { double("comm") }
+  let(:machine) { double("machine", communicate: comm) }
 
   describe ".network_scripts_dir" do
     let(:cap) { caps.get(:network_scripts_dir) }
 
-    it "runs /etc/sysconfig/network" do
-      expect(cap.network_scripts_dir(machine)).to eq("/etc/sysconfig/network")
+    context "when /etc/sysconfig/network exists" do
+      before do
+        allow(comm).to receive(:test).with("test -d /etc/sysconfig/network")
+          .and_return(true)
+      end
+
+      it "returns /etc/sysconfig/network" do
+        expect(cap.network_scripts_dir(machine)).to eq("/etc/sysconfig/network")
+      end
+    end
+
+    context "when /etc/sysconfig/network does not exist" do
+      before do
+        allow(comm).to receive(:test).with("test -d /etc/sysconfig/network")
+          .and_return(false)
+      end
+
+      it "returns /etc/NetworkManager/system-connections" do
+        expect(cap.network_scripts_dir(machine)).to eq("/etc/NetworkManager/system-connections")
+      end
     end
   end
 end


### PR DESCRIPTION
Recent SUSE guests use NetworkManager and no longer include wicked or its ifcfg configuration files. openSUSE MicroOS has been affected since 2022 (#12777, static IPs silently fall back to DHCP). SLE and openSUSE Leap 16 removed wicked entirely, so every Leap 16 guest also fails after `vagrant up`:

```
/sbin/ifdown 'eth1' || true
mv '/tmp/vagrant-network-eth1-...' '/etc/sysconfig/network/ifcfg-eth1'
/sbin/ifup 'eth1'

bash: line 4: /sbin/ifdown: No such file or directory
mv: cannot move '/tmp/vagrant-network-eth1-...' to '/etc/sysconfig/network/ifcfg-eth1': No such file or directory
```

This fix follows the approach used for RHEL 10 guests in #13625: the `network_scripts_dir` capability detects the network configuration location, and `configure_networks` dispatches to the shared `Vagrant::Util::GuestNetworks::Linux` NetworkManager implementation when the wicked configuration directory is absent. The wicked path is unchanged for guests and older boxes that still use it (SLE/Leap 15.x).

Verified with vagrant-libvirt, using a `private_network` with a static IP:

- `cloud-image/opensuse-leap-16.0`: With this change `vagrant up` completes, static and DHCP-typed networks come up as NetworkManager profiles, and addresses persist across reloads.
- `opensuse/MicroOS.x86_64` (the box from #12777): the static address is applied (`ipv4.method: manual`) instead of silently staying on DHCP.
- `cloud-image/opensuse-leap-15.6` (wicked): behavior unchanged, ifcfg path still used.

Fixes #12777

Note: current `opensuse/MicroOS.x86_64` boxes ship with the interactive JeOS firstboot wizard enabled, which blocks first boot until it is answered on the VM console. That is a box packaging issue, outside the scope of this PR.